### PR TITLE
🐛 content: fix database remediation that never reaches the option file

### DIFF
--- a/content/mondoo-mariadb-security.mql.yaml
+++ b/content/mondoo-mariadb-security.mql.yaml
@@ -848,13 +848,19 @@ queries:
             chmod 0600 "$KEY"
             chmod 0644 "$CERT"
 
+            mysqld_appended=0
+
             set_option() {
               local key="$1" value="$2"
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
-              else
-                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
+                return
               fi
+              if [ "$mysqld_appended" -eq 0 ]; then
+                printf "\n[mysqld]\n" >>"$MYCNF"
+                mysqld_appended=1
+              fi
+              printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
             }
 
             set_option ssl_cert "$CERT"
@@ -1521,13 +1527,19 @@ queries:
 
             MYCNF="/etc/mysql/mariadb.conf.d/50-server.cnf"
 
+            mysqld_appended=0
+
             set_option() {
               local key="$1" value="$2"
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
-              else
-                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
+                return
               fi
+              if [ "$mysqld_appended" -eq 0 ]; then
+                printf "\n[mysqld]\n" >>"$MYCNF"
+                mysqld_appended=1
+              fi
+              printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
             }
 
             set_option simple_password_check_digits 2
@@ -3258,17 +3270,24 @@ queries:
 
             install -d -o mysql -g mysql -m 0750 "$(dirname "$AUDIT_LOG")"
 
+            mysqld_appended=0
+
             set_option() {
               local key="$1" value="$2"
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
-              else
-                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
+                return
               fi
+              if [ "$mysqld_appended" -eq 0 ]; then
+                printf "\n[mysqld]\n" >>"$MYCNF"
+                mysqld_appended=1
+              fi
+              printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
             }
 
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*server_audit" "$MYCNF"; then
-              printf "[mysqld]\nplugin_load_add = server_audit.so\n" >>"$MYCNF"
+              printf "\n[mysqld]\nplugin_load_add = server_audit.so\n" >>"$MYCNF"
+              mysqld_appended=1
             fi
 
             set_option server_audit_logging "ON"
@@ -4202,14 +4221,20 @@ queries:
             chown mysql:mysql "$KEY_FILE"
             chmod 0600 "$KEY_FILE"
 
+            mysqld_appended=0
+
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*file_key_management" "$MYCNF"; then
-              printf "[mysqld]\nplugin_load_add = file_key_management.so\n" >>"$MYCNF"
+              printf "\n[mysqld]\nplugin_load_add = file_key_management.so\n" >>"$MYCNF"
+              mysqld_appended=1
             fi
 
             if grep -qE "^\s*file[-_]key[-_]management[-_]filename" "$MYCNF"; then
               sed -i "s|^\s*file[-_]key[-_]management[-_]filename.*|file_key_management_filename = ${KEY_FILE}|" "$MYCNF"
             else
-              printf "[mysqld]\nfile_key_management_filename = %s\n" "$KEY_FILE" >>"$MYCNF"
+              if [ "$mysqld_appended" -eq 0 ]; then
+                printf "\n[mysqld]\n" >>"$MYCNF"
+              fi
+              printf "file_key_management_filename = %s\n" "$KEY_FILE" >>"$MYCNF"
             fi
 
             systemctl restart mariadb

--- a/content/mondoo-mariadb-security.mql.yaml
+++ b/content/mondoo-mariadb-security.mql.yaml
@@ -179,8 +179,9 @@ queries:
             3. Confirm the resulting listeners.
 
             ```bash
-            sudo sed -i "s/^#*\s*bind-address.*/bind-address = 127.0.0.1,10.0.0.5/" \
+            sudo sed -i -E "/^\s*#?\s*bind-address/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nbind-address = 127.0.0.1,10.0.0.5\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo ss -lntp | grep mariadbd
             ```
@@ -202,7 +203,7 @@ queries:
             if grep -qE "^\s*bind[-_]address" "$MYCNF"; then
               sed -i "s|^\s*bind[-_]address.*|bind-address = ${ADDRESSES}|" "$MYCNF"
             else
-              printf "bind-address = %s\n" "$ADDRESSES" >>"$MYCNF"
+              printf "[mysqld]\nbind-address = %s\n" "$ADDRESSES" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -301,8 +302,9 @@ queries:
 
             ```bash
             sudo mariadb -e "SELECT user, host FROM mysql.global_priv WHERE host NOT REGEXP '^[0-9a-fA-F:.%]+$';"
-            sudo sed -i "s/^#*\s*skip[-_]name[-_]resolve.*/skip_name_resolve = ON/" \
+            sudo sed -i -E "/^\s*#?\s*skip[-_]name[-_]resolve/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nskip_name_resolve = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'skip_name_resolve';"
             ```
@@ -331,7 +333,7 @@ queries:
             if grep -qE "^\s*skip[-_]name[-_]resolve" "$MYCNF"; then
               sed -i "s|^\s*skip[-_]name[-_]resolve.*|skip_name_resolve = ON|" "$MYCNF"
             else
-              printf "skip_name_resolve = ON\n" >>"$MYCNF"
+              printf "[mysqld]\nskip_name_resolve = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -428,8 +430,9 @@ queries:
 
             ```bash
             sudo mariadb -e "GRANT SHOW DATABASES ON *.* TO 'dba'@'10.0.0.%';"
-            sudo sed -i "s/^#*\s*skip[-_]show[-_]database.*/skip_show_database = ON/" \
+            sudo sed -i -E "/^\s*#?\s*skip[-_]show[-_]database/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nskip_show_database = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'skip_show_database';"
             ```
@@ -449,7 +452,7 @@ queries:
             if grep -qE "^\s*skip[-_]show[-_]database" "$MYCNF"; then
               sed -i "s|^\s*skip[-_]show[-_]database.*|skip_show_database = ON|" "$MYCNF"
             else
-              printf "skip_show_database = ON\n" >>"$MYCNF"
+              printf "[mysqld]\nskip_show_database = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -547,8 +550,9 @@ queries:
 
             ```bash
             sudo mariadb -e "SHOW VARIABLES LIKE 'have_ssl';"
-            sudo sed -i "s/^#*\s*require[-_]secure[-_]transport.*/require_secure_transport = ON/" \
+            sudo sed -i -E "/^\s*#?\s*require[-_]secure[-_]transport/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nrequire_secure_transport = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'require_secure_transport';"
             ```
@@ -575,7 +579,7 @@ queries:
             if grep -qE "^\s*require[-_]secure[-_]transport" "$MYCNF"; then
               sed -i "s|^\s*require[-_]secure[-_]transport.*|require_secure_transport = ON|" "$MYCNF"
             else
-              printf "require_secure_transport = ON\n" >>"$MYCNF"
+              printf "[mysqld]\nrequire_secure_transport = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -684,8 +688,9 @@ queries:
             3. Restart MariaDB and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*tls[-_]version.*/tls_version = TLSv1.2,TLSv1.3/" \
+            sudo sed -i -E "/^\s*#?\s*tls[-_]version/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\ntls_version = TLSv1.2,TLSv1.3\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'tls_version';"
             ```
@@ -707,7 +712,7 @@ queries:
             if grep -qE "^\s*tls[-_]version" "$MYCNF"; then
               sed -i "s|^\s*tls[-_]version.*|tls_version = ${VERSIONS}|" "$MYCNF"
             else
-              printf "tls_version = %s\n" "$VERSIONS" >>"$MYCNF"
+              printf "[mysqld]\ntls_version = %s\n" "$VERSIONS" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -809,6 +814,7 @@ queries:
             sudo install -o mysql -g mysql -m 0600 server-key.pem /etc/mysql/ssl/server-key.pem
             sudo install -o mysql -g mysql -m 0644 server-cert.pem /etc/mysql/ssl/server-cert.pem
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             ssl_cert = /etc/mysql/ssl/server-cert.pem
             ssl_key  = /etc/mysql/ssl/server-key.pem
             EOF
@@ -847,7 +853,7 @@ queries:
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
               else
-                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
               fi
             }
 
@@ -961,8 +967,9 @@ queries:
 
             ```bash
             sudo install -o mysql -g mysql -m 0644 ca.pem /etc/mysql/ssl/ca.pem
