### PR TITLE
🧹 scan: drop the deprecated inventory format flag aliases

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -49,16 +49,7 @@ func init() {
 	_ = scanCmd.Flags().MarkHidden("inventory-template")
 
 	_ = scanCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible")
-	// "inventory-ansible" is deprecated, use "inventory-format-ansible" instead
-	_ = scanCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible")
-	_ = scanCmd.Flags().MarkDeprecated("inventory-ansible", "use --inventory-format-ansible")
-	_ = scanCmd.Flags().MarkHidden("inventory-ansible")
-
 	_ = scanCmd.Flags().Bool("inventory-format-domainlist", false, "Set the inventory format to domain list")
-	// "inventory-domainlist" is deprecated, use "inventory-format-domainlist" instead
-	_ = scanCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list")
-	_ = scanCmd.Flags().MarkDeprecated("inventory-domainlist", "use --inventory-format-domainlist")
-	_ = scanCmd.Flags().MarkHidden("inventory-domainlist")
 
 	// bundles, packs & incognito mode
 	_ = scanCmd.Flags().Bool("incognito", false, "Run in incognito mode. Do not report scan results to Mondoo Platform")
@@ -120,11 +111,7 @@ To manually configure a policy, use this:
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
 		_ = viper.BindPFlag("inventory-template", cmd.Flags().Lookup("inventory-template"))
 		_ = viper.BindPFlag("inventory-format-ansible", cmd.Flags().Lookup("inventory-format-ansible"))
-		// inventory-ansible is deprecated
-		_ = viper.BindPFlag("inventory-ansible", cmd.Flags().Lookup("inventory-ansible"))
 		_ = viper.BindPFlag("inventory-format-domainlist", cmd.Flags().Lookup("inventory-format-domainlist"))
-		// inventory-domainlist is deprecated
-		_ = viper.BindPFlag("inventory-domainlist", cmd.Flags().Lookup("inventory-domainlist"))
 
 		_ = viper.BindPFlag("policy-bundle", cmd.Flags().Lookup("policy-bundle"))
 		_ = viper.BindPFlag("detect-cicd", cmd.Flags().Lookup("detect-cicd"))

--- a/apps/cnspec/cmd/vuln.go
+++ b/apps/cnspec/cmd/vuln.go
@@ -28,8 +28,8 @@ func init() {
 	vulnCmd.Flags().Lookup("asset-name").Hidden = true
 
 	vulnCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
-	vulnCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible")
-	vulnCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list")
+	vulnCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible")
+	vulnCmd.Flags().Bool("inventory-format-domainlist", false, "Set the inventory format to domain list")
 }
 
 var vulnCmd = &cobra.Command{
@@ -40,8 +40,8 @@ var vulnCmd = &cobra.Command{
 		_ = viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 		_ = viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
-		_ = viper.BindPFlag("inventory-ansible", cmd.Flags().Lookup("inventory-ansible"))
-		_ = viper.BindPFlag("inventory-domainlist", cmd.Flags().Lookup("inventory-domainlist"))
+		_ = viper.BindPFlag("inventory-format-ansible", cmd.Flags().Lookup("inventory-format-ansible"))
+		_ = viper.BindPFlag("inventory-format-domainlist", cmd.Flags().Lookup("inventory-format-domainlist"))
 	},
 }
 

--- a/test/cli/testdata/cnspec_vuln.ct
+++ b/test/cli/testdata/cnspec_vuln.ct
@@ -8,12 +8,12 @@ Available Commands:
   sbom        Check for vulnerabilities read SBOM file on disk
 
 Flags:
-  -h, --help                    help for vuln
-      --inventory-ansible       Set the inventory format to Ansible
-      --inventory-domainlist    Set the inventory format to domain list
-      --inventory-file string   Set the path to the inventory file
-  -o, --output string           Set the output format: compact, csv, full, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
-      --platform-id string      Select a specific target asset by providing its platform ID
+  -h, --help                          help for vuln
+      --inventory-file string         Set the path to the inventory file
+      --inventory-format-ansible      Set the inventory format to Ansible
+      --inventory-format-domainlist   Set the inventory format to domain list
+  -o, --output string                 Set the output format: compact, csv, full, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
+      --platform-id string            Select a specific target asset by providing its platform ID
 
 Global Flags:
       --api-proxy string        Set the proxy for communications with Mondoo Platform API


### PR DESCRIPTION
Part of the v14 deprecation sweep. Markers: `MarkDeprecated("inventory-ansible", …)` and `MarkDeprecated("inventory-domainlist", …)`, no version pinned.

## What

Removes `--inventory-ansible` and `--inventory-domainlist` from `scan`, along with their viper bindings, leaving `--inventory-format-ansible` and `--inventory-format-domainlist`.

## The aliases were already inert on `scan`

The only consumer of these values is mql's `cli/inventoryloader`:

```go
if viper.GetBool("inventory-format-ansible") { … }
if viper.GetBool("inventory-format-domainlist") { … }
```

It reads the `inventory-format-*` keys and never the old ones. So registering and binding the aliases on `scan` had no effect — passing `cnspec scan --inventory-ansible` already did nothing beyond printing a deprecation notice. Removing them is a true no-op.

## 🐛 And a real bug this uncovered

`vuln.go` registered and bound **only the old names**:

```go
vulnCmd.Flags().Bool("inventory-ansible", …)
vulnCmd.Flags().Bool("inventory-domainlist", …)
```

Since the loader never reads those keys, `cnspec vuln --inventory-ansible` is accepted today and silently does nothing — the flag lies. Rather than leave that behind after cleaning up its sibling on `scan`, this PR renames both to the `inventory-format-*` names, so they reach the loader for the first time.

I flagged this rather than splitting it out because removing the aliases from `scan` while leaving `vuln` on the dead names would make the inconsistency permanent and harder to spot. Happy to split if you'd rather land the pure removal alone.

## Verification

- `go build ./...` clean
- `go test ./apps/...` passes
- No generated CLI doc changes: the `scan` aliases were `MarkHidden` so they never appeared in `docs/cli/cnspec_scan.md`, and there is no `cnspec_vuln.md` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)