### PR TITLE
🛑 policy: remove ReportingJob.deprecated_v8_is_data

### DIFF
--- a/policy/cnspec_policy.pb.go
+++ b/policy/cnspec_policy.pb.go
@@ -5688,18 +5688,15 @@ func (x *DataQueryInfo) GetNotify() []string {
 // - uuid specifies the query or policy
 // - spec has all the other results that need to be pulled and their scorings
 type ReportingJob struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// FIXME: DEPRECATED, remove in v10.0 vv
-	// This is replaced by the new type field, which now carries more info
-	DeprecatedV8IsData bool               `protobuf:"varint,8,opt,name=deprecated_v8_is_data,json=deprecatedV8IsData,proto3" json:"deprecated_v8_is_data,omitempty"` // ^^
-	Checksum           string             `protobuf:"bytes,1,opt,name=checksum,proto3" json:"checksum,omitempty"`
-	QrId               string             `protobuf:"bytes,2,opt,name=qr_id,json=qrId,proto3" json:"qr_id,omitempty"`
-	Uuid               string             `protobuf:"bytes,3,opt,name=uuid,proto3" json:"uuid,omitempty"`
-	Notify             []string           `protobuf:"bytes,5,rep,name=notify,proto3" json:"notify,omitempty"`
-	ScoringSystem      ScoringSystem      `protobuf:"varint,6,opt,name=scoring_system,json=scoringSystem,proto3,enum=cnspec.policy.v1.ScoringSystem" json:"scoring_system,omitempty"`
-	Datapoints         map[string]bool    `protobuf:"bytes,7,rep,name=datapoints,proto3" json:"datapoints,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	ChildJobs          map[string]*Impact `protobuf:"bytes,9,rep,name=child_jobs,json=childJobs,proto3" json:"child_jobs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Type               ReportingJob_Type  `protobuf:"varint,10,opt,name=type,proto3,enum=cnspec.policy.v1.ReportingJob_Type" json:"type,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Checksum      string                 `protobuf:"bytes,1,opt,name=checksum,proto3" json:"checksum,omitempty"`
+	QrId          string                 `protobuf:"bytes,2,opt,name=qr_id,json=qrId,proto3" json:"qr_id,omitempty"`
+	Uuid          string                 `protobuf:"bytes,3,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Notify        []string               `protobuf:"bytes,5,rep,name=notify,proto3" json:"notify,omitempty"`
+	ScoringSystem ScoringSystem          `protobuf:"varint,6,opt,name=scoring_system,json=scoringSystem,proto3,enum=cnspec.policy.v1.ScoringSystem" json:"scoring_system,omitempty"`
+	Datapoints    map[string]bool        `protobuf:"bytes,7,rep,name=datapoints,proto3" json:"datapoints,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	ChildJobs     map[string]*Impact     `protobuf:"bytes,9,rep,name=child_jobs,json=childJobs,proto3" json:"child_jobs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type          ReportingJob_Type      `protobuf:"varint,10,opt,name=type,proto3,enum=cnspec.policy.v1.ReportingJob_Type" json:"type,omitempty"`
 	// The MRNs of all the checks/queries this reporting job represents
 	Mrns          []string `protobuf:"bytes,11,rep,name=mrns,proto3" json:"mrns,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -5734,13 +5731,6 @@ func (x *ReportingJob) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ReportingJob.ProtoReflect.Descriptor instead.
 func (*ReportingJob) Descriptor() ([]byte, []int) {
 	return file_cnspec_policy_proto_rawDescGZIP(), []int{57}
-}
-
-func (x *ReportingJob) GetDeprecatedV8IsData() bool {
-	if x != nil {
-		return x.DeprecatedV8IsData
-	}
-	return false
 }
 
 func (x *ReportingJob) GetChecksum() string {
@@ -10042,9 +10032,8 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x05items\x18\x01 \x03(\tR\x05items\";\n" +
 	"\rDataQueryInfo\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
-	"\x06notify\x18\x02 \x03(\tR\x06notify\"\x85\x06\n" +
-	"\fReportingJob\x121\n" +
-	"\x15deprecated_v8_is_data\x18\b \x01(\bR\x12deprecatedV8IsData\x12\x1a\n" +
+	"\x06notify\x18\x02 \x03(\tR\x06notify\"\xef\x05\n" +
+	"\fReportingJob\x12\x1a\n" +
 	"\bchecksum\x18\x01 \x01(\tR\bchecksum\x12\x13\n" +
 	"\x05qr_id\x18\x02 \x01(\tR\x04qrId\x12\x12\n" +
 	"\x04uuid\x18\x03 \x01(\tR\x04uuid\x12\x16\n" +
@@ -10075,7 +10064,7 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\tFRAMEWORK\x10\x05\x12\x0f\n" +
 	"\vRISK_FACTOR\x10\x06\x12\x18\n" +
 	"\x14CHECK_AND_DATA_QUERY\x10\a\x12\x13\n" +
-	"\x0fEXECUTION_QUERY\x10\b\"\xc8\a\n" +
+	"\x0fEXECUTION_QUERY\x10\bJ\x04\b\b\x10\tR\x15deprecated_v8_is_data\"\xc8\a\n" +
 	"\x06Report\x12\x1f\n" +
 	"\vscoring_mrn\x18\x01 \x01(\tR\n" +
 	"scoringMrn\x12\x1d\n" +

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -936,10 +936,9 @@ message DataQueryInfo {
   - spec has all the other results that need to be pulled and their scorings
 */
 message ReportingJob {
-  // FIXME: DEPRECATED, remove in v10.0 vv
-  // This is replaced by the new type field, which now carries more info
-  bool deprecated_v8_is_data = 8;
-  // ^^
+  // 8 was deprecated_v8_is_data, replaced by the type field below
+  reserved 8;
+  reserved "deprecated_v8_is_data";
 
   enum Type {
     UNSPECIFIED = 0;

--- a/policy/cnspec_policy_vtproto.pb.go
+++ b/policy/cnspec_policy_vtproto.pb.go
@@ -1766,7 +1766,6 @@ func (m *ReportingJob) CloneVT() *ReportingJob {
 		return (*ReportingJob)(nil)
 	}
 	r := new(ReportingJob)
-	r.DeprecatedV8IsData = m.DeprecatedV8IsData
 	r.Checksum = m.Checksum
 	r.QrId = m.QrId
 	r.Uuid = m.Uuid
@@ -8155,16 +8154,6 @@ func (m *ReportingJob) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x4a
 		}
 	}
-	if m.DeprecatedV8IsData {
-		i--
-		if m.DeprecatedV8IsData {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x40
-	}
 	if len(m.Datapoints) > 0 {
 		for k := range m.Datapoints {
 			v := m.Datapoints[k]
@@ -13967,9 +13956,6 @@ func (m *ReportingJob) SizeVT() (n int) {
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + 1
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
-	}
-	if m.DeprecatedV8IsData {
-		n += 2
 	}
 	if len(m.ChildJobs) > 0 {
 		for k, v := range m.ChildJobs {
@@ -29971,26 +29957,6 @@ func (m *ReportingJob) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Datapoints[mapkey] = mapvalue
 			iNdEx = postIndex
-		case 8:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DeprecatedV8IsData", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.DeprecatedV8IsData = bool(v != 0)
 		case 9:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ChildJobs", wireType)


### PR DESCRIPTION
Part of the v14 deprecation sweep. Marker: `// FIXME: DEPRECATED, remove in v10.0` — we are on v13, so this is three majors overdue.

**Rebased onto `main`.** This PR previously targeted `pre`, where `generated-files` cannot pass: `make prep/repos` clones mql at `main`, and mql has since dropped the `/v13` major-version suffix from its module path, so the regenerated pb.go imports `go.mondoo.com/mql/llx` while `pre`'s go.mod still requires `go.mondoo.com/mql/v13`. That failure reproduces on every push to `pre` itself and is unrelated to this change. `main` is already on `go.mondoo.com/mql` (v14.0.0-rc.1, #3575) and is where the sweep is now landing (#3389), so this is retargeted there.

## What

`ReportingJob.deprecated_v8_is_data` (field 8) was replaced by the `Type` enum, which distinguishes `CHECK` / `DATA_QUERY` / `CHECK_AND_DATA_QUERY` and more. The field is removed and its tag reserved:

```proto
message ReportingJob {
  // 8 was deprecated_v8_is_data, replaced by the type field below
  reserved 8;
  reserved "deprecated_v8_is_data";
```

## Why this one is safe

`DeprecatedV8IsData` has **no readers or writers anywhere outside generated code** — re-verified against `main` by grepping the tree excluding `*.pb.go` / `*_vtproto.pb.go`. Nothing computes from it, nothing sets it. This is a pure wire-format cleanup.

Reserving the tag *and* the name means the number can never be silently reused with a different type, which would misparse any old payload still carrying field 8. The reservation is visible in the regenerated descriptor as `J\x04\b\b\x10\tR\x15deprecated_v8_is_data`.

## Regenerated

`go generate ./policy`, touching `cnspec_policy.pb.go` and `cnspec_policy_vtproto.pb.go`. The generated diff is exactly the field: struct member, getter, descriptor bytes, and the vtproto clone/marshal/size/unmarshal arms.

Two pins have to match CI to get a byte-identical result, and only one of them is obvious:

- `protoc` — pinned to `33.x` in `.github/env` and stamped into the file header, so a mismatch is visible.
- **the Go toolchain that builds `protoc-gen-go`** — the plugin is invoked via `go tool protoc-gen-go`, so it is compiled with whatever Go is on `PATH`, and it runs its output through `go/format`. gofmt's doc-comment reflow differs between 1.26 and 1.27, which reindents comment lists across the whole file with no version stamp to warn you. `.github/env` pins `golang-version=1.26` and CI sets `GOTOOLCHAIN=local`.

Regenerating with protoc 33.6 and `GOTOOLCHAIN=go1.26.6` reproduces the checked-in file byte for byte; verified with a control run that regenerated the *unchanged* proto and produced no diff at all.

## Verification

- `go build ./...` clean
- `go test ./policy/...` fully green, `policy/scan/pdque` included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