-            sudo sed -i "s|^#*\s*ssl[-_]ca\b.*|ssl_ca = /etc/mysql/ssl/ca.pem|" \
+            sudo sed -i -E "/^\s*#?\s*ssl[-_]ca\b/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nssl_ca = /etc/mysql/ssl/ca.pem\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'ssl_ca';"
             ```
@@ -992,7 +999,7 @@ queries:
             if grep -qE "^\s*ssl[-_]ca\b" "$MYCNF"; then
               sed -i "s|^\s*ssl[-_]ca\b.*|ssl_ca = ${CA_FILE}|" "$MYCNF"
             else
-              printf "ssl_ca = %s\n" "$CA_FILE" >>"$MYCNF"
+              printf "[mysqld]\nssl_ca = %s\n" "$CA_FILE" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -1234,6 +1241,7 @@ queries:
             ```bash
             sudo mariadb -e "INSTALL SONAME 'simple_password_check';"
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add = simple_password_check.so
             EOF
             sudo systemctl restart mariadb
@@ -1261,7 +1269,7 @@ queries:
             fi
 
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*simple_password_check" "$MYCNF"; then
-              printf "plugin_load_add = simple_password_check.so\n" >>"$MYCNF"
+              printf "[mysqld]\nplugin_load_add = simple_password_check.so\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -1368,8 +1376,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*simple_password_check_minimal_length.*/simple_password_check_minimal_length = 14/" \
+            sudo sed -i -E "/^\s*#?\s*simple_password_check_minimal_length/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nsimple_password_check_minimal_length = 14\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'simple_password_check_minimal_length';"
             ```
@@ -1390,7 +1399,7 @@ queries:
             if grep -qE "^\s*simple_password_check_minimal_length" "$MYCNF"; then
               sed -i "s|^\s*simple_password_check_minimal_length.*|simple_password_check_minimal_length = ${MIN_LENGTH}|" "$MYCNF"
             else
-              printf "simple_password_check_minimal_length = %s\n" "$MIN_LENGTH" >>"$MYCNF"
+              printf "[mysqld]\nsimple_password_check_minimal_length = %s\n" "$MIN_LENGTH" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -1491,6 +1500,7 @@ queries:
 
             ```bash
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             simple_password_check_digits            = 2
             simple_password_check_letters_same_case = 2
             simple_password_check_other_characters  = 2
@@ -1516,7 +1526,7 @@ queries:
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
               else
-                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
               fi
             }
 
@@ -1625,6 +1635,7 @@ queries:
             ```bash
             sudo mariadb -e "INSTALL SONAME 'password_reuse_check';"
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add               = password_reuse_check.so
             password_reuse_check_interval = 365
             EOF
@@ -1654,13 +1665,13 @@ queries:
             fi
 
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*password_reuse_check" "$MYCNF"; then
-              printf "plugin_load_add = password_reuse_check.so\n" >>"$MYCNF"
+              printf "[mysqld]\nplugin_load_add = password_reuse_check.so\n" >>"$MYCNF"
             fi
 
             if grep -qE "^\s*password_reuse_check_interval" "$MYCNF"; then
               sed -i "s|^\s*password_reuse_check_interval.*|password_reuse_check_interval = ${INTERVAL}|" "$MYCNF"
             else
-              printf "password_reuse_check_interval = %s\n" "$INTERVAL" >>"$MYCNF"
+              printf "[mysqld]\npassword_reuse_check_interval = %s\n" "$INTERVAL" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -1779,7 +1790,8 @@ queries:
             ```bash
             sudo useradd --system --no-create-home --shell /usr/sbin/nologin mysql || true
             sudo chown -R mysql:mysql /var/lib/mysql /var/log/mysql
-            sudo sed -i "s/^#*\s*user\s*=.*/user = mysql/" /etc/mysql/mariadb.conf.d/50-server.cnf
+            sudo sed -i -E "/^\s*#?\s*user\s*=/d" /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nuser = mysql\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             ps -o user= -C mariadbd
             ```
@@ -1808,7 +1820,7 @@ queries:
             if grep -qE "^\s*user\s*=" "$MYCNF"; then
               sed -i "s|^\s*user\s*=.*|user = ${ACCOUNT}|" "$MYCNF"
             else
-              printf "user = %s\n" "$ACCOUNT" >>"$MYCNF"
+              printf "[mysqld]\nuser = %s\n" "$ACCOUNT" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -1927,8 +1939,9 @@ queries:
             3. Restart MariaDB and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*local[-_]infile.*/local_infile = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*local[-_]infile/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nlocal_infile = OFF\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'local_infile';"
             ```
@@ -1948,7 +1961,7 @@ queries:
             if grep -qE "^\s*local[-_]infile" "$MYCNF"; then
               sed -i "s|^\s*local[-_]infile.*|local_infile = OFF|" "$MYCNF"
             else
-              printf "local_infile = OFF\n" >>"$MYCNF"
+              printf "[mysqld]\nlocal_infile = OFF\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2046,8 +2059,9 @@ queries:
 
             ```bash
             sudo install -d -o mysql -g mysql -m 0750 /var/lib/mysql-files
-            sudo sed -i "s|^#*\s*secure[-_]file[-_]priv.*|secure_file_priv = /var/lib/mysql-files|" \
+            sudo sed -i -E "/^\s*#?\s*secure[-_]file[-_]priv/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nsecure_file_priv = /var/lib/mysql-files\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'secure_file_priv';"
             ```
@@ -2071,7 +2085,7 @@ queries:
             if grep -qE "^\s*secure[-_]file[-_]priv" "$MYCNF"; then
               sed -i "s|^\s*secure[-_]file[-_]priv.*|secure_file_priv = ${FILE_DIR}|" "$MYCNF"
             else
-              printf "secure_file_priv = %s\n" "$FILE_DIR" >>"$MYCNF"
+              printf "[mysqld]\nsecure_file_priv = %s\n" "$FILE_DIR" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2184,8 +2198,9 @@ queries:
 
             ```bash
             sudo find "$(sudo mariadb -N -B -e 'SELECT @@datadir;')" -type l -ls
-            sudo sed -i "s/^#*\s*symbolic[-_]links.*/symbolic_links = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*symbolic[-_]links/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nsymbolic_links = OFF\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'have_symlink';"
             ```
@@ -2215,7 +2230,7 @@ queries:
             if grep -qE "^\s*symbolic[-_]links" "$MYCNF"; then
               sed -i "s|^\s*symbolic[-_]links.*|symbolic_links = OFF|" "$MYCNF"
             else
-              printf "symbolic_links = OFF\n" >>"$MYCNF"
+              printf "[mysqld]\nsymbolic_links = OFF\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2443,8 +2458,9 @@ queries:
             3. Restart MariaDB and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]bin[-_]trust[-_]function[-_]creators.*/log_bin_trust_function_creators = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]bin[-_]trust[-_]function[-_]creators/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nlog_bin_trust_function_creators = OFF\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'log_bin_trust_function_creators';"
             ```
@@ -2464,7 +2480,7 @@ queries:
             if grep -qE "^\s*log[-_]bin[-_]trust[-_]function[-_]creators" "$MYCNF"; then
               sed -i "s|^\s*log[-_]bin[-_]trust[-_]function[-_]creators.*|log_bin_trust_function_creators = OFF|" "$MYCNF"
             else
-              printf "log_bin_trust_function_creators = OFF\n" >>"$MYCNF"
+              printf "[mysqld]\nlog_bin_trust_function_creators = OFF\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2562,8 +2578,9 @@ queries:
 
             ```bash
             sudo mariadb -e "GRANT EXECUTE ON PROCEDURE appdb.sync_orders TO 'app'@'10.0.0.%';"
