### PR TITLE
📝 plcnext: add missing audit sections to the PLCnext Security policy

### DIFF
--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -218,6 +218,10 @@ queries:
       sshd.config.kexs.containsOnly(props.PLCKexAlgos)
     docs:
       desc: Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received
+      audit: |
+        Run `grep -riE '^\s*KexAlgorithms' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null` and review the configured key exchange algorithms.
+
+        A passing controller sets `KexAlgorithms` and lists only algorithms from the approved set in the `PLCKexAlgos` property. A failing controller leaves the directive unset, or names an algorithm outside that set. Run `ssh -Q kex` to see which algorithms the firmware supports before changing the list.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `KexAlgorithms` parameter so that it contains a comma-separated list of the site approved key exchange algorithms:
 
@@ -261,6 +265,10 @@ queries:
       sshd.config.macs.containsOnly(props.PLCMacAlgos)
     docs:
       desc: This variable limits the types of MAC algorithms that SSH can use during communication.
+      audit: |
+        Run `grep -riE '^\s*MACs' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null` and review the configured MAC algorithms.
+
+        A passing controller sets `MACs` and lists only algorithms from the approved set in the `PLCMacAlgos` property. A failing controller leaves the directive unset, or names an algorithm outside that set. Run `ssh -Q mac` to see which algorithms the firmware supports before changing the list.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `MACs` parameter so that it contains a comma-separated list of the site approved MACs:
 
@@ -304,6 +312,10 @@ queries:
       sshd.config.ciphers.containsOnly(props.PLCSshdCiphers)
     docs:
       desc: This variable limits the ciphers that SSH can use during communication.
+      audit: |
+        Run `grep -riE '^\s*Ciphers' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null` and review the configured ciphers.
+
+        A passing controller sets `Ciphers` and lists only ciphers from the approved set in the `PLCSshdCiphers` property. A failing controller leaves the directive unset, or names a cipher outside that set. Run `ssh -Q cipher` to see which ciphers the firmware supports before changing the list.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to add or modify the `Ciphers` parameter so that it contains a comma-separated list of the site approved ciphers:
 
@@ -398,6 +410,10 @@ queries:
         }
     docs:
       desc: An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key corresponding to a public key can authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed.
+      audit: |
+        Run `ls -l /etc/ssh/ssh_host_*_key` and review the mode of each private host key.
+
+        A passing controller reports `-rw-------` or stricter on every private host key, so only the owner can read it. A failing controller grants any read, write, or execute permission to the group or to other users, or marks the key executable for its owner.
       remediation:
         - id: cli
           desc: |
@@ -441,6 +457,10 @@ queries:
         }
     docs:
       desc: An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key corresponding to a private key can authenticate successfully.
+      audit: |
+        Run `ls -l /etc/ssh/ssh_host_*_key.pub` and review the mode of each public host key.
+
+        A passing controller reports `-rw-r--r--` or stricter, so the keys are world-readable but writable only by their owner. A failing controller grants write or execute permission to the group or to other users, or marks the key executable for its owner.
       remediation: |-
         Run this command to set permissions and ownership on the SSH host public key files:
 
@@ -474,6 +494,10 @@ queries:
       sshd.config.params["Protocol"] == 2
     docs:
       desc: 'SSH supports two different and incompatible protocols: SSH1 and SSH2. SSH1 was the original protocol and was subject to security issues. SSH2 is more advanced and secure.'
+      audit: |
+        Run `grep -riE '^\s*Protocol' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `Protocol 2`. A failing controller sets protocol 1 or leaves the directive unset. OpenSSH 7.4 and later implement only protocol 2 and treat the keyword as deprecated, so on current firmware the directive documents the requirement rather than changing behavior, and this check still expects it to be present.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `Protocol` parameter as follows:
 
@@ -512,6 +536,10 @@ queries:
         `INFO` level is the basic level that only records the login activity of SSH users. In many situations, such as incident response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field.
 
         `VERBOSE` level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments.
+      audit: |
+        Run `grep -riE '^\s*LogLevel' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `LogLevel` to `INFO` or `VERBOSE`, so logins and logouts are recorded. A failing controller sets a quieter level such as `QUIET` or `ERROR`, or leaves the directive unset, which leaves no record of who reached the controller and when.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `LogLevel` parameter as follows:
 
