### PR TITLE
🐛 content: add the missing impact score to the Terraform template provider check

### DIFF
--- a/content/terraform-deprecations.mql.yaml
+++ b/content/terraform-deprecations.mql.yaml
@@ -35,6 +35,7 @@ policies:
 queries:
   - uid: terraform-provider-deprecations-template
     title: Ensure Terraform template provider is not used
+    impact: 40
     mql: |
       # ensure it is not declared in required_providers, including under an aliased local name
       terraform.settings.requiredProviders.none(name == "template" || source == "hashicorp/template" || source == "registry.terraform.io/hashicorp/template")


### PR DESCRIPTION
## What

`terraform-provider-deprecations-template` in `content/terraform-deprecations.mql.yaml` was defined without an `impact:`, so it contributed no severity weight when scoring a Terraform HCL scan. This adds `impact: 40`.

## How this was found

I audited every uid referenced under `groups[].checks[]` across all bundles in `content/` and `content/querypacks/` and resolved each one back to its definition in the top-level `queries:` list. This was the only check missing an impact, out of ~3,100 that declare one.

The audit checks impact on the **parent** query, which is the only valid place for it: the `query-variant-uses-non-default-fields` lint rule (`internal/bundle/lint_rules_queries.go`) rejects variants that set `impact`. Embedded checks defined inline under a group were covered separately and none were missing an impact either.

## Why 40

The check flags the archived `hashicorp/template` provider. It blocks upgrades and receives no security patches, but is not itself an exposure. That places it with the other deprecation checks scored at 40:

| Check | Impact |
|---|---|
| Do not use deprecated SPF DNS Record Type | 40 |
| The header Public-Key-Pins is deprecated and should not be used | 40 |
| Ensure that BigQuery views do not use Legacy SQL | 40 |

40 is also the modal tier for `mondoo.com/category: best-practices` policies, which is this policy's category.

No policy version bump: this is a fix, not a change to what the check asserts.

## Verification

- `cnspec policy lint ./content ./content/querypacks` → `valid policy bundle(s)` (the two `terraform.resources` WHERE-clause warnings are pre-existing on `main` and unrelated)
- Re-ran the audit against the branch → 0 checks missing an impact

The formatter wants to reorder an unrelated `summary:` field in this file, which is pre-existing drift on `main`. I left it alone to keep the diff to the one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)