### PR TITLE
🐛 github: scope the organization security policy check to the organization

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.5
+    version: 1.8.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -414,7 +414,7 @@ queries:
   # elsewhere.
   - uid: mondoo-github-organization-security-security-policy
     filters: asset.platform == "github-org"
-    title: Ensure repository defines a security policy
+    title: Ensure the organization defines a default security policy
     impact: 30
     tags:
       compliance/bsi-sys-1-5: false
@@ -432,18 +432,12 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      if ( github.organization.repositories.one(name == ".github") ) {
-        github.organization.repositories.where( name == ".github").all(
-          securityFile.exists
-        ) || github.repository.securityFile.exists
-      } else {
-        github.repository.securityFile.exists
-      }
+      github.organization.repositories.where( name == ".github" ).any( securityFile.exists )
     docs:
       desc: |
-        This check verifies that a security policy is published for the repository, either as an organization-wide default or as a file in the repository itself.
+        This check verifies that the organization publishes a default security policy covering the repositories it owns.
 
-        There is no console toggle behind this check. The artifact is a `SECURITY.md` file, and GitHub resolves it in two places. A `SECURITY.md` in the organization's public `.github` repository serves as the default security policy for every repository the organization owns that does not carry its own, and a repository that does carry one uses its own file instead of the default. GitHub looks for the file in the `.github` folder, the root of the repository, or the `docs` folder. The check passes when the scanned repository is covered either by the organization default or by a file it publishes itself.
+        There is no console toggle behind this check. The artifact is a `SECURITY.md` file in the organization's public `.github` repository, which GitHub then serves as the default security policy for every repository the organization owns that does not carry one of its own. Within that repository GitHub looks for the file in the root, the `docs` folder, or the `.github` folder. The check passes when the `.github` repository publishes such a file, and fails when it does not or when the organization has no `.github` repository. Whether an individual repository publishes its own policy is assessed by a companion check in this policy.
 
         **Why this matters**
 
@@ -455,21 +449,21 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Navigate to the repository on GitHub.
-        2. Look for a `SECURITY.md` file in the repository root, the `docs` directory, or the `.github` directory.
-        3. Check the organization's `.github` repository for a shared `SECURITY.md` that applies to all repositories.
+        1. Navigate to the organization on GitHub.
+        2. Open its public `.github` repository. If the organization has no `.github` repository, the check fails.
+        3. Look for a `SECURITY.md` file in that repository's root, its `docs` directory, or its `.github` directory.
 
-        If a `SECURITY.md` file is present in any of these locations, the check passes. If none exists, the check fails.
+        If a `SECURITY.md` file is present in any of those locations, the check passes.
 
         ### Audit via CLI
 
-        1. Query the repository contents for a security policy file:
+        1. Query the organization's `.github` repository for a security policy file:
 
            ```bash
-           gh api /repos/OWNER/REPO/contents/SECURITY.md --jq '.name'
+           gh api /repos/ORG/.github/contents/SECURITY.md --jq '.name'
            ```
 
-        If the command returns `SECURITY.md`, the check passes. If it returns a `Not Found` error, the check fails.
+        If the command returns `SECURITY.md`, the check passes. If it returns a `Not Found` error, or the `.github` repository does not exist, the check fails.
       remediation:
         - id: github
           desc: |

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -432,7 +432,8 @@ queries:
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      github.organization.repositories.where( name == ".github" ).any( securityFile.exists )
+      github.organization.repositories.any( name == ".github" ) &&
+      github.repository( name: ".github" ).securityFile.exists
     docs:
       desc: |
         This check verifies that the organization publishes a default security policy covering the repositories it owns.


### PR DESCRIPTION
Fixes the first item in #3380.

## The bug

`mondoo-github-organization-security-security-policy` is filtered to `asset.platform == "github-org"`, but both branches of its `if/else` terminated in `github.repository.securityFile.exists`:

```mql
if ( github.organization.repositories.one(name == ".github") ) {
  github.organization.repositories.where( name == ".github").all(
    securityFile.exists
  ) || github.repository.securityFile.exists
} else {
  github.repository.securityFile.exists
}
```

There is no bound repository on an organization asset, so that term cannot resolve as intended. The `else` branch is the worse half: an organization with no `.github` repository was evaluated **entirely** on the unresolvable term.

## The fix

Do what the description says: find the organization's `.github` repository, then read the security file there.

```mql
github.organization.repositories.any( name == ".github" ) &&
github.repository( name: ".github" ).securityFile.exists
```

`github.repository(name:)` resolves the owner from the connection and fetches that one repository by name, so the second term names the repository the control is about instead of reaching it through a filtered list.

### Why the guard cannot be dropped

The bare `github.repository( name: ".github" ).securityFile.exists` looks tidier, but it is wrong for the most common case. When the repository does not exist the resolver returns the API 404 rather than a false, so the check **errors** instead of failing:

```
$ cnquery run github org mondoohq -c 'github.repository(name: "zzz-no-such-repo-98765").securityFile.exists'
rpc error: code = Unknown desc = GET https://api.github.com/repos/mondoohq/zzz-no-such-repo-98765: 404 Not Found []
github.repository.securityFile.exists: no data available
```

Most organizations have no `.github` repository, so that form would turn the majority verdict into an error. Putting the existence test in front means `&&` short-circuits and the right-hand term never runs:

```
$ cnquery run github org mondoohq -c '<guard> && <read>'   # missing repo
[failed] false && _
```

Which is the verdict the description promises: fails when the organization has no `.github` repository.

### Verified against a live organization

Both paths, using the exact two-line form that ships:

| organization state | result |
|---|---|
| `mondoohq` — has `.github` with `SECURITY.md` | `[ok] true` |
| name that does not resolve — simulates no `.github` repo | `[failed] false && _` |

## Also fixed

**The duplicate title.** This check was titled "Ensure repository defines a security policy", byte-identical to `mondoo-github-repository-security-security-policy`. The two were indistinguishable in a report despite being an organization control and a repository control. It is now "Ensure the organization defines a default security policy".

**The description and audit section**, both of which described the old two-place resolution and told the reader to go look at a repository. Both are now organization scoped, and the description points at the companion repository check for the per-repository question. The `**Why this matters**` content from #3378 is unchanged.

## Validation

```
cnspec policy lint content/mondoo-github-security.mql.yaml  → valid policy bundle(s)
typos                                                       → clean
go test ./internal/bundle/...                               → ok
```

Field existence confirmed against the installed provider schema: `github.organization.repositories` is `github.repository`, which carries `securityFile` as a `github.file`.

There is no IaC fixture suite for GitHub platform checks, so this has no fixture coverage. The two remaining items in #3380 are unaffected by this change.

Version 1.8.5 to 1.8.6.

## Note on overlapping PRs

#3383 and the Dependabot fix also touch this file in different regions. They will conflict only on the version line, which merges trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
