### PR TITLE
📝 stackit: add missing audit sections to the STACKIT Security policy

### DIFF
--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -139,6 +139,24 @@ queries:
 
         - **No instance-level filtering:** Without a security group, the server relies entirely on network-level controls, increasing the chance of unintended exposure.
         - **Inconsistent posture:** Servers missing a security group are easy to overlook in audits and drift from the project's intended baseline.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Compute Engine** and select the server.
+        3. Review the server's network interfaces and confirm at least one security group is attached.
+
+        A passing server has one or more security groups attached. A failing server has no security group, so no instance-level filtering applies to its traffic.
+
+        ### Audit via CLI
+
+        1. Describe the server and inspect its attached security groups:
+
+        ```bash
+        stackit server describe <server-id> --output-format json
+        ```
+
+        A passing server reports a non-empty list of security groups. A failing server reports an empty list.
       remediation:
         - id: console
           desc: |
@@ -204,6 +222,30 @@ queries:
 
         - **Data confidentiality:** Encryption protects sensitive data on the volume from disclosure if storage media is decommissioned or accessed improperly.
         - **Compliance:** Many frameworks require encryption of data at rest for regulated workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Compute Engine** and select **Volumes**.
+        3. Review each volume and confirm it is encrypted.
+
+        A passing project has every block storage volume encrypted. A failing project has at least one unencrypted volume.
+
+        ### Audit via CLI
+
+        1. List the volumes in the project:
+
+        ```bash
+        stackit volume list --output-format json
+        ```
+
+        2. Inspect the encryption state of each volume:
+
+        ```bash
+        stackit volume describe <volume-id> --output-format json
+        ```
+
+        A passing volume reports encryption as enabled. A failing volume reports it as disabled.
       remediation:
         - id: console
           desc: |
@@ -259,6 +301,30 @@ queries:
 
         - **Direct administrative exposure:** A world-open SSH port is continuously scanned and attacked across the internet.
         - **Credential risk:** Exposed SSH endpoints are a primary target for password-guessing and key-compromise attacks.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Network** and select **Security Groups**.
+        3. Review the ingress rules of each security group and look for any rule whose port range covers TCP port 22 with a source of `0.0.0.0/0` or `::/0`.
+
+        A passing project has no security group admitting SSH from the open internet. A failing project has at least one such rule.
+
+        ### Audit via CLI
+
+        1. List the security groups in the project:
+
+        ```bash
+        stackit security-group list --output-format json
+        ```
+
+        2. For each security group, list its rules:
+
+        ```bash
+        stackit security-group rule list --security-group-id <security-group-id> --output-format json
+        ```
+
+        A failing rule has `direction` set to `ingress`, a port range that includes 22, and an IP range of `0.0.0.0/0` or `::/0`.
       remediation:
         - id: console
           desc: |
@@ -315,6 +381,30 @@ queries:
 
         - **Remote desktop exposure:** Publicly reachable RDP is aggressively scanned and exploited.
         - **Ransomware vector:** Internet-facing RDP is one of the most common initial-access vectors for ransomware.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Network** and select **Security Groups**.
+        3. Review the ingress rules of each security group and look for any rule whose port range covers TCP port 3389 with a source of `0.0.0.0/0` or `::/0`.
+
+        A passing project has no security group admitting RDP from the open internet. A failing project has at least one such rule.
+
+        ### Audit via CLI
+
+        1. List the security groups in the project:
+
+        ```bash
+        stackit security-group list --output-format json
+        ```
+
+        2. For each security group, list its rules:
+
+        ```bash
+        stackit security-group rule list --security-group-id <security-group-id> --output-format json
+        ```
+
+        A failing rule has `direction` set to `ingress`, a port range that includes 3389, and an IP range of `0.0.0.0/0` or `::/0`.
       remediation:
         - id: console
           desc: |
