### PR TITLE
🐛 alibaba: fix remediation commands that cannot run and console paths that do not exist

### DIFF
--- a/content/mondoo-alibaba-security.mql.yaml
+++ b/content/mondoo-alibaba-security.mql.yaml
@@ -1374,7 +1374,7 @@ queries:
 
               logging {
                 target_bucket = alicloud_oss_bucket.log.id
-                target_prefix  = "log/"
+                target_prefix = "log/"
               }
             }
             ```
@@ -2308,7 +2308,6 @@ queries:
     mql: |
       terraform.state.resources.where(type == "alicloud_ecs_disk").map(values).where(_["encrypted"] == true).all(_["kms_key_id"] != empty)
 
-  # No Terraform variants: instance metadata options (HttpTokens/HttpEndpoint) are not exposed as attributes of the alicloud_instance resource, so the token-required posture cannot be asserted from Terraform HCL, plan, or state.
   - uid: mondoo-alibaba-security-ecs-imds-v2-required
     title: Ensure ECS instances require a session token for metadata (IMDSv2)
     impact: 80
@@ -2356,11 +2355,32 @@ queries:
             To require a metadata token on an instance with the `aliyun` CLI:
 
             ```bash
-            aliyun ecs ModifyInstanceMetadataOptions --InstanceId <instance-id> --HttpTokens required
+            aliyun ecs ModifyInstanceMetadataOptions --InstanceId <instance-id> \
+              --HttpEndpoint enabled --HttpTokens required
             ```
-        # No Terraform remediation: instance metadata options are not exposed as an attribute of the alicloud_instance resource, so the token-required posture cannot be set through Terraform.
+
+            `HttpEndpoint` is mandatory on this call, and passing `enabled` keeps the metadata service reachable while the token requirement is added.
+        - id: terraform
+          desc: |
+            To require a metadata token in Terraform, set `http_tokens` to `required` on the instance:
+
+            ```hcl
+            resource "alicloud_instance" "example" {
+              instance_name   = "example-instance"
+              instance_type   = "ecs.g6.large"
+              image_id        = "aliyun_3_x64_20G_alibase_20240819.vhd"
+              security_groups = [alicloud_security_group.example.id]
+              vswitch_id      = alicloud_vswitch.example.id
+
+              http_endpoint = "enabled"
+              http_tokens   = "required"
+            }
+            ```
     variants:
       - uid: mondoo-alibaba-security-ecs-imds-v2-required-alicloud
+      - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl
+      - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-plan
+      - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-state
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
@@ -2381,6 +2401,29 @@ queries:
     filters: asset.platform == "alicloud-account"
     mql: |
       alicloud.ecs.instances.where(metadataEndpointEnabled == true).all(metadataHttpTokens == "required")
+  - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl
+    filters: |
+      asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "alicloud_instance")
+    mql: |
+      # An omitted http_endpoint leaves the metadata service enabled, which is the state this
+      # check is about, so only an explicit "disabled" takes an instance out of scope.
+      terraform.resources("alicloud_instance").where(arguments["http_endpoint"] != "disabled").all(
+        arguments["http_tokens"] == "required"
+      )
+  - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-plan
+    filters: |
+      asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "alicloud_instance")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "alicloud_instance").map(change.after)
+        .where(_["http_endpoint"] != "disabled")
+        .all(_["http_tokens"] == "required")
+  - uid: mondoo-alibaba-security-ecs-imds-v2-required-terraform-state
+    filters: |
+      asset.platform == "terraform-state" && terraform.state.resources.contains(type == "alicloud_instance")
+    mql: |
+      terraform.state.resources.where(type == "alicloud_instance").map(values)
+        .where(_["http_endpoint"] != "disabled")
+        .all(_["http_tokens"] == "required")
 
   # ===========================================================================
   # ApsaraDB for RDS
@@ -2936,8 +2979,10 @@ queries:
             ```bash
             aliyun polardb ModifyDBClusterTDE \
               --DBClusterId <cluster-id> \
-              --TDEStatus Enabled
+              --TDEStatus Enable
             ```
+
+            The value this call accepts is `Enable`, while the cluster reports its state back as `Enabled`.
         - id: terraform
           desc: |
             To enable TDE on a PolarDB cluster in Terraform, set `tde_status` to `Enabled`:
@@ -3924,7 +3969,7 @@ queries:
         _["key_usage"] == empty || _["key_usage"].downcase == "encrypt/decrypt"
       ).all(_["automatic_rotation"] == "Enabled")
 
-# No Terraform variants: the check bounds the rotation interval numerically, but Terraform expresses rotation_interval as a duration string ("31536000s") that cannot be parsed to an integer inside a variant query in this engine. The Terraform remediation still shows how to set a compliant interval.
+  # No Terraform variants: the check bounds the rotation interval numerically, but Terraform expresses rotation_interval as a duration string ("31536000s") that cannot be parsed to an integer inside a variant query in this engine. The Terraform remediation still shows how to set a compliant interval.
   - uid: mondoo-alibaba-security-kms-key-rotation-interval
     title: Ensure KMS keys rotate at least once every 365 days
     impact: 70
@@ -4869,7 +4914,8 @@ queries:
 
             ```bash
             aliyun slb CreateLoadBalancerHTTPSListener --LoadBalancerId <lb-id> \
