### PR TITLE
🐛 github: correct the Dependabot check title and its one/any predicates

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.5
+    version: 1.8.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1827,7 +1827,7 @@ queries:
   # present.
   - uid: mondoo-github-repository-security-ensure-dependabot-workflow
     filters: asset.platform == "github-repo"
-    title: Ensure a GitHub Actions workflow exists for Dependabot
+    title: Ensure a Dependabot configuration file exists
     impact: 70
     tags:
       compliance/bsi-sys-1-5: false
@@ -1846,15 +1846,15 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |-
       github.repository.files
-        .one( name == ".github" && type == "dir" )
+        .any( name == ".github" && type == "dir" )
       github.repository.files
         .where( path == ".github" )
-        .all( files.one( name.in(["dependabot.yaml", "dependabot.yml"]) ) )
+        .all( files.any( name.in(["dependabot.yaml", "dependabot.yml"]) ) )
     docs:
       desc: |
         This check verifies that the repository is configured for automated dependency update pull requests.
 
-        The artifact here is a configuration file a developer writes and commits, at `.github/dependabot.yml` or `.github/dependabot.yaml`. It declares which package ecosystems and directories Dependabot should watch and how often it should look for newer versions. The check passes only when exactly one of the two files is present. Having neither fails the check, and having both fails it as well.
+        The artifact here is a configuration file a developer writes and commits, at `.github/dependabot.yml` or `.github/dependabot.yaml`. It declares which package ecosystems and directories Dependabot should watch and how often it should look for newer versions. The check passes when the `.github` directory exists and holds either file, and fails when the directory is absent or neither file is present.
 
         **Why this matters**
 


### PR DESCRIPTION
Fixes the second item in #3380.

## Two problems

### The title promises something the query does not assess

It read **"Ensure a GitHub Actions workflow exists for Dependabot"**, while the query looks for `.github/dependabot.yml` or `.github/dependabot.yaml`. That is the Dependabot *configuration* file for version updates. It is not a GitHub Actions workflow, which would live under `.github/workflows/`.

A repository could satisfy one and not the other, so the check and its title described different controls. Retitled to **"Ensure a Dependabot configuration file exists"**, which is what the check actually proves.

### `.one()` where it meant `.any()`

```diff
 github.repository.files
-  .one( name == ".github" && type == "dir" )
+  .any( name == ".github" && type == "dir" )
 github.repository.files
   .where( path == ".github" )
-  .all( files.one( name.in(["dependabot.yaml", "dependabot.yml"]) ) )
+  .all( files.any( name.in(["dependabot.yaml", "dependabot.yml"]) ) )
```

`.one()` requires **exactly one** match, so a repository holding both `dependabot.yml` and `dependabot.yaml` failed a check it should pass. The directory guard had the same construction and would break as soon as anything else matched the predicate.

The outer `.all()` is deliberately kept. It is guarded by the directory statement above it, so it cannot pass vacuously on a repository with no `.github` directory.

## Why not switch the query to check for a workflow instead

That would be a different control rather than a fix, and it would change what the check's compliance mappings assert. Dependabot version updates are configured by this file, not by a workflow, so the file is the correct artifact. If a workflow-based check is wanted, `github.repository.workflows.any( file.path == /dependabot/ )` compiles against the provider and would be a reasonable addition, separately.

## The uid is deliberately unchanged

It still contains `workflow`. Renaming it would break existing compliance mappings and score history for no user-visible benefit, since the title is what appears in reports.

## Validation

```
cnspec policy lint content/mondoo-github-security.mql.yaml  → valid policy bundle(s)
typos                                                       → clean
go test ./internal/bundle/...                               → ok
```

The description already documented the old behavior accurately, including that having both files failed, so that sentence is updated to match the corrected behavior.

Version 1.8.5 to 1.8.6.

## Note on overlapping PRs

#3383 and #3384 touch this file in different regions. All three conflict only on the version line, which merges trivially.

The third item in #3380, the two-level scan depth in `binary-artifacts`, is not addressed here. It cannot be fixed properly in the policy: MQL has no unbounded recursion and `github.file.files` returns one level per hop, so the only in-policy option is hardcoding more levels. The right fix is provider-side, using GitHub's Git Trees API with `recursive=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)