@@ -371,6 +461,30 @@ queries:
 
         - **Broad attack surface:** An all-ports world-open rule exposes every listening service, including management and database ports.
         - **Defeats segmentation:** Such a rule negates the benefit of fine-grained network controls.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Network** and select **Security Groups**.
+        3. Review the ingress rules of each security group and look for any rule that combines a source of `0.0.0.0/0` or `::/0` with the full port range.
+
+        A passing project scopes every world-open ingress rule to specific ports. A failing project has a rule that opens every port to the internet, which exposes all listening services on the attached servers.
+
+        ### Audit via CLI
+
+        1. List the security groups in the project:
+
+        ```bash
+        stackit security-group list --output-format json
+        ```
+
+        2. For each security group, list its rules:
+
+        ```bash
+        stackit security-group rule list --security-group-id <security-group-id> --output-format json
+        ```
+
+        A failing rule has `direction` set to `ingress`, an IP range of `0.0.0.0/0` or `::/0`, and either an unset port range or one spanning 1 to 65535.
       remediation:
         - id: console
           desc: |
@@ -427,6 +541,30 @@ queries:
 
         - **Backend exposure:** Without the target security group, backend servers may be reachable outside the intended load-balancer path.
         - **Posture drift:** Disabling managed assignment shifts responsibility to manual rules that are easy to misconfigure.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Application Load Balancer** and select the load balancer.
+        3. Confirm that automatic target security group assignment is still enabled.
+
+        A passing load balancer leaves the assignment enabled, so its targets stay behind the managed security group. A failing load balancer has it disabled.
+
+        ### Audit via CLI
+
+        1. List the application load balancers in the project:
+
+        ```bash
+        stackit beta alb list --output-format json
+        ```
+
+        2. Describe each load balancer and inspect its target security group setting:
+
+        ```bash
+        stackit beta alb describe <load-balancer-name> --output-format json
+        ```
+
+        A passing load balancer reports target security group assignment as not disabled. A failing load balancer reports it as disabled.
       remediation:
         - id: console
           desc: |
@@ -482,6 +620,30 @@ queries:
         - **Tamper-evidence:** Retained objects support reliable forensic and compliance evidence.
 
         Note: Object Lock must be enabled at bucket creation. Apply this check to buckets that store audit logs, backups, or regulated data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Object Storage** and select the bucket.
+        3. Confirm Object Lock is enabled on the bucket.
+
+        A passing bucket has Object Lock enabled, so its objects are protected against overwrite and deletion. A failing bucket has it disabled. Object Lock can only be set when a bucket is created, so a failing bucket cannot be corrected in place.
+
+        ### Audit via CLI
+
+        1. List the buckets in the project:
+
+        ```bash
+        stackit object-storage bucket list --output-format json
+        ```
+
+        2. Describe each bucket and inspect its Object Lock state:
+
+        ```bash
+        stackit object-storage bucket describe <bucket-name> --output-format json
+        ```
+
+        A passing bucket reports Object Lock as enabled. A failing bucket reports it as disabled.
       remediation:
         - id: console
           desc: |
@@ -529,6 +691,24 @@ queries:
 
         - **Consistent protection:** A default retention guarantees every new object is WORM-protected without relying on per-object configuration.
         - **Operational safety:** Reduces the chance of objects being deletable due to a forgotten retention setting.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Object Storage** and select the bucket.
+        3. For a bucket with Object Lock enabled, review its default retention settings and confirm a retention period of at least one day is configured.
+
+        A passing bucket either has Object Lock disabled, in which case default retention does not apply, or has Object Lock enabled together with a default retention period greater than zero. A failing bucket has Object Lock enabled but no default retention, so new objects are only protected when retention is set on each object individually.
+
+        ### Audit via CLI
+
+        1. Identify which buckets have Object Lock enabled:
+
+        ```bash
+        stackit object-storage bucket describe <bucket-name> --output-format json
+        ```
+
+        The CLI reports whether Object Lock is enabled but exposes no command for the bucket's default retention, so confirm the retention period for each Object-Locked bucket in the STACKIT Portal.
       remediation:
         - id: console
           desc: |
