### PR TITLE
✨ content: add Terraform variants to the ClickHouse Cloud, HCP and Neon policies

### DIFF
--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -23,17 +23,14 @@ policies:
         Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
     groups:
       - title: Network Access
-        filters: asset.platform == "clickhousecloud"
         checks:
           - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips
       - title: Encryption
-        filters: asset.platform == "clickhousecloud"
         checks:
           - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
     scoring_system: highest impact
 queries:
   - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips
-    filters: asset.platform == "clickhousecloud"
     title: Ensure ClickHouse Cloud services are not open to all IP addresses
     impact: 80
     tags:
@@ -51,8 +48,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      clickhousecloud.organization.services.all(openToAllIps == false)
+    variants:
+      - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-clickhousecloud
+        tags:
+          mondoo.com/filter-title: ClickHouse Cloud
+          mondoo.com/filter-icon: clickhousecloud
+      - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that no ClickHouse Cloud service is reachable from any IP address. A service is open to all IPs when its IP access list contains a wildcard entry such as `0.0.0.0/0` or `::/0`, which exposes the database endpoint to the entire internet.
@@ -118,8 +130,26 @@ queries:
         title: ClickHouse Cloud IP access lists
       - url: https://clickhouse.com/docs/cloud/manage/api/api-overview
         title: ClickHouse Cloud API
-  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
+  - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-clickhousecloud
     filters: asset.platform == "clickhousecloud"
+    mql: |
+      clickhousecloud.organization.services.all(openToAllIps == false)
+  # ip_access is required on clickhouse_service, so a service that parses at all declares one. An
+  # absent list is a malformed configuration rather than a permissive one, and the list operation
+  # fails it, which is the safe direction.
+  - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "clickhouse_service")
+    mql: |
+      terraform.resources("clickhouse_service").all(arguments["ip_access"].none(_["source"] == "0.0.0.0/0" || _["source"] == "::/0"))
+  - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "clickhouse_service")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "clickhouse_service").all(change.after["ip_access"].none(_["source"] == "0.0.0.0/0" || _["source"] == "::/0"))
+  - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "clickhouse_service")
+    mql: |
+      terraform.state.resources.where(type == "clickhouse_service").all(values["ip_access"].none(_["source"] == "0.0.0.0/0" || _["source"] == "::/0"))
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest
     title: Ensure ClickHouse Cloud services enable transparent data encryption
     impact: 70
     tags:
@@ -137,8 +167,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-11
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: |
-      clickhousecloud.organization.services.all(hasTransparentDataEncryption == true)
+    variants:
+      - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-clickhousecloud
+        tags:
+          mondoo.com/filter-title: ClickHouse Cloud
+          mondoo.com/filter-icon: clickhousecloud
+      - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that every ClickHouse Cloud service has transparent data encryption enabled, so data stored on disk is encrypted at rest. Transparent data encryption protects the stored data if the underlying storage is ever accessed outside the service.
@@ -169,7 +214,7 @@ queries:
             2. For an existing service, contact ClickHouse Cloud support or recreate the service on a tier that supports encryption at rest, then migrate the data.
         - id: terraform
           desc: |-
-            To provision a service with encryption at rest using the ClickHouse Cloud Terraform provider, configure the encryption key settings supported by the service resource:
+            To provision a service with transparent data encryption using the ClickHouse Cloud Terraform provider, enable it on the service. The feature requires an organization on the Enterprise plan:
 
             ```hcl
             resource "clickhouse_service" "example" {
@@ -185,10 +230,32 @@ queries:
                 }
               ]
 
-              encryption_key                     = var.kms_key_arn
-              encryption_assumed_role_identifier = var.kms_role_arn
+              transparent_data_encryption = {
+                enabled = true
+              }
             }
             ```