-              --ListenerPort 443 --ServerCertificateId <cert-id> --Bandwidth -1
+              --ListenerPort 443 --ServerCertificateId <cert-id> --Bandwidth -1 \
+              --HealthCheck on
             aliyun slb DeleteLoadBalancerListener --LoadBalancerId <lb-id> --ListenerPort 80
             ```
         # No Terraform remediation: SLB listeners are modeled as standalone alicloud_slb_listener resources decoupled from their load balancer's address type, so this posture is asserted against the running configuration rather than a single Terraform attribute.
@@ -4979,8 +5025,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-        2. Go to **Settings** > **Multi-Factor Authentication**.
-        3. Review the MFA setting for each directory.
+        2. Go to **Settings** and open the **User Setting** tab.
+        3. Review **MFA Requirement for Logon** in the **Username-password Login** section of each directory.
 
         A passing directory shows MFA enabled for all users. A failing directory shows it disabled, or enabled only for sign-ins judged risky.
 
@@ -4999,8 +5045,8 @@ queries:
             To require MFA for every Cloud SSO sign-in in the console:
 
             1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-            2. Go to **Settings** > **Multi-Factor Authentication**.
-            3. Set the MFA policy to require a second factor for all users, and save.
+            2. Go to **Settings** and open the **User Setting** tab.
+            3. In the **Username-password Login** section select **Edit** next to **MFA Requirement for Logon**, set it to require a second factor for all users, and save.
         - id: cli
           desc: |
             To require MFA for every sign-in with the `aliyun` CLI:
@@ -5089,8 +5135,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-        2. Go to **Settings** > **Password Policy**.
-        3. Review the minimum length and whether passwords may contain the username.
+        2. Go to **Settings** and open the **User Setting** tab.
+        3. In the **Password Policy** section, review the minimum length and whether passwords may contain the username.
 
         A passing directory requires at least 14 characters and forbids the username. A failing directory requires fewer characters or permits it.
 
@@ -5109,7 +5155,7 @@ queries:
             To harden the Cloud SSO password policy in the console:
 
             1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-            2. Go to **Settings** > **Password Policy**.
+            2. Go to **Settings**, open the **User Setting** tab, and select **Edit** in the **Password Policy** section.
             3. Set the minimum length to 14 or more, forbid passwords containing the username, and save.
         - id: cli
           desc: |
@@ -5220,8 +5266,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-        2. Go to **Settings** > **Login Preference**.
-        3. Review whether users may obtain access credentials for themselves.
+        2. Go to **Settings** and open the **User Setting** tab.
+        3. In the **Login Preference** section, review whether users may obtain access credentials for themselves.
 
         A passing directory has the option turned off. A failing directory allows users to retrieve their own credentials.
 
@@ -5240,7 +5286,7 @@ queries:
             To stop users minting their own credentials in the console:
 
             1. Sign in to the [Cloud SSO console](https://cloudsso.console.aliyun.com/).
-            2. Go to **Settings** > **Login Preference**.
+            2. Go to **Settings**, open the **User Setting** tab, and select **Edit** in the **Login Preference** section.
             3. Turn off the option that lets users obtain access credentials, and save.
         - id: cli
           desc: |
@@ -5339,7 +5385,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-        2. Open the instance and go to **Repositories**.
+        2. Open the instance and go to **Repository** > **Repositories**.
         3. Review the repository type of each repository.
 
         A passing repository is **Private**. A failing repository is **Public**.
@@ -5359,15 +5405,15 @@ queries:
             To make a repository private in the console:
 
             1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-            2. Open the instance, go to **Repositories**, and select the repository.
-            3. In **Repository Information**, change the repository type to **Private**, and save.
+            2. Open the instance, go to **Repository** > **Repositories**, and select **Manage** on the repository.
+            3. On the **Details** page select **Edit**, set the repository type to **Private** in the **Modify Settings** dialog, and confirm.
         - id: cli
           desc: |
-            To make a repository private with the `aliyun` CLI:
+            To make a repository private with the `aliyun` CLI, pass the repository summary alongside the type, since the call rewrites both:
 
             ```bash
             aliyun cr UpdateRepository --InstanceId <instance-id> \
-              --RepoId <repo-id> --RepoType PRIVATE
+              --RepoId <repo-id> --RepoType PRIVATE --Summary <repository-summary>
             ```
         - id: terraform
           desc: |
@@ -5448,8 +5494,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-        2. Open the instance, go to **Repositories**, and select a repository.
-        3. In **Repository Information**, review the tag immutability setting.
+        2. Open the instance, go to **Repository** > **Repositories**, and select **Manage** on a repository.
+        3. On the **Details** page, review whether the repository is marked **Immutable**.
 
         A passing repository has tag immutability enabled. A failing repository has it disabled.
 
@@ -5468,15 +5514,16 @@ queries:
             To enable tag immutability in the console:
 
             1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-            2. Open the instance, go to **Repositories**, and select the repository.
-            3. In **Repository Information**, turn on tag immutability, and save.
+            2. Open the instance, go to **Repository** > **Repositories**, and select **Manage** on the repository.
+            3. On the **Details** page select **Edit**, select **Immutable** in the **Modify Settings** dialog, and confirm.
         - id: cli
           desc: |
-            To enable tag immutability with the `aliyun` CLI:
+            To enable tag immutability with the `aliyun` CLI, pass the repository type and summary alongside the immutability flag, since the call rewrites all of them:
 
             ```bash
             aliyun cr UpdateRepository --InstanceId <instance-id> \
