### PR TITLE
📝 validation: document wiring a new policy into content validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ make test/content/lint   # cnspec policy lint over content/ and content/querypac
 make test/content/iac    # the IaC fixture suites (slow; run when you touch a variant)
 ```
 
+Most of those validators are **allowlist-driven**, so a new policy is covered only once it is registered with them. Adding a `*.mql.yaml` without wiring it into the variant suites and the remediation validators ships the whole bundle unexamined with every gate green — see [Adding a policy: what to register](content/validation/README.md#adding-a-policy-what-to-register).
+
 ### Scanning & policy linting
 
 ```bash

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -425,10 +425,34 @@ Five things gate a content change, and each fails differently:
 
 Three traps worth knowing before you hit them:
 
-- **A validator only sees the policies in its `TARGETS`.** When a policy gains its first `terraform`/`ansible`/`bash`/`chef` remediation, add it to that validator's `TARGETS` in the same change — otherwise it ships unlinted and CI stays green. Terraform needs a `PROVIDER_MAP` entry too.
+- **A validator only sees the policies in its `TARGETS`.** When a policy gains its first `terraform`/`ansible`/`powershell`/`chef` remediation, add it to that validator's `TARGETS` in the same change — otherwise it ships unlinted and CI stays green. Terraform needs a `PROVIDER_MAP` entry too. (`bash.py` is the exception: it globs every policy, deliberately.)
 - **A skipped check is a fixture bug, not a pass.** A variant whose filter never matches anything looks identical to one that passes, in every report, forever.
 - **A stale `KNOWN_BUG.md` marker fails the build.** Adding a check means deleting its markers in the same change.
 
 **Never hand-edit** the checked-in CLI grammars and OpenAPI specs in `validation/data/`; re-run the relevant script in `validation/upstream/dump/` instead.