-            sudo sed -i "s/^#*\s*automatic[-_]sp[-_]privileges.*/automatic_sp_privileges = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*automatic[-_]sp[-_]privileges/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nautomatic_sp_privileges = OFF\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'automatic_sp_privileges';"
             ```
@@ -2583,7 +2600,7 @@ queries:
             if grep -qE "^\s*automatic[-_]sp[-_]privileges" "$MYCNF"; then
               sed -i "s|^\s*automatic[-_]sp[-_]privileges.*|automatic_sp_privileges = OFF|" "$MYCNF"
             else
-              printf "automatic_sp_privileges = OFF\n" >>"$MYCNF"
+              printf "[mysqld]\nautomatic_sp_privileges = OFF\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2683,8 +2700,9 @@ queries:
 
             ```bash
             sudo install -d -o mysql -g mysql -m 0750 /var/log/mysql
-            sudo sed -i "s|^#*\s*log[-_]error\b.*|log_error = /var/log/mysql/error.log|" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]error\b/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nlog_error = /var/log/mysql/error.log\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'log_error';"
             ```
@@ -2708,7 +2726,7 @@ queries:
             if grep -qE "^\s*log[-_]error\b" "$MYCNF"; then
               sed -i "s|^\s*log[-_]error\b.*|log_error = ${LOG_FILE}|" "$MYCNF"
             else
-              printf "log_error = %s\n" "$LOG_FILE" >>"$MYCNF"
+              printf "[mysqld]\nlog_error = %s\n" "$LOG_FILE" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2820,8 +2838,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]warnings.*/log_warnings = 2/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]warnings/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nlog_warnings = 2\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'log_warnings';"
             ```
@@ -2842,7 +2861,7 @@ queries:
             if grep -qE "^\s*log[-_]warnings" "$MYCNF"; then
               sed -i "s|^\s*log[-_]warnings.*|log_warnings = ${LEVEL}|" "$MYCNF"
             else
-              printf "log_warnings = %s\n" "$LEVEL" >>"$MYCNF"
+              printf "[mysqld]\nlog_warnings = %s\n" "$LEVEL" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -2941,8 +2960,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]output.*/log_output = FILE/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]output/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nlog_output = FILE\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'log_output';"
             ```
@@ -2962,7 +2982,7 @@ queries:
             if grep -qE "^\s*log[-_]output" "$MYCNF"; then
               sed -i "s|^\s*log[-_]output.*|log_output = FILE|" "$MYCNF"
             else
-              printf "log_output = FILE\n" >>"$MYCNF"
+              printf "[mysqld]\nlog_output = FILE\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -3064,8 +3084,9 @@ queries:
             3. Remove or rotate any existing general log, because it may contain passwords.
 
             ```bash
-            sudo sed -i "s/^#*\s*general[-_]log\b.*/general_log = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*general[-_]log\b/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\ngeneral_log = OFF\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo shred -u /var/log/mysql/general.log
             ```
@@ -3088,7 +3109,7 @@ queries:
             if grep -qE "^\s*general[-_]log\b" "$MYCNF"; then
               sed -i "s|^\s*general[-_]log\b.*|general_log = OFF|" "$MYCNF"
             else
-              printf "general_log = OFF\n" >>"$MYCNF"
+              printf "[mysqld]\ngeneral_log = OFF\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -3204,6 +3225,7 @@ queries:
             ```bash
             sudo mariadb -e "INSTALL SONAME 'server_audit';"
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add        = server_audit.so
             server_audit_logging   = ON
             server_audit_events    = CONNECT,QUERY,TABLE
@@ -3241,12 +3263,12 @@ queries:
               if grep -qE "^\s*${key}\b" "$MYCNF"; then
                 sed -i "s|^\s*${key}\b.*|${key} = ${value}|" "$MYCNF"
               else
-                printf "%s = %s\n" "$key" "$value" >>"$MYCNF"
+                printf "[mysqld]\n%s = %s\n" "$key" "$value" >>"$MYCNF"
               fi
             }
 
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*server_audit" "$MYCNF"; then
-              printf "plugin_load_add = server_audit.so\n" >>"$MYCNF"
+              printf "[mysqld]\nplugin_load_add = server_audit.so\n" >>"$MYCNF"
             fi
 
             set_option server_audit_logging "ON"
@@ -3370,8 +3392,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*server[-_]audit[-_]events.*/server_audit_events = CONNECT,QUERY,TABLE/" \
+            sudo sed -i -E "/^\s*#?\s*server[-_]audit[-_]events/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nserver_audit_events = CONNECT,QUERY,TABLE\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'server_audit_events';"
             ```
@@ -3393,7 +3416,7 @@ queries:
             if grep -qE "^\s*server[-_]audit[-_]events" "$MYCNF"; then
               sed -i "s|^\s*server[-_]audit[-_]events.*|server_audit_events = ${EVENTS}|" "$MYCNF"
             else
-              printf "server_audit_events = %s\n" "$EVENTS" >>"$MYCNF"
+              printf "[mysqld]\nserver_audit_events = %s\n" "$EVENTS" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -3623,8 +3646,9 @@ queries:
 
             ```bash
             sudo mariadb -e "SELECT plugin_name, plugin_status FROM information_schema.plugins WHERE plugin_name LIKE '%key_management%';"
-            sudo sed -i "s/^#*\s*innodb[-_]encrypt[-_]tables.*/innodb_encrypt_tables = FORCE/" \
+            sudo sed -i -E "/^\s*#?\s*innodb[-_]encrypt[-_]tables/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\ninnodb_encrypt_tables = FORCE\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_tables';"
             ```
@@ -3653,7 +3677,7 @@ queries:
             if grep -qE "^\s*innodb[-_]encrypt[-_]tables" "$MYCNF"; then
               sed -i "s|^\s*innodb[-_]encrypt[-_]tables.*|innodb_encrypt_tables = FORCE|" "$MYCNF"
             else
-              printf "innodb_encrypt_tables = FORCE\n" >>"$MYCNF"
+              printf "[mysqld]\ninnodb_encrypt_tables = FORCE\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -3754,8 +3778,9 @@ queries:
             3. Restart MariaDB and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*innodb[-_]encrypt[-_]log.*/innodb_encrypt_log = ON/" \
+            sudo sed -i -E "/^\s*#?\s*innodb[-_]encrypt[-_]log/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\ninnodb_encrypt_log = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'innodb_encrypt_log';"
             ```
@@ -3784,7 +3809,7 @@ queries:
             if grep -qE "^\s*innodb[-_]encrypt[-_]log" "$MYCNF"; then
               sed -i "s|^\s*innodb[-_]encrypt[-_]log.*|innodb_encrypt_log = ON|" "$MYCNF"
             else
-              printf "innodb_encrypt_log = ON\n" >>"$MYCNF"
+              printf "[mysqld]\ninnodb_encrypt_log = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -3881,8 +3906,9 @@ queries:
             3. Restart MariaDB, then rotate the logs so new files are encrypted.
 
             ```bash
-            sudo sed -i "s/^#*\s*encrypt[-_]binlog.*/encrypt_binlog = ON/" \
+            sudo sed -i -E "/^\s*#?\s*encrypt[-_]binlog/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nencrypt_binlog = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "FLUSH BINARY LOGS;"
             sudo mariadb -e "SHOW VARIABLES LIKE 'encrypt_binlog';"
@@ -3912,7 +3938,7 @@ queries:
             if grep -qE "^\s*encrypt[-_]binlog" "$MYCNF"; then
               sed -i "s|^\s*encrypt[-_]binlog.*|encrypt_binlog = ON|" "$MYCNF"
             else
-              printf "encrypt_binlog = ON\n" >>"$MYCNF"
+              printf "[mysqld]\nencrypt_binlog = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -4010,8 +4036,9 @@ queries:
             3. Restart MariaDB and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*encrypt[-_]tmp[-_]disk[-_]tables.*/encrypt_tmp_disk_tables = ON/" \
+            sudo sed -i -E "/^\s*#?\s*encrypt[-_]tmp[-_]disk[-_]tables/d" \
               /etc/mysql/mariadb.conf.d/50-server.cnf
+            printf '[mysqld]\nencrypt_tmp_disk_tables = ON\n' | sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'encrypt_tmp_disk_tables';"
             ```