@@ -589,6 +769,24 @@ queries:
 
         - **Unauthenticated file access:** NFS typically relies on network reachability for access control; a world-open allow-list exposes the file data broadly.
         - **Data exfiltration risk:** Any reachable host could mount and read or write share contents.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **File Storage** and select the resource pool.
+        3. Review the pool's IP allow-list and confirm it does not contain `0.0.0.0/0` or `::/0`.
+
+        A passing resource pool lists only the specific subnets that must mount its shares. A failing resource pool admits the entire internet, so any host that can reach the endpoint can mount the shares it holds.
+
+        ### Audit via CLI
+
+        1. List the resource pools in the project and inspect their allow-lists:
+
+        ```bash
+        stackit beta sfs resource-pool list --output-format json
+        ```
+
+        A failing resource pool has `0.0.0.0/0` or `::/0` in its IP allow-list.
       remediation:
         - id: console
           desc: |
@@ -642,6 +840,24 @@ queries:
 
         - **Broad share exposure:** A world-open export rule lets any reachable host mount the share.
         - **Lateral movement:** Overly broad NFS access can aid an attacker pivoting within the environment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **File Storage** and select **Export Policies**.
+        3. Review each policy's rules and confirm no rule's IP allow-list contains `0.0.0.0/0` or `::/0`.
+
+        A passing export policy scopes every rule to specific client CIDRs. A failing export policy has a rule open to the entire internet, which removes the network boundary protecting the share data.
+
+        ### Audit via CLI
+
+        1. List the export policies in the project and inspect the allow-list of every rule:
+
+        ```bash
+        stackit beta sfs export-policy list --output-format json
+        ```
+
+        A failing rule has `0.0.0.0/0` or `::/0` in its IP allow-list.
       remediation:
         - id: console
           desc: |
@@ -694,6 +910,30 @@ queries:
 
         - **Recoverability:** Snapshots enable restoration of file data after destructive events.
         - **Ransomware resilience:** Regular snapshots provide a recovery path that does not depend on the live data.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **File Storage** and select the resource pool.
+        3. Confirm a snapshot policy is attached to the pool.
+
+        A passing resource pool has a snapshot policy attached, giving it point-in-time copies to restore from. A failing resource pool has none, so accidental deletion or corruption of its file data has no recovery path.
+
+        ### Audit via CLI
+
+        1. List the resource pools in the project and check whether each references a snapshot policy:
+
+        ```bash
+        stackit beta sfs resource-pool list --output-format json
+        ```
+
+        2. List the snapshot policies available in the project:
+
+        ```bash
+        stackit beta sfs snapshot-policy list --output-format json
+        ```
+
+        A passing resource pool reports a snapshot policy ID. A failing resource pool reports an empty one.
       remediation:
         - id: console
           desc: |
@@ -748,6 +988,24 @@ queries:
 
         - **Direct data exposure:** A world-open database ACL puts the data one credential away from the entire internet.
         - **Attack surface:** Internet-reachable database ports are continuously scanned and attacked.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **PostgreSQL Flex** and select the instance.
+        3. Review the instance's access control list and confirm it does not contain `0.0.0.0/0` or `::/0`.
+
+        A passing instance restricts its ACL to the application subnets that need connectivity. A failing instance is reachable from the entire internet, leaving the data one credential away from any host on the network.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its ACL:
+
+        ```bash
+        stackit postgresflex instance describe <instance-id> --output-format json
+        ```
+
+        A failing instance lists `0.0.0.0/0` or `::/0` in its ACL.
       remediation:
         - id: console
           desc: |
@@ -804,6 +1062,24 @@ queries:
 
         - **Recoverability:** A backup schedule provides restore points for the database.
         - **Business continuity:** Backups limit data loss after a destructive incident.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **PostgreSQL Flex** and select the instance.