-              --RepoId <repo-id> --TagImmutability true
+              --RepoId <repo-id> --TagImmutability true \
+              --RepoType PRIVATE --Summary <repository-summary>
             ```
         - id: terraform
           desc: |
@@ -5561,7 +5608,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-        2. Open the instance and go to **Security** > **Image Scan**.
+        2. Open the instance and go to **Security and Trust** > **Image Scanning**.
         3. Review the configured scan rules.
 
         A passing instance has at least one scan rule. A failing instance has none.
@@ -5581,7 +5628,7 @@ queries:
             To add an image scan rule in the console:
 
             1. Sign in to the [Container Registry console](https://cr.console.aliyun.com/).
-            2. Open the instance and go to **Security** > **Image Scan**.
+            2. Open the instance and go to **Security and Trust** > **Image Scanning**.
             3. Create a scan rule, set its scope to the repositories you want covered, and choose the on-push trigger.
         - id: cli
           desc: |
@@ -5669,8 +5716,10 @@ queries:
 
             ```bash
             aliyun elasticsearch POST /openapi/instances \
-              --body '{"nodeSpec":{"diskEncryption":true}}'
+              --body '{"description":"example-cluster","esVersion":"7.10_with_X-Pack","nodeAmount":2,"esAdminPassword":"<admin-password>","paymentType":"postpaid","nodeSpec":{"spec":"elasticsearch.sn2ne.large","disk":20,"diskType":"cloud_ssd","diskEncryption":true},"networkConfig":{"type":"vpc","vpcId":"<vpc-id>","vswitchId":"<vswitch-id>","vsArea":"<zone-id>"}}'
             ```
+
+            `esVersion`, `nodeAmount`, `esAdminPassword`, `nodeSpec.spec`, and `networkConfig` are all mandatory, so the request has to carry them even though `diskEncryption` is the setting being fixed.
         - id: terraform
           desc: |
             To declare an encrypted cluster in Terraform, set `data_node_disk_encrypted` to `true`:
@@ -5756,8 +5805,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Elasticsearch console](https://elasticsearch.console.aliyun.com/).
-        2. Open each cluster and go to **Security**.
-        3. Review whether the public network endpoint is enabled.
+        2. Open each cluster and go to **Configuration and Management** > **Security**.
+        3. Review whether **Public Network Access** is enabled.
 
         A passing cluster has the public endpoint disabled. A failing cluster has it enabled.
 
@@ -5776,8 +5825,8 @@ queries:
             To turn off the public endpoint in the console:
 
             1. Sign in to the [Elasticsearch console](https://elasticsearch.console.aliyun.com/).
-            2. Open the cluster and go to **Security**.
-            3. Disable the public network access, and save.
+            2. Open the cluster and go to **Configuration and Management** > **Security**.
+            3. Turn off **Public Network Access**, and save.
         - id: cli
           desc: |
             To turn off the public endpoint with the `aliyun` CLI:
@@ -5871,7 +5920,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Elasticsearch console](https://elasticsearch.console.aliyun.com/).
-        2. Open each cluster with a public endpoint and go to **Security** > **Public Network Whitelist**.
+        2. Open each cluster with a public endpoint and go to **Configuration and Management** > **Security**, then review the **Public IP Address Whitelist** section.
         3. Review the entries.
 
         A passing cluster lists only specific ranges, or has no public endpoint at all. A failing cluster lists `0.0.0.0/0`.
@@ -5891,7 +5940,7 @@ queries:
             To narrow the public allowlist in the console:
 
             1. Sign in to the [Elasticsearch console](https://elasticsearch.console.aliyun.com/).
-            2. Open the cluster and go to **Security** > **Public Network Whitelist**.
+            2. Open the cluster, go to **Configuration and Management** > **Security**, and select **Modify** next to **Public IP Address Whitelist**.
             3. Replace `0.0.0.0/0` with the specific ranges that need access, and save.
         - id: cli
           desc: |
@@ -5997,8 +6046,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Function Compute console](https://fcnext.console.aliyun.com/).
-        2. Open each function and go to **Configurations** > **Network**.
-        3. Review whether public internet access is allowed.
+        2. Open each function, select the **Configuration** tab, and open **Advanced Settings**.
+        3. In the **Network** section, review **Allow Default ENI to Access the Internet**.
 
         A passing function has internet access disabled. A failing function has it enabled.
 
@@ -6017,8 +6066,8 @@ queries:
             To turn off internet egress in the console:
 
             1. Sign in to the [Function Compute console](https://fcnext.console.aliyun.com/).
-            2. Open the function and go to **Configurations** > **Network**.
-            3. Set public internet access to disabled, and save.
+            2. Open the function, select the **Configuration** tab, and select **Modify** next to **Advanced Settings**.
+            3. In the **Network** section set **Allow Default ENI to Access the Internet** to disabled, then deploy the change.
         - id: cli
           desc: |
             To turn off internet egress with the `aliyun` CLI:
@@ -6111,8 +6160,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Function Compute console](https://fcnext.console.aliyun.com/).
-        2. Open each function and go to **Configurations** > **Environment Variables**.
-        3. Review the names and values for access keys, tokens, passwords, and private keys.
+        2. Open each function, select the **Configuration** tab, and open **Advanced Settings**.
+        3. In the **Environment Variables** section, review the names and values for access keys, tokens, passwords, and private keys.
 
         A passing function holds only non-sensitive configuration. A failing function holds a credential, or a reference that resolves to one.
 
@@ -6131,8 +6180,8 @@ queries:
             To move a credential out of a function's environment in the console:
 
             1. Store the value in [KMS Secrets Manager](https://kms.console.aliyun.com/) and grant the function's RAM role permission to read it.
-            2. Sign in to the [Function Compute console](https://fcnext.console.aliyun.com/), open the function, and go to **Configurations** > **Environment Variables**.
-            3. Replace the credential with the secret name and have the function fetch the value at startup, then rotate the exposed credential.
+            2. Sign in to the [Function Compute console](https://fcnext.console.aliyun.com/), open the function, select the **Configuration** tab, and select **Modify** next to **Advanced Settings**.
+            3. In the **Environment Variables** section replace the credential with the secret name, have the function fetch the value at startup, then rotate the exposed credential.
         - id: cli
           desc: |
             To replace an inline credential with a secret reference using the `aliyun` CLI:
@@ -6272,7 +6321,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [VPC console](https://vpc.console.aliyun.com/).
-        2. Go to **VPN** > **IPsec Connections** and open each connection.
+        2. Go to **Interconnections** > **VPN** > **IPsec Connections** and open each connection.
         3. Review the encryption algorithm in both the **IKE Configuration** and the **IPsec Configuration**.
 
         A passing connection uses an AES algorithm in both. A failing connection uses `des` or `3des` in either.
@@ -6292,7 +6341,7 @@ queries:
             To move a connection onto AES in the console:
 
             1. Sign in to the [VPC console](https://vpc.console.aliyun.com/).
-            2. Go to **VPN** > **IPsec Connections** and edit the connection.
+            2. Go to **Interconnections** > **VPN** > **IPsec Connections** and edit the connection.
             3. Set the encryption algorithm to `aes256` in both the IKE and IPsec configurations, apply the matching change on the customer gateway, and save.
         - id: cli
           desc: |
@@ -6418,7 +6467,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [VPC console](https://vpc.console.aliyun.com/).
-        2. Go to **VPN** > **IPsec Connections** and open each connection.
+        2. Go to **Interconnections** > **VPN** > **IPsec Connections** and open each connection.
         3. Review the Diffie-Hellman group in both the **IKE Configuration** and the **IPsec Configuration**.
 
         A passing connection uses `group14` or higher in both. A failing connection uses `group1`, `group2`, `group5`, or has it disabled.
@@ -6438,7 +6487,7 @@ queries:
             To raise the Diffie-Hellman group in the console:
 
             1. Sign in to the [VPC console](https://vpc.console.aliyun.com/).
-            2. Go to **VPN** > **IPsec Connections** and edit the connection.
+            2. Go to **Interconnections** > **VPN** > **IPsec Connections** and edit the connection.
             3. Set the DH group to `group14` or higher in both configurations, apply the matching change on the customer gateway, and save.
         - id: cli
           desc: |
@@ -6767,7 +6816,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [KMS console](https://kms.console.aliyun.com/).
-        2. Go to **Secrets Manager** and open each secret.
+        2. Go to **Resource** > **Secrets** and open each secret.
         3. Review the automatic rotation setting.
 
         A passing secret has rotation enabled. A failing secret has it disabled or suspended.
@@ -6787,8 +6836,8 @@ queries:
             To enable automatic rotation in the console:
 
             1. Sign in to the [KMS console](https://kms.console.aliyun.com/).
-            2. Go to **Secrets Manager** and open the secret.
-            3. Enable automatic rotation, set a rotation interval, and save.
+            2. Go to **Resource** > **Secrets** and open the secret.
+            3. Select **Configure Rotation**, turn on **Automatic Rotation**, set a rotation interval, and confirm.
         - id: cli
           desc: |
             To enable automatic rotation with the `aliyun` CLI:
@@ -6878,7 +6927,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [KMS console](https://kms.console.aliyun.com/).
-        2. Go to **Secrets Manager** and open each secret.
+        2. Go to **Resource** > **Secrets** and open each secret.
         3. Review the encryption key it is protected by.
 
         A passing secret names a customer master key. A failing secret shows the service default.
@@ -6898,7 +6947,7 @@ queries:
             The encryption key of a secret is chosen at creation. To move to a customer master key in the console:
 
             1. Sign in to the [KMS console](https://kms.console.aliyun.com/) and create or select a customer master key.
-            2. Go to **Secrets Manager** and create a replacement secret, choosing that key.
+            2. Go to **Resource** > **Secrets** and create a replacement secret, choosing that key.
             3. Point consumers at the new secret, then delete the old one and rotate the value.
         - id: cli
           desc: |
@@ -7103,8 +7152,8 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [ECS console](https://ecs.console.aliyun.com/).
-        2. Go to **Instances & Images** > **Images** and select **Custom Images**.
-        3. Review the sharing state of each image.
+        2. Go to **Instances & Images** > **Images** and open the **Custom Images** tab.
+        3. Review whether each image is published as a community image.
 
         A passing image is not public. A failing image is published to all users.
 
@@ -7123,8 +7172,8 @@ queries:
             To un-publish a custom image in the console:
 
             1. Sign in to the [ECS console](https://ecs.console.aliyun.com/).
-            2. Go to **Instances & Images** > **Images** and select the custom image.
-            3. Cancel the public sharing, then treat any credential the image contains as exposed and rotate it.
+            2. Go to **Instances & Images** > **Images** and open the **Custom Images** tab.
+            3. Find the published community image and unpublish it, then treat any credential the image contains as exposed and rotate it.
         - id: cli
           desc: |
             To un-publish a custom image with the `aliyun` CLI:
@@ -7182,7 +7231,7 @@ queries:
         ### Audit via Console
 
         1. Sign in to the [Cloud Firewall console](https://yundun.console.aliyun.com/?p=cfwnext).
-        2. Go to **Access Control** > **Internet Border** and review the inbound rules.
+        2. Go to **Prevention Configuration** > **Access Control** > **Policy Configuration** > **Internet Border** and open the **Inbound** tab.
         3. Look for an enabled rule whose action is **Accept** with `0.0.0.0/0` as both source and destination and a protocol of **ANY**.
 
         A passing account has no such rule. A failing account has at least one.
@@ -7192,7 +7241,7 @@ queries:
         1. List the inbound control policies:
 
         ```bash