@@ -4040,7 +4067,7 @@ queries:
             if grep -qE "^\s*encrypt[-_]tmp[-_]disk[-_]tables" "$MYCNF"; then
               sed -i "s|^\s*encrypt[-_]tmp[-_]disk[-_]tables.*|encrypt_tmp_disk_tables = ON|" "$MYCNF"
             else
-              printf "encrypt_tmp_disk_tables = ON\n" >>"$MYCNF"
+              printf "[mysqld]\nencrypt_tmp_disk_tables = ON\n" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -4142,6 +4169,7 @@ queries:
             sudo chown mysql:mysql /etc/mysql/encryption/keyfile.enc
             sudo chmod 0600 /etc/mysql/encryption/keyfile.enc
             sudo tee -a /etc/mysql/mariadb.conf.d/50-server.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add              = file_key_management.so
             file_key_management_filename = /etc/mysql/encryption/keyfile.enc
             EOF
@@ -4175,13 +4203,13 @@ queries:
             chmod 0600 "$KEY_FILE"
 
             if ! grep -qE "^\s*plugin[-_]load([-_]add)?\s*=.*file_key_management" "$MYCNF"; then
-              printf "plugin_load_add = file_key_management.so\n" >>"$MYCNF"
+              printf "[mysqld]\nplugin_load_add = file_key_management.so\n" >>"$MYCNF"
             fi
 
             if grep -qE "^\s*file[-_]key[-_]management[-_]filename" "$MYCNF"; then
               sed -i "s|^\s*file[-_]key[-_]management[-_]filename.*|file_key_management_filename = ${KEY_FILE}|" "$MYCNF"
             else
-              printf "file_key_management_filename = %s\n" "$KEY_FILE" >>"$MYCNF"
+              printf "[mysqld]\nfile_key_management_filename = %s\n" "$KEY_FILE" >>"$MYCNF"
             fi
 
             systemctl restart mariadb
@@ -4460,8 +4488,9 @@ queries:
             ```bash
             sudo install -o mysql -g mysql -m 0600 galera.key /etc/mysql/ssl/galera.key
             sudo install -o mysql -g mysql -m 0644 galera.crt /etc/mysql/ssl/galera.crt
-            sudo sed -i "s|^#*\s*wsrep_provider_options.*|wsrep_provider_options = socket.ssl_key=/etc/mysql/ssl/galera.key;socket.ssl_cert=/etc/mysql/ssl/galera.crt;socket.ssl_ca=/etc/mysql/ssl/ca.pem|" \
+            sudo sed -i -E "/^\s*#?\s*wsrep_provider_options/d" \
               /etc/mysql/mariadb.conf.d/60-galera.cnf
+            printf '[galera]\nwsrep_provider_options = socket.ssl_key=/etc/mysql/ssl/galera.key;socket.ssl_cert=/etc/mysql/ssl/galera.crt;socket.ssl_ca=/etc/mysql/ssl/ca.pem\n' | sudo tee -a /etc/mysql/mariadb.conf.d/60-galera.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW STATUS LIKE 'wsrep_cluster_size';"
             ```
@@ -4616,8 +4645,9 @@ queries:
             sudo apt-get install -y mariadb-backup
             sudo mariadb -e "CREATE USER 'sst'@'localhost' IDENTIFIED BY 'changeme';"
             sudo mariadb -e "GRANT RELOAD, PROCESS, LOCK TABLES, BINLOG MONITOR ON *.* TO 'sst'@'localhost';"
-            sudo sed -i "s/^#*\s*wsrep_sst_method.*/wsrep_sst_method = mariabackup/" \
+            sudo sed -i -E "/^\s*#?\s*wsrep_sst_method/d" \
               /etc/mysql/mariadb.conf.d/60-galera.cnf
+            printf '[galera]\nwsrep_sst_method = mariabackup\n' | sudo tee -a /etc/mysql/mariadb.conf.d/60-galera.cnf >/dev/null
             sudo systemctl restart mariadb
             sudo mariadb -e "SHOW VARIABLES LIKE 'wsrep_sst_method';"
             ```

--- a/content/mondoo-mysql-security.mql.yaml
+++ b/content/mondoo-mysql-security.mql.yaml
@@ -173,8 +173,9 @@ queries:
             3. Confirm the resulting listeners.
 
             ```bash
-            sudo sed -i "s/^#*\s*bind-address.*/bind-address = 127.0.0.1,10.0.0.5/" \
+            sudo sed -i -E "/^\s*#?\s*bind-address/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nbind-address = 127.0.0.1,10.0.0.5\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo ss -lntp | grep mysqld
             ```
@@ -295,8 +296,9 @@ queries:
 
             ```bash
             sudo mysql -e "SELECT user, host FROM mysql.user WHERE host NOT REGEXP '^[0-9a-fA-F:.%]+$';"
-            sudo sed -i "s/^#*\s*skip[-_]name[-_]resolve.*/skip_name_resolve = ON/" \
+            sudo sed -i -E "/^\s*#?\s*skip[-_]name[-_]resolve/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nskip_name_resolve = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'skip_name_resolve';"
             ```
@@ -422,8 +424,9 @@ queries:
 
             ```bash
             sudo mysql -e "GRANT SHOW DATABASES ON *.* TO 'dba'@'10.0.0.%';"
-            sudo sed -i "s/^#*\s*skip[-_]show[-_]database.*/skip_show_database = ON/" \
+            sudo sed -i -E "/^\s*#?\s*skip[-_]show[-_]database/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nskip_show_database = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'skip_show_database';"
             ```
@@ -541,8 +544,9 @@ queries:
 
             ```bash
             sudo mysql -e "SHOW VARIABLES LIKE 'have_ssl';"
-            sudo sed -i "s/^#*\s*require[-_]secure[-_]transport.*/require_secure_transport = ON/" \
+            sudo sed -i -E "/^\s*#?\s*require[-_]secure[-_]transport/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nrequire_secure_transport = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'require_secure_transport';"
             ```
@@ -678,8 +682,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*tls[-_]version.*/tls_version = TLSv1.2,TLSv1.3/" \
+            sudo sed -i -E "/^\s*#?\s*tls[-_]version/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ntls_version = TLSv1.2,TLSv1.3\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'tls_version';"
             ```
@@ -803,6 +808,7 @@ queries:
             sudo install -o mysql -g mysql -m 0600 server-key.pem /etc/mysql/ssl/server-key.pem
             sudo install -o mysql -g mysql -m 0644 server-cert.pem /etc/mysql/ssl/server-cert.pem
             sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null <<'EOF'
+            [mysqld]
             ssl_cert = /etc/mysql/ssl/server-cert.pem
             ssl_key  = /etc/mysql/ssl/server-key.pem
             EOF
@@ -961,8 +967,9 @@ queries:
 
             ```bash
             sudo install -o mysql -g mysql -m 0644 ca.pem /etc/mysql/ssl/ca.pem
-            sudo sed -i "s|^#*\s*ssl[-_]ca\b.*|ssl_ca = /etc/mysql/ssl/ca.pem|" \
+            sudo sed -i -E "/^\s*#?\s*ssl[-_]ca\b/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nssl_ca = /etc/mysql/ssl/ca.pem\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'ssl_ca';"
             ```
@@ -1232,8 +1239,9 @@ queries:
             3. Migrate existing accounts, which requires setting each password again.
 
             ```bash
-            sudo sed -i "s/^#*\s*default[-_]authentication[-_]plugin.*/default_authentication_plugin = caching_sha2_password/" \
+            sudo sed -i -E "/^\s*#?\s*default[-_]authentication[-_]plugin/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ndefault_authentication_plugin = caching_sha2_password\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "ALTER USER 'app'@'10.0.0.%' IDENTIFIED WITH caching_sha2_password BY 'new-password';"
             sudo mysql -e "SELECT user, host, plugin FROM mysql.user WHERE plugin = 'mysql_native_password';"
@@ -1374,6 +1382,7 @@ queries:
             ```bash
             sudo mysql -e "INSTALL COMPONENT 'file://component_validate_password';"
             sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add = validate_password.so
             EOF
             sudo systemctl restart mysql