@@ -553,6 +581,10 @@ queries:
       sshd.config.params["X11Forwarding"] == "no"
     docs:
       desc: The X11Forwarding parameter allows tunneling X11 traffic through the connection to enable remote graphic connections.
+      audit: |
+        Run `grep -riE '^\s*X11Forwarding' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `X11Forwarding no`. A failing controller sets it to `yes` or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `X11Forwarding` parameter as follows:
 
@@ -588,6 +620,10 @@ queries:
       sshd.config.params["MaxAuthTries"] <= 4
     docs:
       desc: The `MaxAuthTries` parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half this maximum value, error messages will be written to the `syslog` file detailing the login failure.
+      audit: |
+        Run `grep -riE '^\s*MaxAuthTries' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `MaxAuthTries` to 4 or less. A failing controller sets a higher value or leaves the directive unset, in which case the OpenSSH default of 6 applies and the check fails.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `MaxAuthTries` parameter as follows:
 
@@ -623,6 +659,10 @@ queries:
       sshd.config.params["IgnoreRhosts"] == "yes"
     docs:
       desc: The `IgnoreRhosts` parameter tells the SSH daemon to ignore `.rhosts` and `.shosts` files when deciding whether to authenticate a user. Those files are part of host-based authentication, an obsolete mechanism that trusts a remote host's claim about which user is connecting. That trust is easily spoofed, so disabling it removes a weak path into the controller.
+      audit: |
+        Run `grep -riE '^\s*IgnoreRhosts' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `IgnoreRhosts yes`, so `.rhosts` and `.shosts` trust files are ignored. A failing controller sets it to `no` or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Setting `IgnoreRhosts yes` stops the SSH daemon from honoring per-user `.rhosts` and `.shosts` trust files, which closes off an old and easily spoofed way to bypass real authentication. Modern OpenSSH usually defaults to this already, so on current firmware this setting often just confirms the secure behavior rather than changing it.
 
@@ -660,6 +700,10 @@ queries:
       sshd.config.params["HostbasedAuthentication"] == "no"
     docs:
       desc: The `HostbasedAuthentication` parameter controls whether the SSH daemon will accept a login based on the remote host vouching for the user, using files such as `.rhosts` or `/etc/hosts.equiv`. This trusts a remote host's claim about who the user is, which is easily spoofed and is considered obsolete, so it should stay disabled.
+      audit: |
+        Run `grep -riE '^\s*HostbasedAuthentication' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `HostbasedAuthentication no`, so a remote host cannot vouch for the user. A failing controller sets it to `yes` or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Setting `HostbasedAuthentication no` ensures every login is authenticated by the user's own credentials, such as an SSH key, instead of trusting a remote host to vouch for the user. Host-based trust is easily spoofed and obsolete, so disabling it removes a weak way into the controller. Modern OpenSSH usually defaults to this already, so on current firmware this setting often just confirms the secure behavior rather than changing it.
 
@@ -697,6 +741,10 @@ queries:
       sshd.config.params["PermitRootLogin"] == "no" || sshd.config.params["PermitRootLogin"] == "prohibit-password"
     docs:
       desc: The `PermitRootLogin` parameter specifies if the root user can log in using ssh(1). Blocking direct root login over SSH means an attacker must first compromise a named account before they can reach the most powerful account on the controller, and it ties every privileged action to an individual login for accountability.
+      audit: |
+        Run `grep -riE '^\s*PermitRootLogin' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `PermitRootLogin` to `no` or to `prohibit-password`, so root cannot log in with a password. A failing controller sets `yes` or `forced-commands-only`, or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Disabling direct root SSH login forces administrators to log in as a named user and then elevate, which both adds a barrier for attackers and creates an audit trail of who did what. Setting `prohibit-password` is a middle ground that still allows root login by SSH key while blocking password-based root login.
 
@@ -745,6 +793,10 @@ queries:
       sshd.config.params["PermitEmptyPasswords"] == "no"
     docs:
       desc: The `PermitEmptyPasswords` parameter specifies if the SSH server allows login to accounts with empty password strings.
+      audit: |
+        Run `grep -riE '^\s*PermitEmptyPasswords' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `PermitEmptyPasswords no`. A failing controller sets it to `yes` or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `PermitEmptyPasswords` parameter as follows:
 
