### PR TITLE
📝 kubernetes: rewrite every check description to name the setting and the real risk

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-security
     name: Mondoo Kubernetes Cluster and Workload Security
-    version: 2.1.0
+    version: 2.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -282,17 +282,19 @@ queries:
       kubelet.configuration['authentication']['anonymous']['enabled'] == false
     docs:
       desc: |
-        This check ensures that anonymous authentication is disabled for the kubelet. Disabling anonymous authentication prevents unauthenticated users from accessing the kubelet's HTTPS endpoint, which could otherwise expose sensitive cluster information.
+        This check verifies that the kubelet rejects requests that arrive with no credentials.
+
+        The kubelet serves an HTTPS API on port 10250 that can start containers, stream logs, and run commands inside any Pod on the node. Anonymous authentication decides whether a request carrying no client certificate and no bearer token is still admitted, mapped to the user `system:anonymous`. The setting to change is `authentication.anonymous.enabled` in the kubelet configuration file, or `--anonymous-auth` where the kubelet is still started from flags. Either must be `false`.
 
         **Why this matters**
 
-        The kubelet is a core Kubernetes component responsible for managing pods on each node. If anonymous authentication is enabled:
+        An anonymous request that is admitted is then subject only to the kubelet's authorization mode. Where that mode is `AlwaysAllow`, which is the other half of this pair and is covered by a companion check in this policy, an unauthenticated caller reaches the full kubelet API.
 
-        - Unauthenticated users may gain access to the kubelet API, potentially exposing sensitive data or cluster state.
-        - Attackers could exploit this access to gather information or attempt further attacks on the cluster.
-        - Allowing anonymous requests undermines access control and violates security best practices.
+        That API is not read-only. It offers `exec`, `attach`, `run`, and `portforward` against every container on the node, plus `/pods`, which returns the complete spec of each one. Command execution inside a container is command execution as that container's identity, so the attacker reads its mounted Secrets, uses its service account token against the API server, and reaches whatever the workload can reach on the network.
 
-        By ensuring anonymous authentication is disabled, organizations reduce the risk of unauthorized access and strengthen the overall security posture of their Kubernetes clusters.
+        Because the node hosts Pods from many namespaces, one reachable kubelet collapses the namespace boundary for every workload that landed there. Internet-wide scans for open port 10250 are routine, and the kubelet is a standing target on any cluster whose nodes have public addresses or whose Pod network is reachable from a compromised workload.
+
+        Health probes are the usual reason anonymous access is left on. The kubelet exposes `/healthz` on the same port, so where a probe genuinely cannot authenticate, restrict it at the node firewall to the prober's address rather than opening the whole API, and pair this setting with a non-`AlwaysAllow` authorization mode so that authentication failures are not the only barrier.
       audit: |
         If running the kubelet with the CLI parameter '--anonymous-auth', or running with 'authentication.anonymous.enabled' defined in the kubelet configuration file, ensure that the value is set to 'false'.
       remediation: |
@@ -324,17 +326,19 @@ queries:
       kubelet.configuration['eventRecordQPS'] == 0
     docs:
       desc: |
-        This check ensures that the kubelet is configured to capture all event creation by setting the event record QPS (queries per second) to 0. This configuration guarantees that all events are logged, which is important for auditing and troubleshooting purposes.
+        This check verifies that the kubelet does not rate-limit the events it reports to the API server.
+
+        `eventRecordQPS` caps how many events per second the kubelet will emit and silently discards the rest. A value of `0` removes the cap. The setting to change is `eventRecordQPS` in the kubelet configuration file, or `--event-qps` on the kubelet command line, and it must be `0`.
 
         **Why this matters**
 
-        Capturing all event creation in the kubelet is essential for maintaining a complete audit trail and ensuring visibility into cluster activity. If event recording is limited or disabled:
+        Events are the node's record of what actually happened: image pulls, container starts and restarts, failed mounts, out-of-memory kills, evictions, and probe failures. A rate limit drops that record exactly when there is most to record, because a burst is what a cap discards first.
 
-        - Important events may not be logged, making it difficult to investigate incidents or troubleshoot issues.
-        - Security-relevant activities could go undetected, increasing the risk of unnoticed attacks or misconfigurations.
-        - Compliance with auditing and monitoring requirements may be compromised.
+        Attack activity arrives as a burst. A crash loop from a failing exploit, a run of pulls from an unfamiliar registry, or repeated failed mounts of a node path all produce events faster than steady state, so detection built on the event stream goes quiet during the incident it exists to catch.
 
-        By ensuring the kubelet is configured to capture all event creation, organizations can improve observability, support incident response, and maintain compliance with security best practices.
+        The cap is also directly abusable. An attacker who can generate benign events, which any workload that restarts containers can do, pushes the kubelet against its limit and has their own activity dropped along with the noise. Removing the cap removes that lever.
+
+        Uncapped event recording adds load to the API server and to etcd, and on very large or event-heavy clusters that cost is real; measure it before rolling the setting out fleet-wide. Pair it with an event exporter that ships events off the cluster, because Kubernetes keeps Events for only one hour by default and the retention limit, not the rate limit, is what usually loses the evidence.
       audit: |
         If running the kubelet with the CLI parameter '--event-qps', or running with 'eventRecordQPS' defined in the kubelet configuration file, ensure that the value is set to '0'.
       remediation: |
@@ -366,17 +370,19 @@ queries:
       kubelet.configuration['makeIPTablesUtilChains'] == true
     docs:
       desc: |
-        This check ensures that the kubelet is set up to create IPTables utility rules for various Kubernetes components. This configuration is important for maintaining correct network traffic routing and enforcing security policies at the node level.
+        This check verifies that the kubelet installs and maintains the iptables chains that Kubernetes networking depends on.
+
+        Kubernetes expresses parts of its network enforcement as packet marks, and something has to own the chains that act on those marks. `makeIPTablesUtilChains` tells the kubelet to create the `KUBE-FIREWALL` and `KUBE-MARK-DROP` utility chains on the node and to reconcile them periodically. The setting to change is `makeIPTablesUtilChains` in the kubelet configuration file, or `--make-iptables-util-chains` on the kubelet command line, and it must be `true`.
 
         **Why this matters**
 
-        IPTables utility chains are used by Kubernetes to manage network rules for pods and services. If the kubelet is not configured to create these utility chains:
+        With the setting off, whether those chains exist at all depends on what else on the node happened to write them. kube-proxy and the CNI plugin still mark packets that should be dropped or masqueraded, but the rules that act on the marks may simply be absent, so packets marked for dropping are delivered instead.
 
-        - Network traffic may not be properly routed, leading to connectivity issues between pods and services.
-        - Security policies that rely on IPTables rules may not be enforced, increasing the risk of unauthorized access.
-        - Troubleshooting and auditing network flows can become more difficult due to inconsistent or missing IPTables rules.
+        The failure is quiet. Traffic mostly flows, so nothing looks broken, and the missing piece is the enforcement half rather than the connectivity half. Rules that another tool flushes, for example a host firewall agent that rewrites the table or an `iptables -F` typed during troubleshooting, are never restored because nothing owns them.
 
-        By ensuring the kubelet is configured to create IPTables utility chains, organizations can maintain reliable network operations and enforce security best practices within their Kubernetes clusters.
+        That gap undermines the controls people believe are in place. Source NAT behavior decides how Pod traffic is presented to the rest of the network, and the drop rules decide what the node refuses to carry, so an inconsistent chain set makes both the node's exposure and the effect of network policy unpredictable from one node to the next.
+
+        Clusters running an eBPF data path, such as Cilium in kube-proxy replacement mode, do not depend on these chains in the same way and the setting matters less there. Where iptables is still the data path, leave it enabled and keep node-level firewall tooling from flushing chains it does not own.
       audit: |
         If running the kubelet with the CLI parameter '--make-iptables-util-chains', or running with 'makeIPTablesUtilChains' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
@@ -408,17 +414,19 @@ queries:
       kubelet.configuration["protectKernelDefaults"] == "true"
     docs:
       desc: |
-        This check ensures that the kubelet is configured to protect kernel defaults by setting `protectKernelDefaults` to `true`. This configuration prevents the kubelet from modifying kernel tunables at startup and enforces the use of secure, recommended kernel settings.
+        This check verifies that the kubelet refuses to start rather than silently rewriting the node's kernel tunables.
+
+        The kubelet depends on a handful of sysctl values and, by default, sets them itself at startup. With `protectKernelDefaults` enabled it instead treats those values as the node owner's decision and exits with an error when it finds one that differs from what it expects. The setting to change is `protectKernelDefaults` in the kubelet configuration file, or `--protect-kernel-defaults` on the kubelet command line, and it must be `true`.
 
         **Why this matters**
 
-        The kubelet manages pods and containers on each node and interacts closely with the underlying operating system. If `protectKernelDefaults` is not enabled:
+        Silent overwriting produces drift that both sides believe they won. A node hardened deliberately through a machine image or a configuration management tool has some of that hardening reverted when the kubelet starts, and the tool that set the values still reports success because it ran first.
 
-        - The kubelet may attempt to change kernel parameters, potentially introducing insecure or inconsistent system states.
-        - Security best practices may be bypassed if the kubelet overrides hardened kernel settings.
-        - Unintended modifications to kernel tunables can lead to unpredictable behavior or vulnerabilities.
+        The values involved are not cosmetic. They govern memory overcommit behavior, what the kernel does when it runs out of memory, and whether the kernel panics on an oops, all of which decide how the node behaves under the exact conditions an attacker creates when they exhaust a resource.
 
-        By ensuring that `protectKernelDefaults` is set to `true`, organizations can maintain consistent, secure kernel configurations and reduce the risk of misconfiguration or privilege escalation.
+        Failing loudly converts an invisible divergence into an operational signal. A kubelet that will not start is investigated within minutes; a kernel parameter that was quietly changed at boot is discovered during an incident, if at all.
+
+        Enabling this means a node whose sysctls have not been set will not run the kubelet, so it must be rolled out together with whatever sets those values, normally the machine image or the node bootstrap script. That coupling is the point: the node's kernel configuration becomes an explicit, reviewable artifact instead of a side effect of starting the kubelet.
       audit: |
         If running the kubelet with the CLI parameter '--protect-kernel-defaults', or running with 'protectKernelDefaults' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
@@ -452,17 +460,19 @@ queries:
       kubelet.configuration['readOnlyPort'] == 0 || kubelet.configuration['readOnlyPort'] == null
     docs:
       desc: |
-        This check ensures that the kubelet is not configured to serve unauthenticated read-only access. Disabling the read-only port prevents unauthenticated users from accessing sensitive kubelet information.
+        This check verifies that the kubelet does not serve its unauthenticated read-only API.
+
+        The read-only port, historically 10255, serves a subset of the kubelet API over plain HTTP with no authentication and no authorization at all. The setting to change is `readOnlyPort` in the kubelet configuration file, or `--read-only-port` on the kubelet command line, and it must be `0` or left unset, since the current default is disabled.
 
         **Why this matters**
 
-        The kubelet read-only port, if enabled, allows unauthenticated access to the kubelet's HTTP endpoint. If this port is open:
+        What that port returns is the reconnaissance an attacker would otherwise have to work for. `/pods` gives the full spec of every Pod on the node: image names and tags, mounted volumes, service account names, and every environment variable set inline, which is where credentials passed as literal values end up. `/metrics` and `/stats` add resource usage per container.
 
-        - Unauthenticated users may retrieve sensitive information about pods and containers running on the node.
-        - Attackers could exploit this access to gather data or attempt further attacks on the cluster.
-        - Allowing unauthenticated requests undermines access control and violates security best practices.
+        No credential is required and nothing about the request is authenticated, so any workload that can reach the node's address on the Pod network can read it, as can anything on the node network. Because the transport is plain HTTP, the same data is also readable to anything positioned in the path.
 
-        By ensuring the kubelet read-only port is disabled, organizations reduce the risk of unauthorized access and strengthen the overall security posture of their Kubernetes clusters.
+        Unauthenticated kubelet ports have been a standing target for cluster-scanning malware precisely because harvesting them takes a single HTTP GET and produces a map of what is worth attacking next, including which nodes run workloads with interesting Secrets.
+
+        Some older monitoring agents were written against port 10255 and will break. The replacement is the authenticated port 10250 with a client certificate or a service account token bound to the `nodes/metrics` and `nodes/stats` subresources, which every current metrics agent supports. Fix the agent rather than leaving an unauthenticated listener on every node.
       audit: |
         If running the kubelet with the CLI parameter '--read-only-port', or running with 'readOnlyPort' defined in the kubelet configuration file, ensure that the value is either '0' or simply not set ('0' is the default).
       remediation: |
@@ -494,17 +504,19 @@ queries:
       kubelet.configuration['authorization']['mode'] != "AlwaysAllow"
     docs:
       desc: |
-        This check ensures that the kubelet is not configured with the AlwaysAllow authorization mode. Disabling AlwaysAllow enforces proper access control and prevents unauthorized requests from being automatically permitted.
+        This check verifies that the kubelet does not use the AlwaysAllow authorization mode.
+
+        Authorization mode decides whether the kubelet evaluates requests to its API against the cluster's RBAC policy or accepts them unconditionally. The setting to change is `authorization.mode` in the kubelet configuration file, or `--authorization-mode` on the kubelet command line, and it must be anything other than `AlwaysAllow`, in practice `Webhook`, so that each request is checked with a SubjectAccessReview against the API server.
 
         **Why this matters**
 
-        The AlwaysAllow authorization mode allows all requests to the kubelet API, bypassing access controls and security policies. If this mode is enabled:
+        Authentication and authorization are separate settings on the kubelet, and `AlwaysAllow` disables the second one entirely. Any caller that can authenticate at all is then permitted to do anything the API offers, and in a normal cluster that includes every service account token and every certificate signed by the cluster CA.
 
-        - Any user or process can interact with the kubelet API without restriction, increasing the risk of privilege escalation or cluster compromise.
-        - Sensitive operations and data may be exposed to unauthorized users.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        The kubelet API is not read-only. It offers `exec`, `attach`, `run`, and `portforward` against every container on the node, along with the full spec of each Pod. Reaching it means running commands inside any container on that node, which in turn means reading that container's mounted Secrets and using its service account token against the API server.
 
-        By ensuring the kubelet is not configured with AlwaysAllow, organizations can enforce strong access controls and maintain a secure Kubernetes environment.
+        Because a node hosts Pods from many namespaces, this collapses the namespace boundary. A low-privilege token from one team's namespace becomes command execution inside another team's production Pod purely because both landed on the same node, and RBAC never had a chance to say otherwise.
+
+        `Webhook` mode depends on the kubelet also having credentials to call the API server and on the `system:kubelet-api-admin` style bindings being correct, so verify the delegation works before assuming the mode alone is enough. Pair it with anonymous authentication disabled, since authorization mode only governs requests that authenticated in the first place.
       audit: |
         If running the kubelet with the CLI parameter '--authorization-mode', or running with 'authorization.mode' defined in the kubelet configuration file, ensure that the value is not set to 'AlwaysAllow'.
       remediation: |
@@ -552,17 +564,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kubelet is configured to use only strong cryptography by restricting the allowed TLS cipher suites to a hardened list. This configuration helps prevent the use of weak or outdated ciphers that could expose sensitive data or allow attackers to compromise encrypted communications.
+        This check verifies that the kubelet's HTTPS server negotiates only cipher suites on an approved list.
+
+        `tlsCipherSuites` in the kubelet configuration file, or `--tls-cipher-suites` on the kubelet command line, pins the suites the kubelet will accept during a TLS handshake. The check requires the setting to be present at all, and requires every suite named in it to appear in the `mondooKubernetesSecurityAllowedCiphers` property of this policy, which lists the forward-secret authenticated-encryption suites.
 
         **Why this matters**
 
-        The kubelet is a critical component in Kubernetes clusters, responsible for managing pods and communicating with the API server. If the kubelet allows weak or deprecated TLS ciphers:
+        Left unset, the kubelet accepts the Go runtime's default list, which retains suites for compatibility that nothing in a Kubernetes cluster needs. Those defaults have historically included CBC-mode constructions of the kind that Lucky13 targets and key exchanges with no forward secrecy.
 
-        - Encrypted traffic between the kubelet and other components may be vulnerable to interception or decryption.
-        - Attackers could exploit known weaknesses in legacy ciphers to gain unauthorized access or disrupt cluster operations.
-        - Compliance with security standards and best practices may be violated.
+        Forward secrecy is the durable issue. With an RSA key exchange the session key is protected by the server's long-term private key, so an observer who records traffic today and obtains that key later can decrypt everything they recorded. The kubelet's traffic includes `exec` and `attach` streams and the full specification of every Pod on the node.
 
-        By ensuring the kubelet is restricted to strong, modern TLS ciphers, organizations can protect sensitive data in transit and maintain a robust security posture for their Kubernetes environments.
+        The negotiated suite is chosen from what both sides offer, so an attacker positioned in the path steers the handshake toward the weakest option the server still accepts. Pinning the list removes the weak options rather than relying on every client to prefer a strong one.
+
+        Restricting the list can lock out an older monitoring agent or a custom API client, so verify what connects to port 10250 before rolling it out. Adjust the `mondooKubernetesSecurityAllowedCiphers` property when your environment needs a different set rather than dropping the check, and pair it with a minimum TLS version so the suite list is not the only thing standing between you and an obsolete handshake.
       audit: |
         If running the kubelet with the CLI parameter '--tls-cipher-suites', or running with 'tlsCipherSuites' defined in the kubelet configuration file, ensure that the list of allowed ciphers is not empty and that all included ciphers are included in the following list:
 
@@ -605,17 +619,19 @@ queries:
       kubelet.configuration["tlsPrivateKeyFile"] != empty
     docs:
       desc: |
-        This check ensures that the kubelet is not running with self-signed certificates generated by the kubelet itself. Instead, it requires the kubelet to use a user-provided certificate and key for secure communication.
+        This check verifies that the kubelet serves HTTPS with a certificate you provided rather than one it generated for itself.
+
+        When `tlsCertFile` and `tlsPrivateKeyFile` in the kubelet configuration file are unset, or the equivalent `--tls-cert-file` and `--tls-private-key-file` flags are absent, the kubelet generates a self-signed certificate at startup and serves that. Both settings must name real files.
 
         **Why this matters**
 
-        Using self-signed certificates generated by the kubelet can weaken the security of the Kubernetes cluster. If the kubelet is allowed to generate its own certificates:
+        A self-signed kubelet certificate chains to nothing, so no caller can verify it. In practice that means the API server and every monitoring agent are configured to skip verification, and a client that skips verification accepts any certificate at all, including one presented by an attacker who can answer at the node's address.
 
-        - The certificates may not be trusted by other components or external systems, leading to trust issues.
-        - Self-signed certificates are more susceptible to man-in-the-middle attacks if not managed properly.
-        - Compliance with organizational or regulatory security standards may be compromised.
+        The connections at stake carry the most sensitive traffic in the cluster. `exec` and `attach` are interactive sessions inside containers, `logs` is application output, and the API server presents its own client credential on every one of them. An endpoint that impersonates the kubelet reads all of that and can also return fabricated output to an operator debugging an incident.
 
-        By ensuring that the kubelet uses a user-provided certificate and key, organizations can enforce stronger security controls, maintain trust across cluster components, and align with best practices for certificate management.
+        The self-signed certificate is also regenerated when the kubelet restarts, so pinning it is impractical and the verification gap becomes permanent rather than a temporary bootstrap condition.
+
+        The maintained way to satisfy this is kubelet serving certificate rotation, where the kubelet requests a certificate from the cluster CA through the CertificateSigningRequest API and an approver signs it, rather than a key pair copied onto each node by hand. Pair it with `--kubelet-certificate-authority` on the API server, checked by a companion check in this policy, because a properly issued certificate achieves nothing while the client is still told not to verify.
       audit: |
         The kubelet CLI parameters override values in the kubelet configuration file.
 
@@ -655,17 +671,19 @@ queries:
       kubelet.configuration["rotateCertificates"] != "false"
     docs:
       desc: |
-        This check ensures that the kubelet is running with automatic certificate rotation enabled. This configuration allows the kubelet to automatically renew its certificates with the API server as they approach expiration, maintaining uninterrupted secure communication.
+        This check verifies that the kubelet renews its client certificate automatically before it expires.
+
+        `rotateCertificates` in the kubelet configuration file, or `--rotate-certificates` on the kubelet command line, tells the kubelet to request a replacement client certificate from the cluster CA through the CertificateSigningRequest API as the current one nears expiry. It must not be set to `false`, so both an explicit `true` and the default pass.
 
         **Why this matters**
 
-        Automatic certificate rotation is essential for maintaining secure and reliable communication between the kubelet and the Kubernetes API server. If certificate rotation is not enabled:
+        Kubelet client certificates are usually issued for a year, and expiry takes a node out of the cluster. The kubelet can no longer report status, the node is marked `NotReady`, and its workloads are evicted. On a fleet built from one image on one day, that arrives for every node at roughly the same hour.
 
-        - Expired certificates can disrupt communication, causing nodes to become unavailable or workloads to fail.
-        - Manual certificate management increases operational overhead and the risk of misconfiguration.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Manual rotation pushes teams toward very long lifetimes to avoid the toil, and a ten-year node credential is a credential with no practical revocation story: Kubernetes consults no certificate revocation list, so a certificate that leaked through a machine image, a backup, or a snapshot stays valid until the cluster CA is rotated.
 