@@ -1508,8 +1517,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*validate_password.policy.*/validate_password.policy = STRONG/" \
+            sudo sed -i -E "/^\s*#?\s*validate_password\.policy/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nvalidate_password.policy = STRONG\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'validate_password.policy';"
             ```
@@ -1628,8 +1638,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*validate_password.length.*/validate_password.length = 14/" \
+            sudo sed -i -E "/^\s*#?\s*validate_password\.length/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nvalidate_password.length = 14\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'validate_password.length';"
             ```
@@ -1748,8 +1759,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*validate_password.check_user_name.*/validate_password.check_user_name = ON/" \
+            sudo sed -i -E "/^\s*#?\s*validate_password\.check_user_name/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nvalidate_password.check_user_name = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'validate_password.check_user_name';"
             ```
@@ -1866,8 +1878,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*default[-_]password[-_]lifetime.*/default_password_lifetime = 90/" \
+            sudo sed -i -E "/^\s*#?\s*default[-_]password[-_]lifetime/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ndefault_password_lifetime = 90\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo mysql -e "ALTER USER 'replica'@'10.0.0.%' PASSWORD EXPIRE NEVER;"
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'default_password_lifetime';"
@@ -1992,6 +2005,7 @@ queries:
 
             ```bash
             sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null <<'EOF'
+            [mysqld]
             password_history = 5
             password_reuse_interval = 365
             EOF
@@ -2120,8 +2134,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*password[-_]require[-_]current.*/password_require_current = ON/" \
+            sudo sed -i -E "/^\s*#?\s*password[-_]require[-_]current/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\npassword_require_current = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'password_require_current';"
             ```
@@ -2246,7 +2261,8 @@ queries:
             ```bash
             sudo useradd --system --no-create-home --shell /usr/sbin/nologin mysql || true
             sudo chown -R mysql:mysql /var/lib/mysql /var/log/mysql
-            sudo sed -i "s/^#*\s*user\s*=.*/user = mysql/" /etc/mysql/mysql.conf.d/mysqld.cnf
+            sudo sed -i -E "/^\s*#?\s*user\s*=/d" /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nuser = mysql\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             ps -o user= -C mysqld
             ```
@@ -2394,8 +2410,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*local[-_]infile.*/local_infile = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*local[-_]infile/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nlocal_infile = OFF\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'local_infile';"
             ```
@@ -2513,8 +2530,9 @@ queries:
 
             ```bash
             sudo install -d -o mysql -g mysql -m 0750 /var/lib/mysql-files
-            sudo sed -i "s|^#*\s*secure[-_]file[-_]priv.*|secure_file_priv = /var/lib/mysql-files|" \
+            sudo sed -i -E "/^\s*#?\s*secure[-_]file[-_]priv/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nsecure_file_priv = /var/lib/mysql-files\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'secure_file_priv';"
             ```
@@ -2651,8 +2669,9 @@ queries:
 
             ```bash
             sudo find "$(sudo mysql -N -B -e 'SELECT @@datadir;')" -type l -ls
-            sudo sed -i "s/^#*\s*symbolic[-_]links.*/symbolic_links = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*symbolic[-_]links/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nsymbolic_links = OFF\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'have_symlink';"
             ```
@@ -2910,8 +2929,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]bin[-_]trust[-_]function[-_]creators.*/log_bin_trust_function_creators = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]bin[-_]trust[-_]function[-_]creators/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nlog_bin_trust_function_creators = OFF\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'log_bin_trust_function_creators';"
             ```
@@ -3029,8 +3049,9 @@ queries:
 
             ```bash
             sudo mysql -e "GRANT EXECUTE ON PROCEDURE appdb.sync_orders TO 'app'@'10.0.0.%';"
-            sudo sed -i "s/^#*\s*automatic[-_]sp[-_]privileges.*/automatic_sp_privileges = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*automatic[-_]sp[-_]privileges/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nautomatic_sp_privileges = OFF\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'automatic_sp_privileges';"
             ```
@@ -3150,8 +3171,9 @@ queries:
 
             ```bash
             sudo install -d -o mysql -g mysql -m 0750 /var/log/mysql
-            sudo sed -i "s|^#*\s*log[-_]error\b.*|log_error = /var/log/mysql/error.log|" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]error\b/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nlog_error = /var/log/mysql/error.log\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'log_error';"
             ```
@@ -3287,8 +3309,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]error[-_]verbosity.*/log_error_verbosity = 3/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]error[-_]verbosity/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nlog_error_verbosity = 3\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'log_error_verbosity';"
             ```
@@ -3408,8 +3431,9 @@ queries:
             3. Confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*log[-_]output.*/log_output = FILE/" \
+            sudo sed -i -E "/^\s*#?\s*log[-_]output/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nlog_output = FILE\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'log_output';"
             ```
@@ -3531,8 +3555,9 @@ queries:
             3. Remove or rotate any existing general log, because it may contain passwords.
 
             ```bash
-            sudo sed -i "s/^#*\s*general[-_]log\b.*/general_log = OFF/" \
+            sudo sed -i -E "/^\s*#?\s*general[-_]log\b/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ngeneral_log = OFF\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo shred -u /var/log/mysql/general.log
             ```
@@ -3671,6 +3696,7 @@ queries:
             ```bash
             sudo mysql -e "INSTALL PLUGIN audit_log SONAME 'audit_log.so';"
             sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null <<'EOF'
+            [mysqld]
             plugin_load_add  = audit_log.so
             audit_log_policy = ALL
             audit_log_file   = /var/log/mysql/audit.log
@@ -3824,8 +3850,9 @@ queries:
 
             ```bash
             sudo mysql -e "SELECT * FROM performance_schema.keyring_component_status;"
-            sudo sed -i "s/^#*\s*default[-_]table[-_]encryption.*/default_table_encryption = ON/" \
+            sudo sed -i -E "/^\s*#?\s*default[-_]table[-_]encryption/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ndefault_table_encryption = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "ALTER TABLESPACE innodb_system ENCRYPTION = 'Y';"
             ```
@@ -3955,8 +3982,9 @@ queries:
             3. Restart MySQL, then rotate the logs so new files are encrypted.
 
             ```bash
-            sudo sed -i "s/^#*\s*binlog[-_]encryption.*/binlog_encryption = ON/" \
+            sudo sed -i -E "/^\s*#?\s*binlog[-_]encryption/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\nbinlog_encryption = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "FLUSH BINARY LOGS;"
             sudo mysql -e "SHOW VARIABLES LIKE 'binlog_encryption';"
@@ -4083,8 +4111,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*innodb[-_]redo[-_]log[-_]encrypt.*/innodb_redo_log_encrypt = ON/" \
+            sudo sed -i -E "/^\s*#?\s*innodb[-_]redo[-_]log[-_]encrypt/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ninnodb_redo_log_encrypt = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'innodb_redo_log_encrypt';"
             ```
@@ -4210,8 +4239,9 @@ queries:
             3. Restart MySQL and confirm the effective value.
 
             ```bash
-            sudo sed -i "s/^#*\s*innodb[-_]undo[-_]log[-_]encrypt.*/innodb_undo_log_encrypt = ON/" \
+            sudo sed -i -E "/^\s*#?\s*innodb[-_]undo[-_]log[-_]encrypt/d" \
               /etc/mysql/mysql.conf.d/mysqld.cnf
+            printf '[mysqld]\ninnodb_undo_log_encrypt = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
             sudo systemctl restart mysql
             sudo mysql -e "SHOW VARIABLES LIKE 'innodb_undo_log_encrypt';"
             ```

--- a/content/mondoo-postgresql-security.mql.yaml
+++ b/content/mondoo-postgresql-security.mql.yaml
@@ -149,7 +149,7 @@ queries:
             To bind PostgreSQL to specific interfaces using the CLI:
 
             1. Edit `postgresql.conf` and set `listen_addresses` to the addresses the server must serve.