+
+### A new policy is not covered until it is registered
+
+A new *check* inherits the coverage its policy already has. A new *policy* inherits nothing. Every validator above is allowlist-driven except `bash.py` and the compliance suites, so a brand-new `*.mql.yaml` is not reported as unvalidated; it is simply never visited. The bundle merges with its variants untested, its HCL unlinted and its CLI commands unverified, and every gate stays green.
+
+This is not hypothetical. The four SaaS policies added in PR #3338 were invisible to the remediation validators. Registering them with `terraform.py` in a follow-up commit failed **8 of their 11** HCL snippets against the real provider schemas, and hand-checking their CLI snippets found an entire invented `hcp vault` / `hcp consul` command surface and two `neonctl` flags that do not exist.
+
+Wire the policy up in the **same change** that adds it. [`validation/README.md`](validation/README.md#adding-a-policy-what-to-register) is the definitive list, with what breaks in each case; in short, the policy has to be named in:
+
+- `content/README.md`, the user-facing catalog, always.
+- `tfVariantPolicies` in `validation/scans/iac_variants_test.go`, if it has any IaC variant, plus that file's `extraProviders` if its runtime variant needs a provider beyond the base six.
+- `TARGETS` in each `validation/remediation/code/<language>.py` whose method it ships, and `PROVIDER_MAP` as well for Terraform.
+- a registry under `validation/remediation/commands/`, if it ships `id: cli` / `id: api` blocks or `audit:` steps that invoke a CLI or REST call.
+- `typos.toml`, if the vendor's terminology trips the spell checker.
+
+Adding a policy for a platform with **no** non-interactive surface is a legitimate outcome, not a reason to skip a row. Record it as a comment on the check explaining what the vendor does not expose, so the next pass does not re-derive it, and still register the policy with the validators it *can* use so anything added later is checked from the start.
+
+### Groups in a policy with variants carry no platform filter
+
+This one is an authoring decision, not a registration step, and it is invisible until the fixtures exist.
+
+A group filter is evaluated **before** the check's own filter, so a group carrying `filters: asset.platform == "<api-platform>"` means a Terraform asset never reaches the variant underneath it. Every fixture then reports as *skipped* rather than pass or fail, which is the outcome this whole suite exists to catch.
+
+A policy with variants therefore leaves its groups unfiltered and lets each variant's own `filters:` select its asset, the way `mondoo-tailscale-security` and `mondoo-snowflake-security` do. Convert the groups in the same change that adds the first variant.
 
 Reference links for MQL resources, built-in functions, and the authoring guide are in the repository-root [`CLAUDE.md`](../CLAUDE.md), which loads alongside this file.

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -337,33 +337,43 @@ Things to know when touching this:
 
 ## Adding a policy: what to register
 
-A new check inherits the coverage its policy already has. A new *policy* inherits nothing. Most
-validators here are allowlist-driven, so a `content/*.mql.yaml` that nobody registers is scanned by
-`bash.py` and the lint pass and by nothing else — the bundle ships unexamined with every gate green.
-`bash.py` is the exception on purpose; the comment on its `TARGETS` explains why.
+A new check inherits the coverage its policy already has. A new *policy* inherits nothing. Most validators here are allowlist-driven, so a `content/*.mql.yaml` that nobody registers is linted, spell-checked, scanned by `bash.py` and checked by the compliance suites, and examined by nothing else — the bundle ships with its variants untested and its remediation unverified, with every gate green.
+
+This has already happened. PR #3338 added four SaaS policies; a follow-up commit in the same PR registered them with `remediation/code/terraform.py` and that immediately failed **8 of their 11** HCL snippets against the real provider schemas, and hand-checking their CLI snippets found invented `hcp vault` / `hcp consul` command groups and two `neonctl` flags that do not exist. None of it was visible until the policy was on a list.
 
 Register the policy everywhere it applies, in the same change that adds it:
 
 | Where | When it applies | What happens if you skip it |
 |---|---|---|
-| `remediation/code/terraform.py` → `TARGETS` **and** `PROVIDER_MAP` | any `hcl` remediation block | snippets are never resolved against the provider schema |
-| `remediation/code/{cloudformation,bicep,ansible,powershell,chef}.py` → `TARGETS` | that language appears in a remediation block | same, for that language |
-| `remediation/commands/` → `CLI_VALIDATORS`, `COBRA_CLIS`, or `API_PROVIDERS` | any `bash` remediation calls a vendor CLI or REST API | invented commands and endpoints ship unchallenged |
-| `scans/iac_variants_test.go` → `tfVariantPolicies` | the policy has any IaC variant | variants are never scanned, and coverage never asks for fixtures |
+| `content/README.md` | always — a row under the matching platform heading | the policy is invisible in the user-facing catalog |
+| `scans/iac_variants_test.go` → `tfVariantPolicies` | the policy has any `-terraform-hcl`, `-terraform-plan`, `-terraform-state`, `-cloudformation` or `-bicep` variant | variants are never scanned, and coverage never asks for fixtures |
+| `scans/iac_variants_test.go` → `init()`'s `extraProviders` | its runtime variant needs a provider outside `terraform`/`k8s`/`aws`/`azure`/`gcp`/`cloudformation` (the base list in `main_test.go`) | parallel subtests race to auto-install it and lose with `cannot find resource for identifier '<provider>'` |
+| `remediation/code/terraform.py` → `TARGETS` **and** `PROVIDER_MAP` for each resource prefix | any `- id: terraform` remediation | snippets are never resolved against the provider schema; with `TARGETS` but no `PROVIDER_MAP` entry, `required_providers` comes out empty and `terraform_required_providers` fails *every* resource in the policy |
+| `remediation/code/{cloudformation,bicep,ansible,powershell,chef}.py` → `TARGETS` | that language appears in a remediation block (`powershell.py` also reads ```` ```powershell ```` fences in `audit:`) | same, for that language |
+| `remediation/commands/` → `CLI_VALIDATORS`, `COBRA_CLIS`, or `API_PROVIDERS` | any `- id: cli` / `- id: api` block, or an `audit:` step that invokes a CLI or REST call | invented commands and endpoints ship unchallenged |
+| `compliance/owasp_mapping_test.go` → `llmAnchoredPolicies` | the policy is AI/LLM-focused | nothing guards its OWASP Top 10 for LLM Applications tags against silently going missing |
+| `typos.toml` → `[default.extend-words]` | the vendor's terminology trips the spell checker | `spell-check.yaml` fails |
 
-A policy in `PROVIDER_MAP` needs a real provider source and a version constraint that resolves; a
-constraint matching only prereleases silently fails to resolve.
+A policy in `PROVIDER_MAP` needs a real provider source and a version constraint that resolves; a constraint matching only prereleases silently fails to resolve.
+
+`remediation/code/bash.py` is the exception on purpose and needs no entry — it globs every policy in `content/`, because a `TARGETS` list is a standing invitation to exactly this failure, and the comment on its `TARGETS` says so. The compliance suites glob too (`../../mondoo-*.mql.yaml`), so tag coherence is covered from the first commit.
 
 ### Group filters and variants do not mix
 
-A policy whose groups carry `filters: asset.platform == "<api-platform>"` cannot have IaC variants.
-The group filter is evaluated before the check's own filter, so a Terraform asset never reaches the
-variant and every fixture reports as *skipped* rather than pass or fail. Policies with variants leave
-their groups unfiltered and let each variant's `filters:` select its asset — that is why
-`mondoo-tailscale-security` and `mondoo-snowflake-security` declare no group filters.
+A policy whose groups carry `filters: asset.platform == "<api-platform>"` cannot have IaC variants. The group filter is evaluated before the check's own filter, so a Terraform asset never reaches the variant and every fixture reports as *skipped* rather than pass or fail. Policies with variants leave their groups unfiltered and let each variant's `filters:` select its asset — that is why `mondoo-tailscale-security` and `mondoo-snowflake-security` declare no group filters.
 
-The failure mode is loud once you have fixtures (`check did not run against …`) and invisible before
-that, so convert the groups in the same change that adds the first variant.
+The failure mode is loud once you have fixtures (`check did not run against …`) and invisible before that, so convert the groups in the same change that adds the first variant.
+
+### Registering with the command validators
+
+Which registry depends on how the vendor's interface is reached, and anything that introduces a new binary needs a CI change too:
+
+- **A new REST API** — add an entry to `API_PROVIDERS` in `commands/openapi.py` with the policy file, host, and spec source. A spec pinned to a commit SHA also needs its constant registered in `upstream/pins.py`; a YAML-only spec is converted once by `upstream/dump/api_specs.py` and checked into `data/`.
+- **A new Cobra CLI** — add an entry to `COBRA_CLIS` in `commands/cobra.py` (CLI name, policy list, `include_audit`, install hint). The CLI must also be installed by the `validate-remediation.yaml` commands job, pinned by version **and** SHA-256.
+- **A new cloud CLI with its own grammar source** — a module beside `aws.py`/`azure.py`/`gcloud.py` plus an entry in `CLI_VALIDATORS` in `commands/validate.py`, and the same CI install step.
+- **An existing validator gaining a second policy** — some validators name their policies in module constants rather than a registry (`azure.py` validates both `mondoo-azure-security` and `mondoo-m365-security`, because the M365 policy's CLI remediations also use `az`). Add the file there.
+
+When no registry fits because the vendor has no non-interactive surface at all, that is a finding worth recording rather than a gap to leave silent: say so in a comment on the check, the way the Netlify MFA check does, so the next reader does not re-derive it.
 
 ## Adding a check: what has to pass
 

--- a/skills/mql/SKILL.md
+++ b/skills/mql/SKILL.md
@@ -160,6 +160,43 @@ If the Mondoo MCP server is available, you can use these tools instead of the CL
 | Query compilation validation | `cnspec run local -c "query" --ast` |
 | Policy structure validation | `cnspec policy lint file.mql.yaml -o sarif` |
 
+## Wiring Policies into Content Validation
+
+`cnspec policy lint` proves a policy **compiles**. It does not prove a check reaches the verdict you claim, that an IaC variant ever matches an asset, or that a remediation snippet is well-formed and actually fixes the thing it documents. Those live in a separate suite.
+
+When you are authoring or editing policies **inside the cnspec repository**, every one of those checks lives in `content/validation/`, and [`content/validation/README.md`](../../content/validation/README.md) is the reference for all of it. Authoring rules are in [`content/CLAUDE.md`](../../content/CLAUDE.md).
+
+```bash
+make test/content              # lint + bundle scans + compliance mappings
+make test/content/lint         # run this first, and fix it first
+make test/content/iac          # IaC variant fixture suites
+make test/content/iac/coverage # every IaC variant has pass+fail fixtures
+make test/content/remediation  # remediation code-block linters
+make test/content/commands     # remediation CLI and API validators
+```
+
+**A new policy has to be registered, or nothing validates it.** Every validator except the shell one and the compliance suites is allowlist-driven: it iterates a `TARGETS` dict or a policy slice. A bundle absent from those lists is not reported as unvalidated, it is never visited, so it merges with its variants untested and its remediation unlinted while CI stays green. Register the policy in the same change that adds it:
+
+| Add the policy to | When |
+|---|---|
+| `content/README.md` | always — the user-facing catalog |
+| `tfVariantPolicies` in `content/validation/scans/iac_variants_test.go` | it has `-terraform-hcl` / `-terraform-plan` / `-terraform-state` / `-cloudformation` / `-bicep` variants |
+| `TARGETS` in `content/validation/remediation/code/<language>.py` | it ships that language's remediation. Terraform also needs a `PROVIDER_MAP` entry per resource prefix |
+| a registry under `content/validation/remediation/commands/` | it ships `id: cli` / `id: api` blocks, or `audit:` steps that invoke a CLI or REST call |
+
+**Every IaC variant needs pass and fail fixtures** under `content/validation/scans/fixtures/iac-variants/<policy>/<variant-uid>/{pass,fail}/<scenario>/`, and a coverage gate enforces it at 100%. A variant that asserts exactly what its own `filters:` require has no possible failing input; record that with a `fail/IMPOSSIBLE.md` explaining why, which is the only sanctioned way to ship without a fail fixture.
+
+Scope a run to one check rather than running the whole suite — the trailing slash is what makes it work:
+
+```bash
+go test -tags iac_variants ./content/validation/scans \
+  -run 'TestTerraformVariants/mondoo-aws-security/mondoo-aws-security-s3-bucket-encryption-terraform-hcl/'
+```
+
+Three outcomes are distinguished, and the third matters most: **passed**, **failed**, and **skipped** — the check never ran because no asset matched its `filters:`. A skipped check is a fixture bug, not a pass. It looks identical to a passing one in every report, forever.
+
+**A policy with IaC variants leaves its groups unfiltered.** A group filter is evaluated before the check's own filter, so a group carrying `filters: asset.platform == "<api-platform>"` means a Terraform asset never reaches the variant underneath it and every fixture reports as *skipped*. Let each variant's own `filters:` select its asset instead, and convert the groups in the same change that adds the first variant.
+
 ## MQL Quick Reference
 
 ### Core Syntax
@@ -265,6 +302,7 @@ users.where(shell != null).all(shell == "/bin/bash") # Good
 4. **Write query** - Follow patterns from `mql-reference.md`
 5. **Validate** - Use `cnspec run local -c "query" --ast` to verify syntax
 6. **Test** - Run with `cnspec run` against target systems
+7. **Wire up validation** - For policies in the cnspec repository, add fixtures for any IaC variant and register the policy with the validators that cover its remediation, in the same change. See [Wiring Policies into Content Validation](#wiring-policies-into-content-validation)
 
 ## Platform-Specific Guidance
 

--- a/skills/policy-graph/SKILL.md
+++ b/skills/policy-graph/SKILL.md
@@ -23,6 +23,8 @@ Navigate and understand cnspec policy bundles (`.mql.yaml` files) using structur
 - Linting bundles (`cnspec policy lint`)
 - Editing policy YAML directly (use the Read/Edit tools for that)
 
+For authoring or changing policies, use the `mql` skill instead. Its **Wiring Policies into Content Validation** section covers the fixtures and validator registrations a policy change in the cnspec repository has to ship with.
+
 ## Commands Reference
 
 | Command | Purpose |


### PR DESCRIPTION
Every validator under `content/validation/` except `code/bash.py` and the compliance suites is **allowlist-driven**: it iterates a `TARGETS` dict or a policy slice. A bundle absent from those lists is not reported as unvalidated, it is never visited, so it merges with its variants untested and its remediation unlinted while every gate stays green. Nothing can detect that but a human reading a checklist.

## Rebased onto #3375, and merged rather than replaced

#3375 added its own "Adding a policy: what to register" section to `content/validation/README.md` while this was open. Each version had material the other lacked, so the conflict was resolved by hand.

**Kept from #3375:**

- Its opening, which frames the problem better than what this branch had: *a new check inherits the coverage its policy already has, a new policy inherits nothing.*
- The `PROVIDER_MAP` note about a constraint that matches only prereleases.
- **"Group filters and variants do not mix"** in full. A group filter is evaluated before the check's own filter, so a group scoped to the API platform means a Terraform asset never reaches the variant and every fixture reports as *skipped*. I verified this against the tree rather than taking the commit message for it: #3375 dropped exactly those three group filters from the Neon policy, and the variants carry their own.

**Added from this branch:**

- The **#3338 evidence**. Four SaaS policies merged invisible to the remediation validators; registering them with `code/terraform.py` failed **8 of their 11** HCL snippets against the real provider schemas, and their CLI snippets carried an invented `hcp vault` / `hcp consul` command surface and two `neonctl` flags that do not exist.
- Four table rows #3375 did not have: `content/README.md` (the catalog — still missing those same four policies), `extraProviders`, `llmAnchoredPolicies`, and `typos.toml`.
- **"Registering with the command validators"** — which of the three registries a vendor interface belongs in, and that a new binary also needs a pinned install step in `validate-remediation.yaml`.
- The note that a platform with no non-interactive surface is a finding to record on the check, not a row to skip silently.

**Tightened against the extractors:** `terraform.py` keys off `- id: terraform` and then ```` ```hcl ```` fences within it, not an hcl block anywhere; the command validators read `- id: cli` / `- id: api` blocks **plus `audit:` blocks**, not bash remediation. The section is also unwrapped to match the rest of the file, which is why untouched prose shows as reflowed.

## Beyond the README

| File | What it gains |
|---|---|
| `content/CLAUDE.md` | the short form, deliberately **not** a second copy of the table: framing, evidence, a five-item list of where the policy has to be named, and a link to the definitive section. Plus the group-filter trap, which belongs in the authoring guide because it decides how the bundle is *structured*, not how it is registered |
| `skills/mql/SKILL.md` | knew only `cnspec policy lint`, which proves a policy compiles and nothing else. Now covers the fixture requirement, the registration table, scoping a run to one check, the passed/failed/**skipped** distinction and the group-filter trap, with a step for it in the workflow |
| `skills/policy-graph/SKILL.md` | routes authoring work to the `mql` skill; its "When NOT to Use" already excluded editing policy YAML |
| `CLAUDE.md` | one line under Content validation flagging the allowlist behavior |

## Incidental fix

`content/CLAUDE.md`'s existing trap list named `bash` among the validators needing a `TARGETS` entry. `code/bash.py` is precisely the one that globs every policy, deliberately, because a `TARGETS` list is a standing invitation to this failure. Corrected to `powershell`.

## Verification

- Every symbol cited exists in the rebased tree: `tfVariantPolicies`, `extraProviders`, `llmAnchoredPolicies`, `TARGETS`, `PROVIDER_MAP`, `COBRA_CLIS`, `API_PROVIDERS`, `CLI_VALIDATORS`.
- `typos` clean over all five files.
- `make skills/generate/check` → `agents/AGENTS.md is up to date` (skill frontmatter untouched).
- Anchors and relative links resolve; every `make` target cited exists in the Makefile.

Documentation only. No content or code behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)