+        3. Confirm a backup schedule is configured for the instance.
+
+        A passing instance has a backup schedule set, giving it restore points to recover from. A failing instance has none.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its backup schedule:
+
+        ```bash
+        stackit postgresflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports a cron backup schedule. A failing instance reports an empty one.
       remediation:
         - id: console
           desc: |
@@ -861,6 +1137,24 @@ queries:
 
         - **Direct data exposure:** A world-open ACL exposes the database to the entire internet.
         - **Attack surface:** Open database ports are continuously scanned and attacked.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **MongoDB Flex** and select the instance.
+        3. Review the instance's access control list and confirm it does not contain `0.0.0.0/0` or `::/0`.
+
+        A passing instance restricts its ACL to the application subnets that need connectivity. A failing instance is reachable from the entire internet, making it a standing target for data theft and extortion.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its ACL:
+
+        ```bash
+        stackit mongodbflex instance describe <instance-id> --output-format json
+        ```
+
+        A failing instance lists `0.0.0.0/0` or `::/0` in its ACL.
       remediation:
         - id: console
           desc: |
@@ -917,6 +1211,24 @@ queries:
 
         - **Recoverability:** A backup schedule provides restore points for the database.
         - **Business continuity:** Backups limit data loss after a destructive incident.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **MongoDB Flex** and select the instance.
+        3. Confirm a backup schedule is configured for the instance.
+
+        A passing instance has a backup schedule set, giving it restore points to recover from. A failing instance has none.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its backup schedule:
+
+        ```bash
+        stackit mongodbflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports a cron backup schedule. A failing instance reports an empty one.
       remediation:
         - id: console
           desc: |
@@ -974,6 +1286,24 @@ queries:
 
         - **Direct data exposure:** A world-open ACL exposes the database to the entire internet.
         - **Attack surface:** Open database ports are continuously scanned and attacked.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **SQLServer Flex** and select the instance.
+        3. Review the instance's access control list and confirm it does not contain `0.0.0.0/0` or `::/0`.
+
+        A passing instance restricts its ACL to the application subnets that need connectivity. A failing instance is reachable from the entire internet, exposing it to brute-force and exploitation attempts.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its ACL:
+
+        ```bash
+        stackit beta sqlserverflex instance describe <instance-id> --output-format json
+        ```
+
+        A failing instance lists `0.0.0.0/0` or `::/0` in its ACL.
       remediation:
         - id: console
           desc: |
@@ -1030,6 +1360,24 @@ queries:
 
         - **Recoverability:** A backup schedule provides restore points for the database.
         - **Business continuity:** Backups limit data loss after a destructive incident.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **SQLServer Flex** and select the instance.
+        3. Confirm a backup schedule is configured for the instance.
+
+        A passing instance has a backup schedule set, giving it restore points to recover from. A failing instance has none.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its backup schedule:
+
+        ```bash
+        stackit beta sqlserverflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports a cron backup schedule. A failing instance reports an empty one.
       remediation:
         - id: console
           desc: |
@@ -1089,6 +1437,24 @@ queries:
         - **Durability:** Replication reduces the risk of data loss from a single-node failure.
 
         Note: Single-replica instances may be acceptable for development workloads; tune the expectation to your environment.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **PostgreSQL Flex** and select the instance.
+        3. Review the instance's replica count.
+
+        A passing instance runs two or more replicas, so it survives the loss of a node without an outage. A failing instance runs a single replica and has no automatic failover. A single replica can be a deliberate choice for development workloads, so weigh a failure against the role the instance plays.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its replica count:
+
+        ```bash
+        stackit postgresflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports two or more replicas. A failing instance reports one.
       remediation:
         - id: console
           desc: |
@@ -1149,6 +1515,24 @@ queries:
         - **Durability:** Replication reduces the risk of data loss from a single-node failure.
 
         Note: Single-replica instances may be acceptable for development workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **MongoDB Flex** and select the instance.