+
+            To hold the encryption key yourself rather than letting ClickHouse manage it, also set `encryption_key` and `encryption_assumed_role_identifier`. Those arguments select customer-managed keys; they do not turn the feature on by themselves.
     refs:
       - url: https://clickhouse.com/docs/en/cloud/security/cmek
         title: ClickHouse Cloud data encryption
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-clickhousecloud
+    filters: asset.platform == "clickhousecloud"
+    mql: |
+      clickhousecloud.organization.services.all(hasTransparentDataEncryption == true)
+  # transparent_data_encryption is the attribute the runtime field reflects. encryption_key selects a
+  # customer-managed key for the feature and does not enable it, so a service that sets only the key
+  # arguments is still unencrypted and fails here.
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "clickhouse_service")
+    mql: |
+      terraform.resources("clickhouse_service").all(arguments["transparent_data_encryption"]["enabled"] == true)
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "clickhouse_service")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "clickhouse_service").all(change.after["transparent_data_encryption"]["enabled"] == true)
+  - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "clickhouse_service")
+    mql: |
+      terraform.state.resources.where(type == "clickhouse_service").all(values["transparent_data_encryption"]["enabled"] == true)

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -23,18 +23,14 @@ policies:
         Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
     groups:
       - title: Network Exposure
-        filters: asset.platform == "hcp-organization"
         checks:
           - uid: mondoo-hcp-security-vault-no-public-endpoint
       - title: Logging & Monitoring
-        filters: asset.platform == "hcp-organization"
         checks:
           - uid: mondoo-hcp-security-vault-audit-log-export
     scoring_system: highest impact
 queries:
-  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
   - uid: mondoo-hcp-security-vault-no-public-endpoint
-    filters: asset.platform == "hcp-organization"
     title: Ensure HCP Vault clusters are not exposed without an IP allowlist
     impact: 80
     tags:
@@ -52,8 +48,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      hcp.projects.all(vaultClusters.all(publicEndpoint == false || ipAllowlist != empty))
+    variants:
+      - uid: mondoo-hcp-security-vault-no-public-endpoint-hcp-organization
+        tags:
+          mondoo.com/filter-title: HashiCorp Cloud Platform Organization
+          mondoo.com/filter-icon: hcp
+      - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that no HCP Vault cluster exposes an unrestricted public endpoint. A cluster may keep its public endpoint enabled only when an IP allowlist restricts which source addresses can reach it; a public endpoint with no allowlist puts the secrets engine on the open internet.
@@ -121,9 +132,26 @@ queries:
         title: HCP Vault
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference
-  # No Terraform variants: the runtime evaluates the live control-plane exposure of every cluster in the organization; per-cluster Terraform variants can be added in a follow-up.
-  - uid: mondoo-hcp-security-vault-audit-log-export
+  - uid: mondoo-hcp-security-vault-no-public-endpoint-hcp-organization
     filters: asset.platform == "hcp-organization"
+    mql: |
+      hcp.projects.all(vaultClusters.all(publicEndpoint == false || ipAllowlist != empty))
+  # public_endpoint defaults to false, so an absent argument leaves the cluster private and passes.
+  # ip_allowlist is a block rather than an argument, so a cluster with no allowlist has an empty
+  # blocks list, not a null one, and the disjunction resolves without a null guard.
+  - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcp_vault_cluster")
+    mql: |
+      terraform.resources("hcp_vault_cluster").all(arguments["public_endpoint"] != true || blocks.where(type == "ip_allowlist") != empty)
+  - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "hcp_vault_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "hcp_vault_cluster").all(change.after["public_endpoint"] != true || change.after["ip_allowlist"] != empty)
+  - uid: mondoo-hcp-security-vault-no-public-endpoint-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "hcp_vault_cluster")
+    mql: |
+      terraform.state.resources.where(type == "hcp_vault_cluster").all(values["public_endpoint"] != true || values["ip_allowlist"] != empty)
+  - uid: mondoo-hcp-security-vault-audit-log-export
     title: Ensure HCP Vault clusters export audit logs
     impact: 70
     tags:
@@ -141,8 +169,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-10-2-1
       compliance/soc2-2017: soc2-control-cc7-2-1
       compliance/vda-isa-5: vda-isa-5-5-2-4