-            2. Reload PostgreSQL so the new value takes effect. Changing `listen_addresses` requires a restart rather than a reload.
+            2. Restart PostgreSQL, because this setting cannot be applied with a reload.
             3. Confirm the server is bound only to the intended addresses.
 
             ```bash
@@ -991,6 +991,7 @@ queries:
                   ansible.builtin.meta: flush_handlers
 
                 - name: Find roles still holding a legacy verifier
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -tAc "SELECT rolname FROM pg_authid WHERE rolpassword LIKE 'md5%';"
@@ -1323,11 +1324,15 @@ queries:
           desc: |
             To move authentication rules to SCRAM using the CLI:
 
-            1. Set `password_encryption` to `scram-sha-256` and reset any role that still holds a legacy verifier.
-            2. Replace the `md5` method with `scram-sha-256` in `pg_hba.conf`.
-            3. Reload PostgreSQL and confirm no `md5` rules remain.
+            1. Set `password_encryption` to `scram-sha-256` and reload, so that every password set from now on is stored in the new format.
+            2. Reset any role that still holds a legacy verifier, because a `scram-sha-256` rule cannot authenticate one.
+            3. Replace the `md5` method with `scram-sha-256` in `pg_hba.conf`.
+            4. Reload PostgreSQL and confirm no `md5` rules remain.
 
             ```bash
+            sudo -u postgres sed -i "s/^#*\s*password_encryption.*/password_encryption = scram-sha-256/" \
+              /etc/postgresql/16/main/postgresql.conf
+            sudo systemctl reload postgresql
             sudo -u postgres psql -c "SELECT rolname FROM pg_authid WHERE rolpassword LIKE 'md5%';"
             sudo -u postgres psql -c "\password app_user"
             sudo sed -i -E "s/^([^#].*[[:space:]])md5([[:space:]]*)$/\1scram-sha-256\2/" \
@@ -1378,6 +1383,7 @@ queries:
                 postgresql_hba: /etc/postgresql/16/main/pg_hba.conf
               tasks:
                 - name: Count roles still holding a legacy verifier
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -tAc "SELECT count(*) FROM pg_authid WHERE rolpassword LIKE 'md5%';"
@@ -1493,7 +1499,7 @@ queries:
               printf "hostssl all all %s scram-sha-256\n" "$net" >>"$HBA"
             done
 
-            if grep -qE "^[^#]*[[:space:]](0\.0\.0\.0/0|::/0)[[:space:]]" "$HBA"; then
+            if grep -qE "^host\S*[[:space:]]+\S+[[:space:]]+\S+[[:space:]]+(0\.0\.0\.0/0|::/0|all)([[:space:]]|$)" "$HBA"; then
               echo "wildcard client addresses remain in $HBA; review them manually" >&2
               exit 1
             fi
@@ -1603,7 +1609,7 @@ queries:
 
             ```bash
             sudo -u postgres psql -c "SHOW ssl;"
-            sudo sed -i -E "s/^host(nossl)?(\s+\S+\s+\S+\s+[0-9a-fA-F:.]+\/[0-9]+\s+)/hostssl\2/" \
+            sudo sed -i -E "s/^host(nossl)?(\s+\S+\s+\S+\s+\S+\s+)/hostssl\2/" \
               /etc/postgresql/16/main/pg_hba.conf
             sudo systemctl reload postgresql
             sudo -u postgres psql -c "SELECT count(*) FROM pg_hba_file_rules WHERE type IN ('host', 'hostnossl') AND address IS NOT NULL;"
@@ -1629,7 +1635,7 @@ queries:
             fi
 
             cp -a "$HBA" "${HBA}.bak"
-            sed -i -E "s/^host(nossl)?([[:space:]]+\S+[[:space:]]+\S+[[:space:]]+[0-9a-fA-F:.]+\/[0-9]+[[:space:]]+)/hostssl\2/" "$HBA"
+            sed -i -E "s/^host(nossl)?([[:space:]]+\S+[[:space:]]+\S+[[:space:]]+\S+[[:space:]]+)/hostssl\2/" "$HBA"
 
             systemctl reload postgresql
             ```
@@ -1649,6 +1655,7 @@ queries:
                 postgresql_hba: /etc/postgresql/16/main/pg_hba.conf
               tasks:
                 - name: Read the effective ssl setting
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -tAc "SHOW ssl;"
@@ -1663,7 +1670,7 @@ queries:
                 - name: Convert remote rules to hostssl
                   ansible.builtin.replace:
                     path: "{{ postgresql_hba }}"
-                    regexp: '^host(nossl)?(\s+\S+\s+\S+\s+[0-9a-fA-F:.]+/[0-9]+\s+)'
+                    regexp: '^host(nossl)?(\s+\S+\s+\S+\s+\S+\s+)'
                     replace: 'hostssl\2'
                   notify: Reload postgresql
               handlers:
@@ -2045,6 +2052,7 @@ queries:
                 postgresql_admin_role: dba_alice
               tasks:
                 - name: Create the named administrative role
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: >-
@@ -2053,6 +2061,7 @@ queries:
                   register: role_exists
 
                 - name: Add the role when it is missing
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -c "CREATE ROLE {{ postgresql_admin_role }} LOGIN;"
@@ -3371,17 +3380,20 @@ queries:
             To enable pgaudit using the CLI:
 
             1. Install the extension package matching the server version.
-            2. Add `pgaudit` to `shared_preload_libraries` and restart the server.
-            3. Create the extension and select what it records.
+            2. Read the libraries already preloaded, so adding `pgaudit` does not drop them.
+            3. Append the preload list and the audit classes to `postgresql.conf`, where the last value for a setting is the one that applies.
+            4. Restart the server and create the extension.
 
             ```bash
             sudo apt-get install -y postgresql-16-pgaudit
-            sudo -u postgres sed -i "s/^#*\s*shared_preload_libraries.*/shared_preload_libraries = 'pgaudit'/" \
-              /etc/postgresql/16/main/postgresql.conf
+            libraries=$(sudo -u postgres psql -tAc "SHOW shared_preload_libraries;")
+            sudo -u postgres tee -a /etc/postgresql/16/main/postgresql.conf >/dev/null <<EOF
+            shared_preload_libraries = '${libraries:+$libraries,}pgaudit'
+            pgaudit.log = 'ddl, role, write'
+            EOF
             sudo systemctl restart postgresql
             sudo -u postgres psql -c "CREATE EXTENSION IF NOT EXISTS pgaudit;"
-            sudo -u postgres psql -c "ALTER SYSTEM SET pgaudit.log = 'ddl, role, write';"
-            sudo systemctl reload postgresql
+            sudo -u postgres psql -c "SHOW shared_preload_libraries;"
             ```
         - id: script
           desc: |
@@ -3452,6 +3464,7 @@ queries:
                   ansible.builtin.meta: flush_handlers
 
                 - name: Create the extension
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -c "CREATE EXTENSION IF NOT EXISTS pgaudit;"
@@ -3713,6 +3726,7 @@ queries:
               become: true
               tasks:
                 - name: Resolve the active hba_file path
+                  become: true
                   become_user: postgres
                   ansible.builtin.command:
                     cmd: psql -tAc "SHOW hba_file;"

--- a/content/validation/remediation/code/ansible.py
+++ b/content/validation/remediation/code/ansible.py
@@ -44,6 +44,7 @@ TARGETS = {
     "freebsd": [CONTENT_DIR / "mondoo-freebsd-security.mql.yaml"],
     "mariadb": [CONTENT_DIR / "mondoo-mariadb-security.mql.yaml"],
     "mysql": [CONTENT_DIR / "mondoo-mysql-security.mql.yaml"],
+    "postgresql": [CONTENT_DIR / "mondoo-postgresql-security.mql.yaml"],
     "proxmox": [CONTENT_DIR / "mondoo-proxmox-security.mql.yaml"],
 }
 


### PR DESCRIPTION
Deep audit of every `remediation:` and `audit:` block in the six database
policies: mysql, mariadb, postgresql, snowflake, databricks, mongodbatlas.
Six defects found, all in the three self-managed database policies. Each is
evidenced against an oracle below.

---

## 1. 48 MySQL and MariaDB CLI snippets do nothing when the option is absent