-        aliyun cloudfw DescribeControlPolicy --Direction in
+        aliyun cloudfw DescribeControlPolicy --Direction in --CurrentPage 1 --PageSize 50
         ```
 
         A passing account returns no enabled policy with `AclAction` of `accept`, `Proto` of `ANY`, and `0.0.0.0/0` for both `Source` and `Destination`. A failing account returns one.
@@ -7202,7 +7251,7 @@ queries:
             To narrow an accept-any rule in the console:
 
             1. Sign in to the [Cloud Firewall console](https://yundun.console.aliyun.com/?p=cfwnext).
-            2. Go to **Access Control** > **Internet Border** and edit the rule.
+            2. Go to **Prevention Configuration** > **Access Control** > **Policy Configuration** > **Internet Border**, open the **Inbound** tab, and edit the rule.
             3. Name the specific protocol, destination port, and source range the flow needs, or change the action to **Drop**, and save.
         - id: cli
           desc: |
@@ -7210,10 +7259,13 @@ queries:
 
             ```bash
             aliyun cloudfw ModifyControlPolicy --AclUuid <acl-uuid> --Direction in \
-              --AclAction accept --Proto TCP --DestPort 443/443 \
+              --AclAction accept --Proto TCP --ApplicationName HTTPS \
+              --DestPort 443/443 --DestPortType port \
               --Source 203.0.113.0/24 --SourceType net \
               --Destination 10.0.0.0/16 --DestinationType net
             ```
+
+            `ApplicationName` is mandatory on this call, since a policy must name either a single application or an application list.
         - id: terraform
           desc: |
             To declare a scoped inbound rule in Terraform, name the protocol, port, and source:

--- a/content/validation/scans/fixtures/iac-variants/mondoo-alibaba-security/mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl/fail/token-optional/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-alibaba-security/mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl/fail/token-optional/main.tf
@@ -1,0 +1,10 @@
+resource "alicloud_instance" "app" {
+  instance_name   = "prod-app-01"
+  instance_type   = "ecs.g6.large"
+  image_id        = "aliyun_3_x64_20G_alibase_20240819.vhd"
+  security_groups = [alicloud_security_group.app.id]
+  vswitch_id      = alicloud_vswitch.app.id
+
+  http_endpoint = "enabled"
+  http_tokens   = "optional"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-alibaba-security/mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl/pass/token-required/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-alibaba-security/mondoo-alibaba-security-ecs-imds-v2-required-terraform-hcl/pass/token-required/main.tf
@@ -1,0 +1,10 @@
+resource "alicloud_instance" "app" {
+  instance_name   = "prod-app-01"
+  instance_type   = "ecs.g6.large"
+  image_id        = "aliyun_3_x64_20G_alibase_20240819.vhd"
+  security_groups = [alicloud_security_group.app.id]
+  vswitch_id      = alicloud_vswitch.app.id
+
+  http_endpoint = "enabled"
+  http_tokens   = "required"
+}


### PR DESCRIPTION
Deep audit of every `remediation:` and `audit:` block in `content/mondoo-alibaba-security.mql.yaml`. Every claim below is checked against an oracle and the oracle output is quoted. Oracles used:

- **CLI grammar and parameter requiredness**: Alibaba's own OpenAPI metadata, `https://api.aliyun.com/meta/v1/products/<code>/versions/<version>/api-docs.json`, the same source `content/validation/upstream/dump/alicloud.py` dumps the checked-in grammar from.
- **Terraform attribute names**: `terraform providers schema -json` for `aliyun/alicloud 1.288.0`.
- **Console paths**: Alibaba's published console documentation, fetched per page.