-    mql: |
-      hcp.projects.all(vaultClusters.all(auditLogExport != empty))
+    variants:
+      - uid: mondoo-hcp-security-vault-audit-log-export-hcp-organization
+        tags:
+          mondoo.com/filter-title: HashiCorp Cloud Platform Organization
+          mondoo.com/filter-icon: hcp
+      - uid: mondoo-hcp-security-vault-audit-log-export-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hcp-security-vault-audit-log-export-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-hcp-security-vault-audit-log-export-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that every HCP Vault cluster streams its audit logs to an external destination. Audit logs record authentication events and every secret access, so exporting them off the cluster preserves the trail even if the cluster itself is tampered with or destroyed.
@@ -211,3 +254,21 @@ queries:
         title: HCP Vault audit logs
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference
+  - uid: mondoo-hcp-security-vault-audit-log-export-hcp-organization
+    filters: asset.platform == "hcp-organization"
+    mql: |
+      hcp.projects.all(vaultClusters.all(auditLogExport != empty))
+  # audit_log_config is a block, so a cluster that configures no export has an empty blocks list and
+  # fails. That is the correct verdict: streaming is off until the block names a destination.
+  - uid: mondoo-hcp-security-vault-audit-log-export-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "hcp_vault_cluster")
+    mql: |
+      terraform.resources("hcp_vault_cluster").all(blocks.where(type == "audit_log_config") != empty)
+  - uid: mondoo-hcp-security-vault-audit-log-export-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "hcp_vault_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "hcp_vault_cluster").all(change.after["audit_log_config"] != empty)
+  - uid: mondoo-hcp-security-vault-audit-log-export-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "hcp_vault_cluster")
+    mql: |
+      terraform.state.resources.where(type == "hcp_vault_cluster").all(values["audit_log_config"] != empty)

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -23,19 +23,20 @@ policies:
         Learn more about scanning databases in the [cnspec documentation](https://mondoo.com/docs/cnspec).
     groups:
       - title: Authentication
-        filters: asset.platform == "neon-organization"
         checks:
           - uid: mondoo-neon-security-org-require-mfa
       - title: Network Access
-        filters: asset.platform == "neon-organization"
         checks:
           - uid: mondoo-neon-security-project-block-public-connections
       - title: Data Protection
-        filters: asset.platform == "neon-organization"
         checks:
           - uid: mondoo-neon-security-project-no-stored-passwords
     scoring_system: highest impact
 queries:
+  # No Terraform variant: neither published Neon provider declares an organization resource.
+  # kislerdm/neon reaches org scope only through neon_org_api_key, and
+  # terraform-community-providers/neon stops at projects, so organization MFA cannot be expressed
+  # in HCL. It is also read-only in the API, which is why the remediation is console-only.
   - uid: mondoo-neon-security-org-require-mfa
     filters: asset.platform == "neon-organization"
     title: Ensure the Neon organization requires multi-factor authentication
@@ -104,7 +105,6 @@ queries:
       - url: https://neon.tech/docs/manage/organizations
         title: Neon Organizations
   - uid: mondoo-neon-security-project-block-public-connections
-    filters: asset.platform == "neon-organization"
     title: Ensure Neon projects block public connections
     impact: 80
     tags:
@@ -122,8 +122,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      neon.projects.all(blockPublicConnections == true)
+    variants:
+      - uid: mondoo-neon-security-project-block-public-connections-neon-organization
+        tags:
+          mondoo.com/filter-title: Neon Organization
+          mondoo.com/filter-icon: neon
+      - uid: mondoo-neon-security-project-block-public-connections-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-neon-security-project-block-public-connections-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-neon-security-project-block-public-connections-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that every Neon project blocks public connections. When public connections are blocked, the database is reachable only through the configured private networking or allowed IP ranges rather than from anywhere on the internet.
@@ -190,8 +205,26 @@ queries:
         title: Neon IP Allow
       - url: https://neon.com/docs/cli/projects
         title: Neon CLI projects command
-  - uid: mondoo-neon-security-project-no-stored-passwords
+  - uid: mondoo-neon-security-project-block-public-connections-neon-organization
     filters: asset.platform == "neon-organization"
+    mql: |
+      neon.projects.all(blockPublicConnections == true)
+  # block_public_connections is a string enum, not a bool: the provider documents 'yes' to activate,
+  # 'no' to deactivate, and omission to keep the platform default. Neon allows public connections by
+  # default, so an absent argument is an exposed project and fails.
+  - uid: mondoo-neon-security-project-block-public-connections-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "neon_project")
+    mql: |
+      terraform.resources("neon_project").all(arguments["block_public_connections"] == "yes")
+  - uid: mondoo-neon-security-project-block-public-connections-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "neon_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "neon_project").all(change.after["block_public_connections"] == "yes")
+  - uid: mondoo-neon-security-project-block-public-connections-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "neon_project")
+    mql: |
+      terraform.state.resources.where(type == "neon_project").all(values["block_public_connections"] == "yes")
+  - uid: mondoo-neon-security-project-no-stored-passwords
     title: Ensure Neon does not retain project role passwords
     impact: 60
     tags:
@@ -209,8 +242,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-2
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-5-2-6
-    mql: |
-      neon.projects.all(storePasswords == false)
+    variants:
+      - uid: mondoo-neon-security-project-no-stored-passwords-neon-organization
+        tags:
+          mondoo.com/filter-title: Neon Organization
+          mondoo.com/filter-icon: neon
+      - uid: mondoo-neon-security-project-no-stored-passwords-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-neon-security-project-no-stored-passwords-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-neon-security-project-no-stored-passwords-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |-
         This check ensures that no Neon project has password storage enabled, so Neon does not retain role passwords in a form its API can return. Retaining role passwords widens the blast radius of a control-plane or API-key compromise, because an attacker who reaches the API could read them. Note that some workflows rely on stored passwords for connection-string retrieval, so treat this as a hardening control weighed against that need.
@@ -281,3 +329,21 @@ queries:
         title: Neon Projects
       - url: https://neon.com/docs/reference/api-reference
         title: Neon API reference
+  - uid: mondoo-neon-security-project-no-stored-passwords-neon-organization
+    filters: asset.platform == "neon-organization"
+    mql: |
+      neon.projects.all(storePasswords == false)
+  # store_password is a string enum, not a bool, and it is singular where the API field is plural.
+  # Neon stores role passwords by default, so an absent argument keeps them stored and fails.
+  - uid: mondoo-neon-security-project-no-stored-passwords-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "neon_project")
+    mql: |
+      terraform.resources("neon_project").all(arguments["store_password"] == "no")
+  - uid: mondoo-neon-security-project-no-stored-passwords-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "neon_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "neon_project").all(change.after["store_password"] == "no")
+  - uid: mondoo-neon-security-project-no-stored-passwords-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "neon_project")
+    mql: |
+      terraform.state.resources.where(type == "neon_project").all(values["store_password"] == "no")

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -335,6 +335,36 @@ Things to know when touching this:
 - **Grammars are not string bumps.** The pin records which tool produced the checked-in JSON, so it moves by installing that tool and re-running the dump script. `--all` reports them as skipped rather than pretending.
 - **`upstream/dump/vercel.py` is the one place a version is written twice** (its `VERCEL_VERSION` constant and the JSON's `_meta`). `bump.py --sync-dump-pins` pulls the constant back into line after a regeneration.
 
+## Adding a policy: what to register
+
+A new check inherits the coverage its policy already has. A new *policy* inherits nothing. Most
+validators here are allowlist-driven, so a `content/*.mql.yaml` that nobody registers is scanned by
+`bash.py` and the lint pass and by nothing else — the bundle ships unexamined with every gate green.
+`bash.py` is the exception on purpose; the comment on its `TARGETS` explains why.
+
+Register the policy everywhere it applies, in the same change that adds it:
+
+| Where | When it applies | What happens if you skip it |
+|---|---|---|
+| `remediation/code/terraform.py` → `TARGETS` **and** `PROVIDER_MAP` | any `hcl` remediation block | snippets are never resolved against the provider schema |
+| `remediation/code/{cloudformation,bicep,ansible,powershell,chef}.py` → `TARGETS` | that language appears in a remediation block | same, for that language |
+| `remediation/commands/` → `CLI_VALIDATORS`, `COBRA_CLIS`, or `API_PROVIDERS` | any `bash` remediation calls a vendor CLI or REST API | invented commands and endpoints ship unchallenged |
+| `scans/iac_variants_test.go` → `tfVariantPolicies` | the policy has any IaC variant | variants are never scanned, and coverage never asks for fixtures |
+
+A policy in `PROVIDER_MAP` needs a real provider source and a version constraint that resolves; a
+constraint matching only prereleases silently fails to resolve.
+
+### Group filters and variants do not mix
+
+A policy whose groups carry `filters: asset.platform == "<api-platform>"` cannot have IaC variants.
+The group filter is evaluated before the check's own filter, so a Terraform asset never reaches the
+variant and every fixture reports as *skipped* rather than pass or fail. Policies with variants leave
+their groups unfiltered and let each variant's `filters:` select its asset — that is why
+`mondoo-tailscale-security` and `mondoo-snowflake-security` declare no group filters.
+
+The failure mode is loud once you have fixtures (`check did not run against …`) and invisible before
+that, so convert the groups in the same change that adds the first variant.
+
 ## Adding a check: what has to pass
 
 1. `make test/content/lint` — it compiles.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/fail/cmek-keys-without-tde/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/fail/cmek-keys-without-tde/main.tf
@@ -1,0 +1,18 @@
+# Naming a customer-managed key selects who holds the key for transparent data
+# encryption. It does not turn the feature on, so this service is still unencrypted.
+resource "clickhouse_service" "analytics" {
+  name           = "analytics"
+  cloud_provider = "aws"
+  region         = "us-east-1"
+  password_wo    = var.clickhouse_default_password
+
+  ip_access = [
+    {
+      source      = "203.0.113.0/24"
+      description = "corporate egress"
+    }
+  ]
+
+  encryption_key                     = var.kms_key_arn
+  encryption_assumed_role_identifier = var.kms_role_arn
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/fail/tde-absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/fail/tde-absent/main.tf
@@ -1,0 +1,13 @@
+resource "clickhouse_service" "analytics" {
+  name           = "analytics"
+  cloud_provider = "aws"
+  region         = "us-east-1"
+  password_wo    = var.clickhouse_default_password
+
+  ip_access = [
+    {
+      source      = "203.0.113.0/24"
+      description = "corporate egress"
+    }
+  ]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/pass/tde-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-encryption-at-rest-terraform-hcl/pass/tde-enabled/main.tf
@@ -1,0 +1,17 @@
+resource "clickhouse_service" "analytics" {
+  name           = "analytics"
+  cloud_provider = "aws"
+  region         = "us-east-1"
+  password_wo    = var.clickhouse_default_password
+
+  ip_access = [
+    {
+      source      = "203.0.113.0/24"
+      description = "corporate egress"
+    }
+  ]
+
+  transparent_data_encryption = {
+    enabled = true
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl/fail/open-to-all/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl/fail/open-to-all/main.tf
@@ -1,0 +1,13 @@
+resource "clickhouse_service" "analytics" {
+  name           = "analytics"
+  cloud_provider = "aws"
+  region         = "us-east-1"
+  password_wo    = var.clickhouse_default_password
+
+  ip_access = [
+    {
+      source      = "0.0.0.0/0"
+      description = "anywhere"
+    }
+  ]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl/pass/restricted-cidr/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-clickhousecloud-security/mondoo-clickhousecloud-security-services-not-open-to-all-ips-terraform-hcl/pass/restricted-cidr/main.tf
@@ -1,0 +1,13 @@
+resource "clickhouse_service" "analytics" {
+  name           = "analytics"
+  cloud_provider = "aws"
+  region         = "us-east-1"
+  password_wo    = var.clickhouse_default_password
+
+  ip_access = [
+    {
+      source      = "203.0.113.0/24"
+      description = "corporate egress"
+    }
+  ]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-audit-log-export-terraform-hcl/fail/no-streaming-destination/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-audit-log-export-terraform-hcl/fail/no-streaming-destination/main.tf
@@ -1,0 +1,4 @@
+resource "hcp_vault_cluster" "secrets" {
+  cluster_id = "secrets"
+  hvn_id     = hcp_hvn.main.hvn_id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-audit-log-export-terraform-hcl/pass/cloudwatch-streaming/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-audit-log-export-terraform-hcl/pass/cloudwatch-streaming/main.tf
@@ -1,0 +1,12 @@
+resource "hcp_vault_cluster" "secrets" {
+  cluster_id = "secrets"
+  hvn_id     = hcp_hvn.main.hvn_id
+
+  audit_log_config {
+    cloudwatch_region            = "us-east-1"
+    cloudwatch_group_name        = "hcp-vault-audit"
+    cloudwatch_stream_name       = "secrets"
+    cloudwatch_access_key_id     = var.cloudwatch_access_key_id
+    cloudwatch_secret_access_key = var.cloudwatch_secret_access_key
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/fail/public-no-allowlist/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/fail/public-no-allowlist/main.tf
@@ -1,0 +1,5 @@
+resource "hcp_vault_cluster" "secrets" {
+  cluster_id      = "secrets"
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/pass/private-endpoint/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/pass/private-endpoint/main.tf
@@ -1,0 +1,5 @@
+# public_endpoint defaults to false, so omitting it keeps the cluster off the internet.
+resource "hcp_vault_cluster" "secrets" {
+  cluster_id = "secrets"
+  hvn_id     = hcp_hvn.main.hvn_id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/pass/public-with-allowlist/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-hcp-security/mondoo-hcp-security-vault-no-public-endpoint-terraform-hcl/pass/public-with-allowlist/main.tf
@@ -1,0 +1,10 @@
+resource "hcp_vault_cluster" "secrets" {
+  cluster_id      = "secrets"
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+
+  ip_allowlist {
+    address     = "203.0.113.0/24"
+    description = "corporate egress"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,5 @@
+# Neon allows public connections by default, so omitting the argument leaves the
+# project reachable from the internet.
+resource "neon_project" "app" {
+  name = "app"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/fail/explicitly-allowed/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/fail/explicitly-allowed/main.tf
@@ -1,0 +1,4 @@
+resource "neon_project" "app" {
+  name                     = "app"
+  block_public_connections = "no"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/pass/public-blocked/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-block-public-connections-terraform-hcl/pass/public-blocked/main.tf
@@ -1,0 +1,4 @@
+resource "neon_project" "app" {
+  name                     = "app"
+  block_public_connections = "yes"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-no-stored-passwords-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-no-stored-passwords-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,4 @@
+# Neon stores role passwords by default, so omitting the argument retains them.
+resource "neon_project" "app" {
+  name = "app"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-no-stored-passwords-terraform-hcl/pass/passwords-not-stored/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-neon-security/mondoo-neon-security-project-no-stored-passwords-terraform-hcl/pass/passwords-not-stored/main.tf
@@ -1,0 +1,4 @@
+resource "neon_project" "app" {
+  name           = "app"
+  store_password = "no"
+}

--- a/content/validation/scans/iac_variants_test.go
+++ b/content/validation/scans/iac_variants_test.go
@@ -96,6 +96,9 @@ var tfVariantPolicies = []tfVariantPolicy{
 	{"mondoo-hetzner-security-", "mondoo-hetzner-security.mql.yaml", ""},
 	{"mondoo-tailscale-security-", "mondoo-tailscale-security.mql.yaml", ""},
 	{"mondoo-m365-security-", "mondoo-m365-security.mql.yaml", ""},
+	{"mondoo-clickhousecloud-security-", "mondoo-clickhousecloud-security.mql.yaml", ""},
+	{"mondoo-hcp-security-", "mondoo-hcp-security.mql.yaml", ""},
+	{"mondoo-neon-security-", "mondoo-neon-security.mql.yaml", ""},
 }
 
 // checkOutcome distinguishes a check that ran and passed, ran and failed, or was


### PR DESCRIPTION
## What this does

Follows up #3338 by giving its checks Terraform coverage. Six of the nine checks across the four SaaS policies can be expressed against Terraform; each now carries `terraform-hcl`, `terraform-plan` and `terraform-state` variants beside its API check.

| Policy | Check | Terraform surface |
|---|---|---|
| clickhousecloud | services not open to all IPs | `clickhouse_service.ip_access` |
| clickhousecloud | transparent data encryption | `clickhouse_service.transparent_data_encryption` |
| hcp | Vault clusters not publicly exposed | `hcp_vault_cluster.public_endpoint` + `ip_allowlist` block |
| hcp | Vault audit log export | `hcp_vault_cluster.audit_log_config` block |
| neon | projects block public connections | `neon_project.block_public_connections` |
| neon | no retained role passwords | `neon_project.store_password` |

## The three that cannot

Recorded as comments in the policies rather than left to be re-derived:

- **Neon organization MFA** — neither published Neon provider declares an organization resource. `kislerdm/neon` reaches org scope only through `neon_org_api_key`; `terraform-community-providers/neon` stops at projects.
- **Netlify MFA and forced HTTPS** — the provider exposes neither; documented in the previous change.

## Two provider details that drove the MQL

- **The Neon arguments are string enums, not booleans.** The provider documents `'yes'` to activate, `'no'` to deactivate, and omission to keep the platform default. Neon allows public connections and stores role passwords by default, so an absent argument is the insecure state and fails.
- **`ip_allowlist` and `audit_log_config` are blocks, not arguments.** An unconfigured cluster has an empty blocks list rather than a null one, so the disjunction resolves without a null guard. `public_endpoint` defaults to false, so the HCL variant asserts `!= true` and an absent argument passes.

## A defect the variant exposed

The encryption check's remediation set `encryption_key` and `encryption_assumed_role_identifier`. Those select *who holds the key* for transparent data encryption; they do not turn the feature on. The check reads `hasTransparentDataEncryption`, which the provider expresses as `transparent_data_encryption.enabled` — so the remediation configured a different feature from the one being checked, and the closed-loop test could not see it because the check had no Terraform variant to close the loop against.

The snippet now enables TDE and mentions the key arguments as the customer-managed-key option. A `fail/cmek-keys-without-tde` fixture pins the distinction.

## Group filters had to go

Registering the policies with `tfVariantPolicies` required dropping the group-level `filters: asset.platform == "<api-platform>"`. The group filter is evaluated before the check's own filter, so a Terraform asset never reached the variant and every fixture reported as *skipped* rather than pass or fail. Policies with variants leave their groups unfiltered and let each variant select its own asset — what `mondoo-tailscale-security` and `mondoo-snowflake-security` already do.

`content/validation/README.md` gains the **Adding a policy: what to register** section that `CLAUDE.md` links to, covering both traps.

## Validation

Each of the eighteen variants was run against an input that should pass and one that should fail:

- `make test/content/iac/terraform` scoped to the three policies — the six HCL variants, 16 fixtures, all pass.
- The twelve plan and state variants were verified against hand-built `terraform show -json` documents, since those suffixes take no fixtures.
- `TestTerraformVariantCoverage` — passes.
- `TestRemediationSatisfiesCheck` — all six terraform-hcl variants pass.
- `cnspec policy lint ./content` — no new findings against a pristine-`main` baseline.
- `go test ./content/validation/...`, `terraform.py` for all four policies, and `typos` — pass.
- `mondoo-tailscale-security` and `mondoo-snowflake-security` still pass, confirming the registry addition is inert for existing policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)