@@ -780,6 +832,10 @@ queries:
       sshd.config.params["PermitUserEnvironment"] == "no"
     docs:
       desc: The `PermitUserEnvironment` option allows users to present environment options to the `ssh` daemon.
+      audit: |
+        Run `grep -riE '^\s*PermitUserEnvironment' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `PermitUserEnvironment no`, so a user cannot inject environment options at login. A failing controller sets it to `yes` or leaves the directive unset. The check reads the configured value rather than the effective one, so a directive that is absent from the configuration fails even though `sshd -T` reports the secure default.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `PermitUserEnvironment` parameter as follows:
 
@@ -820,6 +876,10 @@ queries:
       }
     docs:
       desc: The two options `ClientAliveInterval` and `ClientAliveCountMax` control the timeout of ssh sessions. When the `ClientAliveInterval` variable is set, ssh sessions that have no activity for the specified length of time are terminated. When the `ClientAliveCountMax` variable is set, `sshd` will send client alive messages at every `ClientAliveInterval` interval. When the number of consecutive client alive messages are sent with no response from the client, the `ssh` session is terminated. For example, if the `ClientAliveInterval` is set to 15 seconds and the `ClientAliveCountMax` is set to 3, the client `ssh` session will be terminated after 45 seconds of idle time.
+      audit: |
+        Run `grep -riE '^\s*ClientAlive(Interval|CountMax)' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null` and review both values together.
+
+        A passing controller sets `ClientAliveInterval` between 1 and 300 seconds and `ClientAliveCountMax` between 1 and 3, so an idle session is closed within a bounded time. A failing controller leaves either directive unset, or sets either to 0, which OpenSSH treats as never terminating an idle connection.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `ClientAliveInterval` and `ClientAliveCountMax` parameters according to site policy:
 
@@ -859,6 +919,10 @@ queries:
       }
     docs:
       desc: The `LoginGraceTime` parameter specifies the time allowed for successful authentication to the SSH server. The longer the grace period is, the more open unauthenticated connections can exist. Like other session controls, the grace period should be limited to appropriate organizational limits to ensure the service is available for needed access.
+      audit: |
+        Run `grep -riE '^\s*LoginGraceTime' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets `LoginGraceTime` between 1 and 60 seconds. A failing controller sets a longer window or 0, which removes the limit entirely, or leaves the directive unset, in which case the OpenSSH default of 120 seconds applies and the check fails.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file to set the `LoginGraceTime` parameter as follows:
 
@@ -903,6 +967,10 @@ queries:
         The `DenyUsers` variable gives the system administrator the option of denying specific users to `ssh` into the system. The list consists of space-separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying user access from a particular host, the entry can be specified in the form of user@host. `DenyGroups`
 
         The `DenyGroups` variable gives the system administrator the option of denying specific groups of users to `ssh` into the system. The list consists of space-separated group names. Numeric group IDs are not recognized with this variable.
+      audit: |
+        Run `grep -riE '^\s*(Allow|Deny)(Users|Groups)' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`.
+
+        A passing controller sets at least one of `AllowUsers`, `AllowGroups`, `DenyUsers`, or `DenyGroups`, so SSH is limited to a named set of accounts. A failing controller sets none of them, which leaves every account on the device able to log in over SSH.
       remediation: |-
         Edit the `/etc/ssh/sshd_config` file and add at least one of these parameters:
 
@@ -945,6 +1013,10 @@ queries:
       sshd.config.params["Banner"] != "none"
     docs:
       desc: The `Banner` parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed. A login banner states the system is restricted and use is monitored, which supports legal action against unauthorized access and warns casual intruders off before they authenticate.