The checked-in `validate.py alicloud` grammar verifies that an action exists and that each flag is a parameter of it. It does **not** check whether *mandatory* parameters are present, nor whether a literal is a value the API accepts. Every defect below sits in that gap, which is why all 147 commands passed the validator before and after.

---

## 1. `ecs ModifyInstanceMetadataOptions` omits a mandatory parameter

`mondoo-alibaba-security-ecs-imds-v2-required`, `- id: cli`.

```
aliyun ecs ModifyInstanceMetadataOptions --InstanceId <instance-id> --HttpTokens required
```

`HttpEndpoint` is mandatory:

```
== ecs ModifyInstanceMetadataOptions
   RegionId       required=True
   InstanceId     required=None
   HttpEndpoint   required=True   ex='enabled'
   HttpTokens     required=None   ex='optional'
```

The call as written returns `MissingParameter`. Fixed by passing `--HttpEndpoint enabled`, which is also the semantically correct value: the check scopes to instances whose metadata endpoint is enabled, so the fix must keep it enabled while adding the token requirement.

## 2. The IMDSv2 check claims a Terraform surface that does exist

Same check carried two comments:

```yaml
# No Terraform variants: instance metadata options (HttpTokens/HttpEndpoint) are not exposed as attributes of the alicloud_instance resource …
# No Terraform remediation: instance metadata options are not exposed as an attribute of the alicloud_instance resource …
```