-        By enabling automatic certificate rotation, organizations ensure that kubelet certificates are always valid, reducing the risk of outages and maintaining a strong security posture.
+        Short lifetimes are the only real containment for a stolen node credential. That credential authenticates as a member of `system:nodes`, and even with the Node authorizer and the NodeRestriction admission plugin in place it still reads the Secrets of every Pod scheduled to that node.
+
+        Rotation depends on a CSR approver running and on the signer being configured; without those the kubelet's renewal requests accumulate as pending CSRs and the certificate expires anyway, so watch pending CSRs and node certificate expiry as an operational signal. This setting covers the client certificate only; the serving certificate is configured separately and is the subject of a companion check in this policy.
       audit: |
         Check the kubelet CLI parameters to ensure '--rotate-certificates' is not set to false, and that the kubelet config file has not set 'rotateCertificates' to false.
       remediation: |
@@ -714,17 +732,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kubelet configuration file is owned by the root user and group, and that its permissions are set to restrict access to only the root user. This configuration helps prevent unauthorized users from accessing or modifying sensitive kubelet settings.
+        This check verifies that the kubelet configuration file can be read and written only by root.
+
+        The kubelet's own configuration decides how it authenticates callers, how it authorizes them, which CA it trusts, and which directory it watches for static Pods. The check inspects the file named by `--config` on the kubelet, normally `/var/lib/kubelet/config.yaml`, and requires ownership by `root:root` with read access for the owner and nothing for anyone else, which is mode `600` or `400`.
 
         **Why this matters**
 
-        The kubelet configuration file contains critical settings that control the behavior and security of the Kubernetes node. If ownership or permissions are misconfigured:
+        Write access to this file is node takeover with no credential required. Setting `authorization.mode` to `AlwaysAllow` and enabling anonymous authentication turns the kubelet API into an unauthenticated remote execution service for every container on the node, and the change takes effect at the next kubelet restart.
 
-        - Unauthorized users may gain access to sensitive configuration details or credentials.
-        - Malicious actors could modify the file to weaken node security or disrupt cluster operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        Read access is less dramatic and still valuable to an attacker. The file names the paths of the serving certificate and key, the client CA bundle, and the static Pod directory, which tells them exactly which files to target next and where to drop a manifest that the kubelet will run.
 
-        By ensuring proper ownership and restrictive permissions on the kubelet configuration file, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        The static Pod directory named in this file deserves particular attention, because anything written there becomes a Pod the kubelet starts without the API server, without admission control, and without any policy engine seeing it.
+
+        Permissions here usually drift because a configuration management tool wrote the file with the process umask rather than an explicit mode, so fix the tool instead of the file; otherwise the next node built from the same path repeats it. Node access control is the real boundary in any case, since these permissions only matter once someone is already on the node.
       audit: |
         The file evaluated here is the one the kubelet was started with, named by its `--config` argument and defaulting to `/var/lib/kubelet/config.yaml`. It is not `/etc/kubernetes/kubelet.conf`, which is the kubelet's kubeconfig.
 
@@ -824,17 +844,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kubelet's certificate authorities configuration file is owned by the root user and group, and that its permissions are set to restrict access to only the root user. This configuration helps prevent unauthorized users from accessing or modifying the certificate authorities file, which is critical for secure kubelet authentication.
+        This check verifies that the kubelet's client certificate authority bundle exists and is writable only by root.
+
+        `authentication.x509.clientCAFile` in the kubelet configuration file, or `--client-ca-file` on the kubelet command line, names the bundle the kubelet uses to validate client certificates presented to its API. The check requires the setting to be present, and requires the file it names to be owned by `root:root` with read access for the owner and no group or other permissions.
 
         **Why this matters**
 
-        The certificate authorities file is used to validate client certificates for kubelet authentication. If ownership or permissions are misconfigured:
+        If the setting is absent, certificate authentication to the kubelet is simply off, and whatever else is configured, or anonymous access, becomes the only way in.
 
-        - Unauthorized users may gain access to sensitive certificate data, increasing the risk of credential compromise.
-        - Malicious actors could modify the file to weaken authentication or disrupt cluster operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        A writable bundle is worse than a missing one. Anyone who can append a certificate authority to that file can then issue themselves a client certificate for any subject they like and authenticate to the kubelet as an identity the cluster treats as privileged. Nothing distinguishes the forged identity from a real one in any log the node keeps, so it is an authentication bypass that leaves no trace.
 
-        By ensuring proper ownership and restrictive permissions on the kubelet's certificate authorities file, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        Read access matters too, though less. The bundle discloses which authorities are trusted, which tells an attacker precisely which private key is worth stealing and from which host.
+
+        Review the contents as well as the permissions. Every certificate authority in the file is a full authentication path into the kubelet, so the bundle should hold the cluster CA and nothing else; an extra authority added for a one-off integration routinely outlives the integration.
       audit: |
         The file evaluated here is the one named by `authentication.x509.clientCAFile` in the kubelet configuration, so read that path before inspecting anything. The path differs by distribution: kubeadm nodes use `/etc/kubernetes/pki/ca.crt` and GKE nodes use `/etc/srv/kubernetes/pki/ca-certificates.crt`.
 
@@ -931,17 +953,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the API server pod specification file has permissions set to `600` and is owned by `root:root`. This configuration restricts access to the file, ensuring that only the root user can read or modify it.
+        This check verifies that the API server's static Pod manifest can be modified only by root.
+
+        On a kubeadm-style control plane the API server runs as a static Pod defined by `/etc/kubernetes/manifests/kube-apiserver.yaml`, a file the kubelet watches directly and applies without the API server, admission control, or any policy engine in the path. The check requires the file, when present, to be owned by `root:root` and to be readable and writable by its owner alone.
 
         **Why this matters**
 
-        The API server pod specification file is critical for the operation and security of the Kubernetes control plane. If ownership or permissions are misconfigured:
+        Write access to this file is control plane takeover and needs no cluster credential. Adding `--anonymous-auth=true`, setting `--authorization-mode=AlwaysAllow`, or pointing `--token-auth-file` at a file the attacker wrote all take effect within seconds, because the kubelet restarts the static Pod as soon as the manifest changes.
 
-        - Unauthorized users may gain access to sensitive configuration details or credentials.
-        - Malicious actors could modify the file to weaken cluster security or disrupt operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        Nothing sees the change while it happens. Static Pods bypass the API server entirely, so no ValidatingAdmissionPolicy, PodSecurity evaluation, or webhook is consulted, and the object appears in the API only afterward as a mirror Pod that reflects whatever was already started.
 
-        By ensuring the API server pod specification file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        Read access leaks the control plane's full configuration: which admission plugins are loaded, where the certificates and encryption provider configuration live, and which authentication paths are enabled. That is the map an attacker uses to choose which file to modify.
+
+        The whole `/etc/kubernetes/manifests` directory needs the same treatment, not this file alone, since the kubelet starts anything placed there. Treat interactive access to control plane nodes as equivalent to cluster-admin, because file permissions only begin to matter after someone is already on the node.
       audit: |
         On each control plane node, inspect the ownership and permissions of the API server pod specification file:
 
@@ -1045,17 +1069,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the etcd data directory has permissions set to `700` and is owned by the `etcd` user and group. This configuration restricts access to sensitive etcd data, such as Kubernetes Secrets, to only the etcd service account.
+        This check verifies that the etcd data directory is accessible only to the etcd service account.
+
+        etcd stores the whole of Kubernetes state on disk, and unless an encryption provider is configured it stores it unencrypted. The check inspects `/var/lib/etcd`, falling back to the directory named by etcd's `--data-dir` flag when that path does not exist, and requires ownership by `etcd:etcd` with access for the owner alone.
 
         **Why this matters**
 
-        The etcd data directory contains critical cluster data, including secrets and configuration information. If ownership or permissions are misconfigured:
+        Everything the cluster knows is in those files, including every Secret in every namespace. Reading the directory is equivalent to reading every Secret in the cluster, and it is done without an API request, so RBAC never applies and the audit log records nothing.
 
-        - Unauthorized users may gain access to sensitive data stored in etcd, increasing the risk of credential compromise or data leakage.
-        - Malicious actors could modify or delete etcd data, potentially disrupting cluster operations or weakening security controls.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        Write access is worse. Modifying etcd's data changes RoleBindings, Secrets, and admission configuration directly, with no validation, no admission control, and no controller reconciling the change back. The API server serves whatever it finds there.
 
-        By ensuring the etcd data directory is owned by the `etcd` user and group and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        The exposure travels with copies of the data. Snapshots taken for backup carry the same plaintext, so a snapshot written to object storage with permissive access is a full cluster credential compromise that generates no cluster-side alert at all.
+
+        Permissions are the floor rather than the control. Pair them with encryption at rest through an `EncryptionConfiguration` using a KMS provider, verified by a companion check in this policy, and treat etcd snapshots as the most sensitive artifact the cluster produces, with access controls and retention to match.
       audit: |
         On the etcd node, identify the data directory and inspect its ownership and permissions:
 
@@ -1128,17 +1154,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `admin.conf` file is owned by `root:root` and has permissions set to `600`. This configuration restricts access to the file, ensuring that only the root user can read or modify it.
+        This check verifies that the cluster administrator kubeconfig can be read only by root.
+
+        `/etc/kubernetes/admin.conf` embeds a client certificate whose subject places the holder in the `system:masters` group. The check requires the file, when present, to be owned by `root:root` and to be readable and writable by its owner alone.
 
         **Why this matters**
 
-        The `admin.conf` file contains credentials and configuration for cluster administration. If ownership or permissions are misconfigured:
+        `system:masters` is special-cased in the API server's authorization chain. RBAC is not consulted for it, so the permission cannot be narrowed by any Role or ClusterRole, and no admission policy the cluster runs can constrain what the holder does.
 
-        - Unauthorized users may gain access to sensitive configuration details or credentials.
-        - Malicious actors could modify the file to weaken cluster security or disrupt operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        It also cannot be revoked. Kubernetes checks no certificate revocation list and no OCSP responder, so an issued certificate is valid until it expires, typically a year. Anyone who copies this file keeps unrestricted control of the cluster from anywhere the API server is reachable, and the only real remediation is rotating the cluster CA and reissuing every certificate that depended on it.
 
-        By ensuring the `admin.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        Its use is close to invisible. The audit log records the identity `kubernetes-admin`, which is the identity every operator uses for routine work, so a stolen credential and a legitimate one produce the same entries and there is nothing to correlate against.
+
+        Treat the file as break-glass rather than as a working credential. Copy it off the node to controlled storage during bootstrap, remove or tightly restrict the local copy, and give people their own identities through an OIDC provider or short-lived certificates so that day-to-day work never runs as `system:masters`.
       audit: |
         On each control plane node, inspect the ownership and permissions of the `admin.conf` file:
 
@@ -1227,17 +1255,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `scheduler.conf` file is owned by `root:root` and has permissions set to `600`. This configuration restricts access to the file, ensuring that only the root user can read or modify it.
+        This check verifies that the scheduler's kubeconfig can be read only by root.
+
+        `/etc/kubernetes/scheduler.conf` holds the client credential the kube-scheduler uses to authenticate to the API server as `system:kube-scheduler`. The check requires the file, when present, to be owned by `root:root` and to be readable and writable by its owner alone.
 
         **Why this matters**
 
-        The `scheduler.conf` file contains credentials and configuration for the Kubernetes scheduler. If ownership or permissions are misconfigured:
+        That identity decides where Pods run. It can bind any pending Pod to any node, which means placing a workload on a node the attacker already controls so that the Pod's Secrets can be read from the node's disk, or placing an attacker's Pod onto a control plane node where the PKI directory and etcd data live.
 
-        - Unauthorized users may gain access to sensitive configuration details or credentials.
-        - Malicious actors could modify the file to weaken cluster security or disrupt operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        It also reads Pods, Nodes, PersistentVolumes, and related objects cluster-wide, which is complete reconnaissance of what runs where and on which storage, without touching anything that looks unusual in an audit log.
 
-        By ensuring the `scheduler.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        Write access to the file is a different problem. Changing the server address or the embedded credential either redirects the scheduler or simply stops scheduling cluster-wide, and an outage caused that way looks like a component bug rather than an intrusion.
+
+        Exposure of this file is a rotation event, not a permissions fix: regenerate it with `kubeadm init phase kubeconfig scheduler` and restart the component. The same reasoning applies to `kubelet.conf` on every node, which carries a node identity with its own reach.
       audit: |
         On each control plane node, inspect the ownership and permissions of the `scheduler.conf` file:
 
@@ -1326,17 +1356,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `controller-manager.conf` file is owned by `root:root` and has permissions set to `600`. This configuration restricts access to the file, ensuring that only the root user can read or modify it.
+        This check verifies that the controller manager's kubeconfig can be read only by root.
+
+        `/etc/kubernetes/controller-manager.conf` holds the client credential the kube-controller-manager uses to authenticate as `system:kube-controller-manager`. The check requires the file, when present, to be owned by `root:root` and to be readable and writable by its owner alone.
 
         **Why this matters**
 
-        The `controller-manager.conf` file contains credentials and configuration for the Kubernetes controller manager. If ownership or permissions are misconfigured:
+        This is the most privileged identity in the cluster short of `system:masters`. The controller manager creates service account tokens as part of its normal work, so possession of its credential means minting a token for any service account in any namespace, including ones bound to `cluster-admin`. That is a direct route to full control that never touches an RBAC object.
 
-        - Unauthorized users may gain access to sensitive configuration details or credentials.
-        - Malicious actors could modify the file to weaken cluster security or disrupt operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        It reads every Secret in the cluster as well, because it must resolve image pull secrets and populate service account credentials, so the credential is also a cluster-wide read of everything sensitive.
 
-        By ensuring the `controller-manager.conf` file is owned by `root:root` and has restrictive permissions, organizations can reduce the risk of unauthorized access and maintain a secure Kubernetes environment.
+        The resulting audit trail points at the wrong place. Actions taken with a minted token are recorded as that service account, so an investigation sees a workload behaving oddly rather than a stolen control plane credential.
+
+        The node running the controller manager is normally also where the cluster signing key lives, since `--cluster-signing-cert-file` and its key are read from disk there, so protect that path with equal care. Treat exposure of this file as a credential rotation plus a review of recently issued tokens rather than as a permissions correction.
       audit: |
         On each control plane node, inspect the ownership and permissions of the `controller-manager.conf` file:
 
@@ -1423,17 +1455,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the Kubernetes PKI/SSL directory is owned by `root:root`. This configuration restricts access to sensitive certificate and key material, ensuring that only the root user and group can modify or access these files.
+        This check verifies that the directory holding the cluster's certificates and private keys is owned by root.
+
+        The check locates the PKI directory from the directory containing the file named by the API server's `--etcd-certfile` flag, falling back to `/etc/kubernetes/pki`, and requires it to be owned by `root:root`.
 
         **Why this matters**
 
-        The PKI/SSL directory contains critical certificates and keys used to secure communication within the Kubernetes cluster. If ownership is misconfigured:
+        Directory ownership governs creation and replacement, not only reading, and that is why it is checked separately from the file modes inside. A non-root owner of the directory can unlink a key file and write a new one in its place even when that file is mode `600`, because the permission to do so comes from the directory rather than from the file.
 
-        - Unauthorized users may gain access to or modify certificates, compromising cluster security.
-        - Attackers could replace trusted certificates, enabling man-in-the-middle attacks or unauthorized access.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        What the directory holds makes that decisive. The cluster CA private key mints a client certificate for any subject, including one in `system:masters`, which is unrestricted cluster control that no RBAC rule limits and that cannot be revoked. The service account signing key mints a valid token for any service account without touching the API at all. The etcd client and peer keys read cluster state directly, bypassing the API server and its audit log.
 
-        By ensuring the PKI/SSL directory is owned by `root:root`, organizations can maintain strong access controls and protect the integrity of cluster encryption and authentication.
+        Replacement is as damaging as theft. Substituting a CA certificate that the control plane trusts inserts an authority the attacker controls, after which they issue their own credentials at will and every one of them validates correctly.
+
+        Ownership is one half of the control; verify the file modes inside as well, because a world-readable private key in a root-owned directory is still a world-readable private key. Longer term, moving the signing keys to a hardware or KMS-backed signer removes an exposure that file permissions can only reduce.
       audit: |
         On each control plane node, inspect the ownership of the Kubernetes PKI/SSL directory:
 
@@ -1485,17 +1519,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver is not listening on an insecure HTTP port. Disabling the insecure port enforces encrypted communication and prevents sensitive data from being transmitted in plaintext.
+        This check verifies that the API server does not offer an unauthenticated plaintext port.
+
+        The API server's insecure port served the full API over HTTP with authentication and authorization skipped altogether: every request arrived as `system:anonymous` and every check was bypassed. The flag is `--insecure-port` on the API server, set in its static Pod manifest at `/etc/kubernetes/manifests/kube-apiserver.yaml`, and it must be `0`.
 
         **Why this matters**
 
-        The Kubernetes API server is the central management point for the cluster. If it listens on an insecure HTTP port:
+        Anything that reached that port held unrestricted control of the cluster. There was no credential to steal because none was required, and the audit trail attributed everything to the anonymous user, so a compromise through it produced no identity to investigate.
 
-        - Unencrypted traffic can be intercepted, exposing sensitive cluster data and credentials.
-        - Attackers may exploit the insecure port to gain unauthorized access or disrupt cluster operations.
-        - Compliance with security best practices and regulatory requirements may be violated.
+        It bound to the loopback address by default, which sounds contained until you notice what shares loopback on a control plane node. Any Pod scheduled there with `hostNetwork: true` sees it, as does any process on the node and any debugging proxy someone left running, so the practical exposure was much wider than the bind address suggested.
 
-        By ensuring the kube-apiserver does not listen on an insecure HTTP port, organizations can protect sensitive data in transit and maintain a strong security posture for their Kubernetes clusters.
+        The flag was deprecated in Kubernetes 1.10 and removed in 1.20. A cluster where it still has a non-zero value is therefore running a release that has been out of support for years and is missing every security fix issued since, which is a larger problem than the port itself.
+
+        On Kubernetes 1.20 and later the flag no longer exists and there is nothing to set. Read a failure here as a signal about cluster age and plan the upgrade rather than only editing the manifest.
       audit: |
         Inspect the API server arguments on each control plane node:
 
@@ -1545,17 +1581,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver does not allow anonymous authentication. Disabling anonymous authentication enforces proper access control and prevents unauthenticated users from accessing the Kubernetes API server.
+        This check verifies that the API server rejects requests that carry no credentials.
+
+        With anonymous authentication enabled the API server accepts unauthenticated requests and evaluates them as the user `system:anonymous` in the group `system:unauthenticated`. The flag is `--anonymous-auth` on the API server, set in its static Pod manifest, and it must be `false`.
 
         **Why this matters**
 
-        The Kubernetes API server is the central management point for the cluster. If anonymous authentication is enabled:
+        Whether anonymous access is harmless depends entirely on what RBAC grants `system:unauthenticated`, and that group is a recurring accident. A ClusterRoleBinding written to mean "everyone in the company" should name `system:authenticated`; when it names the anonymous group instead, or binds to all groups, the cluster API is public.
 
-        - Unauthenticated users may gain access to sensitive cluster resources and information.
-        - Attackers could exploit this access to perform unauthorized actions or escalate privileges.
-        - Compliance with security standards and best practices may be compromised.
+        Even the default bindings let an anonymous caller read the version and health endpoints, which is enough to fingerprint the exact Kubernetes release from outside and pick a matching exploit before trying anything else.
 
-        By ensuring that anonymous authentication is disabled, organizations can maintain strong access controls and protect the security and integrity of their Kubernetes clusters.
+        Anonymous is also the fallback identity when a bearer token is malformed or expired, so a client bug quietly becomes an unauthenticated request that succeeds against whatever the anonymous user can reach, instead of failing loudly with a 401 that someone would investigate.
+
+        Load balancer and health probes are the usual reason teams leave this on. Kubernetes 1.32 and later can restrict anonymous access to a named list of endpoints such as `/healthz` through the authentication configuration file, which is the right shape for that requirement. Audit ClusterRoleBindings for `system:unauthenticated` and `system:anonymous` subjects as well, because turning the flag off and leaving the binding in place fixes only half of it.
       audit: |
         Inspect the API server arguments on each control plane node:
 