+      audit: |
+        Run `grep -riE '^\s*Banner' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null`, then read the file it points at to confirm the notification text is present.
+
+        A passing controller sets `Banner` to the path of a system use notification file, typically `/opt/plcnext/config/System/Um/SystemUseNotification.txt`. A failing controller leaves the directive unset or sets it to `none`, so a user sees no warning before authenticating.
       remediation: |-
         Create a banner file containing your organization's system use notification, then point the SSH daemon at it:
 
@@ -997,6 +1069,10 @@ queries:
         While there are benefits to using only SSH key authentication, it is important to ensure that your SSH keys are managed properly, with strong passwords, and are backed up in case of loss or corruption.
 
         In summary, allowing only SSH key authentication can provide a more secure and convenient way to access remote systems, but it is important to manage your keys properly to ensure that the increased security is not compromised.
+      audit: |
+        Run `grep -riE '^\s*(Password|Pubkey)Authentication' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/ 2>/dev/null` and review both values together.
+
+        A passing controller sets `PasswordAuthentication no` and `PubkeyAuthentication yes`, so logins require a key. A failing controller allows password authentication, or leaves either directive unset. `PubkeyAuthentication` defaults to `yes`, but this check expects it to be set explicitly, so confirm the directive is present rather than relying on the default.
       remediation: |-
         Set up key-based authentication for your administrative account before disabling password authentication. If you disable password authentication without a working key, you lose SSH access to the controller.
 


### PR DESCRIPTION
## What

19 of the 22 checks in `mondoo-phoenix-plcnext-security.mql.yaml` had `desc:` and `remediation:` but no `audit:`. `content/CLAUDE.md` requires all three, but no lint rule enforces it, so `cnspec policy lint` passed the bundle.

With this and #3369, **every policy bundle in `content/` has full audit coverage** — 7,740 of 7,740 scored checks.

## Shape

This policy runs against an ARM Linux controller over SSH (`require: provider: os`), not a cloud API, so the audits name the command to run on the device shell and what its output must show. That matches the terse prose the three already-documented checks use (`phoenix-plcnext-01`, `-02`, `-06`) rather than importing the `### Audit via Console` / `### Audit via CLI` structure the cloud policies carry — there is no console path here.

## Why the audits grep the config file instead of running `sshd -T`

This is the detail that decides whether the audits are correct.

In the `os` provider, `sshd.config.params`, `.ciphers`, `.macs`, and `.kexs` are parsed from `/etc/ssh/sshd_config` and its `Include` files (`providers/os/resources/sshd.go:254`). `effectiveCiphers`, `effectiveMacs`, and `effectiveKexs` are *separate* fields backed by `sshd -T` (`sshd.go:388`). All 19 checks here read the file-parsed side.

So `sshd -T` — the obvious audit command — would be actively misleading. For a directive like `X11Forwarding`, whose OpenSSH default is already `no`, `sshd -T` prints `x11forwarding no` and reads as a pass, while the check sees `params["X11Forwarding"]` as null and **fails**. An auditor following that step would contradict the scanner and conclude the scanner was wrong.

The audits therefore grep the configuration, and for the seven directives whose built-in default already matches the secure value (`X11Forwarding`, `IgnoreRhosts`, `HostbasedAuthentication`, `PermitRootLogin`, `PermitEmptyPasswords`, `PermitUserEnvironment`, `PubkeyAuthentication`) they state explicitly that an absent directive still fails.

## Verification

- All 17 grep patterns run against a sample `sshd_config`, including an indented directive and the two multi-match cases (`ClientAlive(Interval|CountMax)`, `(Password|Pubkey)Authentication`)
- Every OpenSSH default named in the prose checked against `sshd_config(5)`: `MaxAuthTries` 6, `LoginGraceTime` 120s, `X11Forwarding` no, `IgnoreRhosts` yes, `HostbasedAuthentication` no, `PermitEmptyPasswords` no, `PermitUserEnvironment` no, `PermitRootLogin` prohibit-password, `PubkeyAuthentication` yes, `Banner` none
- `cnspec policy lint` — valid
- `go test ./content/validation/compliance` — ok
- `typos` — clean

No check logic, filters, impact, or compliance tags changed, so the policy version stays at 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)