Both are false. From the provider schema:

```
$ terraform providers schema -json | jq '…resource_schemas.alicloud_instance…'
http_endpoint: "string"
http_put_response_hop_limit: "number"
http_tokens: "string"
```

These have been on `alicloud_instance` since provider 1.209. The check now ships `-terraform-hcl`, `-terraform-plan` and `-terraform-state` variants plus the `- id: terraform` remediation, and both comments are gone.

The variants assert `http_tokens == "required"` scoped by `http_endpoint != "disabled"` rather than `== "enabled"`, because an omitted `http_endpoint` leaves the metadata service enabled, which is exactly the state the check is about. `== "enabled"` would drop every instance that relied on the default.

New fixtures: `pass/token-required`, `fail/token-optional`. The closed-loop suite scans the new remediation snippet against the new HCL variant and it passes.

## 3. `slb CreateLoadBalancerHTTPSListener` omits a mandatory parameter

`mondoo-alibaba-security-slb-listener-not-plaintext`, `- id: cli`.

```
   LoadBalancerId  required=True
   Bandwidth       required=True
   ListenerPort    required=True
   HealthCheck     required=True   ex='on'   ("是否开启健康检查。取值：on / off")
   StickySession   required=False
```

The snippet passed the first three and not `HealthCheck`. Fixed with `--HealthCheck on`. `StickySession` was deliberately **not** added: the metadata marks it optional, and I do not add parameters I cannot show are required.

## 4. `cr UpdateRepository` omits mandatory parameters, twice

```
== cr UpdateRepository
   InstanceId  required=True
   RepoId      required=None
   RepoType    required=True   ex='PUBLIC'
   Summary     required=True   ex='test repo'
   TagImmutability required=None
```

- `mondoo-alibaba-security-acr-repository-not-public` passed `RepoType` but not `Summary`.
- `mondoo-alibaba-security-acr-repository-tag-immutability` passed neither `RepoType` nor `Summary`.

Both calls return `MissingParameter`. Both now carry the mandatory set, and each `desc` says why the extra arguments are there, since the call rewrites the fields rather than patching one.

## 5. `cloudfw DescribeControlPolicy` omits mandatory pagination

`mondoo-alibaba-security-cloudfirewall-no-unrestricted-accept`, audit block.

```
== cloudfw DescribeControlPolicy
   Direction    required=None  enum=['out','in']
   CurrentPage  required=True  ex='1'
   PageSize     required=True  ex='10'
```

An auditor running the documented command gets an error rather than a policy list. Now `--CurrentPage 1 --PageSize 50`.

## 6. `cloudfw ModifyControlPolicy` names no application

Same check, `- id: cli`. The metadata note on both `ApplicationName` and `ApplicationNameList` reads:

> ApplicationNameList和ApplicationName二选一，必须传其中一个，不能同时为空。
> (Choose one of ApplicationNameList and ApplicationName; one must be passed, they cannot both be empty.)

The snippet passed neither. Added `--ApplicationName HTTPS`, matching the `application_name = "HTTPS"` the check's own Terraform snippet already sets, and `--DestPortType port` for parity with `dest_port_type` there.

