### PR TITLE
🐛 dockerfile/chef: fix remediation that does not satisfy its own check

### DIFF
--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -389,14 +389,13 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set the target permissions on your /etc/chef/client.rb file. The guard keeps the recipe from creating an empty file on a node where the configuration is absent:
+            Use this Chef Infra recipe code to set the target permissions on your /etc/chef/client.rb file:
 
             ```ruby
             file '/etc/chef/client.rb' do
               owner 'root'
               group 'root'
               mode '0640'
-              only_if { ::File.exist?('/etc/chef/client.rb') }
             end
             ```
     refs:
@@ -476,14 +475,13 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /etc/chef/client.pem file. The guard matters here: a `file` resource with no content creates an empty file when the path is missing, and a zero-byte key would stop Chef Infra Client from authenticating instead of letting it re-register:
+            Use this Chef Infra recipe code to set proper permissions on your /etc/chef/client.pem file:
 
             ```ruby
             file '/etc/chef/client.pem' do
               owner 'root'
               group 'root'
               mode '0600'
-              only_if { ::File.exist?('/etc/chef/client.pem') }
             end
             ```
     refs:

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -389,13 +389,14 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set the target permissions on your /etc/chef/client.rb file:
+            Use this Chef Infra recipe code to set the target permissions on your /etc/chef/client.rb file. The guard keeps the recipe from creating an empty file on a node where the configuration is absent:
 
             ```ruby
             file '/etc/chef/client.rb' do
               owner 'root'
               group 'root'
               mode '0640'
+              only_if { ::File.exist?('/etc/chef/client.rb') }
             end
             ```
     refs:
@@ -475,13 +476,14 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this Chef Infra recipe code to set proper permissions on your /etc/chef/client.pem file:
+            Use this Chef Infra recipe code to set proper permissions on your /etc/chef/client.pem file. The guard matters here: a `file` resource with no content creates an empty file when the path is missing, and a zero-byte key would stop Chef Infra Client from authenticating instead of letting it re-register:
 
             ```ruby
             file '/etc/chef/client.pem' do
               owner 'root'
               group 'root'
               mode '0600'
+              only_if { ::File.exist?('/etc/chef/client.pem') }
             end
             ```
     refs:
@@ -887,10 +889,10 @@ queries:
           desc: |
             **Using CLI**
 
-            Delete any line containing `ssl_verify_mode :verify_none` from `/etc/chef/client.rb`. Commenting the line out is not enough; remove it entirely:
+            Delete any active `ssl_verify_mode :verify_none` setting from `/etc/chef/client.rb`. Commenting the line out is not enough; remove it entirely. Match the setting with a pattern rather than a fixed string, because Ruby accepts `ssl_verify_mode(:verify_none)` and extra whitespace between the setting and its value, and a literal search misses both spellings:
 
             ```bash
-            sed -i '/ssl_verify_mode :verify_none/d' /etc/chef/client.rb
+            sed -i -E '/^[[:space:]]*ssl_verify_mode[[:space:]]*\(?[[:space:]]*:verify_none/d' /etc/chef/client.rb
             ```
 
             To explicitly enable verification, add:

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -396,7 +396,6 @@ queries:
               owner 'opscode'
               group 'root'
               mode '0600'
-              only_if { ::File.exist?('/etc/opscode/webui_priv.pem') }
             end
             ```
     refs:

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -215,14 +215,14 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this recipe code to set the permissions on the /etc/opscode/pivotal.pem file:
+            Use this recipe code to set the permissions on the /etc/opscode/pivotal.pem file. The guard matters here: a `file` resource with no content creates an empty file when the path is missing, and a zero-byte superuser key would break server authentication:
 
             ```ruby
             file '/etc/opscode/pivotal.pem' do
               owner 'opscode'
               group 'root'
               mode '0600'
-              action :create
+              only_if { ::File.exist?('/etc/opscode/pivotal.pem') }
             end
             ```
     refs:
@@ -301,14 +301,14 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this recipe code to set the permissions on the /etc/opscode/private-chef-secrets.json file:
+            Use this recipe code to set the permissions on the /etc/opscode/private-chef-secrets.json file. The guard keeps the recipe from replacing a missing secrets vault with an empty file that the next reconfigure would fail on:
 
             ```ruby
             file '/etc/opscode/private-chef-secrets.json' do
               owner 'root'
               group 'root'
               mode '0600'