@@ -1603,17 +1641,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Pod mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The Pod's specification must declare no `hostPath` volume under `spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -1685,17 +1725,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the CronJob mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The CronJob's pod template must declare no `hostPath` volume under `spec.jobTemplate.spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -1772,17 +1814,19 @@ queries:
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the StatefulSet mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The StatefulSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -1855,17 +1899,19 @@ queries:
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Deployment mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The Deployment's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -1938,17 +1984,19 @@ queries:
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Job mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The Job's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2021,17 +2069,19 @@ queries:
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the ReplicaSet mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The ReplicaSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2104,17 +2154,19 @@ queries:
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/docker.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the Docker socket (`/var/run/docker.sock`). Mounting the Docker socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the DaemonSet mounts the host's Docker socket.
+
+        The Docker socket at `/var/run/docker.sock` is the control channel of the node's container runtime, and any process that can write to it can ask the runtime to start containers with any settings it likes. The DaemonSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the Docker socket can lead to significant security risks:
+        A mount of the runtime socket is a container escape by design rather than by exploit. A process inside the Pod speaks the Docker API directly, and the daemon on the other end runs as root on the node, outside every Kubernetes admission control and RBAC rule.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. The attacker asks the daemon for a new container with the node's root filesystem bind-mounted at `/host` and `Privileged` set, then chroots into it. Nothing about that container exists in the Kubernetes API, so it survives deletion of the original Pod, appears in no `kubectl get pods` output, and leaves nothing in the API audit log.
 
-        By ensuring that containers do not mount the Docker socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Cryptomining campaigns against Kubernetes, including the TeamTNT activity that scanned for exposed Docker endpoints, have relied on exactly this path, and it needs no vulnerability in the runtime at all.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A `volumes` list that mounts `/var/run/docker.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2187,17 +2239,19 @@ queries:
     mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Pod mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The Pod's specification must declare no `hostPath` volume under `spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2266,17 +2320,19 @@ queries:
     mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the CronJob mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The CronJob's pod template must declare no `hostPath` volume under `spec.jobTemplate.spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2353,17 +2409,19 @@ queries:
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the StatefulSet mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The StatefulSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2436,17 +2494,19 @@ queries:
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers in Deployments do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Deployment mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The Deployment's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2519,17 +2579,19 @@ queries:
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Job mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The Job's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2602,17 +2664,19 @@ queries:
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the ReplicaSet mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The ReplicaSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2685,17 +2749,19 @@ queries:
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/run/containerd/containerd.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the containerd socket (`/run/containerd/containerd.sock`). Mounting the containerd socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the DaemonSet mounts the host's containerd socket.
+
+        The containerd socket at `/run/containerd/containerd.sock` is the control channel of the node's container runtime, and write access to it is equivalent to running `ctr` or `crictl` as root on the node. The DaemonSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the containerd socket can lead to significant security risks:
+        containerd runs as root on the node and applies none of the Kubernetes admission controls that govern Pods. A process holding its socket creates containers directly, with whatever mounts, capabilities, and namespaces it chooses.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Pull or reuse an image, create a task with the node's root filesystem bind-mounted and host namespaces joined, then chroot into it. Containers created this way, particularly in a namespace other than `k8s.io`, do not appear as Pods anywhere in the Kubernetes API, so they survive deletion of the workload that created them and show up in no cluster-side inventory.
 
-        By ensuring that containers do not mount the containerd socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. Because containerd is the default runtime on most managed Kubernetes offerings, this socket, rather than Docker's, is the one usually present to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A `volumes` list that mounts `/run/containerd/containerd.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2768,17 +2834,19 @@ queries:
     mql: k8s.pod.podSpec['volumes'] == null || k8s.pod.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Pod mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The Pod's specification must declare no `hostPath` volume under `spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2847,17 +2915,19 @@ queries:
     mql: k8s.cronjob.podSpec['volumes'] == null || k8s.cronjob.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the CronJob mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The CronJob's pod template must declare no `hostPath` volume under `spec.jobTemplate.spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -2934,17 +3004,19 @@ queries:
     mql: k8s.statefulset.podSpec['volumes'] == null || k8s.statefulset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the StatefulSet mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The StatefulSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -3017,17 +3089,19 @@ queries:
     mql: k8s.deployment.podSpec['volumes'] == null || k8s.deployment.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Deployment mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The Deployment's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -3100,17 +3174,19 @@ queries:
     mql: k8s.job.podSpec['volumes'] == null || k8s.job.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the Job mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The Job's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -3183,17 +3259,19 @@ queries:
     mql: k8s.replicaset.podSpec['volumes'] == null || k8s.replicaset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the ReplicaSet mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The ReplicaSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -3266,17 +3344,19 @@ queries:
     mql: k8s.daemonset.podSpec['volumes'] == null || k8s.daemonset.podSpec['volumes'].where(_['hostPath'] != empty).all(_['hostPath']['path'] != '/var/run/crio/crio.sock')
     docs:
       desc: |
-        This check ensures that containers do not mount the CRI-O socket (`/var/run/crio/crio.sock`). Mounting the CRI-O socket into a container provides direct access to the container runtime, bypassing Kubernetes security controls and authentication.
+        This check verifies that no container in the DaemonSet mounts the host's CRI-O socket.
+
+        The CRI-O socket at `/var/run/crio/crio.sock` speaks the Container Runtime Interface, the same API the kubelet uses to create and destroy pods and containers on the node. The DaemonSet's pod template must declare no `hostPath` volume under `spec.template.spec.volumes` whose `path` is that socket.
 
         **Why this matters**
 
-        Allowing containers to access the CRI-O socket can lead to significant security risks:
+        Holding the CRI socket means issuing the kubelet's own instructions to the runtime. A process inside the Pod can create a pod sandbox and containers on the node with any mounts, capabilities, and namespaces it asks for, and CRI-O carries all of it out as root.
 
-        - Containers can create or control other containers on the host, potentially escalating privileges.
-        - Attackers may gain access to the host file system or create containers that are not visible to the Kubernetes API.
-        - Sensitive information and credentials may be exposed, and compliance with security best practices may be violated.
+        The move is short. Create a container with the node's root filesystem mounted and privileged options set, then chroot into it. Because the request never reaches the API server, no admission plugin, PodSecurity profile, or policy webhook evaluates it, and no scheduler decision or audit entry records it. The resulting workload is invisible to `kubectl` entirely.
 
-        By ensuring that containers do not mount the CRI-O socket, organizations can prevent privilege escalation, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        From the node, the reachable material is the kubelet's client credential, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud provider instance metadata service with the node's IAM role behind it. CRI-O is the default runtime on OpenShift, so on those clusters this is the socket that exists to be mounted.
+
+        A small number of workloads genuinely want the runtime socket: node-level log shippers, image builders, and some monitoring agents. Try the runtime-agnostic route first, reading container logs from `/var/log/containers` or building images with a rootless builder such as Kaniko or Buildah. Where the mount is unavoidable, pin that workload to dedicated nodes, restrict who may create Pods in its namespace, and mount it read-only if the tool supports it. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A `volumes` list that mounts `/var/run/crio/crio.sock` as a `hostPath` triggers this check, as shown in the manifest below:
 
@@ -3350,17 +3430,19 @@ queries:
       k8s.pod.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the Pod can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3416,17 +3498,19 @@ queries:
       k8s.cronjob.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the CronJob can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.jobTemplate.spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3490,17 +3574,19 @@ queries:
       k8s.statefulset.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the StatefulSet can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3560,17 +3646,19 @@ queries:
       k8s.deployment.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the Deployment can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3630,17 +3718,19 @@ queries:
       k8s.job.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the Job can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3700,17 +3790,19 @@ queries:
       k8s.replicaset.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the ReplicaSet can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
 
@@ -3770,17 +3862,19 @@ queries:
       k8s.daemonset.allowsPrivilegeEscalation == false
     docs:
       desc: |
-        This check ensures that privilege escalation is not allowed in containers by setting `allowPrivilegeEscalation` to `false` in the security context. This configuration prevents processes within containers from gaining more privileges than their parent process, reducing the risk of privilege escalation attacks.
+        This check verifies that no container in the DaemonSet can gain more privileges than the process that started it.
+
+        `allowPrivilegeEscalation` controls the kernel's `no_new_privs` bit. With the bit set, `execve` cannot grant the new program any capability, setuid identity, or file capability that the caller did not already hold. Set `securityContext.allowPrivilegeEscalation: false` on every container and init container under `spec.template.spec`, since Kubernetes defaults the field to `true`.
 
         **Why this matters**
 
-        Allowing privilege escalation in containers can enable attackers or compromised processes to gain elevated privileges, potentially leading to container escapes or unauthorized access to the host system. If privilege escalation is permitted:
+        Without `no_new_privs`, any setuid-root binary left in the image is a path from an unprivileged container user straight back to root inside the container. Images built from full distributions ship several by default, among them `su`, `mount`, and `ping`, and none of them were part of anybody's threat model when the image was chosen.
 
-        - Containers may be able to bypass security boundaries and access sensitive resources.
-        - Attackers could exploit vulnerabilities to gain root or administrative access on the host.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Root inside the container is not root on the node, but it is the launch pad for what follows. It grants write access to every mounted volume regardless of file ownership, read access to the Secrets projected into the Pod, the ability to raise the container's capability set to its bounding limit, and reach into kernel interfaces an ordinary user cannot touch. Published escapes such as the `runc` file descriptor overwrite tracked as CVE-2019-5736 need root in the container as their only precondition.
 
-        By ensuring that privilege escalation is disallowed, organizations can strengthen container isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        The field is also forced to `true` whenever the container is privileged or holds `CAP_SYS_ADMIN`, so a hardened base image never delivers this setting for you; it has to be written into the manifest.
+
+        Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A DaemonSet container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true`. The following manifest shows the violating configuration:
 
@@ -3838,17 +3932,19 @@ queries:
       k8s.pod.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the Pod runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -3916,17 +4012,19 @@ queries:
       k8s.cronjob.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the CronJob runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.jobTemplate.spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4006,17 +4104,19 @@ queries:
       k8s.statefulset.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the StatefulSet runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4090,17 +4190,19 @@ queries:
       k8s.deployment.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the Deployment runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4174,17 +4276,19 @@ queries:
       k8s.job.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the Job runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4258,17 +4362,19 @@ queries:
       k8s.replicaset.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the ReplicaSet runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4342,17 +4448,19 @@ queries:
       k8s.daemonset.runsPrivileged == false
     docs:
       desc: |
-        This check ensures that containers are not running as privileged containers. Privileged containers have the same capabilities as the host, including unrestricted access to all devices and the host's network, which can undermine Kubernetes security controls.
+        This check verifies that no container in the DaemonSet runs in privileged mode.
+
+        A privileged container is started with the full Linux capability set, every device node in the node's `/dev` exposed, seccomp and AppArmor confinement dropped, and the masked and read-only paths in `/proc` and `/sys` removed. Leave `securityContext.privileged` unset or set it to `false` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Running containers as privileged grants them elevated permissions that can be exploited to compromise the host or other workloads. If containers are allowed to run as privileged:
+        Privileged mode is not a stronger container. It is an unconfined root process that happens to have its own filesystem view, and nearly everything Kubernetes does to isolate a workload is switched off for it.
 
-        - Attackers may gain access to sensitive host resources or escalate privileges outside the container.
-        - The isolation between workloads is weakened, increasing the risk of container escapes.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The escape is a handful of commands, and none of them are exploits. The container holds `CAP_SYS_ADMIN`, so it mounts the node's root block device, which is visible under `/dev` because device access is unrestricted, and reads or writes any file on the node. It can also write to `/sys` and `/proc/sys`, which means loading a kernel module, changing kernel parameters, or using the cgroup `release_agent` interface to have the kernel execute a chosen binary as root on the node.
 
-        By ensuring that containers do not run as privileged, organizations can maintain strong workload isolation and reduce the risk of privilege escalation or host compromise.
+        Once on the node, the reachable material is the kubelet's client credential, the container runtime socket, the on-disk copy of every Secret mounted into every Pod scheduled there, and the cloud instance credentials. On a control plane node it also includes the etcd data directory, which holds every Secret in the cluster in plaintext unless encryption at rest is configured.
+
+        Some node-level agents genuinely require it, notably CNI plugins, CSI node drivers, and a few storage and observability agents. For those, look for the narrowest replacement that works: a single capability such as `CAP_NET_ADMIN`, one device through the device plugin API, or a targeted `hostPath` mount. Where privileged mode really is required, keep the workload in its own namespace and hold Pod creation rights there tightly, because anyone who can create a Pod in that namespace has root on the node. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A container's `securityContext` that sets `privileged: true` triggers this check, as shown in the manifest below:
 
@@ -4426,17 +4534,19 @@ queries:
       k8s.pod.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the Pod run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4494,17 +4604,19 @@ queries:
       k8s.cronjob.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the CronJob run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.jobTemplate.spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4570,17 +4682,19 @@ queries:
       k8s.statefulset.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the StatefulSet run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4642,17 +4756,19 @@ queries:
       k8s.deployment.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the Deployment run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4714,17 +4830,19 @@ queries:
       k8s.job.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the Job run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4786,17 +4904,19 @@ queries:
       k8s.replicaset.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the ReplicaSet run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4858,17 +4978,19 @@ queries:
       k8s.daemonset.hasWritableRootFilesystem == false
     docs:
       desc: |
-        This check ensures that containers are configured to use an immutable (read-only) root filesystem. This configuration prevents processes within the container from modifying the filesystem at runtime, reducing the risk of unauthorized changes or persistence by attackers.
+        This check verifies that containers in the DaemonSet run with an immutable root filesystem.
+
+        An immutable root filesystem mounts the container's image layers read-only, so writes succeed only in volumes you declared, such as an `emptyDir` mounted at `/tmp`. Set `securityContext.readOnlyRootFilesystem: true` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Allowing containers to write to the root filesystem can introduce significant security risks:
+        A writable root filesystem is what turns code execution into persistence. An attacker who reaches a shell writes a tool to disk, adds a cron entry, replaces a binary on the `PATH`, or drops a web shell into the application's static directory. With the layers read-only, every one of those writes fails and the attacker is confined to memory and to the few paths you chose to make writable.
 
-        - Attackers or compromised processes may modify binaries or configuration files, enabling privilege escalation or persistence.
-        - Malicious changes to the filesystem can go undetected, making incident response and recovery more difficult.
-        - Compliance with security best practices and organizational policies may be compromised.
+        It removes a class of supply chain behavior along with it. A malicious post-install step in a dependency, an update endpoint that tries to overwrite the application binary, and a cryptominer that unpacks itself into `/usr/local/bin` all fail on write rather than succeeding quietly.
 
-        By ensuring that containers use a read-only root filesystem, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        It also narrows forensics in a useful direction. When the root layers cannot change, the running container is byte for byte the image you can pull and inspect, so a responder compares behavior against a known artifact instead of an unknown one.
+
+        Applications that write inside their image directory need explicit volumes before this can be turned on, most often an `emptyDir` at `/tmp` plus one at whatever run or cache directory the runtime uses, for example `/var/run` for nginx or the user cache directory for Python tooling. Language runtimes that compile on first use and servers that write PID files are the usual sources of failure. Roll it out with those mounts declared rather than exempting the workload. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Each container's `securityContext` should set `readOnlyRootFilesystem: true`. The manifest below shows the required configuration:
 
@@ -4931,17 +5053,19 @@ queries:
       k8s.pod.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the Pod run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5028,17 +5152,19 @@ queries:
       k8s.cronjob.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the CronJob run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.jobTemplate.spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5140,17 +5266,19 @@ queries:
       k8s.statefulset.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the StatefulSet run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5244,17 +5372,19 @@ queries:
       k8s.deployment.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the Deployment run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5349,17 +5479,19 @@ queries:
       k8s.job.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the Job run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5453,17 +5585,19 @@ queries:
       k8s.replicaset.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the ReplicaSet run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5557,17 +5691,19 @@ queries:
       k8s.daemonset.runsAsRoot == false
     docs:
       desc: |
-        This check ensures that containers do not run as the root user by requiring `runAsNonRoot: true` in the security context. This configuration enforces that containers run with a non-root user, reducing the risk of privilege escalation and unauthorized access.
+        This check verifies that containers in the DaemonSet run as a non-root user.
+
+        A container with no `runAsUser` and no `USER` line in its image runs as UID 0, and on a cluster without user namespace remapping that is UID 0 on the node as well. Set `securityContext.runAsNonRoot: true` together with an explicit numeric `securityContext.runAsUser` under `spec.template.spec`, either on the pod-level security context or per container.
 
         **Why this matters**
 
-        Running containers as the root user grants them the same privileges as root on the host system. If containers run as root:
+        Root in a container is not root on the node, but it is the precondition for nearly every escape that follows. It carries the container's full capability set rather than an empty one, write access to every mounted volume regardless of file ownership, and reach into kernel interfaces that an ordinary UID cannot touch.
 
-        - Attackers or compromised processes may gain elevated privileges, increasing the risk of container escapes or host compromise.
-        - Security boundaries between workloads are weakened, making it easier to access sensitive resources.
-        - Compliance with security best practices and organizational policies may be violated.
+        Concretely, UID 0 in the container is UID 0 on any `hostPath` volume the Pod mounts, so a node directory mounted for a seemingly harmless reason becomes writable node state. It is also the sole prerequisite for several published escapes, including the `runc` binary overwrite tracked as CVE-2019-5736 and the cgroup `release_agent` technique.
 
-        By ensuring that containers run as non-root, organizations can strengthen workload isolation, reduce the attack surface, and maintain a secure Kubernetes environment.
+        Running as an ordinary UID collapses all of that. The same remote code execution now lands on an account that cannot write to system directories, cannot bind ports below 1024, and holds no capabilities to begin with, so the attacker's next step usually fails instead of escalating.
+
+        Images that assume root normally do so to bind port 80 or to write into directories owned by root at build time. Bind above 1024 and let the Service map the port, and `chown` the writable directories during the image build rather than granting root at runtime. Set `runAsNonRoot` alongside a numeric `runAsUser`, because `runAsNonRoot` alone only rejects images that declare UID 0 and cannot resolve a username that happens to map to 0. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Each container's `securityContext` should set `runAsNonRoot: true`. The manifest below shows the required configuration:
 
@@ -5660,18 +5796,19 @@ queries:
     mql: k8s.pod.hostNetwork != true
     docs:
       desc: |
-        This check ensures that pods are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the Pod does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -5726,18 +5863,19 @@ queries:
     mql: k8s.cronjob.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the CronJob does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.jobTemplate.spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -5800,18 +5938,19 @@ queries:
     mql: k8s.statefulset.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods in StatefulSets are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the StatefulSet does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -5870,18 +6009,19 @@ queries:
     mql: k8s.deployment.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods in Deployments are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the Deployment does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -5940,18 +6080,19 @@ queries:
     mql: k8s.job.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods in Jobs are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the Job does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -6011,18 +6152,19 @@ queries:
       k8s.replicaset.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods in ReplicaSets are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the ReplicaSet does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -6082,18 +6224,19 @@ queries:
       k8s.daemonset.podSpec['hostNetwork'] != true
     docs:
       desc: |
-        This check ensures that pods in DaemonSets are not configured to use the `hostNetwork` namespace. Setting `hostNetwork: true` allows containers to share the host's network namespace, including access to loopback devices and network interfaces.
+        This check verifies that the DaemonSet does not share the node's network namespace.
+
+        `hostNetwork: true` places the Pod's containers directly in the node's network namespace instead of giving them one of their own. They then see the node's interfaces and addresses, bind node ports with no port mapping, and bypass the CNI data path entirely. Leave `spec.template.spec.hostNetwork` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host network can introduce significant security risks:
+        Network policy stops applying to that workload. NetworkPolicy is enforced by the CNI plugin against a Pod's own IP address, and a host-network Pod does not have one; it has the node's. Every rule that selects it stops matching, and the workload is reachable on whatever the node's firewall permits.
 
-        - Containers may intercept or interfere with network traffic intended for other pods or the host.
-        - Attackers could exploit this access to escalate privileges or bypass network policies.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        The Pod also gains reach it would never have had. Node loopback is now in scope, which is where control plane components, the kubelet's own listeners, and unauthenticated debugging endpoints bind precisely because they assume only node-local callers can reach them. On managed clusters the node network is also the route to the cloud instance metadata service, so a compromised host-network Pod can request the node's IAM credentials.
 
-        By ensuring that pods do not use the host network, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        Finally the Pod can bind any free port on the node, which lets a compromised workload sit in front of a legitimate node service or occupy a port a system component expects to have.
+
+        A few workloads need it: CNI agents, kube-proxy replacements, and ingress controllers that terminate traffic on the node itself. For everything else the alternative is a Service, and where a node-level entry point is genuinely required, a `NodePort` Service exposes one port rather than the whole namespace. Where host networking must stay, pair it with node-level firewall rules, since NetworkPolicy will not help. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A pod `spec` that sets `hostNetwork: true` triggers this check, as shown in the manifest below:
 
@@ -6152,18 +6295,19 @@ queries:
     mql: k8s.pod.hostPID != true
     docs:
       desc: |
-        This check ensures that pods are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the Pod does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6216,18 +6360,19 @@ queries:
     mql: k8s.cronjob.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the CronJob does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.jobTemplate.spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6288,18 +6433,19 @@ queries:
     mql: k8s.statefulset.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods in StatefulSets are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the StatefulSet does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6356,18 +6502,19 @@ queries:
     mql: k8s.deployment.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods in Jobs are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the Deployment does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6424,18 +6571,19 @@ queries:
     mql: k8s.job.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods in Jobs are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the Job does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6492,18 +6640,19 @@ queries:
     mql: k8s.replicaset.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods in DaemonSets are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the ReplicaSet does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6561,18 +6710,19 @@ queries:
       k8s.daemonset.podSpec['hostPID'] != true
     docs:
       desc: |
-        This check ensures that pods in DaemonSets are not configured to use the `hostPID` namespace. Setting `hostPID: true` allows containers to share the host's process ID namespace, which can be used to escalate privileges outside a container.
+        This check verifies that the DaemonSet does not share the node's process ID namespace.
+
+        `hostPID: true` gives the Pod's containers the node's process table instead of a private one, so `/proc` inside the container lists every process on the machine. Leave `spec.template.spec.hostPID` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host PID namespace can introduce significant security risks:
+        The node's process list is a credential store in practice. Command lines are world readable through `/proc/<pid>/cmdline`, and control plane components, database clients, and backup jobs routinely take tokens, connection strings, and passwords as arguments. A container with `hostPID` reads all of them with no privilege beyond being in the namespace.
 
-        - Containers may view or interact with processes running on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Process environments are readable too when the UIDs line up, through `/proc/<pid>/environ`, and that is where most injected Secrets end up. A container running as root with `hostPID` therefore reads the environment of every process on the node, which in a typical cluster means the Secrets of every Pod that landed there.
 
-        By ensuring that pods do not use the host PID namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It breaks isolation in the other direction as well. Process IDs are shared, so a container that also holds `CAP_SYS_PTRACE` can attach a debugger to a node process, and one that can signal PID 1 can stop or restart node services. Combined with a node mount, `/proc/<pid>/root` becomes a path into another container's filesystem.
+
+        Node-level profilers, debuggers, and some monitoring agents need it, and there is no narrower substitute for a tool whose job is to inspect other processes. For those, restrict who can schedule into the namespace and drop `CAP_SYS_PTRACE` unless the tool actually attaches to processes. Where the goal is only to see sidecar processes rather than node ones, `shareProcessNamespace` within a single Pod does that without exposing the node. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A pod `spec` that sets `hostPID: true` triggers this check, as shown in the manifest below:
 
@@ -6630,18 +6780,19 @@ queries:
       k8s.pod.hostIPC != true
     docs:
       desc: |
-        This check ensures that pods are not configured to use the `hostIPC` namespace. Setting `hostIPC: true` allows containers to share the host's IPC namespace, which can be used to break container isolation.
+        This check verifies that the Pod does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.hostIPC` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host IPC namespace can introduce significant security risks:
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
 
