### PR TITLE
🐛 github: accept the stricter `none` base permission

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.4
+    version: 1.8.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -349,7 +349,7 @@ queries:
         2. Go to **Settings** > **Member privileges**.
         3. Review the "Base permissions" setting.
 
-        If base permissions are set to "Read," the check passes. If they are set to "No permission," "Write," or "Admin," the check fails.
+        If base permissions are set to "No permission" or "Read," the check passes. If they are set to "Write" or "Admin," the check fails.
 
         ### Audit via CLI
 
@@ -359,7 +359,7 @@ queries:
            gh api /orgs/ORG --jq '.default_repository_permission'
            ```
 
-        If the command returns `read`, the check passes. If it returns any other value, the check fails.
+        If the command returns `none` or `read`, the check passes. If it returns `write` or `admin`, the check fails.
       remediation:
         - id: github
           desc: |
@@ -367,7 +367,7 @@ queries:
 
             1. Navigate to your organization on GitHub.
             2. Go to **Settings** > **Member privileges**.
-            3. Under "Base permissions," select the appropriate default permission level for members, such as "Read."
+            3. Under "Base permissions," select "Read," or select "No permission" and grant repository access explicitly through teams.
             4. Save the changes.
 
             For more details, see [Setting base permissions for an organization](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/setting-base-permissions-for-an-organization) in the GitHub documentation.
@@ -398,19 +398,19 @@ queries:
         title: Setting base permissions for an organization
   - uid: mondoo-github-organization-security-default-permission-level-github
     filters: asset.platform == "github-org"
-    mql: github.organization.defaultRepositoryPermission == "read"
+    mql: github.organization.defaultRepositoryPermission.in(["none", "read"])
   - uid: mondoo-github-organization-security-default-permission-level-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "github_organization_settings")
     mql: |
-      terraform.resources("github_organization_settings").all(arguments["default_repository_permission"] == "read")
+      terraform.resources("github_organization_settings").all(arguments["default_repository_permission"].in(["none", "read"]))
   - uid: mondoo-github-organization-security-default-permission-level-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "github_organization_settings")
     mql: |
-      terraform.plan.resourceChanges.where(type == "github_organization_settings").all(change.after.default_repository_permission == "read")
+      terraform.plan.resourceChanges.where(type == "github_organization_settings").all(change.after.default_repository_permission.in(["none", "read"]))
   - uid: mondoo-github-organization-security-default-permission-level-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "github_organization_settings")
     mql: |
-      terraform.state.resources.where(type == "github_organization_settings").all(values.default_repository_permission == "read")
+      terraform.state.resources.where(type == "github_organization_settings").all(values.default_repository_permission.in(["none", "read"]))
   # No Terraform variants: this check looks for a SECURITY.md file in the org's .github
   # repository (or in each repo as a fallback). File-content presence is not a Terraform
   # configuration property — github_repository_file can manage the file, but verifying its

--- a/content/validation/scans/fixtures/iac-variants/mondoo-github-security/mondoo-github-organization-security-default-permission-level-terraform-hcl/pass/none/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-github-security/mondoo-github-organization-security-default-permission-level-terraform-hcl/pass/none/main.tf
@@ -1,0 +1,4 @@
+resource "github_organization_settings" "main" {
+  billing_email = "ops@example.com"
+  default_repository_permission = "none"
+}


### PR DESCRIPTION
Fixes #3379.

## The bug

`mondoo-github-organization-security-default-permission-level` required the organization base permission to be exactly `read`. GitHub offers four levels, and `none` is the strongest of them: members get no implicit access to organization repositories at all, so access has to be granted explicitly per team or per repository.

An organization that had done that failed the check at impact 50, and the remediation would have moved them to a weaker setting.

All four variants shared the defect, so the Terraform HCL, plan, and state versions failed on the same configuration.

## The fix

```diff
-github.organization.defaultRepositoryPermission == "read"
+github.organization.defaultRepositoryPermission.in(["none", "read"])
```

and the equivalent change to the `default_repository_permission` comparison in each Terraform variant.

The `audit:` section claimed the check fails on "No permission", which described the defect rather than the intent. That sentence and the console remediation step now name both passing levels.

## Regression test

Added a `pass/none` Terraform HCL fixture, and verified it is a real test rather than one that happens to be green:

| Fixture | Before the fix | After |
|---|---|---|
| `pass/none` | **FAIL** | PASS |
| `pass/read` | PASS | PASS |
| `fail/write` | PASS | PASS |
| `fail/admin` | PASS | PASS |

Proven by reverting the query, running `pass/none` alone and watching it fail, then restoring:

```
--- FAIL: TestTerraformVariants/mondoo-github-security/…-terraform-hcl/pass/none (0.15s)
```

## Validation

```
cnspec policy lint content/mondoo-github-security.mql.yaml   → valid policy bundle(s)
typos content/mondoo-github-security.mql.yaml               → clean
go test ./internal/bundle/...                                → ok
go test -tags iac_variants -run 'TestTerraformVariants/…default-permission-level-terraform-hcl/' .
                                                             → ok, 4/4 subtests pass
```

Version 1.8.4 to 1.8.5.

## Interaction with #3378

#3378 rewrites the descriptions in this policy and is still open. It deliberately does **not** touch this check's `mql`, `audit`, or `remediation`, so the two do not overlap except on the version line, which merges trivially.

Its description for this check was written against the current behavior and says the check passes only on Read. Once this merges I will update that branch so the sentence names both levels. Merging this one first is the cleaner order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)