-              action :create
+              only_if { ::File.exist?('/etc/opscode/private-chef-secrets.json') }
             end
             ```
     refs:
@@ -475,13 +475,14 @@ queries:
           desc: |
             **Using Chef Infra**
 
-            Use this recipe code to set the permissions on the /etc/opscode/chef-server.rb file:
+            Use this recipe code to set the permissions on the /etc/opscode/chef-server.rb file. The guard keeps the recipe from creating an empty configuration file on a host where Chef Infra Server is not configured:
 
             ```ruby
             file '/etc/opscode/chef-server.rb' do
               owner 'root'
               group 'root'
               mode '0640'
+              only_if { ::File.exist?('/etc/opscode/chef-server.rb') }
             end
             ```
     refs:

--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -134,7 +134,7 @@ queries:
       remediation:
         - id: dockerfile
           desc: |
-            Combine update and install commands in a single `RUN` instruction:
+            Combine update and install commands in a single `RUN` instruction. The replacement also adds `--no-install-recommends`, so the result satisfies the sibling package-hygiene checks as well:
 
             ```dockerfile
             # Instead of:
@@ -142,7 +142,9 @@ queries:
             RUN apt-get install -y package
 
             # Use:
-            RUN apt-get update && apt-get install -y package && rm -rf /var/lib/apt/lists/*
+            RUN apt-get update && \
+                apt-get install -y --no-install-recommends package && \
+                rm -rf /var/lib/apt/lists/*
 
             # For Alpine, instead of:
             RUN apk update
@@ -199,10 +201,10 @@ queries:
     title: Clean apt-get cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "apt-get" && subcommand == "install")).all(commands.any(binary == "rm" && args.any(_ == /\/var\/lib\/apt\/lists/))))
+      docker.file.stages.all(run.where(commands.any(binary == "apt-get" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/lib\/apt\/lists\/?$/) || commands.any(binary == "rm" && args.any(_ == /\/var\/lib\/apt\/lists/))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `apt-get install` should also clean up the apt package lists in the same layer.
+        Dockerfile `RUN` instructions that use `apt-get install` should also clean up the apt package lists in the same layer, or keep them out of the image by mounting `/var/lib/apt/lists` as a BuildKit cache.
 
         **Why this matters**
 
@@ -214,9 +216,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `apt-get install`: `grep -nE 'RUN.*apt-get install' Dockerfile`.
-        3. Confirm each matched instruction also references `/var/lib/apt/lists` to remove the cached index in the same `RUN` statement.
+        3. Confirm each matched instruction either removes `/var/lib/apt/lists` in the same `RUN` statement or mounts it as a BuildKit cache with `--mount=type=cache,target=/var/lib/apt/lists`.
 
-        If every `apt-get install` instruction cleans `/var/lib/apt/lists`, the check passes. If any omits the cleanup, the check fails.
+        If every `apt-get install` instruction cleans or cache-mounts `/var/lib/apt/lists`, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -251,10 +253,10 @@ queries:
     title: Clean yum cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "yum" && subcommand == "install")).all(commands.any(binary == "yum" && subcommand == "clean" && args.contains("all"))))
+      docker.file.stages.all(run.where(commands.any(binary == "yum" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/yum\/?$/) || commands.any(binary == "yum" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `yum install` should also run `yum clean all` in the same layer.
+        Dockerfile `RUN` instructions that use `yum install` should also run `yum clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/yum` as a BuildKit cache.
 
         **Why this matters**
 
@@ -266,9 +268,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `yum install`: `grep -nE 'RUN.*yum install' Dockerfile`.
-        3. Confirm each matched instruction also runs `yum clean all` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `yum clean all` in the same `RUN` statement or mounts the cache with `--mount=type=cache,target=/var/cache/yum`.
 
-        If every `yum install` instruction runs `yum clean all`, the check passes. If any omits it, the check fails.
+        If every `yum install` instruction cleans or cache-mounts `/var/cache/yum`, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -297,10 +299,10 @@ queries:
     title: Clean dnf cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "dnf" && subcommand == "install")).all(commands.any(binary == "dnf" && subcommand == "clean" && args.contains("all"))))
+      docker.file.stages.all(run.where(commands.any(binary == "dnf" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/dnf\/?$/) || commands.any(binary == "dnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `dnf install` should also run `dnf clean all` in the same layer.
+        Dockerfile `RUN` instructions that use `dnf install` should also run `dnf clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/dnf` as a BuildKit cache.
 
         **Why this matters**
 
@@ -312,9 +314,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `dnf install`: `grep -nE 'RUN.*dnf install' Dockerfile`.
-        3. Confirm each matched instruction also runs `dnf clean all` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `dnf clean all` in the same `RUN` statement or mounts the cache with `--mount=type=cache,target=/var/cache/dnf`.
 
-        If every `dnf install` instruction runs `dnf clean all`, the check passes. If any omits it, the check fails.
+        If every `dnf install` instruction cleans or cache-mounts `/var/cache/dnf`, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -343,10 +345,10 @@ queries:
     title: Clean zypper cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "zypper" && subcommand == "install")).all(commands.any(binary == "zypper" && subcommand == "clean")))
+      docker.file.stages.all(run.where(commands.any(binary == "zypper" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/zypp\/?$/) || commands.any(binary == "zypper" && subcommand == "clean")))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `zypper install` should also run `zypper clean` in the same layer.
+        Dockerfile `RUN` instructions that use `zypper install` should also run `zypper clean` in the same layer, or keep the cache out of the image by mounting `/var/cache/zypp` as a BuildKit cache.
 
         **Why this matters**
 
@@ -358,9 +360,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `zypper install`: `grep -nE 'RUN.*zypper install' Dockerfile`.
-        3. Confirm each matched instruction also runs `zypper clean` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `zypper clean` in the same `RUN` statement or mounts the cache with `--mount=type=cache,target=/var/cache/zypp`.
 
-        If every `zypper install` instruction runs `zypper clean`, the check passes. If any omits it, the check fails.
+        If every `zypper install` instruction cleans or cache-mounts `/var/cache/zypp`, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -388,10 +390,10 @@ queries:
     title: Use --no-cache-dir with pip install
     impact: 40
     mql: |
-      docker.file.stages.all(run.all(commands.where(binary == "pip" && subcommand == "install").all(flags.contains("--no-cache-dir"))))
+      docker.file.stages.all(run.where(commands.any(binary == "pip" && subcommand == "install")).all(mounts.any(type == "cache" && target == /pip/) || commands.where(binary == "pip" && subcommand == "install").all(flags.contains("--no-cache-dir"))))
     docs:
       desc: |
-        `pip install` commands in Dockerfile `RUN` instructions should include the `--no-cache-dir` flag.
+        `pip install` commands in Dockerfile `RUN` instructions should include the `--no-cache-dir` flag, or mount the pip cache directory as a BuildKit cache so it never lands in an image layer.
 
         **Why this matters**
 
@@ -403,9 +405,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `pip install`: `grep -nE 'RUN.*pip install' Dockerfile`.
-        3. Confirm each matched instruction includes the `--no-cache-dir` flag.
+        3. Confirm each matched instruction either includes the `--no-cache-dir` flag or mounts the pip cache with `--mount=type=cache,target=/root/.cache/pip`.
 
-        If every `pip install` uses `--no-cache-dir`, the check passes. If any omits it, the check fails.
+        If every `pip install` disables or cache-mounts the cache, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -437,10 +439,10 @@ queries:
     title: Clean yarn cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "yarn" && subcommand == "install")).all(commands.any(binary == "yarn" && subcommand == "cache" && args.contains("clean"))))
+      docker.file.stages.all(run.where(commands.any(binary == "yarn" && subcommand == "install")).all(mounts.any(type == "cache" && target == /yarn/) || commands.any(binary == "yarn" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `yarn install` should also run `yarn cache clean` in the same layer. This check targets Yarn Classic (Yarn 1.x), where the cache lives in a global directory. Yarn Berry (Yarn 2 and later) manages its cache differently through Plug'n'Play and zero-installs, so the `yarn cache clean` step does not apply there.
+        Dockerfile `RUN` instructions that use `yarn install` should also run `yarn cache clean` in the same layer, or mount the yarn cache directory as a BuildKit cache so it never lands in an image layer. This check targets Yarn Classic (Yarn 1.x), where the cache lives in a global directory. Yarn Berry (Yarn 2 and later) manages its cache differently through Plug'n'Play and zero-installs, so the `yarn cache clean` step does not apply there.
 
         **Why this matters**
 
@@ -452,9 +454,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `yarn install`: `grep -nE 'RUN.*yarn install' Dockerfile`.
-        3. Confirm each matched instruction also runs `yarn cache clean` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `yarn cache clean` in the same `RUN` statement or mounts the yarn cache with `--mount=type=cache,target=/usr/local/share/.cache/yarn`.
 
-        If every `yarn install` instruction runs `yarn cache clean`, the check passes. If any omits it, the check fails.
+        If every `yarn install` instruction cleans or cache-mounts the yarn cache, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -483,11 +485,11 @@ queries:
     title: Clean npm cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "install")).all(commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
-      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "ci")).all(commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
+      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "install")).all(mounts.any(type == "cache" && target == /npm/) || commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
+      docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "ci")).all(mounts.any(type == "cache" && target == /npm/) || commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `npm install` or `npm ci` should also run `npm cache clean` in the same layer.
+        Dockerfile `RUN` instructions that use `npm install` or `npm ci` should also run `npm cache clean` in the same layer, or mount the npm cache directory as a BuildKit cache so it never lands in an image layer.
 
         **Why this matters**
 
@@ -499,9 +501,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `npm install` or `npm ci`: `grep -nE 'RUN.*npm (install|ci)' Dockerfile`.
-        3. Confirm each matched instruction also runs `npm cache clean` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `npm cache clean` in the same `RUN` statement or mounts the npm cache with `--mount=type=cache,target=/root/.npm`.
 
-        If every `npm install` and `npm ci` instruction runs `npm cache clean`, the check passes. If any omits it, the check fails.
+        If every `npm install` and `npm ci` instruction cleans or cache-mounts the npm cache, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |
@@ -911,10 +913,10 @@ queries:
     title: Clean microdnf cache after installing packages
     impact: 40
     mql: |
-      docker.file.stages.all(run.where(commands.any(binary == "microdnf" && subcommand == "install")).all(commands.any(binary == "microdnf" && subcommand == "clean" && args.contains("all"))))
+      docker.file.stages.all(run.where(commands.any(binary == "microdnf" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/(dnf|yum)\/?$/) || commands.any(binary == "microdnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `microdnf install` should also run `microdnf clean all` in the same layer. microdnf is a minimal DNF implementation used in Red Hat UBI micro images, and like other package managers it caches downloaded packages and metadata.
+        Dockerfile `RUN` instructions that use `microdnf install` should also run `microdnf clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/dnf` as a BuildKit cache. microdnf is a minimal DNF implementation used in Red Hat UBI micro images, and like other package managers it caches downloaded packages and metadata.
 
         **Why this matters**
 
@@ -926,9 +928,9 @@ queries:
 
         1. Open the Dockerfile in a text editor or print it with `cat Dockerfile`.
         2. Locate every `RUN` instruction containing `microdnf install`: `grep -nE 'RUN.*microdnf install' Dockerfile`.
-        3. Confirm each matched instruction also runs `microdnf clean all` in the same `RUN` statement.
+        3. Confirm each matched instruction either runs `microdnf clean all` in the same `RUN` statement or mounts the cache with `--mount=type=cache,target=/var/cache/dnf`.
 
-        If every `microdnf install` instruction runs `microdnf clean all`, the check passes. If any omits it, the check fails.
+        If every `microdnf install` instruction cleans or cache-mounts the package cache, the check passes. If any omits both, the check fails.
       remediation:
         - id: dockerfile
           desc: |

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -1301,7 +1301,7 @@ queries:
             FROM alpine:3.20 AS deps
             COPY ./deps /deps
 
-            FROM build
+            FROM alpine:3.20
             RUN --mount=type=bind,from=deps,source=/deps,target=/deps ./build.sh
             ```
 

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-apt-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-apt-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:12-slim
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-dnf-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-dnf-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,3 @@
+FROM fedora:40
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    dnf install -y httpd

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-microdnf-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-microdnf-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,3 @@
+FROM redhat/ubi9-micro:9.4
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    microdnf install -y httpd

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-npm-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-npm-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-pip-no-cache-dir/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-pip-no-cache-dir/pass/cache-mount/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.12-slim
+COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-yarn-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-yarn-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    yarn install

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-yum-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-yum-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    yum install -y httpd

--- a/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-zypper-clean-cache/pass/cache-mount/Dockerfile
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-dockerfile-best-practices/mondoo-docker-best-practice-zypper-clean-cache/pass/cache-mount/Dockerfile
@@ -1,0 +1,3 @@
+FROM opensuse/leap:15.6
+RUN --mount=type=cache,target=/var/cache/zypp,sharing=locked \
+    zypper --non-interactive install httpd


### PR DESCRIPTION
Remediation deep dive over the two Dockerfile policies and the two Chef Infra policies. Every `remediation:` block was read, and every snippet that could be executed against an oracle was. Five defects, all verified before filing.

---

## 1. Eight BuildKit cache-mount remediations fail the check that recommends them

`mondoo-dockerfile-best-practices.mql.yaml` documents a second, BuildKit-based option under eight checks: "with BuildKit you can keep the cache out of the image entirely by mounting it". An operator who follows that option still fails the check.

Verified by scanning each snippet exactly as documented, one Dockerfile per snippet:

```
=== apt ===       ✕ MEDIUM (40): Clean apt-get cache after installing packages
=== yum ===       ✕ MEDIUM (40): Clean yum cache after installing packages
=== dnf ===       ✕ MEDIUM (40): Clean dnf cache after installing packages
=== zypper ===    ✕ MEDIUM (40): Clean zypper cache after installing packages
=== microdnf ===  ✕ MEDIUM (40): Clean microdnf cache after installing packages
=== pip ===       ✕ MEDIUM (40): Use --no-cache-dir with pip install
=== yarn ===      ✕ MEDIUM (40): Clean yarn cache after installing packages
=== npm ===       ✕ MEDIUM (40): Clean npm cache after installing packages
```

Eight for eight. The two forms are not reconcilable by editing the snippet either: `pip install --no-cache-dir` disables the very cache the mount exists to persist, and `dnf clean all` / `npm cache clean --force` erase the mounted directory, so "mount it *and* clean it" is not real advice.

The check is the side that was wrong. Every one of these checks states its objective in `desc` as keeping the cache out of the image layer, and a `type=cache` mount achieves that more completely than cleaning does: BuildKit never commits mount contents to a layer at all. So the eight queries now accept an equivalent cache mount on the install instruction, alongside the existing cleanup command. The mount match is tight (`type == "cache"` **and** the target being the package manager's own cache directory), so it cannot be satisfied by an unrelated mount.

```coffee
docker.file.stages.all(run.where(commands.any(binary == "yum" && subcommand == "install")).all(
  mounts.any(type == "cache" && target == /^\/var\/cache\/yum\/?$/) ||
  commands.any(binary == "yum" && subcommand == "clean" && args.contains("all"))))
```

`docker.file.run.mount` exposes `type` and `target`, confirmed against the installed provider schema:

```
docker.file.run.mount :: env, from, gid, id, mode, readOnly, required, sharing, sizeLimit, source, target, type, uid
```

Each new query was run against the existing pass fixture, the existing fail fixture(s), and the documented cache-mount snippet before the edit landed. 26 assertions, 0 regressions:

```
PASS  ok      apt-clean-cache/pass/cleaned        -> [ok]
PASS  failed  apt-clean-cache/fail/not-cleaned    -> [failed]
PASS  ok      t/apt (cache mount)                 -> [ok]
...
bad: 0
```

`desc:` and `audit:` were updated on all eight so the stated pass condition matches what the query now asserts, and a `pass/cache-mount` fixture was added for each so the accepted form is regression-protected. `TestDockerfileVariants` is green including the eight new scenarios, and `TestTerraformVariantCoverage` still reports 100%.

## 2. `no-update-alone`'s apt example fails a sibling check

The "Use:" line was `RUN apt-get update && apt-get install -y package && rm -rf /var/lib/apt/lists/*`, with no `--no-install-recommends`. Scanned:

```
Failing:
✕ MEDIUM (60):    Use --no-install-recommends with apt-get install
```

The `use-apt-get` and `apt-get-assume-yes` examples immediately around it already carry the flag and say so in their prose, so this one was simply missed. Corrected; the snippet now scans clean apart from `HEALTHCHECK`, which a package-install fragment is not expected to declare.

## 3. `no-sensitive-bind-mount-sources` demonstrates `FROM build`, which resolves to nothing

The "stage the input in an earlier stage" example ended with:

```dockerfile
FROM alpine:3.20 AS deps
COPY ./deps /deps

FROM build
RUN --mount=type=bind,from=deps,source=/deps,target=/deps ./build.sh
```

`build` is not a stage the snippet declares, and it is not parsed as a stage reference either:

```
1: { from: { name: "", image: "build", tag: "" } }
```

So `docker build` would try to pull an image literally named `build`, and the snippet fails `mondoo-docker-best-practice-from-tag-specified` in this same policy:

```
Failing:
✕ HIGH (80):      Ensure FROM base images specify a version tag
```

Changed to `FROM alpine:3.20`. The corrected snippet now passes every check in the policy, including the bind-mount check it is the remediation for.

## 4. Five Chef permission recipes create an empty key or config where none exists

The `id: chef` recipes for `client.rb`, `client.pem`, `pivotal.pem`, `private-chef-secrets.json` and `chef-server.rb` used a bare `file` resource to set ownership and mode. Chef's `file` provider gates creation on path existence only, never on whether `content` was supplied ([lib/chef/provider/file.rb](https://github.com/chef/chef/blob/main/lib/chef/provider/file.rb)):

```ruby
@needs_creating = !::TargetIO::File.exist?(new_resource_path) || needs_unlinking?
...
def do_create_file
  if needs_creating?
    converge_by("create new file #{new_resource.path}") do
      deployment_strategy.create(new_resource.path)
```

So on a node where the path is absent, the recipe writes a zero-byte file and then chmods it. For `client.pem` that turns a self-healing state, where Chef Infra Client re-registers and writes a fresh key, into a hard `OpenSSL::PKey::RSAError`. For `private-chef-secrets.json` it puts an empty secrets vault where the next `chef-server-ctl reconfigure` expects one.

Corrected after review. A guard is only worth adding where the check can actually fire on a node without the file, and for three of these five it cannot: `client-rb-permissions`, `client-pem-permissions` and `webui-pem-permissions` wrap their assertions in `if (file(...).exists)`, so the check is skipped entirely and the `only_if` is unreachable. The `webui_priv.pem` guard I cited as the established pattern is itself redundant for the same reason, so it is removed here too.

The guard stays on `pivotal.pem`, `private-chef-secrets.json` and `chef-server.rb`, whose checks have no existence test. An unguarded `file()` block on a missing path returns false:

```
$ cnquery run local -c 'file("/etc/definitely-not-here") { user.name == "root" }'
file: {
  user.name == "root": false
}
```

so those three do fire on a host without the file, and without a guard the recipe would create a zero-byte key with the right mode, passing the check while breaking the server. `cookstyle` is clean: 28 PASS, 0 FAIL.

Worth a maintainer decision separately: those three are the only permission checks in the server policy without the existence test their `webui_priv.pem` sibling has. Adding it would make all four consistent and let the last three guards go too, at the cost of no longer failing when the file is absent. That is a presence concern rather than a permissions one, so I have not changed the checks here.

## 5. The `ssl_verify_mode` sed misses two spellings the check flags

`ssl-verification-enabled` detects with an anchored pattern that tolerates a parenthesised call and arbitrary whitespace:

```coffee
file("/etc/chef/client.rb").content != /^\s*ssl_verify_mode\s*\(?\s*:verify_none/m
```

The remediation deleted a fixed string. Against a `client.rb` holding all three spellings:

```
ssl_verify_mode(:verify_none)
ssl_verify_mode   :verify_none
ssl_verify_mode :verify_none
```

after the documented `sed -i '/ssl_verify_mode :verify_none/d'`:

```
ssl_verify_mode(:verify_none)
ssl_verify_mode   :verify_none
```

```
[failed] file.content != /(?m)^\s*ssl_verify_mode\s*\(?\s*:verify_none/
```

The operator runs the documented fix and the finding stays. The sed now uses the same shape the check does, and as a bonus stops deleting commented-out lines, which the check never flagged:

```bash
sed -i -E '/^[[:space:]]*ssl_verify_mode[[:space:]]*\(?[[:space:]]*:verify_none/d' /etc/chef/client.rb
```

Result after the corrected sed: `[ok]`.

---

## Checked and found correct

Candidates that looked wrong and verified out, plus coverage that produced no finding.

**Dockerfile security.** Every "Use:" snippet in the policy was assembled into a complete Dockerfile and scanned against the whole policy. The APT signed-by keyring block, the `rpm --import` blocks for dnf and zypper, the COPY-instead-of-ADD replacements including the checksum-verified download, the `--mount=type=secret` netrc example, the non-root `groupadd`/`chown`/`USER` block, and the corrected bind-mount example all pass every check in the policy with no failures. The `# Instead of:` halves are labelled as the anti-pattern and are not offered as fixes.

**Chef Infra resource and CLI claims**, each checked against chef/chef source, the cookbook repos, or a live endpoint rather than from memory:

- `chef_client_config` is real and `introduced "16.6"`; `chef_server_url` is `required: true`; `ssl_verify_mode` accepts `%i{verify_none verify_peer}` as Symbol or String; `data_collector_server_url` and `data_collector_token` exist (`introduced: "17.8"`); `additional_config` is a String appended verbatim to the bottom of client.rb.
- `data_bag_decrypt_minimum_version` has no dedicated `chef_client_config` property but is a real client.rb setting (`default :data_bag_decrypt_minimum_version, 0` in chef-config), so `additional_config 'data_bag_decrypt_minimum_version 3'` is the correct mechanism, exactly as documented.
- `data_collector.token` and `data_collector.server_url` are the correct dotted client.rb spellings; the `chef_client_config` template emits them literally under the comment `These data_collector options are special as they have a '.'`.
- `chef_client_updater` takes `version, kind_of: [String, Symbol]` with no `equal_to`, and its README documents a bare major, so `version '18'` is valid.
- `chef_ingredient` has `property :version, [String, Symbol]` and `action :upgrade`, and `version_latest?` explicitly accepts the string `'latest'`.
- `Chef::Util::FileEdit#insert_line_if_no_match(regex, newline)`, `#search_file_delete_line(regex)` and `#write_file` all exist with the signatures used.
- `omnitruck.chef.io/install.sh` parses `P) project` and `v) version`, and a bare major resolves: `metadata?v=18` returns `version 18.11.11`. `omnitruck.cinc.sh/install.sh` is the same script and accepts `-P cinc`.
- `chef-client --why-run` is real (`short: "-W"`).
- `opscode-reporting-ctl uninstall` and `opscode-analytics-ctl uninstall` are documented verbatim in chef-web-docs; `uninstall` is in omnibus-ctl's unconditional base command map, which covers `opscode-push-jobs-server-ctl`. `chef-server-ctl stop keepalived` appears verbatim in Chef's HA docs.
- Forward `notifies :run, 'execute[reconfigure chef server]', :immediately` to a resource declared later in the recipe resolves correctly, because the collection is compiled before converge.
- The `ruby_block` + `Chef::Util::FileEdit` recipes for `secure-tls-only`, `disable-insecure-addon-compat`, `postgresql-not-externally-accessible` and `search-not-externally-accessible` write exactly the strings their checks look for, including `nginx['ssl_protocols'] = 'TLSv1.2'` rendering as the `ssl_protocols TLSv1.2;` the check greps for.
- `sed -i '/data_collector\.token/d'` in `avoid-reporting-tokens-in-config` is equivalent to that check's plain `contains("data_collector.token")` substring test; no gap there.

**Validation run**

```
cnspec policy lint (all four)                          valid policy bundle(s)
go test -tags iac_variants -run TestDockerfileVariants  PASS (incl. 8 new cache-mount scenarios)
go test -tags iac_variants coverage                     PASS, 100%
go test ./content/validation/{scans,compliance}/...      ok
content/validation/remediation/code/chef.py chef         28 PASS, 0 FAIL
content/validation/remediation/code/bash.py              exit 0
typos                                                    exit 0
```

Policy `version:` deliberately not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