-        - Containers may access or interfere with IPC resources on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
 
-        By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -6695,18 +6846,19 @@ queries:
       k8s.cronjob.podSpec['hostIPC'] != true
     docs:
       desc: |
-        This check ensures that pods in CronJobs are not configured to use the `hostIPC` namespace. Setting `hostIPC: true` allows containers to share the host's IPC namespace, which can be used to break container isolation.
+        This check verifies that the CronJob does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.jobTemplate.spec.template.spec.hostIPC` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host IPC namespace can introduce significant security risks:
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
 
-        - Containers may access or interfere with IPC resources on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
 
-        By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -6768,18 +6920,19 @@ queries:
       k8s.statefulset.podSpec['hostIPC'] != true
     docs:
       desc: |
-        This check ensures that pods in StatefulSets are not configured to use the `hostIPC` namespace. Setting `hostIPC: true` allows containers to share the host's IPC namespace, which can be used to break container isolation.
+        This check verifies that the StatefulSet does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.template.spec.hostIPC` unset or set it to `false`.
 
         **Why this matters**
 
-        Allowing pods to use the host IPC namespace can introduce significant security risks:
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
 
-        - Containers may access or interfere with IPC resources on the host, increasing the risk of privilege escalation or container escapes.
-        - Attackers could exploit this access to interfere with host processes or gain unauthorized access to sensitive information.
-        - The isolation between workloads is weakened, making it easier for threats to move laterally within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
 
-        By ensuring that pods do not use the host IPC namespace, organizations can maintain strong process isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -6836,7 +6989,19 @@ queries:
     mql: k8s.deployment.podSpec['hostIPC'] != true
     docs:
       desc: |
-        Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
+        This check verifies that the Deployment does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.template.spec.hostIPC` unset or set it to `false`.
+
+        **Why this matters**
+
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
+
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
+
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -6894,7 +7059,19 @@ queries:
       k8s.job.podSpec['hostIPC'] != true
     docs:
       desc: |
-        Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
+        This check verifies that the Job does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.template.spec.hostIPC` unset or set it to `false`.
+
+        **Why this matters**
+
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
+
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
+
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -6952,7 +7129,19 @@ queries:
       k8s.replicaset.podSpec['hostIPC'] != true
     docs:
       desc: |
-        Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
+        This check verifies that the ReplicaSet does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.template.spec.hostIPC` unset or set it to `false`.
+
+        **Why this matters**
+
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
+
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
+
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -7010,7 +7199,19 @@ queries:
       k8s.daemonset.podSpec['hostIPC'] != true
     docs:
       desc: |
-        Enabling `hostIPC` gives containers access to the host's IPC namespace and breaks container isolation.
+        This check verifies that the DaemonSet does not share the node's inter-process communication namespace.
+
+        `hostIPC: true` joins the Pod's containers to the node's System V IPC and POSIX message queue namespace, so shared memory segments, semaphores, and message queues created anywhere on the node are visible inside the container and the reverse holds too. Leave `spec.template.spec.hostIPC` unset or set it to `false`.
+
+        **Why this matters**
+
+        Shared memory is where processes put data they consider already inside the trust boundary. Databases keep buffer pools there, and application servers cache decrypted material in it. A container in the node IPC namespace enumerates those segments with `ipcs` and attaches to any whose permissions allow it, which for segments created under the same UID means all of them.
+
+        Write access is the sharper edge. Attaching to another process's segment and modifying it corrupts that process's view of its own memory, which is a direct route to influencing its control flow rather than merely reading its data. `/dev/shm` is shared as well, so files another workload wrote there are both readable and replaceable.
+
+        The namespace also outlives the container. A compromised Pod can leave data or a communication channel behind in it for a later Pod scheduled onto the same node to pick up, which is a covert channel between workloads that never share a network path.
+
+        Legitimate uses are narrow and involve attaching to shared memory created by a node agent, most often in high performance computing and some GPU stacks. Where two containers only need to share memory with each other, put them in the same Pod and use an `emptyDir` with `medium: Memory` or `shareProcessNamespace` instead of exposing the node's namespace. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         A pod `spec` that sets `hostIPC: true` triggers this check, as shown in the manifest below:
 
@@ -7070,13 +7271,19 @@ queries:
       k8s.pod.serviceAccountName != 'default' || k8s.pod.automountServiceAccountToken == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the Pod either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7161,13 +7368,19 @@ queries:
       k8s.cronjob.podSpec['serviceAccountName'] != 'default' || k8s.cronjob.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the CronJob either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.jobTemplate.spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.jobTemplate.spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7268,13 +7481,19 @@ queries:
       k8s.statefulset.podSpec['serviceAccountName'] != 'default' || k8s.statefulset.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the StatefulSet either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7367,13 +7586,19 @@ queries:
       k8s.deployment.podSpec['serviceAccountName'] != 'default' || k8s.deployment.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the Deployment either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7466,13 +7691,19 @@ queries:
       k8s.job.podSpec['serviceAccountName'] != 'default' || k8s.job.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the Job either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7565,13 +7796,19 @@ queries:
       k8s.replicaset.podSpec['serviceAccountName'] != 'default' || k8s.replicaset.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the ReplicaSet either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7664,13 +7901,19 @@ queries:
       k8s.daemonset.podSpec['serviceAccountName'] != 'default' || k8s.daemonset.podSpec['automountServiceAccountToken'] == false
     docs:
       desc: |
-        Pods that interact with the Kubernetes API using a ServiceAccount should use specific ServiceAccounts.
-        These ServiceAccounts should only have the permissions necessary.
-        The Pods should not use the default ServiceAccount (named 'default') that is included in every Namespace.
-        The only valid use for the default ServiceAccount is for Pods that set '.spec.automountServiceAccountToken' to 'false'.
-        In this case, the Pod explicitly asks for no ServiceAccount to be mounted into the Pod's filesystem, and the Pod is therefore a ServiceAccount-less Pod.
-        When every Pods uses the default ServiceAccount and the ServiceAccount's privileges get extended, all Pods get these permissions.
-        When a Pod is compromised, the attacker has access to the API using the default ServiceAccount.
+        This check verifies that the DaemonSet either runs under a service account chosen for it or has API token mounting turned off.
+
+        Every namespace ships a service account named `default`, and a Pod that names none is assigned it. Set `spec.template.spec.serviceAccountName` to an account created for this workload, and where the deprecated `serviceAccount` field is still present make sure the two agree. A workload that does not call the Kubernetes API can instead set `spec.template.spec.automountServiceAccountToken: false`, which satisfies this check because no API credential is placed in the Pod at all.
+
+        **Why this matters**
+
+        The `default` service account is shared by every workload in the namespace that did not ask for its own, so any permission granted to it is granted to all of them at once. Roles accumulate on it precisely because it is the account people bind to when one workload needs API access, and the grant silently spreads to every neighbor.
+
+        It also destroys attribution. Audit logs record the requesting identity, so a namespace where ten workloads all authenticate as `system:serviceaccount:<namespace>:default` produces a trail that cannot say which one read a Secret or deleted an object, and incident response has nothing to narrow on.
+
+        The token is the immediate prize. Unless mounting is disabled, the kubelet projects a valid API bearer token into every container at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Any code execution in the Pod reads it, and every permission the account holds becomes the attacker's.
+
+        Most workloads never call the Kubernetes API, and for those the right answer is not a dedicated account but `automountServiceAccountToken: false`, which removes the credential entirely. Where the workload does call the API, give it its own service account bound to a Role listing only the verbs and resources it uses. Setting `automountServiceAccountToken: false` on the `default` service account object itself is a useful backstop for the whole namespace. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check that Pods do not set the legacy '.spec.serviceAccount':
 
@@ -7775,8 +8018,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
-        Avoid using rolling tags like `latest` or `master` as they can change over time.
+        This check verifies that containers in the Pod name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container, init container, and ephemeral container under `spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
+
+        **Why this matters**
+
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
+
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
+
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -7843,8 +8097,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
-        Avoid using rolling tags like `latest` or `master` as they can change over time.
+        This check verifies that containers in the CronJob name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.jobTemplate.spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
+
+        **Why this matters**
+
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
+
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
+
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -7919,8 +8184,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        It's important that each time a pod is started the same container is pulled, so that services across pods behave the same. To ensure the same container is always used, manifests should set `imagePullPolicy: Always` and the `image` configuration should pull either a tag or a digest (SHA).
-        Avoid using rolling tags like `latest` or `master` as they can change over time.
+        This check verifies that containers in the StatefulSet name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
+
+        **Why this matters**
+
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
+
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
+
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -7991,18 +8267,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        This check ensures that Deployments are configured to always pull a specific container image using a tag or digest, and that the `imagePullPolicy` is set to `Always`. This configuration guarantees that each time a pod is started, the same container image is used, ensuring consistency and predictability across workloads.
+        This check verifies that containers in the Deployment name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
 
         **Why this matters**
 
-        Consistent image pulling is important for several reasons:
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
 
-        - Ensures that all pods run the intended version of the container, reducing the risk of unexpected behavior or incompatibility.
-        - Prevents the use of rolling tags like `latest` or `master`, which can change over time and introduce untested or insecure code into production.
-        - Supports traceability and reproducibility, which are essential for debugging, auditing, and compliance.
-        - Reduces the risk of supply chain attacks by ensuring only approved images are used.
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
 
-        By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -8073,18 +8350,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        This check ensures that Jobs are configured to always pull a specific container image using a tag or digest, and that the `imagePullPolicy` is set to `Always`. This configuration guarantees that each time a pod is started, the same container image is used, ensuring consistency and predictability across workloads.
+        This check verifies that containers in the Job name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
 
         **Why this matters**
 
-        Consistent image pulling is important for several reasons:
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
 
-        - Ensures that all pods run the intended version of the container, reducing the risk of unexpected behavior or incompatibility.
-        - Prevents the use of rolling tags like `latest` or `master`, which can change over time and introduce untested or insecure code into production.
-        - Supports traceability and reproducibility, which are essential for debugging, auditing, and compliance.
-        - Reduces the risk of supply chain attacks by ensuring only approved images are used.
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
 
-        By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -8155,18 +8433,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        This check ensures that ReplicaSets are configured to always pull a specific container image using a tag or digest, and that the `imagePullPolicy` is set to `Always`. This configuration guarantees that each time a pod is started, the same container image is used, ensuring consistency and predictability across deployments.
+        This check verifies that containers in the ReplicaSet name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
 
         **Why this matters**
 
-        Consistent image pulling is important for several reasons:
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
 
-        - Ensures that all pods run the intended version of the container, reducing the risk of unexpected behavior or incompatibility.
-        - Prevents the use of rolling tags like `latest` or `master`, which can change over time and introduce untested or insecure code into production.
-        - Supports traceability and reproducibility, which are essential for debugging, auditing, and compliance.
-        - Reduces the risk of supply chain attacks by ensuring only approved images are used.
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
 
-        By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -8237,18 +8516,19 @@ queries:
         .all( imagePullPolicy == 'Always' && imageName != /:latest/ && imageName.contains(':') == true )
     docs:
       desc: |
-        This check ensures that DaemonSets are configured to always pull a specific container image using a tag or digest, and that the `imagePullPolicy` is set to `Always`. This configuration guarantees that each time a pod is started, the same container image is used, ensuring consistency and predictability across deployments.
+        This check verifies that containers in the DaemonSet name a specific image tag and re-pull it on every start.
+
+        Three things are required of every container and init container under `spec.template.spec`: `imagePullPolicy` set to `Always`, an image reference that carries an explicit tag rather than relying on the implicit `latest`, and a tag that is not `latest`. Images that legitimately cannot meet this can be listed in the `mondooKubernetesSecurityExcludedByFixedImages` property of this policy, which the check skips.
 
         **Why this matters**
 
-        Consistent image pulling is important for several reasons:
+        `imagePullPolicy: IfNotPresent` means the node runs whatever it already has cached under that name. If a compromised or simply outdated image sits in the node's cache under the same tag, a new Pod runs it and no pull happens for a registry audit log or an admission-time scanner to see. `Always` also forces a registry authorization check on every start, which is what makes revoking a pull secret actually stop an image from running.
 
-        - Ensures that all pods run the intended version of the container, reducing the risk of unexpected behavior or incompatibility.
-        - Prevents the use of rolling tags like `latest` or `master`, which can change over time and introduce untested or insecure code into production.
-        - Supports traceability and reproducibility, which are essential for debugging, auditing, and compliance.
-        - Reduces the risk of supply chain attacks by ensuring only approved images are used.
+        The `latest` tag is the other half. It is mutable, so the image behind it changes while the manifest stays the same, and two replicas of the same workload started an hour apart can be running different code. That breaks rollback, because there is no earlier reference to roll back to, and it breaks incident response, because the digest that was scanned is not necessarily the digest that ran.
 
-        By enforcing strict image pull policies and avoiding mutable tags, organizations can improve reliability, security, and maintainability of their Kubernetes workloads.
+        Together the two settings make the image reference mean something. A pinned tag with `Always` says that the workload's code is identified in the manifest and fetched under current credentials rather than inherited from whatever a node happened to keep.
+
+        Air-gapped clusters and nodes that side-load images cannot use `Always`, and those images belong in the excluded-images property so the exception is recorded rather than the check skipped. Referencing an image by digest, as `image@sha256:...`, pins the exact bytes and is stronger than any tag policy, though this check still expects `Always` alongside it. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Each container should set `imagePullPolicy: Always` and reference `image` by a specific tag or SHA digest. The manifest below shows the required configuration:
 
@@ -8308,18 +8588,19 @@ queries:
       k8s.pod.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that pods are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Pod declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that pods define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8375,18 +8656,19 @@ queries:
       k8s.cronjob.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that CronJobs are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the CronJob declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.jobTemplate.spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that CronJobs define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8450,18 +8732,19 @@ queries:
       k8s.statefulset.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that StatefulSets are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the StatefulSet declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that StatefulSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8521,18 +8804,19 @@ queries:
       k8s.deployment.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that Deployments are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Deployment declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that Deployments define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8592,18 +8876,19 @@ queries:
       k8s.job.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that Jobs are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Job declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that Jobs define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8663,18 +8948,19 @@ queries:
       k8s.replicaset.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that ReplicaSets are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the ReplicaSet declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that ReplicaSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8734,18 +9020,19 @@ queries:
       k8s.daemonset.hasCpuLimit == true
     docs:
       desc: |
-        This check ensures that DaemonSets are configured with CPU limits for all containers. Setting CPU limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the DaemonSet declares a CPU limit.
+
+        A CPU limit is enforced by the kernel's CFS bandwidth controller, which throttles the container's cgroup once it exceeds its quota within each scheduling period. Set `resources.limits.cpu` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting CPU limits for containers can introduce significant operational and security risks:
+        Without a limit, a container's CPU use is bounded only by the node. One workload in a hot loop, whether from a bug, a retry storm, or a cryptominer an attacker dropped, takes whatever the scheduler will give it, and every other Pod on that node slows down. That includes the kubelet, and a starved kubelet misses its node status updates, which leads the control plane to mark the node `NotReady` and evict workloads that were never at fault.
 
-        - Containers without CPU limits may consume all available CPU on the node, causing other workloads to be throttled or the node to become unresponsive.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Availability is a security property here rather than a separate concern. The pattern is an ordinary denial of service: one unlimited container degrades a shared node, and on tightly packed clusters the failure cascades as evicted Pods reschedule onto neighbors and repeat it there.
 
-        By ensuring that DaemonSets define CPU limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        Limits also give unauthorized compute somewhere to become visible. A cryptominer in a container with no limit simply consumes the node and looks like load. In a container with a limit it hits a ceiling and shows up as sustained throttling in metrics, which is something an alert can fire on.
+
+        Latency-sensitive workloads can be hurt by CPU limits, because CFS throttling adds tail latency even when the node has spare capacity, so some teams deliberately set requests without limits for those. Where that is the choice, bound it with a namespace `ResourceQuota` and `LimitRange` so the exception is explicit, and keep limits on everything that does not need it. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Each container should declare a CPU value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8805,18 +9092,19 @@ queries:
       k8s.pod.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that pods are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Pod declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that pods define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8874,7 +9162,19 @@ queries:
       k8s.cronjob.hasMemoryLimit == true
     docs:
       desc: |
