### PR TITLE
🛑 reporter: remove the deprecated ScoreValue.score field

### DIFF
--- a/cli/reporter/cnspec_report.pb.go
+++ b/cli/reporter/cnspec_report.pb.go
@@ -138,11 +138,9 @@ func (x *ScoreValues) GetValues() map[string]*ScoreValue {
 }
 
 type ScoreValue struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// FIXME: DEPRECATED, remove in v13, replaced by riskScore below
-	Score         uint32 `protobuf:"varint,1,opt,name=score,proto3" json:"score,omitempty"` // ^
-	Status        string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
-	RiskScore     uint32 `protobuf:"varint,3,opt,name=riskScore,proto3" json:"riskScore,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	RiskScore     uint32                 `protobuf:"varint,3,opt,name=riskScore,proto3" json:"riskScore,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -175,13 +173,6 @@ func (x *ScoreValue) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ScoreValue.ProtoReflect.Descriptor instead.
 func (*ScoreValue) Descriptor() ([]byte, []int) {
 	return file_cnspec_report_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *ScoreValue) GetScore() uint32 {
-	if x != nil {
-		return x.Score
-	}
-	return 0
 }
 
 func (x *ScoreValue) GetStatus() string {
@@ -224,12 +215,11 @@ const file_cnspec_report_proto_rawDesc = "" +
 	"\x06values\x18\x01 \x03(\v20.mondoo.report.cnspec.v1.ScoreValues.ValuesEntryR\x06values\x1a^\n" +
 	"\vValuesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
-	"\x05value\x18\x02 \x01(\v2#.mondoo.report.cnspec.v1.ScoreValueR\x05value:\x028\x01\"X\n" +
+	"\x05value\x18\x02 \x01(\v2#.mondoo.report.cnspec.v1.ScoreValueR\x05value:\x028\x01\"O\n" +
 	"\n" +
-	"ScoreValue\x12\x14\n" +
-	"\x05score\x18\x01 \x01(\rR\x05score\x12\x16\n" +
+	"ScoreValue\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1c\n" +
-	"\triskScore\x18\x03 \x01(\rR\triskScoreB#Z!go.mondoo.com/cnspec/cli/reporterb\x06proto3"
+	"\triskScore\x18\x03 \x01(\rR\triskScoreJ\x04\b\x01\x10\x02R\x05scoreB#Z!go.mondoo.com/cnspec/cli/reporterb\x06proto3"
 
 var (
 	file_cnspec_report_proto_rawDescOnce sync.Once

--- a/cli/reporter/cnspec_report.proto
+++ b/cli/reporter/cnspec_report.proto
@@ -21,9 +21,9 @@ message ScoreValues {
 }
 
 message ScoreValue {
-  // FIXME: DEPRECATED, remove in v13, replaced by riskScore below
-  uint32 score = 1;
-  // ^
+  // 1 was score, replaced by riskScore below
+  reserved 1;
+  reserved "score";
 
   string status = 2;
   uint32 riskScore = 3;

--- a/cli/reporter/proto.go
+++ b/cli/reporter/proto.go
@@ -239,7 +239,6 @@ func gatherScoreValue(score *policy.Score) *ScoreValue {
 	}
 
 	return &ScoreValue{
-		Score:     score.Value,
 		Status:    status,
 		RiskScore: 100 - score.Value,
 	}

--- a/cli/reporter/proto_test.go
+++ b/cli/reporter/proto_test.go
@@ -35,7 +35,7 @@ func TestProtoConversion(t *testing.T) {
 		assert.Equal(t, 53, len(report.Scores[assetMrn].Values))
 
 		score := report.Scores[assetMrn].Values["//policy.api.mondoo.app/queries/mondoo-linux-security-permissions-on-etcgshadow-are-configured"]
-		assert.Equal(t, 100, int(score.Score))
+		assert.Equal(t, 0, int(score.RiskScore))
 		assert.Equal(t, "pass", score.Status)
 	})
 }

--- a/cli/reporter/testdata/cnspec_report_mixed.json
+++ b/cli/reporter/testdata/cnspec_report_mixed.json
@@ -10,10 +10,10 @@
     "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuQKwk": {
       "values": {
         "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-control-access-to-audit-records": {
-          "score": 100,
           "status": "pass"
         },
         "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-reduce-the-sudo-timeout-period": {
+          "riskScore": 100,
           "status": "fail"
         },
       }

--- a/cli/reporter/testdata/cnspec_report_pass.json
+++ b/cli/reporter/testdata/cnspec_report_pass.json
@@ -10,11 +10,9 @@
     "//policy.api.mondoo.com/assets/2x5c0nwiaianioOv2cda2OuAAzk": {
       "values": {
         "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-control-access-to-audit-records": {
-          "score": 100,
           "status": "pass"
         },
         "//local.cnspec.io/run/local-execution/queries/mondoo-macos-security-reduce-the-sudo-timeout-period": {
-          "score": 100,
           "status": "pass"
         }
       }


### PR DESCRIPTION
Part of the v14 deprecation sweep. Marker: `// FIXME: DEPRECATED, remove in v13, replaced by riskScore below`.

## Rebased onto `main`

This PR previously targeted `pre` and was failing `generated-files`. The failure was not caused by the change — all three open `pre` PRs (#3385, #3386, #3389) failed identically.

`make prep/repos` clones mql's `main` branch **unpinned**, and mql main has moved to the unversioned module path `go.mondoo.com/mql` (v14.0.0-rc.1). `pre` still pins `go.mondoo.com/mql/v13`, so regeneration emitted `.pb.go` files importing `go.mondoo.com/mql/llx` while `go.mod` provided `go.mondoo.com/mql/v13/llx`:

```
policy/cnspec_policy.pb.go:13:2: no required module provides package go.mondoo.com/mql/llx
```

`pre` has since been bypassed: `main` is now `module go.mondoo.com/cnspec` on mql v14-rc, and still carries every deprecation marker this sweep targets. So the branch is rebased onto `main` and retargeted there, dropping the three commits already merged into `pre`.

## What

`ScoreValue.score` (field 1) is removed and its tag reserved:

```proto
message ScoreValue {
  // 1 was score, replaced by riskScore below
  reserved 1;
  reserved "score";

  string status = 2;
  uint32 riskScore = 3;
}
```

`gatherScoreValue` already dual-wrote both fields (`Score: score.Value` alongside `RiskScore: 100 - score.Value`), so nothing was ever derived from `score` alone. Dropping the assignment is a one-line change.

## ⚠️ Breaking: JSON reporter output

This is the one PR in the sweep with a user-visible output change. The `score` key disappears from `cnspec scan -o json` score values. Consumers read `riskScore` instead, which is the inverse:

```
riskScore == 100 - score
```

So a passing check that reported `"score": 100` now reports `"riskScore": 0`. This is exactly the kind of change a major exists for, but it is worth calling out in the release notes.

## Reporter testdata

`main` has `cnspec_report_compare.go` and its test, which `pre` did not. Both fixtures it loads used `"score"`, and `FromJSON` unmarshals through encoding/json, which drops unknown keys silently — a leftover `"score"` would have loaded as nothing and left every `RiskScore` at 0, leaving `TestReportComparisonWithExplicitMrn` to separate the two reports on `status` alone.

Rewriting the values as `riskScore` keeps the numeric dimension. Because `riskScore = 100 - score` and zero is `omitempty`, the pass entries drop the key entirely and the mixed fixture's failing entry gains `"riskScore": 100`.

Verified with two mutation controls:

- equalise both fixtures' `status` so **only** `riskScore` differs → the test still separates them, proving `riskScore` is read
- additionally strip `riskScore` so the fixtures are identical → the test fails, proving nothing else was propping it up

## Verification

- `make cnspec/generate` with protoc 33.6 (the version `.github/env` pins) — the reserved range and name land correctly in the raw descriptor (`J\x04\b\x01\x10\x02R\x05score`)
- `go build ./...` clean
- `go test ./cli/reporter/...` passes
- `go test ./cli/... ./policy/...` — one unrelated pre-existing failure, `TestNextAvailableFilename` in `policy/scan/pdque`, which collides on nanosecond-timestamp filenames on fast hardware and reproduces on pristine `main`

Note on regeneration: `protoc-gen-go` formats its output with the `go/format` of the toolchain that compiled the plugin. Regenerating locally under Go 1.27 reflows every doc-comment list in `policy/cnspec_policy.pb.go` (98 lines, comments only), which CI's pinned Go 1.26 does not produce. Confirmed by regenerating on a pristine `main` tree, where the identical churn appears with no changes applied, so that file is deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)