**Where:** 25 `- id: cli` blocks in `mondoo-mysql-security.mql.yaml`, 23 in
`mondoo-mariadb-security.mql.yaml`, plus the two `user =` blocks.

Every one of them set an option like this:

```bash
sudo sed -i "s/^#*\s*skip[-_]name[-_]resolve.*/skip_name_resolve = ON/" \
  /etc/mysql/mysql.conf.d/mysqld.cnf
```

`sed s///` only rewrites a line that already exists. When the option is absent
from the option file the command is a **no-op**, and absent is precisely the
state that makes the check fail.

**Evidence.** The packaged option files do not contain these options, not even
commented out. From Ubuntu's `mysql-8.0` source package
(`debian/additions/mysql.conf.d/mysqld.cnf`, 78 lines, the file the snippets
target):

```
$ for o in skip.name.resolve skip.show.database require.secure.transport \
           tls.version ssl.ca default.authentication.plugin validate_password \
           default.password.lifetime password.require.current local.infile \
           secure.file.priv symbolic.links log.bin.trust.function.creators \
           automatic.sp.privileges log.output default.table.encryption \
           binlog.encryption innodb.redo.log.encrypt innodb.undo.log.encrypt; do
    printf "%-40s %s\n" "$o" "$(grep -ciE "^[#[:space:]]*$o" mysqld.cnf)"
  done
skip.name.resolve                        0
skip.show.database                       0
require.secure.transport                 0
tls.version                              0
ssl.ca                                   0
default.authentication.plugin            0
validate_password                        0
default.password.lifetime                0
password.require.current                 0
local.infile                             0
secure.file.priv                         0
symbolic.links                           0
log.bin.trust.function.creators          0
automatic.sp.privileges                  0
log.output                               0
default.table.encryption                 0
binlog.encryption                        0
innodb.redo.log.encrypt                  0
innodb.undo.log.encrypt                  0
```

Debian's `mariadb-server` `50-server.cnf` gives the same answer for 16 of the
22 options the MariaDB policy targets.

Demonstrated end to end on the real file:

```
$ cp ubuntu-mysqld.cnf a.cnf
$ perl -pi -e 's/^#*\s*skip[-_]name[-_]resolve.*/skip_name_resolve = ON/' a.cnf
$ diff ubuntu-mysqld.cnf a.cnf ; echo "exit $?"
exit 0        # file unchanged
```

The `script` and `ansible` entries of the **same checks** already handle this.
`script` branches on `grep -q ... ; else printf ... >>`, and `ansible` uses
`community.general.ini_file`, which creates the option when missing. Only the
`cli` entry could not add one, so the three documented methods disagreed and
the CLI one was the broken one.

**Fix.** Delete any existing occurrence, commented or not, then append under an
explicit group header:

```bash
sudo sed -i -E "/^\s*#?\s*skip[-_]name[-_]resolve/d" \
  /etc/mysql/mysql.conf.d/mysqld.cnf
printf '[mysqld]\nskip_name_resolve = ON\n' | sudo tee -a /etc/mysql/mysql.conf.d/mysqld.cnf >/dev/null
```

Verified against the packaged file, including that the neighbouring
`mysqlx-bind-address` is left alone by the `bind-address` rule:

```
$ tail -4 mysqld.cnf
[mysqld]
skip_name_resolve = ON
[mysqld]
bind-address = 127.0.0.1,10.0.0.5
$ grep -n 'bind-address' mysqld.cnf
31:mysqlx-bind-address	= 127.0.0.1
81:bind-address = 127.0.0.1,10.0.0.5
```

The option regex of each snippet is carried over unchanged, so the `\b`
anchors that keep `log_error` off `log_error_verbosity` and `general_log` off
`general_log_file` still hold.

---

## 2. MariaDB appends land in a group the check does not read

**Where:** the 6 heredoc `tee -a` blocks and the 31 `printf ... >>"$MYCNF"`
fallbacks in `mondoo-mariadb-security.mql.yaml`.

Debian's packaged `50-server.cnf` ends in a version-pinned group:

```
$ grep -n '^\[' 50-server.cnf
6:[server]
9:[mariadbd]
109:[embedded]
114:[mariadbd]
119:[mariadb-11.8]
$ tail -1 50-server.cnf
[mariadb-11.8]
```

Anything appended at end of file therefore lands in `[mariadb-11.8]`. The
resource behind these checks does not read that group:

```go
// providers/os/resources/mycnf/flavor.go:169
func ServerGroups(flavor string) []string {
	if flavor == FlavorMariaDB {
		return []string{"client-server", "mysqld", "server", "mariadb", "mariadbd"}
	}
	return []string{"mysqld", "server"}
}
```

No `mariadb-X.Y` entry, so `mariadb.conf.serverOptions` never sees the option
and the check keeps failing after the documented fix is applied.

**Fix.** Every MariaDB append now names `[mysqld]`, which is in `ServerGroups`
for both flavors and is confirmed as a server group by MariaDB itself:

> "The following groups are read: mysqld server mysqld-10.11 mariadb
> mariadb-10.11 mariadbd mariadbd-10.11 client-server galera"
> — <https://mariadb.com/kb/en/configuring-mariadb-with-option-files/>

The two Galera snippets use `[galera]` instead, because
`mariadb.conf.wsrepProviderOptions` and `wsrepSstMethod` read
`galeraOptions`, which is `optionMap("galera")`
(`providers/os/resources/mariadb.go:428-433`). Debian's `60-galera.cnf`
contains neither `wsrep_provider_options` nor `wsrep_sst_method`, so those two
CLI snippets were no-ops under defect 1 as well.

---

## 3. The Ansible validator never saw mondoo-postgresql-security

**Where:** `content/validation/remediation/code/ansible.py`, `TARGETS`.

The policy ships 29 `- id: ansible` snippets and was absent from the
validator's allowlist, which is the exact failure mode
`content/validation/README.md` warns about. Adding it:

```
$ python3 content/validation/remediation/code/ansible.py postgresql
23 passed, 6 failed
[FAIL] mondoo-postgresql-security-password-encryption-scram
       partial-become[task]: ``become_user`` should have a corresponding ``become`` at the same level as itself. (Task/Handler: Find roles still holding a legacy verifier)
[FAIL] mondoo-postgresql-security-hba-no-md5-auth
[FAIL] mondoo-postgresql-security-hba-remote-connections-require-tls
[FAIL] mondoo-postgresql-security-ident-no-superuser-mappings
[FAIL] mondoo-postgresql-security-pgaudit-extension-enabled
[FAIL] mondoo-postgresql-security-hba-file-restricted-permissions
```

**Fix.** Added the policy to `TARGETS` and paired `become: true` with each of
the seven `become_user: postgres` tasks.

```
$ python3 content/validation/remediation/code/ansible.py postgresql
29 passed, 0 failed
```

---

## 4. PostgreSQL: the hostssl conversion misses four of six address forms

**Where:** `mondoo-postgresql-security-hba-remote-connections-require-tls`,
`cli`, `script` and `ansible`.

The check is:

```coffee
postgresql.hba.rules != empty
postgresql.hba.rules.where(address != "" && address.downcase != "samehost").none(type.downcase == "host" || type.downcase == "hostnossl")
```

so **every** remote rule must be `hostssl`. The conversion only matched an
address in CIDR notation (`[0-9a-fA-F:.]+\/[0-9]+`). Run against the legal
address forms listed in the `pg_hba.conf` documentation:

```
$ perl -pe 's/^host(nossl)?(\s+\S+\s+\S+\s+[0-9a-fA-F:.]+\/[0-9]+\s+)/hostssl$2/' pg_hba.conf
local   all             postgres                                peer
hostssl    all             all             127.0.0.1/32            scram-sha-256
host    all             all             samenet                 scram-sha-256      <-- unchanged
host    all             all             all                     scram-sha-256      <-- unchanged
hostnossl all           all             app.example.com         scram-sha-256      <-- unchanged
host    all             all             10.0.0.0  255.255.255.0 scram-sha-256      <-- unchanged
hostssl    replication     replicator      10.0.0.5/32             scram-sha-256
```