-        Kubernetes pod configurations should set memory limits for containers defined in the manifest. This prevents the pod from exhausting the host's resources in case of an application malfunction or an attack.
+        This check verifies that every container in the CronJob declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.jobTemplate.spec.template.spec`.
+
+        **Why this matters**
+
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
+
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
+
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -8940,18 +9240,19 @@ queries:
       k8s.statefulset.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that StatefulSets are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the StatefulSet declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that StatefulSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -9013,18 +9314,19 @@ queries:
       k8s.deployment.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that Deployments are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Deployment declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that Deployments define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -9086,18 +9388,19 @@ queries:
       k8s.job.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that Jobs are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the Job declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that Jobs define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -9159,18 +9462,19 @@ queries:
       k8s.replicaset.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that ReplicaSets are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the ReplicaSet declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that ReplicaSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -9232,18 +9536,19 @@ queries:
       k8s.daemonset.hasMemoryLimit == true
     docs:
       desc: |
-        This check ensures that DaemonSets are configured with memory limits for all containers. Setting memory limits prevents containers from consuming excessive host resources, which could lead to node instability or denial of service.
+        This check verifies that every container in the DaemonSet declares a memory limit.
+
+        A memory limit becomes the container cgroup's memory ceiling, and the kernel's out-of-memory killer terminates the container's processes when it is exceeded. Set `resources.limits.memory` on every container and init container under `spec.template.spec`.
 
         **Why this matters**
 
-        Not setting memory limits for containers can introduce significant operational and security risks:
+        Memory has no throttle. A container without a limit that keeps allocating is stopped only when the node runs out, and at that point the kernel picks a victim by score rather than by fault. It frequently kills something else, so a leak in one workload surfaces as a crash in an unrelated one, and the node can become unresponsive before anything is killed at all.
 
-        - Containers without memory limits may consume all available memory on the node, causing other workloads to be evicted or the node to crash.
-        - Attackers or malfunctioning applications could exploit the lack of limits to perform denial-of-service attacks.
-        - Predictable resource usage is essential for reliable scheduling and cluster stability.
-        - Compliance with security best practices and organizational policies may be compromised.
+        That makes an unbounded container a cheap denial of service. An attacker who can influence memory use, through a large upload, a decompression bomb, or a query that materializes an unbounded result, takes down a node rather than a Pod, and every tenant sharing that node goes with it.
 
-        By ensuring that DaemonSets define memory limits for all containers, organizations can maintain cluster stability, prevent resource exhaustion, and improve the overall security posture of their Kubernetes environment.
+        A limit turns the same event into a contained, attributable restart. The offending container is killed, its Pod reports `OOMKilled`, the controller restarts it, and its neighbors keep running. It also fixes the workload's Quality of Service class, which is what decides who is evicted first when the node is genuinely under pressure.
+
+        Set limits from observed usage with headroom, since a limit set too low turns a normal peak into a restart loop, and align JVM or Go runtime heap settings with the cgroup limit so the runtime does not keep allocating while it believes it has room. Pair limits with a namespace `LimitRange` so new workloads inherit a sane default instead of none. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Each container should declare a memory value under `resources.limits`. The manifest below shows the required configuration:
 
@@ -9310,18 +9615,19 @@ queries:
       k8s.pod.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that pods are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the Pod cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container, init container, and ephemeral container under `spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in pods to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that pods do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check to ensure no Pods have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9391,18 +9697,19 @@ queries:
       k8s.daemonset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that DaemonSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the DaemonSet cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in DaemonSets to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that DaemonSets do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check to ensure no DaemonSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9476,18 +9783,19 @@ queries:
       k8s.replicaset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that ReplicaSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the ReplicaSet cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in ReplicaSets to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that ReplicaSets do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check to ensure no ReplicaSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9561,18 +9869,19 @@ queries:
       k8s.job.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that Jobs are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the Job cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in Jobs to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that Jobs do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check to ensure no Jobs have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9646,18 +9955,19 @@ queries:
       k8s.deployment.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that Deployments are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the Deployment cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in Deployments to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that Deployments do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check to ensure no Deployments have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9731,18 +10041,19 @@ queries:
       k8s.statefulset.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that StatefulSets are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the StatefulSet cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in StatefulSets to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that StatefulSets do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check to ensure no StatefulSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9816,18 +10127,19 @@ queries:
       k8s.cronjob.containers.all( droppedCapabilities.any( _.upcase == /^NET_RAW$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that CronJobs are not running with the NET_RAW capability. The NET_RAW capability allows a process to write raw packets to the network interface, which can be used to craft malicious ARP or DNS responses and bypass network security controls.
+        This check verifies that containers in the CronJob cannot craft raw network packets.
+
+        `CAP_NET_RAW` lets a process open raw and packet sockets, building Ethernet and IP frames by hand instead of going through the kernel's normal socket path. Container runtimes grant it by default, so removing it takes an explicit `securityContext.capabilities.drop` of `NET_RAW` or `ALL` on every container under `spec.jobTemplate.spec.template.spec`, and no container may add it back through `capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in CronJobs to run with the NET_RAW capability can introduce significant security risks:
+        Raw sockets are the toolkit for attacking the Pod network from inside it. With `NET_RAW` a compromised container forges ARP replies to put itself between two Pods on the same node, forges DNS responses that beat the real resolver, and sends packets with a source address that is not its own, which defeats any control that identifies workloads by IP.
 
-        - Containers may be able to craft or intercept network packets, enabling network attacks such as spoofing or man-in-the-middle.
-        - Attackers could exploit this capability to escalate privileges or disrupt network communications within the cluster.
-        - The isolation between workloads is weakened, increasing the risk of lateral movement or compromise of other resources.
-        - Compliance with security best practices and organizational policies may be compromised.
+        DNS spoofing is the practical one. Cluster DNS traffic is plain UDP, and a container with raw socket access on the same node can answer a neighbor's query for a Service name before CoreDNS does, redirecting that neighbor's traffic to an endpoint of the attacker's choosing without touching a single Kubernetes object.
 
-        By ensuring that CronJobs do not run with the NET_RAW capability, organizations can reduce the attack surface, maintain strong network isolation, and improve the overall security posture of their Kubernetes environment.
+        Raw sockets also enable quiet reconnaissance and exfiltration. Scanning the cluster network, fingerprinting neighbors, and tunneling data inside ICMP payloads all need this capability, and none of them create the connection records that ordinary sockets would.
+
+        The capability is needed by workloads that ping, run traceroute, or capture traffic, which in practice means network debugging tools, some service mesh init containers, and a few monitoring agents. Grant it to those explicitly rather than leaving it enabled everywhere by default. Dropping `NET_RAW` is not a substitute for NetworkPolicy, since the container can still open ordinary connections; the two controls cover different halves of the problem. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check to ensure no CronJobs have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
@@ -9906,18 +10218,19 @@ queries:
       k8s.pod.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that pods are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the Pod requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container, init container, and ephemeral container under `spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in pods to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that pods do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check to ensure no Pods have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -9966,18 +10279,19 @@ queries:
       k8s.daemonset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that DaemonSets are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the DaemonSet requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in DaemonSets to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that DaemonSets do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check to ensure no DaemonSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10028,8 +10342,19 @@ queries:
       k8s.replicaset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        ReplicaSets should not run with SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls.
-        It even allows containers not running as root to run certain tasks as if the user was root.
+        This check verifies that no container in the ReplicaSet requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
+
+        **Why this matters**
+
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
+
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
+
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check to ensure no ReplicaSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10080,18 +10405,19 @@ queries:
       k8s.job.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that Jobs are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the Job requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in Jobs to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that Jobs do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check to ensure no Jobs have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10141,18 +10467,19 @@ queries:
     mql: k8s.deployment.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that Deployments are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the Deployment requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in Deployments to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that Deployments do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check to ensure no Deployments have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10203,18 +10530,19 @@ queries:
       k8s.statefulset.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that StatefulSets are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the StatefulSet requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in StatefulSets to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that StatefulSets do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check to ensure no StatefulSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10265,18 +10593,19 @@ queries:
       k8s.cronjob.containers.all( addedCapabilities.none( _.upcase == /^SYS_ADMIN$|^ALL$/ ) )
     docs:
       desc: |
-        This check ensures that CronJobs are not running with the SYS_ADMIN capability. The SYS_ADMIN capability enables a wide range of elevated system calls and can grant containers powerful privileges, even if they are not running as root.
+        This check verifies that no container in the CronJob requests the SYS_ADMIN capability.
+
+        `CAP_SYS_ADMIN` is the catch-all Linux capability, covering filesystem mounts, entering other namespaces with `setns`, manipulating cgroups, and dozens of other operations that had nowhere else to go. No container among every container under `spec.jobTemplate.spec.template.spec` may name `SYS_ADMIN` or `ALL` in `securityContext.capabilities.add`.
 
         **Why this matters**
 
-        Allowing containers in CronJobs to run with the SYS_ADMIN capability can introduce significant security risks:
+        Granting `CAP_SYS_ADMIN` is close to granting privileged mode, and it is often chosen because it looks narrower while delivering most of the same power.
 
-        - Containers may perform privileged operations that could compromise the host or other workloads.
-        - Attackers could exploit this capability to escalate privileges or bypass security controls.
-        - The isolation between workloads is weakened, increasing the risk of container escapes or lateral movement within the cluster.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Mount is the sharp edge. A container holding it can mount a filesystem, which is the basis of the cgroup `release_agent` escape: mount a cgroup v1 hierarchy inside the container, write a node path into `release_agent`, and the kernel executes that file as root on the node when the cgroup empties. It can also mount node block devices where they are reachable, and use `setns` to step into another process's namespaces when combined with `hostPID`.
 
-        By ensuring that CronJobs do not run with the SYS_ADMIN capability, organizations can reduce the attack surface, maintain workload isolation, and improve the overall security posture of their Kubernetes environment.
+        The capability additionally removes confinement people assume is still in place. It is what lets a container remount `/proc` and `/sys` paths that the runtime masked, exposing kernel interfaces such as `/proc/sysrq-trigger` and `/sys/kernel/uevent_helper`, both of which have documented paths to code execution on the node.
+
+        Very few applications need it, and when a workload asks for it the real requirement is usually one specific operation with a narrower answer: a CSI driver for mounting, `CAP_BPF` and `CAP_PERFMON` on modern kernels for observability, `CAP_SYS_PTRACE` for debugging. Where it genuinely is required, treat that Pod as node-privileged and control who can create Pods in its namespace accordingly. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check to ensure no CronJobs have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
@@ -10330,18 +10659,19 @@ queries:
       k8s.pod.initContainers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that pods do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the Pod binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container and init container under `spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in pods to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that pods do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check to ensure no Pods are binding any of their containers to a host port:
 
@@ -10394,18 +10724,19 @@ queries:
       k8s.daemonset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that DaemonSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the DaemonSet binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in DaemonSets to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that DaemonSets do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check to ensure no DaemonSets are binding any of their containers to a host port:
 
@@ -10460,18 +10791,19 @@ queries:
       k8s.replicaset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that ReplicaSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the ReplicaSet binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in ReplicaSets to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that ReplicaSets do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check to ensure no ReplicaSets are binding any of their containers to a host port:
 
@@ -10526,18 +10858,19 @@ queries:
       k8s.job.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that Jobs do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the Job binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in Jobs to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that Jobs do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check to ensure no Jobs are binding any of their containers to a host port:
 
@@ -10592,18 +10925,19 @@ queries:
       k8s.deployment.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that Deployments do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the Deployment binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in Deployments to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that Deployments do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check to ensure no Deployments are binding any of their containers to a host port:
 
@@ -10658,18 +10992,19 @@ queries:
       k8s.statefulset.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that StatefulSets do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the StatefulSet binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in StatefulSets to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that StatefulSets do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check to ensure no StatefulSets are binding any of their containers to a host port:
 
@@ -10724,18 +11059,19 @@ queries:
       k8s.cronjob.containers.all( ports == null || ports.none( _['hostPort']))
     docs:
       desc: |
-        This check ensures that CronJobs do not bind any of their containers to a host port. Binding to host ports allows containers to bypass Kubernetes network policies and access control systems, potentially exposing the container directly to the host network.
+        This check verifies that no container in the CronJob binds a port directly on the node.
+
+        A `hostPort` on a container port makes the kubelet program a forwarding rule on the node so that traffic arriving at that node port reaches the container, bypassing Services and their endpoint selection. No entry in the `ports` list of every container under `spec.jobTemplate.spec.template.spec` may set `hostPort`.
 
         **Why this matters**
 
-        Allowing containers in CronJobs to bind to host ports can introduce significant security risks:
+        A `hostPort` exposes the workload at the node's own address, on every node it can be scheduled to, outside anything the Service layer or an ingress controller mediates. Whatever the node network reaches can now reach the container, and in most clusters that is the whole VPC or subnet rather than the Pod network.
 
-        - Containers may bypass network segmentation and access controls, increasing the risk of lateral movement or unauthorized access.
-        - Host ports expose container services directly on the host, which may not be intended and can be exploited by attackers.
-        - Misconfigured host port bindings can lead to port conflicts, service disruptions, or accidental exposure of sensitive services.
-        - Compliance with security best practices and organizational policies may be compromised.
+        NetworkPolicy does not cover this path. Policy applies to Pod IP traffic on the CNI data path, while `hostPort` traffic arrives through node-level NAT rules, so a workload that looks fully restricted by policy can still be answering requests from outside the cluster.
 
-        By ensuring that CronJobs do not bind to host ports, organizations can maintain strong network isolation, reduce the attack surface, and improve the overall security posture of their Kubernetes environment.
+        It also constrains scheduling in a way that becomes an availability problem. Only one Pod per node can hold a given host port, so replicas silently stay `Pending`, and an attacker who can create a Pod can claim a port a legitimate component needs and take its place at the node's address.
+
+        Ingress controllers and some node agents use host ports deliberately, and expressing that as a DaemonSet is the honest form of it. For everything else use a Service, a `NodePort` where a node-level entry point is genuinely required, or a LoadBalancer. Where a host port must be used, restrict the node firewall to the sources that should reach it, because no Kubernetes object will. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check to ensure no CronJobs are binding any of their containers to a host port:
 
@@ -10845,18 +11181,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that pods do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the Pod mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container, init container, and ephemeral container under `spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in pods to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check to ensure no containers in a Pod are mounting hostPath volumes as read-write:
 
@@ -10925,18 +11262,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that DaemonSets do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the DaemonSet mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in DaemonSets to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check to ensure no containers in a DaemonSet are mounting hostPath volumes as read-write:
 
@@ -11007,18 +11345,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that ReplicaSets do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the ReplicaSet mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in ReplicaSets to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check to ensure no containers in a ReplicaSet are mounting hostPath volumes as read-write:
 
@@ -11089,18 +11428,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that Jobs do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the Job mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in Jobs to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check to ensure no containers in a Job are mounting hostPath volumes as read-write:
 
@@ -11171,18 +11511,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that Deployments do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the Deployment mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in Deployments to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check to ensure no containers in a Deployment are mounting hostPath volumes as read-write:
 
@@ -11253,18 +11594,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that StatefulSets do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the StatefulSet mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in StatefulSets to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check to ensure no containers in a StatefulSet are mounting hostPath volumes as read-write:
 
@@ -11335,18 +11677,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that CronJobs do not mount hostPath volumes as read-write. Mounting hostPath volumes as read-write allows containers to modify the underlying host filesystem, which can break container isolation and introduce significant security risks.
+        This check verifies that containers in the CronJob mount any node directory read-only.
+
+        A `hostPath` volume mounts a path from the node's filesystem into the container, and the `readOnly` flag on the mount decides whether the container can change what it finds there. Every `volumeMounts` entry among every container under `spec.jobTemplate.spec.template.spec` that refers to a `hostPath` volume must set `readOnly: true`.
 
         **Why this matters**
 
-        Allowing containers in CronJobs to write to hostPath volumes can lead to:
+        A writable node path is a straight line out of the container. Depending on the path, an attacker who reaches the container can write a static Pod manifest into `/etc/kubernetes/manifests`, which the kubelet starts as a Pod with any settings it likes including privileged, or drop a file into a systemd unit directory, a cron directory, or a binary on the node's `PATH` and wait for the node to run it.
 
-        - Containers mutating or damaging the host system, potentially leading to container escapes.
-        - Attackers gaining the ability to persist changes or escalate privileges on the host.
-        - Increased risk of lateral movement within the cluster or compromise of other workloads.
-        - Violations of security best practices and organizational policies.
+        Mounts that look innocuous are the usual culprits. `/var/log` is a common one for log shipping and it is node state that other tools follow; `/var/lib/kubelet` holds the on-disk copy of the Secrets projected into every Pod on that node; `/` and `/etc` mounted to read one configuration file rarely need write access at all.
 
-        By ensuring that hostPath volumes are mounted as read-only, organizations can reduce the attack surface, maintain workload isolation, and protect the integrity of the Kubernetes environment.
+        Read-only does not make a `hostPath` safe, it makes it one-directional. The container still reads whatever the path exposes, so the mount should also be as narrow as the workload allows, ideally a single file rather than a directory.
+
+        Node agents that genuinely write to the node, such as CNI installers placing binaries in `/opt/cni/bin` and CSI drivers creating mount points, are the legitimate exception. For everything else prefer a volume type with a real access model: an `emptyDir` for scratch, a `configMap` or `secret` for configuration, a PersistentVolume for data, and `hostPath` only where the node's own filesystem is the point of the workload. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check to ensure no containers in a CronJob are mounting hostPath volumes as read-write:
 
@@ -11402,18 +11745,19 @@ queries:
       k8s.deployment.containers.none( imageName.contains("tiller") )
     docs:
       desc: |
-        This check ensures that deployments are not running Tiller (the in-cluster component for the Helm v2 package manager). Tiller communicates directly with the Kubernetes API and has broad RBAC permissions, which can expose the cluster to significant security risks if not properly controlled.
+        This check verifies that the Deployment does not run Tiller, the server-side component of Helm v2.
+
+        Tiller is identified by its image, so this check fails when any container under `spec.template.spec` uses an image whose name contains `tiller`. The remediation is removal rather than reconfiguration.
 
         **Why this matters**
 
-        Running Tiller can introduce several security risks:
+        Tiller ran inside the cluster with a service account that almost every installation bound to `cluster-admin`, because it had to create whatever a chart declared. That alone made it the highest value target in any cluster running it.
 
-        - Tiller has cluster-wide access and can perform administrative actions, increasing the risk of privilege escalation.
-        - If Tiller is exposed or misconfigured, attackers could exploit it to gain unauthorized access or control over the cluster.
-        - Historical incidents have shown that exposed Tiller instances can lead to cluster compromise and abuse.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Its gRPC listener had no authentication or authorization of its own in the default configuration. Any workload that could reach Tiller's port on the Pod network could ask it to install a chart, and a chart can contain anything, including a privileged Pod or a ClusterRoleBinding granting the caller admin. In practice that turned any container compromise into a full cluster takeover with no credential involved.
 
-        By ensuring that deployments do not run Tiller, organizations can reduce the attack surface, protect sensitive cluster resources, and maintain a secure Kubernetes environment.
+        Helm v2 and Tiller reached end of life in November 2020 and receive no security fixes. Helm v3 removed the server-side component entirely and acts through the caller's own kubeconfig credentials, so installing a chart uses the installer's permissions rather than a shared administrative identity.
+
+        There is no supported configuration in which Tiller should still be running. Migrate releases with `helm 2to3 convert`, then delete the Tiller workload and its ClusterRoleBinding, and look for stale release ConfigMaps or Secrets left behind in `kube-system`. Deleting the Pod achieves nothing while the Deployment exists, since the ReplicaSet recreates it within seconds; remove the Deployment together with its service account and ClusterRoleBinding.
       audit: |
         Verify there are no deployments running Tiller:
 
@@ -11449,18 +11793,19 @@ queries:
       k8s.pod.ephemeralContainers.none( imageName.contains("tiller") )
     docs:
       desc: |
-        This check ensures that pods are not running Tiller (the in-cluster component for the Helm v2 package manager). Tiller communicates directly with the Kubernetes API and has broad RBAC permissions, which can expose the cluster to significant security risks if not properly controlled.
+        This check verifies that the Pod does not run Tiller, the server-side component of Helm v2.
+
+        Tiller is identified by its image, so this check fails when any container, init container, or ephemeral container under `spec` uses an image whose name contains `tiller`. The remediation is removal rather than reconfiguration.
 
         **Why this matters**
 
-        Running Tiller can introduce several security risks:
+        Tiller ran inside the cluster with a service account that almost every installation bound to `cluster-admin`, because it had to create whatever a chart declared. That alone made it the highest value target in any cluster running it.
 
-        - Tiller has cluster-wide access and can perform administrative actions, increasing the risk of privilege escalation.
-        - If Tiller is exposed or misconfigured, attackers could exploit it to gain unauthorized access or control over the cluster.
-        - Historical incidents have shown that exposed Tiller instances can lead to cluster compromise and abuse.
-        - Compliance with security best practices and organizational policies may be compromised.
+        Its gRPC listener had no authentication or authorization of its own in the default configuration. Any workload that could reach Tiller's port on the Pod network could ask it to install a chart, and a chart can contain anything, including a privileged Pod or a ClusterRoleBinding granting the caller admin. In practice that turned any container compromise into a full cluster takeover with no credential involved.
 
-        By ensuring that pods do not run Tiller, organizations can reduce the attack surface, protect sensitive cluster resources, and maintain a secure Kubernetes environment.
+        Helm v2 and Tiller reached end of life in November 2020 and receive no security fixes. Helm v3 removed the server-side component entirely and acts through the caller's own kubeconfig credentials, so installing a chart uses the installer's permissions rather than a shared administrative identity.
+
+        There is no supported configuration in which Tiller should still be running. Migrate releases with `helm 2to3 convert`, then delete the Tiller workload and its ClusterRoleBinding, and look for stale release ConfigMaps or Secrets left behind in `kube-system`. A Tiller Pod created directly stays deleted once removed, but check for a Deployment or an add-on manager that would recreate it before assuming the cluster is clean.
       audit: |
         Verify there are no pods running Tiller:
 
@@ -11496,18 +11841,19 @@ queries:
       k8s.deployment.labels["k8s-app"] == null || k8s.deployment.labels["k8s-app"] != "kubernetes-dashboard"
     docs:
       desc: |
-        This check ensures that deployments are not running the Kubernetes dashboard. The Kubernetes dashboard provides a web-based UI for managing cluster resources, which can expose sensitive information and administrative capabilities if not properly secured.
+        This check verifies that the Deployment is not running the Kubernetes Dashboard.
+
+        The Dashboard is identified two ways: an image name containing `kubernetes-dashboard` or `kubernetesui` on any container under `spec.template.spec`, and an `app` or `k8s-app` label with the value `kubernetes-dashboard` on the Deployment itself. Neither may be present.
 
         **Why this matters**
 
-        Running the Kubernetes dashboard can introduce significant security risks:
+        The Dashboard is a web UI backed by a service account, and its risk comes from how it is deployed rather than from its code. Installations that grant its service account broad permissions so the UI can display everything turn it into a path to those permissions for anyone who reaches its port.
 
-        - The dashboard may expose sensitive cluster resources, such as workloads, configmaps, and secrets, to unauthorized users.
-        - If the dashboard is publicly accessible or misconfigured, attackers could exploit it to extract credentials or escalate privileges.
-        - Historical incidents, such as the 2019 Tesla breach, have demonstrated that exposed dashboards can lead to cluster compromise and abuse (e.g., unauthorized deployments or cryptocurrency mining).
-        - Compliance with security best practices and organizational policies may be compromised.
+        This is not hypothetical. The 2018 compromise of Tesla's Kubernetes cluster began with a Dashboard exposed without authentication and ended with attackers running cryptomining workloads and reading cloud credentials from the cluster. The pattern recurs whenever the Dashboard is put behind an ingress for convenience.
 
-        By ensuring that deployments do not run the Kubernetes dashboard, organizations can reduce the attack surface, protect sensitive cluster data, and maintain a secure Kubernetes environment.
+        The Dashboard also offers `exec` into Pods and the ability to create and edit workloads, so access to it is equivalent to `kubectl` access with its service account's rights, minus the audit context a named human user would have provided.
+
+        Where a UI is genuinely wanted, deploy it with authentication in front of it, a service account scoped to read-only, and no ingress reachable from outside the cluster, then reach it through `kubectl proxy` or port-forward. Teams that only need visibility are usually better served by a read-only observability tool that authenticates each user individually. Remove the Deployment along with its Service, any ingress in front of it, and its ClusterRoleBinding, so that nothing recreates the workload or re-exposes it.
       audit: |
         Verify there are no deployments running Kubernetes dashboard:
 
@@ -11545,18 +11891,19 @@ queries:
       k8s.pod.labels["k8s-app"] == null || k8s.pod.labels["k8s-app"] != "kubernetes-dashboard"
     docs:
       desc: |
-        This check ensures that pods are not running the Kubernetes dashboard. The Kubernetes dashboard provides a web-based UI for managing cluster resources, which can expose sensitive information and administrative capabilities if not properly secured.
+        This check verifies that the Pod is not running the Kubernetes Dashboard.
+
+        The Dashboard is identified two ways: an image name containing `kubernetes-dashboard` or `kubernetesui` on any container, init container, or ephemeral container under `spec`, and an `app` or `k8s-app` label with the value `kubernetes-dashboard` on the Pod itself. Neither may be present.
 
         **Why this matters**
 
-        Running the Kubernetes dashboard can introduce significant security risks:
+        The Dashboard is a web UI backed by a service account, and its risk comes from how it is deployed rather than from its code. Installations that grant its service account broad permissions so the UI can display everything turn it into a path to those permissions for anyone who reaches its port.
 
-        - The dashboard may expose sensitive cluster resources, such as workloads, configmaps, and secrets, to unauthorized users.
-        - If the dashboard is publicly accessible or misconfigured, attackers could exploit it to extract credentials or escalate privileges.
-        - Historical incidents, such as the 2019 Tesla breach, have demonstrated that exposed dashboards can lead to cluster compromise and abuse (e.g., unauthorized deployments or cryptocurrency mining).
-        - Compliance with security best practices and organizational policies may be compromised.
+        This is not hypothetical. The 2018 compromise of Tesla's Kubernetes cluster began with a Dashboard exposed without authentication and ended with attackers running cryptomining workloads and reading cloud credentials from the cluster. The pattern recurs whenever the Dashboard is put behind an ingress for convenience.
 
-        By ensuring that pods do not run the Kubernetes dashboard, organizations can reduce the attack surface, protect sensitive cluster data, and maintain a secure Kubernetes environment.
+        The Dashboard also offers `exec` into Pods and the ability to create and edit workloads, so access to it is equivalent to `kubectl` access with its service account's rights, minus the audit context a named human user would have provided.
+
+        Where a UI is genuinely wanted, deploy it with authentication in front of it, a service account scoped to read-only, and no ingress reachable from outside the cluster, then reach it through `kubectl proxy` or port-forward. Teams that only need visibility are usually better served by a read-only observability tool that authenticates each user individually. A Dashboard Pod created directly stays deleted once removed, but check for a Deployment, a Helm release, or an add-on manager that would bring it back.
       audit: |
         Verify there are no pods running Kubernetes dashboard:
 
@@ -11590,18 +11937,19 @@ queries:
       k8s.pod.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in pods explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the Pod start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that pods drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
         Check to ensure all Pods drop ALL capabilities:
 
@@ -11651,18 +11999,19 @@ queries:
       k8s.daemonset.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in DaemonSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the DaemonSet start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that DaemonSets drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
         Check to ensure all DaemonSets drop ALL capabilities:
 
@@ -11714,18 +12063,19 @@ queries:
       k8s.replicaset.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in ReplicaSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the ReplicaSet start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that ReplicaSets drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
         Check to ensure all ReplicaSets drop ALL capabilities:
 
@@ -11777,18 +12127,19 @@ queries:
       k8s.job.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in Jobs explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the Job start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that Jobs drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
         Check to ensure all Jobs drop ALL capabilities:
 
@@ -11840,18 +12191,19 @@ queries:
       k8s.deployment.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in Deployments explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the Deployment start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that Deployments drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
         Check to ensure all Deployments drop ALL capabilities:
 
@@ -11903,18 +12255,19 @@ queries:
       k8s.statefulset.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in StatefulSets explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the StatefulSet start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that StatefulSets drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
         Check to ensure all StatefulSets drop ALL capabilities:
 
@@ -11966,18 +12319,19 @@ queries:
       k8s.cronjob.dropsAllCapabilities == true
     docs:
       desc: |
-        This check ensures that all containers in CronJobs explicitly drop ALL Linux capabilities. The Kubernetes Pod Security Standards Restricted profile requires containers to drop all capabilities and only add back specific ones that are needed.
+        This check verifies that containers in the CronJob start from an empty Linux capability set.
+
+        Container runtimes grant a default capability set that includes `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `NET_RAW`, and `KILL` whether or not the workload uses any of them. Set `securityContext.capabilities.drop: ["ALL"]` on every container and init container under `spec.jobTemplate.spec.template.spec`, then add back only what the workload actually needs.
 
         **Why this matters**
 
-        Linux capabilities grant specific privileged operations to processes. By default, container runtimes assign a set of capabilities to containers that most workloads do not need. Failing to drop all capabilities means containers run with unnecessary privileges:
+        The default set is a standing grant of privileges almost no application uses. `DAC_OVERRIDE` alone lets a process bypass file permission checks entirely, so a container running as an unprivileged user still reads and writes files it has no permission for. `SETUID` and `SETGID` let it change identity, which is what makes a setuid binary in the image worth anything to an attacker, and `CHOWN` with `FOWNER` let it rewrite ownership and permissions on any mounted volume.
 
-        - Containers retain default capabilities like NET_RAW, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, NET_BIND_SERVICE, SYS_CHROOT, MKNOD, and AUDIT_WRITE.
-        - Attackers who compromise a container can leverage these capabilities to escalate privileges, manipulate files, or perform network attacks.
-        - The principle of least privilege is violated, increasing the blast radius of any container compromise.
-        - Compliance with the Kubernetes Pod Security Standards Restricted profile requires dropping ALL capabilities.
+        Dropping the set changes what a foothold is worth. The same remote code execution now runs with no capabilities at all, so file permissions actually hold, raw sockets are unavailable, and the usual first moves after landing in a container fail with `EPERM` instead of proceeding.
 
-        By ensuring that CronJobs drop ALL capabilities, organizations enforce the principle of least privilege, reduce the attack surface, and align with Kubernetes security best practices.
+        This is also the control the Kubernetes Pod Security Standards restricted profile names directly, so satisfying it is what lets a namespace move from `baseline` to `restricted` enforcement rather than stalling there.
+
+        A workload that needs one capability should drop `ALL` and add that one back, for example `NET_BIND_SERVICE` for a server that must listen below port 1024, which is far narrower than accepting the default set. Applications that break after this change are usually leaning on `DAC_OVERRIDE` to paper over file ownership set wrongly at image build time, and fixing the ownership in the image is the durable answer. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
         Check to ensure all CronJobs drop ALL capabilities:
 
@@ -12031,19 +12385,19 @@ queries:
       k8s.persistentVolumes.none(spec["hostPath"] != null)
     docs:
       desc: |
-        This check ensures that no PersistentVolumes in the cluster use hostPath as a volume source.
+        This check verifies that no PersistentVolume is backed by a directory on a node.
+
+        A `hostPath` PersistentVolume presents a path on whichever node the consuming Pod lands on as though it were storage. No PersistentVolume in the cluster may declare `spec.hostPath`; use a CSI-backed StorageClass, or a `local` volume with node affinity where node-attached disks are genuinely wanted.
 
         **Why this matters**
 
-        hostPath PersistentVolumes mount directories from the host node's filesystem directly into pods, creating significant security risks:
+        It converts a namespaced, RBAC-controlled object into node filesystem access. Anyone who can create a PersistentVolumeClaim that binds to it gets read and write access to that node path from inside their Pod, without needing permission to declare a `hostPath` volume directly and without tripping the PodSecurity evaluation that would have blocked one.
 
-        - **Container escape**: Pods with access to the host filesystem can read or modify sensitive host files, including credentials, configuration, and container runtime sockets.
-        - **Cross-pod data access**: Any pod that mounts the same hostPath can access data belonging to other pods or the host, breaking namespace isolation.
-        - **Privilege escalation**: Write access to host paths such as `/etc`, `/var/run`, or `/var/lib/kubelet` can be chained with other vulnerabilities to escalate to host-level root access.
-        - **Node compromise**: A compromised container with hostPath access can modify host binaries, install backdoors, or tamper with kubelet configuration.
-        - **Multi-tenant risk**: In shared clusters, hostPath volumes bypass all namespace-level isolation boundaries.
+        The path chosen is rarely harmless. A PersistentVolume pointing at `/`, `/var`, `/etc`, or `/var/lib/kubelet` hands over node configuration, the kubelet's on-disk copy of Pod Secrets, or the static Pod manifest directory, and the last of those is a direct route to running a privileged Pod on that node.
 
-        Use cloud-native storage provisioners, CSI drivers, or network-attached storage instead of hostPath for persistent data.
+        It is also broken as storage. The data lives on one node with no replication and no snapshot, so a Pod rescheduled elsewhere sees an empty directory and a node failure loses the data outright, which is how these volumes end up silently empty in production.
+
+        `hostPath` PersistentVolumes are a development convenience, and the supported replacements are a CSI driver for real storage, `local` volumes with node affinity for node-attached disks, or an `emptyDir` for scratch space. Where one must exist, restrict who can create PersistentVolumeClaims in the namespaces able to bind it, since PersistentVolume objects are cluster-scoped and claims are how they are reached.
       audit: |
         List all PersistentVolumes that use a `hostPath` volume source:
 
@@ -12121,13 +12475,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver `--authorization-mode` flag includes both `Node` and `RBAC` and excludes `AlwaysAllow`. Without RBAC, every authenticated request is permitted; without `Node`, kubelets can read or modify resources unrelated to their own node; `AlwaysAllow` disables authorization entirely and must never be set on a production cluster.
+        This check verifies that the API server authorizes requests with the Node and RBAC authorizers and never with AlwaysAllow.
+
+        `--authorization-mode` on the API server takes an ordered list of authorizers, and a request is allowed as soon as one of them allows it. The list must contain both `Node` and `RBAC` and must not contain `AlwaysAllow`; `Node,RBAC` is the standard value.
 
         **Why this matters**
 
-        - `AlwaysAllow` makes every request succeed regardless of identity, allowing complete cluster takeover with any valid (or anonymous) credential.
-        - Missing `Node` lets a compromised kubelet read Secrets, ConfigMaps, and Pods from other nodes, expanding lateral-movement opportunities.
-        - Missing `RBAC` removes the role-based access control plane that limits what tokens, users, and ServiceAccounts can do.
+        `AlwaysAllow` anywhere in the list makes everything else decorative. Any authenticated request is permitted, so the RBAC policy the cluster carefully maintains is written, reviewed, and never consulted.
+
+        RBAC is what turns an identity into a bounded set of permissions. The alternatives are ABAC, which is a static file on the control plane node that needs an API server restart to change and cannot express namespaced roles cleanly, or nothing at all.
+
+        The `Node` authorizer constrains kubelets specifically. It limits each node's credential to the objects relevant to the Pods scheduled on that node, so a credential stolen from one worker reads the Secrets and ConfigMaps its own Pods use rather than every Secret in the cluster. Without it, compromising the least protected node in the fleet is equivalent to compromising all of them.
+
+        Pair the `Node` authorizer with the `NodeRestriction` admission plugin, which a companion check in this policy verifies: the authorizer limits what a node may read, while the admission plugin limits what it may write about itself and other nodes. Neither one substitutes for the other.
       audit: |
         Inspect the API server `--authorization-mode` argument on each control plane node:
 
@@ -12176,11 +12536,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `AlwaysAdmit` admission plugin is not enabled on the kube-apiserver. `AlwaysAdmit` accepts every admission request, bypassing all admission validation and security policy enforcement performed by other plugins.
+        This check verifies that the API server does not load the AlwaysAdmit admission controller.
+
+        Admission controllers run after authentication and authorization and decide whether an otherwise permitted request is acceptable. `AlwaysAdmit` returns an unconditional allow and does nothing else. The flag is `--enable-admission-plugins` on the API server, and it must either be unset or not name `AlwaysAdmit`.
 
         **Why this matters**
 
-        Admission controllers are the last line of defense before objects are persisted in etcd. Enabling `AlwaysAdmit` voids policy controls such as `PodSecurity`, `NodeRestriction`, and `ResourceQuota`, allowing privileged or non-compliant workloads to be created.
+        `AlwaysAdmit` was deprecated in Kubernetes 1.13 and nothing needs it. It does not switch off the other plugins in the chain, but its presence is a reliable sign that the admission configuration was copied from an old or permissive template rather than assembled deliberately, and such configurations are usually missing the plugins that matter.
+
+        Admission is where the controls that actually constrain workloads live. `PodSecurity` rejects a privileged Pod, `NodeRestriction` stops a compromised kubelet from editing other nodes, `ResourceQuota` bounds a namespace, and validating webhooks enforce whatever policy engine the cluster runs.
+
+        Because admission runs after authorization, it is the last opportunity to refuse a request that RBAC already permitted. RBAC can say that a service account may create Pods; only admission can say that the Pods it creates may not be privileged. A thin admission chain therefore makes every permission grant as broad as its verb allows.
+
+        Removing `AlwaysAdmit` changes nothing by itself, so treat a finding here as a prompt to review the whole plugin list. Compare the enabled set against the defaults for your Kubernetes version and against the plugins the companion checks in this policy require, notably `NodeRestriction`, `PodSecurity`, and `EventRateLimit`.
       audit: |
         Inspect the API server `--enable-admission-plugins` argument on each control plane node:
 
@@ -12221,11 +12589,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `NodeRestriction` admission plugin is enabled on the kube-apiserver. `NodeRestriction` limits a kubelet to modifying only its own Node and Pod objects, preventing a compromised kubelet from tampering with workloads on other nodes.
+        This check verifies that the API server loads the NodeRestriction admission controller.
+
+        `NodeRestriction` limits what a kubelet credential may change: a node may modify only its own Node object and only Pods bound to it, and it may not give itself labels in the `node-restriction.kubernetes.io/` namespace. The plugin is enabled by adding `NodeRestriction` to `--enable-admission-plugins` on the API server.
 
         **Why this matters**
 
-        Without `NodeRestriction`, an attacker who compromises a single node can use the node's kubelet credentials to read or modify Pods, Secrets, and Nodes across the entire cluster.
+        Without it, any node's kubelet credential can edit other Node objects and Pods bound to other nodes. Worker nodes are the most exposed part of a cluster, so this turns a single node compromise, which is the likeliest breach of all, into a lever on every node.
+
+        The label restriction is the subtle half. Workloads are steered to nodes by labels, so a kubelet that can label itself can claim membership of a pool reserved for control plane components or for regulated workloads, and have those Pods and their Secrets scheduled onto a machine the attacker already owns.
+
+        Node objects also carry taints and status conditions. A node that can edit others can taint them, drain their workloads, and collect the rescheduled Pods itself, which is a quiet way to gather Secrets from across the cluster without touching the API objects that anyone watches.
+
+        The plugin only makes sense together with the `Node` authorizer, which a companion check in this policy verifies. Neither prevents a compromised node from reading the Secrets of the Pods legitimately scheduled to it, so genuinely sensitive workloads still need their own node pools rather than relying on this control alone.
       audit: |
         Inspect the API server `--enable-admission-plugins` argument on each control plane node:
 
@@ -12266,11 +12642,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the built-in `PodSecurity` admission plugin is enabled on the kube-apiserver so that namespaces can enforce the Pod Security Standards (`privileged`, `baseline`, `restricted`).
+        This check verifies that the API server loads the PodSecurity admission controller.
+
+        `PodSecurity` is the built-in enforcement of the Pod Security Standards. It evaluates each Pod against the `privileged`, `baseline`, or `restricted` profile that its namespace selects through labels, and rejects, warns, or audits accordingly. The plugin is enabled by adding `PodSecurity` to `--enable-admission-plugins` on the API server.
 
         **Why this matters**
 
-        `PodSecurity` is the supported successor to PodSecurityPolicy. Without it, namespaces cannot enforce the baseline/restricted security profiles that block privileged containers, hostPath mounts, and host networking.
+        Without admission-time enforcement, every workload control in this policy is detective rather than preventive. A privileged Pod with the node filesystem mounted is created successfully, runs, and is reported afterward, which means it ran for however long it took someone to look at a report.
+
+        Prevention is what matters against an attacker who holds Pod create rights in some namespace. That permission is common, granted to CI systems, operators, and application teams, and with no PodSecurity in the chain it is equivalent to root on a node: the first Pod created can be privileged, mount `/`, and step onto the host.
+
+        Clusters upgraded past Kubernetes 1.25 are a particular risk. PodSecurityPolicy was removed in that release, and PSP objects simply stopped being honored without anything failing loudly, so a cluster that believed it had enforcement can have been running without any since the upgrade.
+
+        The plugin is enabled by default from Kubernetes 1.23 onward, but enabling it does nothing until namespaces carry a `pod-security.kubernetes.io/enforce` label, which a companion check in this policy verifies. Roll out with `warn` and `audit` labels first to see what would break, then move namespaces to `enforce`.
       audit: |
         Inspect the API server `--enable-admission-plugins` argument on each control plane node:
 
@@ -12319,11 +12703,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the `EventRateLimit` admission plugin is enabled on the kube-apiserver. `EventRateLimit` caps the rate at which the API server accepts events, mitigating denial-of-service conditions caused by event floods.
+        This check verifies that the API server loads the EventRateLimit admission controller.
+
+        `EventRateLimit` caps how fast Event objects can be created, with separate limits available per server, per namespace, per user, and per source and object, configured through an `EventRateLimit` section in the admission configuration file. The plugin is enabled by adding `EventRateLimit` to `--enable-admission-plugins` on the API server.
 
         **Why this matters**
 
-        A misbehaving or hostile workload can generate millions of events per minute. Without `EventRateLimit`, this load can saturate the API server and etcd, causing cluster-wide instability.
+        Events are stored in etcd like every other object. An unbounded flood of them fills etcd, and a full etcd is a cluster-wide outage: the API server goes read-only, controllers stop reconciling, nothing schedules, and recovery requires manual compaction and defragmentation under pressure.
+
+        That makes event flooding a denial of service available to almost any identity, since permission to create events is granted broadly and every workload that restarts containers produces them as a matter of course.
+
+        A flood also destroys the signal in the event stream. An attacker who generates enough noise buries their own container starts, image pulls, and failed mounts under it, which defeats the detection built on events and wastes responder time during the incident.
+
+        The plugin fails the API server at startup if it is enabled with no configuration, so write the `EventRateLimit` configuration first and derive the limits from the observed event rate of a healthy cluster. Keep alerting on etcd database size regardless, since rate limiting reduces this risk rather than removing it.
       audit: |
         Inspect the API server `--enable-admission-plugins` argument on each control plane node:
 
@@ -12364,11 +12756,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver writes audit events to disk via `--audit-log-path`. Audit logs record every API request, providing the forensic evidence needed for incident response and compliance reporting.
+        This check verifies that the API server writes an audit log.
+
+        `--audit-log-path` on the API server names the file that audit events are written to. When it is absent the audit backend is off and no record of API activity is produced at all. The flag must be present and non-empty.
 
         **Why this matters**
 
-        Without an audit log path, the cluster has no record of who created, modified, or deleted resources, making it impossible to detect or investigate intrusions, privilege abuse, or misconfiguration.
+        The API server audit log is the only complete record of what happened in a cluster. Every kubectl command, every controller action, and every use of a service account token arrives as an API request, so without this log there is no way to answer who read a Secret, who created a Pod, or when a RoleBinding changed.
+
+        Container and application logs cannot stand in for it. They show what a workload did, not who told it to exist, and an attacker who deletes a Pod deletes its logs along with it. The audit log records the deletion and the identity behind it.
+
+        Detection depends on the same stream. Rules for anonymous access, `exec` into production Pods, service account token creation, and RBAC escalation are all written against audit events, so a cluster without them is not merely hard to investigate after the fact; it is unmonitored while the incident is in progress.
+
+        A path alone is not enough: without an audit policy the file stays empty, and a companion check in this policy covers that half. Ship the log off the node as well, since it lives on control plane disk, rotates away, and can be edited in place by anyone who reaches the node.
       audit: |
         Inspect the API server `--audit-log-path` argument on each control plane node:
 
@@ -12409,11 +12809,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver is started with an `--audit-policy-file`. An audit policy declares which events are recorded and at what level (`None`, `Metadata`, `Request`, `RequestResponse`).
+        This check verifies that the API server loads an audit policy.
+
+        The audit policy is a YAML file of rules deciding, per request, whether to record nothing, metadata only, the request body, or both request and response. Without `--audit-policy-file` the API server records no events even when an audit log path is configured. The flag must be present and non-empty.
 
         **Why this matters**
 
-        Without a policy file, the audit log either is silent or records every event at maximum verbosity, causing valuable signals to be missed or drowned in noise. A tuned policy ensures security-relevant events such as authentication failures, RBAC changes, and Secret access are captured.
+        Audit is a two-part configuration and both parts are required. A cluster with a log path and no policy produces an empty file, which passes every dashboard check that only looks for the file, so the gap survives review indefinitely.
+
+        The policy is also where the useful detail is decided. `Metadata` on Secret reads tells you that someone read a Secret; `RequestResponse` on the same resource would write the Secret's contents into the log, which is usually the wrong trade. Getting the level right per resource is what makes the log both useful and safe to store.
+
+        Rule ordering is easy to get wrong in a way that looks fine. The first matching rule wins, so a broad `None` rule near the top silently discards everything the rules below it would have captured, and the file's existence tells you nothing about whether the events you need are being recorded.
+
+        Start from the policy shipped by your distribution or the reference policy in the Kubernetes documentation, then raise the level to `RequestResponse` only for the small set of objects where you need the body, typically RBAC objects and admission configuration. Revisit it when new custom resources carrying sensitive data are introduced, because unmatched requests fall through to the default and are usually not recorded.
       audit: |
         Inspect the API server `--audit-policy-file` argument on each control plane node:
 
@@ -12454,11 +12862,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver retains audit logs locally for at least 30 days via `--audit-log-maxage`. Most incident response timelines exceed two weeks, so shorter retention destroys evidence before investigators can review it.
+        This check verifies that audit logs are retained for at least 30 days.
+
+        `--audit-log-maxage` on the API server is the number of days rotated audit log files are kept before deletion. The flag must be present and set to 30 or more.
 
         **Why this matters**
 
-        Audit logs are the primary forensic record of activity in the cluster. Truncated retention windows make breach detection and root-cause analysis impossible after the fact.
+        Intrusions are found late. Published incident response reporting has consistently put median dwell time at weeks, and often longer for intrusions discovered internally rather than by a ransom note, so a retention window of a few days deletes the evidence of the initial access well before anyone knows to look for it.
+
+        Investigation needs the period before the alert, not the period after it. The questions that matter are when a credential was first used, what else it touched, and whether the access predates the change you are looking at, and all of them require logs covering the whole span between compromise and detection.
+
+        Retention is also a requirement with a number attached in several frameworks. PCI DSS requirement 10.5.1 calls for at least twelve months of audit history with the most recent three months immediately available for analysis, so a short node-local window has to be backed by shipping the events somewhere durable.
+
+        Thirty days on the node is a floor rather than a target. Ship audit events to a log platform with its own retention and access controls, after which the node-local window only needs to survive a shipping outage. Size `--audit-log-maxsize` and `--audit-log-maxbackup` alongside this, because a full control plane disk truncates the log no matter what the age setting says.
       audit: |
         Inspect the API server `--audit-log-maxage` argument on each control plane node:
 
@@ -12499,11 +12915,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver is configured with `--encryption-provider-config`, which enables encryption at rest for Kubernetes Secrets and other sensitive resources stored in etcd.
+        This check verifies that the API server encrypts Secrets before writing them to etcd.
+
+        `--encryption-provider-config` on the API server points at an `EncryptionConfiguration` that names, per resource, the providers used to encrypt and decrypt data at rest. Without it the API server writes objects to etcd as they are, so Secret values sit on disk base64-encoded and otherwise in the clear. The flag must be present and non-empty.
 
         **Why this matters**
 
-        By default, etcd stores Kubernetes Secrets, ConfigMaps, and tokens in plaintext. An attacker with read access to etcd files or backups can recover every credential in the cluster. Encryption at rest defends against offline disclosure of these stores.
+        Base64 is an encoding, not encryption. Anyone who reads the etcd data directory, an etcd snapshot, a backup in object storage, or a decommissioned control plane disk reads every Secret in the cluster: database passwords, cloud credentials, TLS private keys, and service account tokens.
+
+        That path never touches the API, so RBAC does not apply and the audit log records nothing. A snapshot copied into a bucket with permissive access is the common form of this, and it is a complete credential compromise that produces no cluster-side signal at all.
+
+        Encryption at rest moves the boundary from file permissions to key custody. With a KMS provider the data encryption keys are wrapped by a key the cluster itself does not hold, so a stolen snapshot is inert unless the KMS is compromised too.
+
+        The `aescbc` and `secretbox` providers keep the key in the same file on the same control plane node, which protects backups and detached disks but not an attacker already on that node; a KMS v2 provider is the meaningful version of this control. Enabling encryption does not rewrite existing objects, so follow it by re-writing what is already stored with `kubectl get secrets --all-namespaces -o json | kubectl replace -f -`.
       audit: |
         Inspect the API server `--encryption-provider-config` argument on each control plane node:
 
@@ -12549,11 +12973,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver does not negotiate TLS versions older than 1.2. Earlier versions (TLS 1.0/1.1, SSLv3) contain known cryptographic weaknesses and are deprecated by every major standards body.
+        This check verifies that the API server does not negotiate TLS older than version 1.2.
+
+        `--tls-min-version` on the API server sets the floor for its TLS handshake. The check accepts the flag being unset, since current Kubernetes releases already default to TLS 1.2, or set to `VersionTLS12` or `VersionTLS13`.
 
         **Why this matters**
 
-        Allowing TLS 1.0/1.1 leaves API server connections vulnerable to BEAST, downgrade, and renegotiation attacks. Modern Kubernetes clients all support TLS 1.2+, so requiring it does not reduce compatibility.
+        TLS 1.0 and 1.1 have been withdrawn. RFC 8996 deprecated both in 2021, and their problems are structural rather than configurable: the CBC construction that BEAST and Lucky13 exploit, MD5 and SHA-1 in handshake signatures, and no authenticated encryption anywhere in the suite list.
+
+        API server traffic is the most sensitive traffic in the cluster. Every kubectl command, every controller reconcile loop, and every Secret read crosses it, and each request carries a bearer token in its Authorization header. A downgraded connection puts those tokens within reach of anyone positioned in the network path.
+
+        Downgrade is the practical attack rather than a break of the protocol itself. An attacker in the path strips the stronger options from the client hello, and if the server still accepts an obsolete version the connection completes on it with neither side warning anybody.
+
+        `VersionTLS13` is stronger still, but confirm that every client can negotiate it first, since older kubectl builds and some SDKs cannot. Pair the version floor with an explicit cipher suite list, which a companion check in this policy verifies, because a current protocol version can still be paired with a weak suite.
       audit: |
         Inspect the API server `--tls-min-version` argument on each control plane node:
 
@@ -12597,11 +13029,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver explicitly enumerates an allowlist of TLS cipher suites via `--tls-cipher-suites` and that the list excludes weak ciphers (RC4, 3DES). Without an explicit allowlist, the Go default may include ciphers that are no longer considered safe.
+        This check verifies that the API server refuses obsolete TLS cipher suites.
+
+        `--tls-cipher-suites` on the API server pins the suites it will negotiate. The check requires the flag to be set at all, and requires the list to contain no suite whose name includes `TLS_RSA_WITH_3DES`, `TLS_RSA_WITH_RC4`, `TLS_ECDHE_RSA_WITH_RC4`, or `TLS_ECDHE_ECDSA_WITH_RC4`.
 
         **Why this matters**
 
-        Weak cipher suites such as RC4 and 3DES have known practical attacks. Restricting the API server to AEAD ciphers with PFS (e.g., `TLS_ECDHE_*_WITH_AES_*_GCM_*`, `TLS_CHACHA20_POLY1305_*`) removes that attack surface.
+        RC4 is broken as a stream cipher. Statistical biases in its keystream allow plaintext recovery when the same data is encrypted repeatedly under different keys, which describes an Authorization header sent on every single API request. RFC 7465 prohibited RC4 in TLS in 2015.
+
+        3DES has a 64-bit block, and that is what the Sweet32 birthday attack exploits: after roughly 32 GB on a single connection, repeated plaintext blocks become recoverable. Long-lived watch connections from controllers and kubelets to the API server are exactly the kind that carry that much data on one connection.
+
+        Leaving the flag unset accepts the Go runtime's default list, which has historically retained suites for compatibility with clients that no Kubernetes cluster has. Pinning the list turns the negotiated suite into a decision rather than an inherited default.
+
+        Choose forward-secret authenticated-encryption suites only, meaning ECDHE key exchange with AES-GCM or ChaCha20-Poly1305, and verify your clients first, since too narrow a list locks out an old component rather than warning about it. Note that this check rejects the named obsolete families and does not by itself require the remaining suites to be forward-secret, so review the full list you set.
       audit: |
         Inspect the API server `--tls-cipher-suites` argument on each control plane node:
 
@@ -12646,11 +13086,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver loads a `--client-ca-file` so that incoming client certificates are validated against a trusted CA.
+        This check verifies that the API server can authenticate clients by certificate.
+
+        `--client-ca-file` on the API server names the certificate authority bundle used to validate client certificates. Any certificate signed by an authority in that bundle authenticates, with the certificate's common name taken as the username and its organization fields as groups. The flag must be present and non-empty.
 
         **Why this matters**
 
-        Without a client CA file, certificate-based authentication for users and components (such as kubelets and admin clients) is disabled or accepts unverified certificates, weakening cluster authentication.
+        Certificate authentication is what the control plane components use among themselves, what each node's kubelet uses, and what the break-glass administrator credential is. With no bundle configured, none of those identities can authenticate and the cluster falls back to whatever other authenticator is present, which in a minimal setup is a static token file or nothing.
+
+        The bundle is a security boundary in its own right, because every authority in it can mint any identity, including one in `system:masters`. Adding a corporate CA so that employee certificates work is a common and severe mistake: it means anyone who can obtain a certificate from that CA, issued for any purpose at all, is a cluster user.
+
+        Certificate identities also cannot be revoked. Kubernetes consults no certificate revocation list and no OCSP responder, so invalidating an issued certificate means rotating the CA and reissuing everything that trusted it.
+
+        Keep the bundle to the cluster CA and nothing else, and give human users short-lived credentials or an OIDC provider where revocation actually works. Where the file must hold more than one authority, document each entry, because each one is a full authentication path into the cluster.
       audit: |
         Inspect the API server `--client-ca-file` argument on each control plane node:
 
@@ -12693,11 +13141,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver presents a client certificate (`--kubelet-client-certificate` and `--kubelet-client-key`) when connecting to kubelets. This enables mutual TLS between the API server and each kubelet.
+        This check verifies that the API server presents a client certificate when it calls a kubelet.
+
+        The API server opens connections to each node's kubelet for `logs`, `exec`, `attach`, and `portforward`. `--kubelet-client-certificate` and `--kubelet-client-key` on the API server are the credential it presents on those connections, and both must be present and non-empty.
 
         **Why this matters**
 
-        Kubelets accept exec, logs, and port-forward requests from the API server. Without mTLS, an attacker who can intercept this traffic could impersonate the API server or extract sensitive workload data.
+        Without a client credential the API server is an anonymous caller to the kubelet, and whether it is served then depends on the kubelet's own settings. The configuration that makes it work anyway is anonymous authentication with `AlwaysAllow` authorization, which is precisely what the companion kubelet checks in this policy forbid.
+
+        That combination is the one that turns any network reach to port 10250 into command execution inside every container on the node. Giving the API server a real identity is what allows the kubelet to be locked down without breaking `kubectl logs` and `kubectl exec`.
+
+        The certificate's subject is also what the kubelet authorizes against, so it is how a cluster grants the API server access to kubelet subresources while denying everyone else, instead of treating the port as trusted because it happens to be on the node network.
+
+        Issue the certificate from an authority the kubelets trust, normally the cluster CA, with a subject that maps to a group the kubelet's authorization allows; kubeadm clusters conventionally use `system:masters` for this. Pair it with `--kubelet-certificate-authority` so the trust runs both ways, which a companion check in this policy covers.
       audit: |
         Inspect the API server kubelet client certificate arguments on each control plane node:
 
@@ -12737,11 +13193,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver communicates with kubelets over HTTPS (`--kubelet-https=true`). The default is `true`; this check fails if it has been explicitly disabled.
+        This check verifies that the API server contacts kubelets over HTTPS.
+
+        `--kubelet-https` on the API server controlled whether kubelet connections used HTTPS or plain HTTP. The check accepts the flag being absent, which is the modern behavior since it was removed and HTTPS became unconditional, or set explicitly to `true`.
 
         **Why this matters**
 
-        Plaintext API-server-to-kubelet traffic exposes exec session contents, log streams, and resource metadata to anyone on the management network.
+        The traffic on those connections is the most sensitive the cluster carries. `exec` and `attach` are interactive sessions inside containers, `logs` is application output that routinely includes tokens and query parameters, and `portforward` carries whatever the forwarded connection carries. Over HTTP all of it is readable to anyone on the path between the control plane and the node.
+
+        The API server's own credential to the kubelet travels on the same connection, so a plaintext session discloses it and lets it be replayed by whoever captured it.
+
+        Without TLS there is also no server authentication, so any host that can answer at the node's address receives the requests intended for the real kubelet. That includes whatever a cluster administrator types into an `exec` session while debugging an incident.
+
+        On any supported Kubernetes release the flag no longer exists and HTTPS is the only behavior, so a finding here means an old cluster or an inherited manifest that still sets `false`. Encryption alone is not sufficient in any case: pair it with `--kubelet-certificate-authority` so the API server verifies which kubelet answered.
       audit: |
         Inspect the API server `--kubelet-https` argument on each control plane node:
 
@@ -12782,11 +13246,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver validates kubelet TLS certificates against a known CA via `--kubelet-certificate-authority`. Without a CA, the API server cannot detect a forged kubelet cert presented by a man-in-the-middle.
+        This check verifies that the API server validates the certificate a kubelet presents.
+
+        `--kubelet-certificate-authority` on the API server names the CA bundle used to verify kubelet serving certificates. Without it the API server still connects over TLS but skips verification and accepts any certificate at all. The flag must be present and non-empty.
 
         **Why this matters**
 
-        Skipping kubelet certificate verification allows a node-level adversary on the network path to impersonate a kubelet and intercept exec, logs, or port-forward traffic.
+        TLS without verification stops passive eavesdropping and nothing more. An attacker who can answer at a node's address, whether through ARP or DNS interference on the node network or by taking over the node itself, terminates the API server's connection and is trusted implicitly.
+
+        What that yields is the content of every `exec`, `attach`, `logs`, and `portforward` session the control plane sends to that node, plus the ability to return fabricated output. An operator debugging a production incident is typing into the attacker's shell and reading the attacker's answers, and nothing in kubectl indicates a difference.
+
+        The API server presents its own client credential on that connection, so the impersonating endpoint collects that too and can then use it against the real kubelet.
+
+        Verification requires kubelets to serve certificates issued by the named authority, which in practice means enabling kubelet serving certificate rotation and running a CSR approver rather than leaving each kubelet with the self-signed certificate it generates by default. A companion check in this policy covers the kubelet side of that arrangement.
       audit: |
         Inspect the API server `--kubelet-certificate-authority` argument on each control plane node:
 
@@ -12828,11 +13300,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver provides `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile` so that connections to etcd are mutually authenticated over TLS.
+        This check verifies that the API server authenticates to etcd with a client certificate over TLS.
+
+        Three flags on the API server govern that connection: `--etcd-cafile`, so the API server verifies which etcd it reached, and `--etcd-certfile` with `--etcd-keyfile`, so etcd can verify the API server. All three must be present and non-empty.
 
         **Why this matters**
 
-        etcd contains every Secret, ConfigMap, and resource definition in the cluster. Unauthenticated or unencrypted access permits direct read/write of the entire cluster state, completely bypassing Kubernetes authorization.
+        etcd holds the entire cluster state and knows nothing about Kubernetes RBAC. Anything that can talk to it reads and writes every object directly, including every Secret, every RoleBinding, and the admission configuration itself, with no authorization check and no audit record anywhere.
+
+        Without client certificates, etcd's access control reduces to network reachability. On a control plane node that means every process on the node, and every Pod scheduled there with `hostNetwork: true`, can reach it on loopback.
+
+        Without the CA file the API server does not verify which endpoint it reached, so a host answering at etcd's address receives the cluster's writes and can return whatever state it likes. Fabricated RoleBindings served that way are honored by the API server exactly as if an administrator had created them.
+
+        Configure etcd itself with `--client-cert-auth` and `--trusted-ca-file`, because presenting a certificate achieves nothing if the server does not require one. Give peer connections between etcd members the same treatment through the `--peer-*` options, and keep the key files in the PKI directory covered by a companion check in this policy.
       audit: |
         Inspect the API server etcd TLS arguments on each control plane node:
 
@@ -12872,11 +13352,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver verifies ServiceAccount tokens against the live API state via `--service-account-lookup=true`. With lookup disabled, deleted ServiceAccounts and revoked tokens may continue to authenticate.
+        This check verifies that the API server confirms a service account token still has a live object behind it.
+
+        `--service-account-lookup` on the API server makes it check, on every request, that the service account and the Secret backing a legacy token still exist before accepting the token. The check accepts the flag being absent, since it defaults to true on current releases, or set explicitly to `true`.
 
         **Why this matters**
 
-        Long-lived ServiceAccount tokens that survive deletion become attractive targets. Lookup is the mechanism that makes "delete the ServiceAccount" actually revoke its tokens; without it, deleted accounts remain functional until their signing key rotates.
+        Legacy service account tokens are signed JWTs with no expiry. Without the lookup, validation is purely cryptographic: the signature verifies, so the token is accepted, no matter what has happened to the account since it was issued.
+
+        That makes deletion meaningless as a revocation mechanism. Deleting a compromised service account or its token Secret does not stop the token from working, so a credential that leaked through a Pod, a log file, or a git repository stays valid until the service account signing key is rotated across the whole cluster.
+
+        With the lookup enabled, deleting the Secret or the account invalidates the token immediately, which restores the response that people assume they already have when they are working an incident under time pressure.
+
+        The durable answer is bound service account tokens, which carry an audience, an expiry, and a binding to the Pod object, and which have been the default projection since Kubernetes 1.21. Where legacy token Secrets still exist, this flag is what makes revoking them possible, so audit for them and migrate the workloads that still rely on them.
       audit: |
         Inspect the API server `--service-account-lookup` argument on each control plane node:
 
@@ -12917,11 +13405,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver verifies ServiceAccount tokens with a dedicated public key supplied via `--service-account-key-file`. Without it, the API server falls back to the TLS serving key, conflating two distinct trust roots.
+        This check verifies that the API server has a dedicated key for validating service account tokens.
+
+        `--service-account-key-file` on the API server names the public key or keys used to verify service account token signatures. When it is unset, the API server falls back to the key from `--tls-private-key-file`, which makes the cluster's TLS serving key its token signing key as well. The flag must be present and non-empty.
 
         **Why this matters**
 
-        Using a separate key pair lets operators rotate the ServiceAccount signing key without re-issuing the API server's TLS cert, and keeps the ServiceAccount trust root scoped to one purpose.
+        Reusing the serving key couples two lifecycles that have nothing to do with each other. TLS certificates are rotated routinely, often automatically and often by a component that knows nothing about tokens, and rotating that key invalidates every service account token in the cluster at once, stopping every workload that talks to the API server.
+
+        It also widens the blast radius of one key. A TLS private key is handled by more tooling and deployed in more places than a signing key needs to be, and if it leaks the holder can not only impersonate the API server but also mint a valid token for any service account in any namespace.
+
+        Tokens forged that way are close to undetectable. They verify correctly, so the audit log shows ordinary requests from an ordinary service account and there is nothing anomalous to alert on.
+
+        Keep the signing key separate, store it with the care given to the cluster CA key, and give the controller manager the matching private key through `--service-account-private-key-file`. Where the cluster publishes an OIDC discovery document for projected tokens, plan rotation as an overlap: publish the new public key alongside the old one before you stop signing with the old one.
       audit: |
         Inspect the API server `--service-account-key-file` argument on each control plane node:
 
@@ -12961,11 +13457,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver runs with `--profiling=false`. The Go pprof endpoint is intended for debugging and exposes detailed runtime data that an attacker can use to fingerprint the cluster or extract sensitive memory contents.
+        This check verifies that the API server does not serve Go profiling endpoints.
+
+        With profiling enabled the API server exposes `/debug/pprof`, which produces CPU profiles, heap dumps, goroutine stacks, and execution traces on request. The flag is `--profiling` on the API server, and it must be `false`.
 
         **Why this matters**
 
-        pprof responses can leak goroutine stacks, heap allocations, and request data. Production clusters have no need for the endpoint, and its presence increases the API server's attack surface.
+        A heap profile is a sample of the process's memory. The API server's memory holds the objects it is currently serving, so a heap dump can contain Secret contents, bearer tokens presented on in-flight requests, and request bodies mid-processing. Nothing in the endpoint distinguishes that data from ordinary allocations before returning it.
+
+        Goroutine and trace endpoints disclose internal state that helps an attacker map the control plane: which controllers are active, what the request load looks like, and which code paths are hot enough to be worth attacking.
+
+        The endpoints are also a denial of service. A CPU profile or a full goroutine dump on a busy API server is expensive to produce, and requesting them in a loop degrades the control plane for every client of the cluster.
+
+        Access to `/debug/pprof` is subject to RBAC, so disabling it is defense in depth; the reason to do it is that the RBAC barrier is one over-broad ClusterRole away from failing. When you genuinely need a profile for a performance investigation, enable it deliberately for the duration, capture what you need, and turn it off again.
       audit: |
         Inspect the API server `--profiling` argument on each control plane node:
 
@@ -13005,11 +13509,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the kube-apiserver is not started with a `--token-auth-file`. Static token files contain unrotated bearer tokens stored in plaintext on disk and are intended only for development.
+        This check verifies that the API server does not authenticate users from a static token file.
+
+        `--token-auth-file` on the API server points at a CSV file of bearer tokens with usernames, user IDs, and groups, all of which the API server accepts as credentials. The flag must be absent or empty.
 
         **Why this matters**
 
-        Tokens in `--token-auth-file` cannot be revoked without restarting the API server, are visible to anyone who can read the file, and predate modern authenticators (OIDC, ServiceAccount, x509).
+        The tokens in that file never expire and cannot be revoked individually. Changing the file requires restarting the API server, so in practice the tokens live for the life of the cluster and get copied into scripts, CI configuration, and runbooks along the way.
+
+        The file sits in plaintext on the control plane node, so anyone who reads it holds every identity it defines, and because the format carries a group column those identities are frequently `system:masters`, which RBAC does not constrain at all.
+
+        There is also no way to tell one use from another. The audit log shows the username from the file, so a stolen token and legitimate use produce identical entries, and the only remediation for a suspected leak is to rewrite the file and restart the control plane.
+
+        Static token files were meant for bootstrapping and testing, and every use has a better replacement: service account tokens for workloads, an OIDC provider for humans, and client certificates or bootstrap tokens for nodes joining the cluster. If the file survives for one legacy integration, migrate that integration rather than keeping a credential that cannot be revoked in the authentication chain.
       audit: |
         Inspect the API server `--token-auth-file` argument on each control plane node:
 
@@ -13052,17 +13564,19 @@ queries:
       k8s.serviceaccounts.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( isClusterAdmin == false )
     docs:
       desc: |
-        This check ensures that no service account is granted the built-in `cluster-admin` role, or an equivalent role that grants unrestricted access through wildcard verbs, API groups, and resources. Service accounts are non-human identities consumed by workloads, and a workload that runs as a cluster-admin service account holds full control of every resource in the cluster.
+        This check verifies that no service account outside the exempt namespaces holds cluster-admin.
+
+        A service account holds `cluster-admin` when a ClusterRoleBinding or RoleBinding names it as a subject and points at the `cluster-admin` ClusterRole. No service account may hold it except in namespaces listed in the `mondooKubernetesSecurityExcludedNamespaces` property of this policy.
 
         **Why this matters**
 
-        A service account with cluster-admin access removes every authorization boundary for the pods that use it:
+        `cluster-admin` is every verb on every resource in every API group, cluster-wide. The holder reads every Secret in every namespace, creates a privileged Pod on any node, rewrites RBAC to grant itself more, and removes the audit and admission configuration that would have recorded any of it.
 
-        - **Full cluster compromise:** anyone who compromises a single pod inherits its token and can read every Secret, create privileged pods on any node, and modify or delete any resource in the cluster.
-        - **Lateral movement and persistence:** an attacker can create new bindings, deploy backdoors, and disable security controls cluster-wide.
-        - **No blast-radius containment:** the principle of least privilege is the primary defense against a compromised workload; a cluster-admin service account defeats it entirely.
+        The credential is not a person, it is a token file inside a Pod. Any code execution in any container that mounts it, including a compromised third-party dependency pulled in at build time, is cluster-admin. There is no multi-factor prompt, no session, and no conditional access standing in front of it.
 
-        Workloads should be granted only the specific permissions they need, scoped to the namespaces they operate in.
+        These bindings are almost always accidental in origin. An operator or Helm chart needed broad access during installation and kept it, or a debugging grant outlived the debugging. Because nothing breaks afterward, they persist for years.
+
+        Operators that genuinely need broad rights should be scoped to the resources they manage rather than to everything, and the few that legitimately cannot be, such as certain cluster lifecycle controllers, belong in a namespace listed in the excluded-namespaces property so the exception is explicit and reviewable. Run `kubectl get clusterrolebindings -o wide` and treat every `ServiceAccount` subject as a finding until it is justified.
       audit: |
         List the subjects bound to the `cluster-admin` ClusterRole and look for any `ServiceAccount` entries:
 
@@ -13152,17 +13666,19 @@ queries:
       k8s.serviceaccounts.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( canEscalatePrivileges == false )
     docs:
       desc: |
-        This check ensures that no service account is bound to a role that allows RBAC privilege escalation. The `escalate` and `bind` verbs on roles and bindings, and the `impersonate` verb on users, groups, or service accounts, let a subject grant itself more privileges than it currently holds — bypassing the protections that normally stop a user from creating a role more powerful than their own.
+        This check verifies that no service account outside the exempt namespaces can grant itself more permissions.
+
+        Some ordinary-looking RBAC grants let an account obtain rights it was never given. No service account may hold them except in namespaces listed in the `mondooKubernetesSecurityExcludedNamespaces` property of this policy.
 
         **Why this matters**
 
-        Privilege-escalation verbs turn a limited foothold into full control:
+        Several permissions are cluster-admin with extra steps. `create` on `clusterrolebindings` or `rolebindings` lets an account bind itself to any role it can name. The `bind` and `escalate` verbs on ClusterRoles lift the guard that normally prevents granting permissions you do not already hold. `impersonate` on users and groups lets an account act as a member of `system:masters` directly.
 
-        - **`escalate`** lets a subject create or edit a Role or ClusterRole containing permissions it does not already have, defeating the built-in escalation prevention.
-        - **`bind`** lets a subject bind any existing role — including `cluster-admin` — to itself or another identity.
-        - **`impersonate`** lets a subject act as any other user, group, or service account, including cluster administrators.
+        Others are indirect but just as effective. `create` on Pods in a namespace whose service accounts are privileged means creating a Pod that mounts the privileged token, and `get` on Secrets means reading a token outright. A grant that reads as workload management is a path to the strongest identity in its namespace.
 
-        A workload holding any of these verbs is effectively one step away from cluster-admin, so they should never be granted to application service accounts.
+        Because the escalation is carried out with permissions that were legitimately granted, nothing in the audit trail looks anomalous until the new binding appears, and by then it has already been used.
+
+        Review any grant of `escalate`, `bind`, or `impersonate`, and any wildcard verb on RBAC resources, since those are the four ways this happens. Where a controller genuinely must create bindings, for example an operator provisioning per-tenant roles, restrict it to specific role names with `resourceNames` and list its namespace in the excluded-namespaces property so the exception is recorded.
       audit: |
         Inspect the Roles and ClusterRoles bound to your service accounts for the `escalate`, `bind`, or `impersonate` verbs:
 
@@ -13236,17 +13752,19 @@ queries:
       k8s.roles.where( namespace.in(props.mondooKubernetesSecurityExcludedNamespaces) == false ).all( hasWildcardRule == false )
     docs:
       desc: |
-        This check ensures that Roles and ClusterRoles do not use the wildcard `*` for verbs, API groups, or resources. A wildcard rule grants every current and future permission in its scope, which almost always exceeds what a workload or user actually needs and silently expands as new APIs are added to the cluster.
+        This check verifies that Roles and ClusterRoles name the resources and verbs they grant instead of using a wildcard.
+
+        A wildcard is `*` in the `apiGroups`, `resources`, or `verbs` list of a policy rule. Roles and ClusterRoles must list what they grant explicitly. The check skips the ClusterRoles Kubernetes ships under the `system:` prefix, along with anything named in the `mondooKubernetesSecurityExcludedClusterRoles` and `mondooKubernetesSecurityExcludedNamespaces` properties of this policy.
 
         **Why this matters**
 
-        Wildcard rules break the principle of least privilege in ways that are hard to reason about:
+        A wildcard grants permissions that do not exist yet. Install a custom resource definition next week and every role with `resources: ["*"]` covers it immediately, including a CRD that stores credentials, with no change for anyone to review.
 
-        - **Unbounded access:** `resources: ["*"]` and `verbs: ["*"]` grant access to Secrets, RBAC objects, and every other resource, including ones that did not exist when the role was written.
-        - **Hidden escalation paths:** a wildcard over `rbac.authorization.k8s.io` includes the `escalate` and `bind` verbs, opening a path to cluster-admin.
-        - **Audit blindness:** reviewers cannot tell from a wildcard rule what the workload actually uses, so over-grants go unnoticed.
+        Wildcard verbs include the ones nobody meant to grant. `verbs: ["*"]` covers `escalate`, `bind`, and `impersonate` on RBAC resources, and `create` on `pods/exec`, which is command execution inside running containers.
 
-        Roles should enumerate the specific API groups, resources, and verbs a subject requires.
+        It also makes the grant unreadable. Nobody can answer what a role permits by reading it, so reviews approve wildcards on trust and audits cannot distinguish an over-broad role from a correct one.
+
+        The default `system:` ClusterRoles are exempt because Kubernetes ships them and the control plane reconciles them back. Where a controller genuinely needs broad rights over a class of objects it owns, list that class explicitly and revisit the list when the controller gains a resource, and record deliberate exceptions in the excluded cluster roles property rather than leaving an undocumented wildcard.
       audit: |
         List the Roles and ClusterRoles that contain a wildcard in their verbs, API groups, or resources:
 
@@ -13311,17 +13829,19 @@ queries:
       k8s.clusterrolebindings.where( name != /^system:/ && name.in(props.mondooKubernetesSecurityExcludedClusterRoleBindings) == false ).all( grantsClusterAdmin == false )
     docs:
       desc: |
-        This check ensures that ClusterRoleBindings do not grant the `cluster-admin` role — or any ClusterRole with wildcard verbs, API groups, and resources — to users, groups, or service accounts. A cluster-admin binding hands its subjects unrestricted control of every resource in the cluster.
+        This check verifies that no ClusterRoleBinding outside the exempt list grants the cluster-admin role.
+
+        A ClusterRoleBinding pointing at the `cluster-admin` ClusterRole gives every subject it names unrestricted control of the cluster. The check skips bindings Kubernetes ships under the `system:` prefix and anything listed in the `mondooKubernetesSecurityExcludedClusterRoleBindings` property of this policy.
 
         **Why this matters**
 
-        Cluster-admin bindings are the single largest concentration of privilege in a cluster:
+        Every subject of such a binding, whether a user, a group, or a service account, can read every Secret in every namespace, which in a shared cluster usually means the cloud credentials, database passwords, and signing keys of every team on it.
 
-        - **Unrestricted control:** subjects can read every Secret, schedule privileged pods on any node, and modify or delete any resource.
-        - **Large attack surface:** every user, group, or service account in the binding becomes a path to full cluster compromise.
-        - **Hard to revoke quietly:** broad bindings accumulate over time and are rarely reviewed, so stale admin grants persist long after they are needed.
+        Group subjects are where this quietly becomes broad. A binding to a group populated by a corporate identity provider grants cluster-admin to whoever the directory says belongs to that group today, and membership changes without anything in Kubernetes changing or being reviewed.
 
-        Cluster-admin should be reserved for a small, deliberately managed set of break-glass identities, not granted through everyday bindings.
+        `cluster-admin` also erases the boundary that the rest of this policy depends on. The holder edits or removes admission configuration, changes audit settings, and rewrites RBAC, so it is the one permission that nothing else in the cluster can constrain.
+
+        The `cluster-admin` binding to `system:masters` that kubeadm creates is expected, which is why `system:` names are skipped. For people, prefer a role covering day-to-day work plus a separate break-glass path that is requested, time-bounded, and logged. Record any binding that must remain, such as one for a cluster lifecycle controller, in the excluded cluster role bindings property.
       audit: |
         List the ClusterRoleBindings that reference `cluster-admin` or another role granting unrestricted access, along with their subjects:
 
@@ -13393,17 +13913,19 @@ queries:
       k8s.clusterroles.where( name != /^system:/ && name.in(props.mondooKubernetesSecurityExcludedClusterRoles) == false ).all( canReadSecrets == false )
     docs:
       desc: |
-        This check ensures that no ClusterRole grants read access (`get`, `list`, or `watch`) to Secrets across the whole cluster. A ClusterRole applies to every namespace, so cluster-wide Secret read access exposes credentials, tokens, and keys belonging to every team and workload in the cluster.
+        This check verifies that no custom ClusterRole grants read access to Secrets across the whole cluster.
+
+        A ClusterRole with `get`, `list`, or `watch` on `secrets` grants that access in every namespace at once. The check skips the ClusterRoles Kubernetes ships under the `system:` prefix and anything listed in the `mondooKubernetesSecurityExcludedClusterRoles` property of this policy.
 
         **Why this matters**
 
-        Secrets hold the cluster's most sensitive data, and broad read access undermines every secret-based control:
+        Secrets are where the cluster's other credentials live: cloud provider keys, database passwords, TLS private keys, registry pull secrets, and service account tokens. Cluster-wide read on them is effectively a grant of all of those, so the permission is far larger than it looks in a role file.
 
-        - **Credential theft:** `list` and `watch` on Secrets return the decoded values, so a subject can harvest database passwords, TLS private keys, and service-account tokens cluster-wide.
-        - **Token replay:** stolen service-account tokens let an attacker authenticate as other workloads and move laterally.
-        - **Need-to-know violation:** a workload almost never needs Secrets outside its own namespace; cluster-wide read access is far broader than required.
+        `list` and `watch` are the sharp verbs. `list` returns values rather than names, so one request retrieves every Secret in the cluster in a single response, and `watch` delivers new ones as they are created without any further request being made.
 
-        Secret access should be granted with namespaced Roles, scoped to the specific Secrets a workload consumes.
+        Any workload bound to such a role inherits it, so one compromised monitoring agent, ingress controller, or CI runner becomes a cluster-wide credential dump rather than a single-namespace incident.
+
+        Most tools that ask for this actually need Secrets from a few namespaces or a few names. Use a namespaced Role, or a ClusterRole restricted with `resourceNames` where specific Secrets are read, and prefer per-namespace RoleBindings over one ClusterRoleBinding. Where a controller must watch Secrets cluster-wide, such as a certificate manager, list it in the excluded cluster roles property and hold its own permissions and image supply chain to proportionate scrutiny.
       audit: |
         List the ClusterRoles that grant read verbs on Secrets:
 
@@ -13471,17 +13993,19 @@ queries:
       k8s.namespace.name.in(props.mondooKubernetesSecurityExcludedNamespaces) || k8s.namespace.enforcesPodSecurity == true
     docs:
       desc: |
-        This check ensures that each namespace enforces a non-privileged Pod Security Standards level by setting the `pod-security.kubernetes.io/enforce` label to `baseline` or `restricted`. Pod Security admission rejects pods that violate the configured level at creation time; a namespace without an enforce label admits any pod, including privileged ones.
+        This check verifies that each namespace opts in to Pod Security Standards enforcement.
+
+        PodSecurity admission is driven by labels on the namespace: `pod-security.kubernetes.io/enforce` selects the profile that is enforced, while `warn` and `audit` give non-blocking feedback. Every namespace must carry an enforce label, except those listed in the `mondooKubernetesSecurityExcludedNamespaces` property of this policy.
 
         **Why this matters**
 
-        Per-workload security controls only help if something stops insecure pods from being created in the first place:
+        Enabling the PodSecurity admission plugin does nothing on its own. It evaluates each Pod against the profile its namespace requests, and a namespace with no enforce label requests nothing, so every Pod in it is admitted regardless of what it asks for.
 
-        - **Defense at admission:** an enforced baseline or restricted level blocks privileged containers, host namespace sharing, and dangerous capabilities before the pod ever runs.
-        - **Closes the bypass:** without enforcement, the `audit` and `warn` modes only log or warn, so a violating pod is still admitted and runs.
-        - **Consistent guardrails:** namespace-level enforcement applies to every current and future workload in the namespace, regardless of who deploys it.
+        That leaves the workload controls in this policy detective rather than preventive in an unlabeled namespace. A privileged Pod with the node filesystem mounted is created successfully and reported afterward; with enforcement on, the same request is rejected at admission and never runs at all.
 
-        Set the enforce label on every workload namespace; reserve the `privileged` level for system namespaces that genuinely require it.
+        The gap follows new namespaces. Enforcement is per-namespace opt-in, so a namespace created by a team, a CI pipeline, or an operator is unrestricted until somebody labels it, and nothing about creating one prompts for the label.
+
+        Roll out with `warn` and `audit` set to `restricted` first to see what would fail without blocking anything, then set `enforce` to `baseline` and move to `restricted` where workloads allow. Namespaces that genuinely host node-level agents need the `privileged` profile and belong in the excluded-namespaces property. A cluster-wide default in the admission configuration is worth adding as well, so that new namespaces inherit a profile instead of inheriting nothing.
       audit: |
         List the Pod Security enforce label on every namespace:
 


### PR DESCRIPTION
All 183 check descriptions in `content/mondoo-kubernetes-security.mql.yaml` carried the templated shape the OS policies shed in #3371. This applies the same treatment to the Kubernetes policy.

## Defect counts, before and after

| Defect | Before | After |
|---|---|---|
| Closing paragraph restating the opener ("By ensuring ... organizations can ...") | 136 | 0 |
| "security posture" / "attack surface" / "may be compromised" | 107 | 0 |
| Missing the `This check` opener | 16 | 0 |
| Missing a `**Why this matters**` section | 16 | 0 |
| Em dash or en dash | 2 | 0 |
| `**Risk mitigation**` heading | 0 | 0 |
| Byte-identical sibling descriptions | many | 0 |

## Example

Before, `mondoo-kubernetes-security-kubelet-authorization-mode`:

> This check ensures that the kubelet is not configured with the AlwaysAllow authorization mode. Disabling AlwaysAllow enforces proper access control and prevents unauthorized requests from being automatically permitted.
>
> **Why this matters**
>
> The AlwaysAllow authorization mode allows all requests to the kubelet API, bypassing access controls and security policies. If this mode is enabled:
>
> - Any user or process can interact with the kubelet API without restriction, increasing the risk of privilege escalation or cluster compromise.
> - Sensitive operations and data may be exposed to unauthorized users.
> - Compliance with security best practices and regulatory requirements may be violated.
>
> By ensuring the kubelet is not configured with AlwaysAllow, organizations can enforce strong access controls and maintain a secure Kubernetes environment.

After:

> This check verifies that the kubelet does not use the AlwaysAllow authorization mode.
>
> Authorization mode decides whether the kubelet evaluates requests to its API against the cluster's RBAC policy or accepts them unconditionally. The setting to change is `authorization.mode` in the kubelet configuration file, or `--authorization-mode` on the kubelet command line, and it must be anything other than `AlwaysAllow`, in practice `Webhook`, so that each request is checked with a SubjectAccessReview against the API server.
>
> **Why this matters**
>
> Authentication and authorization are separate settings on the kubelet, and `AlwaysAllow` disables the second one entirely. Any caller that can authenticate at all is then permitted to do anything the API offers, and in a normal cluster that includes every service account token and every certificate signed by the cluster CA.
>
> The kubelet API is not read-only. It offers `exec`, `attach`, `run`, and `portforward` against every container on the node, along with the full spec of each Pod. Reaching it means running commands inside any container on that node, which in turn means reading that container's mounted Secrets and using its service account token against the API server.
>
> Because a node hosts Pods from many namespaces, this collapses the namespace boundary. A low-privilege token from one team's namespace becomes command execution inside another team's production Pod purely because both landed on the same node, and RBAC never had a chance to say otherwise.
>
> `Webhook` mode depends on the kubelet also having credentials to call the API server and on the `system:kubelet-api-admin` style bindings being correct, so verify the delegation works before assuming the mode alone is enough. Pair it with anonymous authentication disabled, since authorization mode only governs requests that authenticated in the first place.

## What the new shape is

1. First sentence names the capability being verified, never a config key.
2. Second paragraph names the thing the reader actually edits: a manifest field path (`securityContext.readOnlyRootFilesystem` under `spec.template.spec`, `spec.hostNetwork`, `automountServiceAccountToken`), a kubelet setting with both its config-file field and its flag, an API server flag, an RBAC object, or a namespace label. No MQL resource paths or scanner accessors appear anywhere in the prose.
3. One `**Why this matters**` section with the concrete mechanism: the runtime-socket mount that creates a privileged container invisible to `kubectl` and to the audit log, the cgroup `release_agent` escape behind `CAP_SYS_ADMIN`, the `/proc/<pid>/environ` read that `hostPID` grants, the plaintext Secrets in an unencrypted etcd data directory, CVE-2019-5736 as the escape that needs only root in the container.
4. Final paragraph says when the control legitimately should not apply and what to pair it with. Per-controller siblings each close with the nuance specific to that controller, so a DaemonSet, a CronJob, and a generated ReplicaSet no longer read identically.

## Validation

```
$ cnspec policy lint content/mondoo-kubernetes-security.mql.yaml
→ valid policy bundle(s)

$ typos content/mondoo-kubernetes-security.mql.yaml
(no output)

$ go test ./internal/bundle/...
ok  	go.mondoo.com/cnspec/v13/internal/bundle	1.451s

$ python3 checks: 0 descriptions failing startswith("This check"), 0 missing
  "**Why this matters**", 0 containing an em dash / en dash / " -- ",
  0 containing "**Risk mitigation**", 0 identical sibling descriptions
```

Diff scope was verified structurally: parsing both revisions and comparing the bundles with `docs.desc` and the policy `version` removed shows them identical. **No `mql`, `filters`, `tags`, `impact`, `props`, `title`, `audit`, or `remediation` content changed.** Policy version bumped 2.1.0 to 2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