+        3. Review the instance's replica count.
+
+        A passing instance runs two or more replicas, so it survives the loss of a node without an outage. A failing instance runs a single replica and has no automatic failover. A single replica can be a deliberate choice for development workloads, so weigh a failure against the role the instance plays.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its replica count:
+
+        ```bash
+        stackit mongodbflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports two or more replicas. A failing instance reports one.
       remediation:
         - id: console
           desc: |
@@ -1212,6 +1596,24 @@ queries:
         - **Durability:** Replication reduces the risk of data loss from a single-node failure.
 
         Note: Single-replica instances may be acceptable for development workloads.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **SQLServer Flex** and select the instance.
+        3. Review the instance's replica count, which follows from the edition the instance runs.
+
+        A passing instance runs two or more replicas, so it survives the loss of a node without an outage. A failing instance runs a single replica and has no automatic failover. A single replica can be a deliberate choice for development workloads, so weigh a failure against the role the instance plays.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its replica count:
+
+        ```bash
+        stackit beta sqlserverflex instance describe <instance-id> --output-format json
+        ```
+
+        A passing instance reports two or more replicas. A failing instance reports one.
       remediation:
         - id: console
           desc: |
@@ -1250,6 +1652,24 @@ queries:
 
         - **Sensitive data exposure:** Secrets Manager holds credentials whose compromise can cascade across systems.
         - **Reduced attack surface:** Restricting the ACL limits who can even attempt to reach the secrets API.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Secrets Manager** and select the instance.
+        3. Review the instance's access control list and confirm it does not contain `0.0.0.0/0` or `::/0`.
+
+        A passing instance restricts its ACL to the subnets that must reach the secrets API. A failing instance accepts connections from the entire internet, widening the attack surface around the credentials it stores.
+
+        ### Audit via CLI
+
+        1. Describe the instance and inspect its ACL:
+
+        ```bash
+        stackit secrets-manager instance describe <instance-id> --output-format json
+        ```
+
+        A failing instance lists `0.0.0.0/0` or `::/0` in its ACL.
       remediation:
         - id: console
           desc: |
@@ -1298,6 +1718,30 @@ queries:
 
         - **Bounded exposure:** An expiry limits how long a leaked key remains usable.
         - **Forced rotation:** Expiring keys drive regular credential rotation, reducing the blast radius of a compromise.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Service Accounts** and select the account.
+        3. Review its keys and confirm every active key carries a validity end date.
+
+        A passing project has an expiry on every active service account key. A failing project has an active key that never expires, so a leak of that key grants programmatic access until someone revokes it by hand.
+
+        ### Audit via CLI
+
+        1. List the service accounts in the project:
+
+        ```bash
+        stackit service-account list --output-format json
+        ```
+
+        2. For each service account, list its keys:
+
+        ```bash
+        stackit service-account key list --email <service-account-email> --output-format json
+        ```
+
+        A failing key is active and reports no validity end date.
       remediation:
         - id: console
           desc: |
@@ -1345,6 +1789,30 @@ queries:
 
         - **Bounded exposure:** An expiry limits how long a leaked token remains usable.
         - **Credential hygiene:** Enforcing expiry drives regular rotation of access tokens.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Service Accounts** and select the account.
+        3. Review its access tokens and confirm every active token carries a validity end date.
+
+        A passing project has an expiry on every active access token. A failing project has an active token that never expires, so a leak of that token grants programmatic access until someone revokes it by hand.
+
+        ### Audit via CLI
+
+        1. List the service accounts in the project:
+
+        ```bash
+        stackit service-account list --output-format json
+        ```
+
+        2. For each service account, list its access tokens:
+
+        ```bash
+        stackit service-account token list --email <service-account-email> --output-format json
+        ```
+
+        A failing token is active and reports no validity end date.
       remediation:
         - id: console
           desc: |
@@ -1383,6 +1851,30 @@ queries:
 
         - **Irreversible data loss:** Data encrypted with a deleted KMS key cannot be decrypted.
         - **Early detection:** Surfacing pending deletions allows the deletion to be cancelled before it is too late.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Key Management Service** and select the key ring.
+        3. Review its keys and confirm none carries a scheduled deletion date.
+
+        A passing key has no deletion date set. A failing key is scheduled for deletion, and once that date passes any data still encrypted under it becomes unrecoverable.
+
+        ### Audit via CLI
+
+        1. List the key rings in the project:
+
+        ```bash
+        stackit kms keyring list --output-format json
+        ```
+
+        2. For each key ring, list its keys and inspect their deletion dates:
+
+        ```bash
+        stackit kms key list --keyring-id <keyring-id> --output-format json
+        ```
+
+        A failing key reports a deletion date.
       remediation:
         - id: console
           desc: |
@@ -1420,6 +1912,30 @@ queries:
 
         - **Operational integrity:** A key in an error state may prevent decryption of protected data.
         - **Early detection:** Surfacing unhealthy keys prompts investigation before dependent workloads fail.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Key Management Service** and select the key ring.
+        3. Review the reported state of each key.
+
+        A passing key reports a healthy state. A failing key reports `errors_exist` or `not_available` and cannot perform cryptographic operations, which breaks encryption and decryption for everything depending on it.
+
+        ### Audit via CLI
+
+        1. List the key rings in the project:
+
+        ```bash
+        stackit kms keyring list --output-format json
+        ```
+
+        2. For each key ring, list its keys and inspect their states:
+
+        ```bash
+        stackit kms key list --keyring-id <keyring-id> --output-format json
+        ```
+
+        A failing key reports a state of `errors_exist` or `not_available`.
       remediation:
         - id: console
           desc: |
@@ -1458,6 +1974,24 @@ queries:
 
         - **Patch and policy enforcement:** An unhealthy cluster may not reliably apply updates or admission controls.
         - **Operational visibility:** Surfacing unhealthy clusters prompts timely investigation.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Kubernetes Engine (SKE)** and select the cluster.
+        3. Review the cluster's reported state.
+
+        A passing cluster reports any state other than unhealthy, including hibernated, which is a valid operational state. A failing cluster reports `STATE_UNHEALTHY`, meaning it may not be applying updates or enforcing admission policy reliably.
+
+        ### Audit via CLI
+
+        1. Describe the cluster and inspect its status:
+
+        ```bash
+        stackit ske cluster describe <cluster-name> --output-format json
+        ```
+
+        A failing cluster reports a status of `STATE_UNHEALTHY`.
       remediation:
         - id: console
           desc: |
@@ -1495,6 +2029,24 @@ queries:
 
         - **Timely patching:** Auto-update ensures the cluster receives Kubernetes security fixes during its maintenance window.
         - **Supported versions:** Staying current avoids running end-of-life Kubernetes releases that no longer receive fixes.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Kubernetes Engine (SKE)** and select the cluster.
+        3. Open its maintenance settings and confirm automatic Kubernetes version updates are enabled.
+
+        A passing cluster has automatic Kubernetes version updates enabled, so security fixes land during its maintenance window. A failing cluster has them disabled and will drift onto unsupported versions.
+
+        ### Audit via CLI
+
+        1. Describe the cluster and inspect its maintenance configuration:
+
+        ```bash
+        stackit ske cluster describe <cluster-name> --output-format json
+        ```
+
+        A passing cluster reports automatic Kubernetes version updates as enabled under its maintenance settings. A failing cluster reports them as disabled or absent.
       remediation:
         - id: console
           desc: |
@@ -1550,6 +2102,24 @@ queries:
         - **Private is stronger than filtered:** An `SNA` control plane is not published on the internet at all, which removes the API server from internet-wide scanning entirely rather than relying on an allow-list to filter it.
         - **Control-plane exposure:** A PUBLIC, unrestricted API server is continuously scanned and is a primary target for credential and exploit attacks.
         - **Defense in depth:** Where the control plane must remain public, an IP allow-list that excludes the open-internet ranges ensures only known networks can even attempt to authenticate to the cluster.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Kubernetes Engine (SKE)** and select the cluster.
+        3. Review the control-plane access scope. If the scope is `SNA`, the API server is private and no further review is needed. If the scope is `PUBLIC`, open the cluster's API-server ACL settings and confirm the ACL is enabled and its allowed ranges exclude `0.0.0.0/0` and `::/0`.
+
+        A passing cluster either runs a private control plane or publishes one behind an enabled ACL whose allowed ranges exclude the open internet. A failing cluster publishes its API server with the ACL disabled, or with an allow-list that admits any address.
+
+        ### Audit via CLI
+
+        1. Describe the cluster and inspect its control-plane access scope and API-server ACL:
+
+        ```bash
+        stackit ske cluster describe <cluster-name> --output-format json
+        ```
+
+        A failing cluster reports a public control-plane access scope together with an ACL that is disabled or that lists `0.0.0.0/0` or `::/0`.
       remediation:
         - id: console
           desc: |
@@ -1605,6 +2175,24 @@ queries:
 
         - **False sense of security:** A world-open entry in the allow-list defeats the purpose of the ACL.
         - **Control-plane exposure:** Any host on the internet can reach the Kubernetes API server and attempt to authenticate.
+      audit: |
+        ### Audit via Console
+
+        1. Sign in to the STACKIT Portal.
+        2. Open **Kubernetes Engine (SKE)** and select the cluster.
+        3. Review the API-server ACL and confirm its allowed ranges do not include `0.0.0.0/0` or `::/0`.
+
+        A passing cluster lists only specific administrative or VPN ranges. A failing cluster carries a world-open entry, which leaves the ACL configured in appearance while admitting every host on the internet.
+
+        ### Audit via CLI
+
+        1. Describe the cluster and inspect the allowed ranges of its API-server ACL:
+
+        ```bash
+        stackit ske cluster describe <cluster-name> --output-format json
+        ```
+
+        A failing cluster lists `0.0.0.0/0` or `::/0` among its allowed ranges.
       remediation:
         - id: console
           desc: |
@@ -1661,6 +2249,14 @@ queries:
 
         - **Bounded exposure:** Expiring tokens limit how long a leaked credential remains valid.
         - **Credential hygiene:** Enforcing expiry encourages regular rotation.
+      audit: |
+        1. Sign in to the STACKIT Portal.
+        2. Open **Telemetry Router** and select the router.
+        3. Review its access tokens and confirm each one carries an expiry time.
+
+        A passing router has an expiry on every access token. A failing router has a token that never expires, so a leak of that token stays usable until someone revokes it by hand.
+
+        The STACKIT CLI has no telemetry router commands, so review the tokens in the STACKIT Portal.
       remediation:
         - id: console
           desc: |
@@ -1710,6 +2306,14 @@ queries:
 
         - **Stale credential cleanup:** Removing expired tokens reduces clutter and the chance of confusion during audits.
         - **Hygiene:** Lingering expired credentials can mask active ones during review.
+      audit: |
+        1. Sign in to the STACKIT Portal.
+        2. Open **Telemetry Router** and select the router.
+        3. Review its access tokens and compare each expiry time against the current date.
+
+        A passing router carries no token whose expiry has already passed. A failing router still holds an expired token, which clutters the credential list and can mask the active tokens during a review.
+
+        The STACKIT CLI has no telemetry router commands, so review the tokens in the STACKIT Portal.
       remediation:
         - id: console
           desc: |
@@ -1749,6 +2353,14 @@ queries:
 
         - **Bounded exposure:** A validity end date limits how long a leaked token remains usable.
         - **Credential hygiene:** Enforcing expiry encourages regular rotation of inference credentials.
+      audit: |
+        1. Sign in to the STACKIT Portal.
+        2. Open **Model Serving** and review the project's authentication tokens.
+        3. Confirm each token carries a validity end date.
+
+        A passing project has a validity end date on every Model Serving token. A failing project has a token that never expires, so a leak of that token grants inference access until someone revokes it by hand.
+
+        The STACKIT CLI has no Model Serving commands, so review the tokens in the STACKIT Portal.
       remediation:
         - id: console
           desc: |
@@ -1797,6 +2409,14 @@ queries:
 
         - **Stale credential cleanup:** Removing expired tokens reduces clutter and audit confusion.
         - **Hygiene:** Lingering expired credentials can obscure active ones during review.
+      audit: |
+        1. Sign in to the STACKIT Portal.
+        2. Open **Model Serving** and review the project's authentication tokens.
+        3. Compare each token's validity end date against the current date.
+
+        A passing project carries no token whose validity has already lapsed. A failing project still holds an expired token, which clutters the credential list and can obscure the active tokens during a review.
+
+        The STACKIT CLI has no Model Serving commands, so review the tokens in the STACKIT Portal.
       remediation:
         - id: console
           desc: |
@@ -1981,10 +2601,16 @@ queries:
 
         ### Audit via CLI
 
-        1. List the keys in the project and inspect their versions:
+        1. List the key rings in the project:
 
         ```bash