Four rules survive as `host`/`hostnossl` and keep failing the check.

**Fix.** Match the address field as `\S+`. The `^host` anchor already excludes
`local` rules, and `hostssl`/`hostgssenc` are untouched because the anchor
requires whitespace right after `host` or `hostnossl`:

```
$ perl -pe 's/^host(nossl)?(\s+\S+\s+\S+\s+\S+\s+)/hostssl$2/' pg_hba.conf
local   all             postgres                                peer
hostssl    all             all             127.0.0.1/32            scram-sha-256
hostssl    all             all             samenet                 scram-sha-256
hostssl    all             all             all                     scram-sha-256
hostssl all           all             app.example.com         scram-sha-256
hostssl    all             all             10.0.0.0  255.255.255.0 scram-sha-256
hostssl    replication     replicator      10.0.0.5/32             scram-sha-256
```

While here, the sibling `hba-no-unrestricted-client-addresses` script verified
its own work with `grep -qE "^[^#]*[[:space:]](0\.0\.0\.0/0|::/0)[[:space:]]"`,
which omits the `all` address the check also rejects and can match the database
or user column. It now anchors on the address field and includes `all`,
matching the check exactly.

---

## 5. PostgreSQL: the md5-to-SCRAM CLI fix never sets password_encryption

**Where:** `mondoo-postgresql-security-hba-no-md5-auth`, `- id: cli`.

Step 1 read "Set `password_encryption` to `scram-sha-256` and reset any role
that still holds a legacy verifier", but no command in the block set it. The
block went straight to `\password app_user`, which stores the new verifier in
whatever format `password_encryption` currently is. If that is still `md5`,
the reset writes another md5 verifier, and the next command rewrites the rule
to `scram-sha-256`, which cannot authenticate one.

**Evidence.** PostgreSQL 16 documentation, "Password Authentication":

> "The availability of the different password-based authentication methods
> depends on how a user's password on the server is encrypted (or hashed, more
> accurately). This is controlled by the configuration parameter
> `password_encryption` at the time the password is set."

> "To ease transition from the `md5` method to the newer SCRAM method, if `md5`
> is specified as a method in `pg_hba.conf` but the user's password on the
> server is encrypted for SCRAM, then SCRAM-based authentication will
> automatically be chosen instead."

The fallback exists only in the md5-rule direction. There is none the other
way, which is why the check's own `audit:` block says the legacy verifiers
"would break after the rule change".

**Fix.** Set `password_encryption` in `postgresql.conf` and reload before
resetting any password, and split step 1 into two steps so the order is
explicit.

---

## 6. PostgreSQL: the pgaudit fix uses ALTER SYSTEM and drops preloaded libraries

**Where:** `mondoo-postgresql-security-pgaudit-extension-enabled`, `- id: cli`.

Two problems in one block:

```bash
sudo -u postgres sed -i "s/^#*\s*shared_preload_libraries.*/shared_preload_libraries = 'pgaudit'/" ...
sudo -u postgres psql -c "ALTER SYSTEM SET pgaudit.log = 'ddl, role, write';"
```

**a.** `ALTER SYSTEM` is the one thing the policy's own scope section tells
remediation not to do:

> "Settings changed with `ALTER SYSTEM` are written to `postgresql.auto.conf`
> in the data directory rather than to `postgresql.conf`. PostgreSQL applies
> that file last, so it takes precedence over everything this policy reads.
> Remediation steps therefore edit `postgresql.conf` directly, which keeps the
> effective configuration and the audited configuration in agreement."
> — `mondoo-postgresql-security.mql.yaml` line 32

This was the only `ALTER SYSTEM` in the file.

**b.** The `sed` replaces the whole preload list with `'pgaudit'`, discarding
anything already loaded such as `pg_stat_statements`. The `script` entry for
the same check states the opposite intent in its first step: "Preserve any
libraries already listed instead of overwriting them."

**Fix.** Read the current list, append both settings to `postgresql.conf`, and
drop the `ALTER SYSTEM` call. Appending is safe and visible to the check
because the parser is last-value-wins, matching PostgreSQL:

```go
// providers/os/resources/postgresql/parser.go:125
default:
    c.Params[key] = value
```

---

## 7. PostgreSQL: a step that contradicts itself

`mondoo-postgresql-security-listen-addresses-restricted`, `- id: cli`, step 2
read "Reload PostgreSQL so the new value takes effect. Changing
`listen_addresses` requires a restart rather than a reload." The snippet does
restart. Reworded to say restart once.

---

## Validation

```
$ cnspec policy lint ./content/mondoo-{mysql,mariadb,postgresql,snowflake,databricks,mongodbatlas}-security.mql.yaml
→ valid policy bundle(s)          (all six)

$ python3 content/validation/remediation/code/bash.py all
3554 passed, 0 failed

$ python3 content/validation/remediation/code/ansible.py mysql       # 35 passed, 0 failed
$ python3 content/validation/remediation/code/ansible.py mariadb     # 37 passed, 0 failed
$ python3 content/validation/remediation/code/ansible.py postgresql  # 29 passed, 0 failed  (new target)

$ typos content/mondoo-{mysql,mariadb,postgresql}-security.mql.yaml  # clean
```

No `version:` bumped.

---

## Checked and found correct

Candidates that looked wrong and verified as sound, so they are deliberately
**not** changed:

- **`local_preload_libraries = ''` satisfies its own check.** The check is
  `params["local_preload_libraries"] == empty` and the fix writes `''`. The
  parser's `unquoteConfValue` reduces `''` to the empty string, and MQL treats
  that as `empty`:
  `mql run -c 'x = {"a": ""}; if(x["a"] == empty) { return "EMPTY_TRUE" }'` →
  `if: "EMPTY_TRUE"`.
- **MariaDB `simple_password_check_letters_same_case`.** The check reads
  `simplePasswordCheckLetters`, which looked like a name mismatch against the
  option the snippet writes. `mariadb.go:244` resolves it to
  `simple_password_check_letters_same_case`, exactly what the snippet sets.
- **MariaDB's plaintext-password fix writing `~/.my.cnf`.** Looked like the
  snippet demonstrating the pattern the check forbids. It does not:
  `clientOptions` reads `ClientGroups(FlavorMariaDB)` over the system option
  file chain, and the check's own `desc:` names "a per-user option file
  restricted to its owner" as the intended remedy. MariaDB ships no
  `mysql_config_editor`, so the MySQL login-path answer is not available here.
- **MySQL script appends.** `printf ... >>"$MYCNF"` at end of
  `mysql.conf.d/mysqld.cnf` lands in `[mysqld]`, the file's only group, so
  defect 2 does not apply to the MySQL policy's script entries.
- **PostgreSQL CLI `sed` snippets.** The mirror of defect 1 does not exist
  here: Debian's `postgresql.conf` is the fully annotated file with every
  setting present and commented, so `s/^#*\s*OPT.*/.../` matches.
- **Snowflake**: 24 Terraform snippets pass
  `remediation/code/terraform.py snowflake` (24 passed, 0 failed) against
  `snowflakedb/snowflake ~> 2.0`; all 25 console entries navigate Snowsight
  ("Governance & security » Users & roles", "Network policies") with no
  surviving Classic Console paths.
- **Databricks**: 25 CLI entries pass
  `remediation/commands/validate.py databricks` against the installed CLI's
  own command tree, and 25 Terraform snippets pass
  `remediation/code/terraform.py databricks`. Traced all 25 Terraform snippets
  against their checks' `mql:`; the secret-scope snippet correctly omits
  `initial_manage_principal = "users"`, which would have been an instance of
  the pattern its check flags.
- **MongoDB Atlas**: 83 API and audit calls pass
  `remediation/commands/validate.py mongodbatlas` against the pinned Atlas
  Admin API spec; the 40 console entries match current Atlas navigation.
- **`token-no-nonexpiring` (Databricks) has no `mql:`.** It carries a
  `variants:` block instead, which is correct.
- Neither `remediation-budget.json` nor any `KNOWN_BUG.md` marker references
  these six policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