Causal chain re-checked: the check fails a rule that is `accept` + `ANY` + `0.0.0.0/0` on both ends. The command sets `Proto TCP`, a `/24` source and a `/16` destination, so applying it makes the check pass.

## 7. `polardb ModifyDBClusterTDE` passes a value the API does not accept

`mondoo-alibaba-security-polardb-cluster-tde-enabled`, `- id: cli`, used `--TDEStatus Enabled`. The request parameter is documented as:

> 修改TDE状态。取值固定为**Enable**。  (Modify TDE status. The value is fixed at **Enable**.)

while the *response* of `DescribeDBClusterTDE` uses the other spelling:

> TDEStatus: 是否开通TDE加密，取值：* **Enabled**：开通 * **Disabled**：关闭

So the audit block quoting `Enabled` is right and the remediation quoting `Enabled` is wrong. Changed to `Enable`, with one line saying why the two spellings differ, so nobody "fixes" it back.

The Terraform side stays `Enabled`, which is correct there:

> `tde_status` … Valid values are `Enabled`, `Disabled`. Default to `Disabled`.
> https://github.com/aliyun/terraform-provider-alicloud/blob/master/website/docs/r/polardb_cluster.html.markdown

## 8. The Elasticsearch create-instance body is missing every mandatory field

`mondoo-alibaba-security-es-instance-disk-encrypted`, `- id: cli`, was:

```
aliyun elasticsearch POST /openapi/instances --body '{"nodeSpec":{"diskEncryption":true}}'
```

`nodeSpec.diskEncryption` is real, but the request also requires `nodeAmount`, `esVersion`, `esAdminPassword`, `networkConfig` and `nodeSpec.spec`, all `required: true` in the `createInstance` schema. The body now carries them, modelled on the schema's own example, with a line noting why a fix for one field needs a full create request.

## 9. Console paths that name menus the product does not have

Each verified against the vendor page cited. Where a path could not be confirmed from an Alibaba doc it was left alone rather than guessed at.