-        stackit kms key list --output-format json
+        stackit kms keyring list --output-format json
+        ```
+
+        2. For each key ring, list its keys and inspect their versions:
+
+        ```bash
+        stackit kms key list --keyring-id <keyring-id> --output-format json
         ```
 
         For each key, confirm the newest active version's creation date is within the last year. A failing key's most recent active version is older than one year.


### PR DESCRIPTION
## What

33 of the 36 checks in `mondoo-stackit-security.mql.yaml` had `desc:` and `remediation:` but no `audit:` section. `content/CLAUDE.md` requires all three, but no lint rule enforces it, so `cnspec policy lint` passed the bundle and the gap survived review since the policy landed in #2862.

This adds an `audit:` block to all 33, bringing the policy to full coverage. It is the second-worst bundle in `content/`; the remaining one is `mondoo-phoenix-plcnext-security.mql.yaml` at 19 of 22, which this PR does not touch.

## Shape

Each audit follows the house style already set by the policy's three documented checks:

- **Audit via Console** — numbered click-through, ending in what a passing vs. failing result looks like.
- **Audit via CLI** — the `stackit` command that reads the same state, ending in the same pass/fail sentence.

Telemetry Router and Model Serving have no commands in the STACKIT CLI, so those four checks are console-only and say why, per the "fall back to console click-through when no CLI exists" rule.

## Command verification

There is no STACKIT command validator in `content/validation/` — unlike `azure_commands.json` or `vercel_commands.json`, nothing would catch a hallucinated flag at CI time. Every `stackit` invocation was instead resolved against the CLI's own generated command reference (the 641 `docs/stackit_*.md` files in `stackitcloud/stackit-cli`), matching each command path to a real doc file and each flag to that command's documented flag set. All 23 distinct commands resolve.

That check also caught a defect in an **existing** audit: `mondoo-stackit-security-kms-key-recently-rotated` ran `stackit kms key list --output-format json`, but the CLI requires `--keyring-id` to scope the listing. Fixed here to list the key rings first, matching the two new KMS audits.

## Verification

- `cnspec policy lint ./content` — valid (the two `terraform.resources` warnings are pre-existing and from other bundles)
- `go test ./content/validation/compliance` — ok
- `typos content/mondoo-stackit-security.mql.yaml` — clean
- YAML re-parsed and every check confirmed to resolve a non-empty `docs.audit`

No check logic, filters, impact, or compliance tags changed, so the policy version stays at 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)