| Check family | Was | Now | Source |
|---|---|---|---|
| Cloud SSO MFA | Settings > Multi-Factor Authentication | Settings > **User Setting** tab > Username-password Login > MFA Requirement for Logon | [manage-mfa](https://www.alibabacloud.com/help/en/cloudsso/user-guide/manage-mfa) |
| Cloud SSO password policy, login preference | Settings > Password Policy / Login Preference | Settings > **User Setting** tab > the named section | [set-password-policy](https://help.aliyun.com/zh/cloudsso/user-guide/set-password-policy) |
| ACR repo type, tag immutability | "Repository Information" page | Repository > Repositories > Manage > **Details** > Edit > Modify Settings | [turn-on-immutable-image-version](https://www.alibabacloud.com/help/en/acr/user-guide/turn-on-immutable-image-version) |
| ACR scan rules | Security > Image Scan | **Security and Trust** > **Image Scanning** | [scan-container-images](https://www.alibabacloud.com/help/en/acr/user-guide/scan-container-images) |
| Elasticsearch public endpoint | Security | **Configuration and Management** > Security, **Public Network Access** | [configure-a-public-or-private-ip-address-whitelist…](https://www.alibabacloud.com/help/en/es/user-guide/configure-a-public-or-private-ip-address-whitelist-for-an-elasticsearch-cluster) |
| Elasticsearch public whitelist | Security > Public Network Whitelist | Configuration and Management > Security, then Modify next to **Public IP Address Whitelist** | same |
| Function Compute network, env vars | Configurations > Network / Environment Variables | **Configuration** tab > **Advanced Settings** > Modify, then the Network / Environment Variables section | [configure-network-settings-3](https://www.alibabacloud.com/help/en/functioncompute/fc-3-0/user-guide/configure-network-settings-3) |
| VPN IPsec connections | VPN > IPsec Connections | **Interconnections** > VPN > IPsec Connections | [create-multiple-ipsec-vpn-connections…](https://www.alibabacloud.com/help/en/vpn/sub-product-ipsec-vpn/use-cases/create-multiple-ipsec-vpn-connections-over-the-internet-for-load-balancing) |
| Cloud Firewall inbound rules | Access Control > Internet Border | **Prevention Configuration** > Access Control > **Policy Configuration** > Internet Border, Inbound tab | [create-inbound-and-outbound-access-control-policies…](https://www.alibabacloud.com/help/en/cloud-firewall/cloudfirewall/user-guide/create-inbound-and-outbound-access-control-policies-for-the-internet-firewall) |
| KMS secrets | Secrets Manager | **Resource** > **Secrets**; rotation via **Configure Rotation** | [manage-and-use-ecs-secrets](https://www.alibabacloud.com/help/en/kms/user-guide/manage-and-use-ecs-secrets) |
| ECS public image | "Cancel the public sharing" | **Custom Images** tab, unpublish the community image | [unpublish-a-community-image](https://www.alibabacloud.com/help/en/elastic-compute-service/latest/unpublish-a-community-image) |

The ECS wording matters beyond the menu name: the check reads `isPublic`, which is community-image publication, and Alibaba's per-account "Cancel Sharing" is a different operation that would not clear the finding.

## 10. Two cosmetic fixes

A `# No Terraform variants:` comment above `mondoo-alibaba-security-kms-key-rotation-interval` sat at column 0 instead of the two-space indent every other one uses, and the `logging` block in the OSS logging snippet had a misaligned `=`.

---

# Checked and found correct

Candidates that looked wrong and verified as correct, so nobody re-opens them:

- **`aliyun ram SetPasswordPolicy --MaxLoginAttemps 5`** — reads like a typo, is the real upstream parameter name. Present in Alibaba's metadata spelled exactly that way.
- **Omitted `--RegionId`** on 14 ECS, VPC, RDS and SLB commands. The metadata marks `RegionId` mandatory, but the aliyun CLI supplies it from the profile, which is why `aliyun ecs DescribeInstances` works unqualified. Not a defect, and not "fixed".
- **Action names used against ROA products** — `aliyun elasticsearch UpdatePublicNetwork …`, `aliyun fc UpdateFunction …`. A previous PR concluded RESTful products need the `POST /path` form. They do not; `openapi/commando.go` resolves a two-argument invocation through `GetApi` and dispatches on `api.Method, api.PathPattern`, so the action-name form is valid for ROA products too. Both spellings left as they are. Verified `UpdatePublicNetwork` → `PATCH|POST /openapi/instances/{InstanceId}/public-network` carrying `enablePublic`, and `fc UpdateFunction` → `PUT /2023-03-30/functions/{functionName}` carrying `internetAccess` and `environmentVariables`.
- **Every Terraform attribute in the file.** All 264 arguments and nested blocks across the 51 HCL snippets resolve against `aliyun/alicloud 1.288.0`, including the Cloud SSO `password_policy` and `login_preference` blocks and `alicloud_oss_bucket_public_access_block.block_public_access`. Zero unknown or read-only names.
- **`ram UpdateAccessKey --Status Inactive`, `rds ModifyDBInstanceTDE --TDEStatus Enabled`, `dds ModifyDBInstanceTDE --TDEStatus enabled` (lowercase is right for dds), `dds ModifyAuditPolicy --AuditStatus enable`, `r-kvstore ModifyInstanceSSL --SSLEnabled Enable`, `r-kvstore ModifyInstanceVpcAuthMode --VpcAuthMode Open`, `nas ModifyAccessRule --RWAccessType RDONLY`, `vpc CreateFlowLog --TrafficType All`, `actiontrail CreateTrail --EventRW All`, `ecs ModifyImageSharePermission --IsPublic false`, `cr CreateScanRule --ScanScope NAMESPACE --TriggerType AUTO --ScanType VUL`** — every literal matches the documented value set. The four case variations that look inconsistent between products are each what that product's own API specifies.
- **`# No CLI remediation` on OSS Block Public Access.** Checked against the 47 ossutil subcommands in the grammar: nothing matching public or block exists. The comment is accurate.
- **`# No Terraform remediation` on RDS public endpoint.** `alicloud_db_instance` really has no network-type attribute; the closest names in its schema are `connection_string_prefix`, `whitelist_network_type` and the `ssl_*` set, none of which control Internet versus Intranet.
- **The `DB_PASSWORD_SECRET` example in the Function Compute remediation.** It looked like the snippet demonstrates the pattern the check forbids. It does not: the key regex is anchored (`^db_password$`), so `db_password_secret` does not match, and the value is a secret name rather than a credential.
- **`cs POST /clusters` with `endpoint_public_access`.** Confirmed the field exists in the ACK `CreateCluster` request model.
- **Snippets referencing resources they do not declare** (`alicloud_kms_key.example`, `alicloud_vswitch.example`, `alicloud_security_group.example`). Left alone: this is the convention throughout `content/`, the snippets are fragments for an operator who already has those resources, and tflint accepts them.
- **Elasticsearch disk-encryption console location.** The current text says **Basic Information**, and I could not find an Alibaba page that states where post-creation encryption state is shown. Unverifiable, so unchanged rather than replaced with a guess.
- **Cloud SSO "Login Preference" credentials toggle.** The section exists on the User Setting tab, confirmed; Alibaba documents only its IP-whitelist field, so the step now names the right tab and section without asserting a control name I could not confirm.

# Validation

```
cnspec policy lint ./content/mondoo-alibaba-security.mql.yaml       → valid policy bundle(s)
make test/content/lint                                             → valid (2 pre-existing warnings, same on main)
python3 content/validation/remediation/commands/validate.py alicloud → 147 passed, 0 failed
python3 content/validation/remediation/code/terraform.py alibaba    → 51 passed, 0 failed
python3 content/validation/remediation/code/bash.py                 → 3554 passed, 0 failed
go test -tags iac_variants … -run TestTerraformVariants/mondoo-alibaba-security/  → ok
go test -tags iac_variants … -run TestRemediationSatisfiesCheck/mondoo-alibaba-security → ok
make test/content/iac/coverage                                     → mondoo-alibaba-security -terraform-hcl: 50/50 (100.0%)
typos                                                              → clean
```

No `version:` bump: this is a fix, not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
