### PR TITLE
📝 cisco: rewrite check descriptions across iosxe, iosxr, and nxos policies

### DIFF
--- a/content/mondoo-cisco-iosxe-security.mql.yaml
+++ b/content/mondoo-cisco-iosxe-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-iosxe-security
     name: Mondoo Cisco IOS-XE Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -130,17 +130,15 @@ queries:
       cisco.iosxe.ssh.enabled == true
     docs:
       desc: |
-        This check verifies that SSH is enabled on the device. SSH provides encrypted remote management access, replacing insecure protocols like Telnet.
+        This check verifies that the device offers an encrypted channel for remote command-line administration.
+
+        IOS-XE does not run an SSH server until it has an identity to present. A hostname, a domain name set with `ip domain name`, and an RSA key pair created by `crypto key generate rsa modulus 2048` are all prerequisites, after which `show ip ssh` reports the server as enabled. The check requires the SSH server to be running.
 
         **Why this matters**
 
-        Without SSH enabled, the device cannot provide encrypted management access. If SSH is not enabled:
+        Without SSH, remote administration falls back to telnet, which carries the username, the password, the enable secret typed at the prompt, and every configuration command as readable text across the network. An attacker positioned anywhere on the path, on a span port, on a compromised neighboring switch, or on the same broadcast domain running ARP spoofing, harvests the credential without ever touching the router. From there the device is theirs: they add a local account, mirror traffic to a port they control, or change routing so that traffic detours through equipment they own.
 
-        - Remote management must rely on insecure protocols such as Telnet.
-        - All management traffic including credentials is transmitted in clear text.
-        - Compliance with security frameworks requiring encrypted management access cannot be met.
-
-        Enabling SSH ensures that secure, encrypted remote management access is available.
+        Bringing up SSH is only half the work. The VTY lines must actually accept it and must have a login method attached, so pair this with the transport restriction and the AAA login configuration that companion checks in this policy cover, or remote access still lands on telnet.
       audit: |-
         To verify that SSH is enabled on the device:
 
@@ -199,17 +197,17 @@ queries:
       cisco.iosxe.ssh.version == "2.0"
     docs:
       desc: |
-        This check verifies that SSH version 2 is enforced. SSH version 1 has known cryptographic vulnerabilities and must not be used.
+        This check verifies that the device negotiates only the modern SSH protocol version.
+
+        `show ip ssh` reports the version the server offers. IOS-XE reports 2.0 when only SSHv2 is accepted and 1.99 when the server still falls back to SSHv1 for older clients. The check requires 2.0, which the global `ip ssh version 2` command sets.
 
         **Why this matters**
 
-        SSH version 1 has well-documented weaknesses including susceptibility to man-in-the-middle attacks. If SSH version 2 is not enforced:
+        SSHv1 has a broken integrity model. It protects packets with a CRC-32 checksum rather than a keyed message authentication code, which lets an attacker able to modify ciphertext in flight inject chosen plaintext into an authenticated session. That insertion attack was published in 1998 and remains straightforward to execute. The protocol also has no downgrade protection in its key exchange.
 
-        - Management sessions are vulnerable to cryptographic attacks in SSH version 1.
-        - Session integrity cannot be guaranteed.
-        - Compliance with modern security frameworks cannot be met.
+        The 1.99 setting is the trap. It looks like version 2 is available, and it is, but the server still advertises SSHv1 alongside it and a client that asks for the older protocol gets it. An attacker who can influence the client, or who simply connects with an SSHv1 tool, obtains the weak session while the operator believes the device is on version 2.
 
-        Enforcing SSH version 2 ensures all remote management sessions use strong cryptographic protections.
+        Legacy management tools that speak only SSHv1 stop working once the fallback is removed, so inventory them before the change rather than discovering them after it.
       audit: |-
         To verify that SSH version 2 is enforced:
 
@@ -262,16 +260,15 @@ queries:
       cisco.iosxe.ssh.timeoutSeconds <= 120
     docs:
       desc: |
-        This check verifies that an SSH login timeout is configured to limit the time allowed for authentication. The timeout should be 120 seconds or less.
+        This check verifies that an unauthenticated SSH connection cannot hold a session slot indefinitely.
+
+        The `ip ssh time-out` value bounds how long IOS-XE waits for a client to finish authenticating before tearing the connection down. The device reports the value in seconds and will not accept more than 120. The check requires a value between 1 and 120 seconds, which rejects a device where the timeout has been zeroed out.
 
         **Why this matters**
 
-        Without an SSH timeout, connection attempts can remain open indefinitely during authentication. If the timeout is not configured:
+        The router has a small, fixed number of VTY slots, typically sixteen. Every half-open SSH connection occupies one from the moment the TCP handshake completes until authentication succeeds, fails, or times out. An attacker who opens connections and then simply never sends credentials consumes all of them in seconds, and the result is that no administrator can log in. On a device that is also the default gateway for a site, losing management access during an incident means driving to the building with a console cable.
 
-        - Resources are consumed by stale connection attempts.
-        - Slow brute-force attacks can keep connections open for extended periods.
-
-        Configuring an SSH timeout limits the authentication window and reduces resource consumption.
+        A short authentication window is the cheapest defense against that. Pair it with an inbound access class on the VTY lines so those connections never reach the authentication stage from untrusted addresses, and with `service tcp-keepalives-in` so that sessions which died mid-flight are reaped rather than left holding a slot.
       audit: |-
         To verify that an SSH login timeout is configured:
 
@@ -323,16 +320,15 @@ queries:
       cisco.iosxe.cryptoKeysRsa.any(modulusSize >= 2048)
     docs:
       desc: |
-        This check verifies that at least one RSA key pair has a modulus of 2048 bits or larger. Keys smaller than 2048 bits are considered cryptographically weak.
+        This check verifies that the host key protecting SSH sessions is long enough to resist factoring.
+
+        `crypto key generate rsa modulus 2048` creates the key pair IOS-XE presents to SSH clients and uses to prove the device's identity. Older devices frequently carry a 512-bit or 1024-bit key generated years earlier and never rotated, because no modulus was specified at the time and the default was small. The check requires at least one RSA key pair on the device with a modulus of 2048 bits or more.
 
         **Why this matters**
 
-        RSA keys with fewer than 2048 bits can be factored with current computing resources. If the key size is insufficient:
+        A 512-bit RSA modulus is factorable on rented compute for a few dollars in a few hours. Recovering the private key lets an attacker impersonate the router outright: they intercept the SSH connection, present the genuine host key, and the client accepts it with no warning because the fingerprint matches the one it cached. The administrator then types their password and enable credential directly into the attacker's session, and every command they believe they are sending to the router is being relayed and read.
 
-        - The SSH host key can potentially be compromised.
-        - Compliance with NIST and other standards requiring minimum 2048-bit RSA keys cannot be met.
-
-        Using RSA keys of at least 2048 bits ensures adequate cryptographic strength.
+        Rotating the key changes the device's SSH host identity, so every client that stored the old fingerprint prompts on the next connection and any automation that pins the host key needs updating first. A device can also hold more than one key pair, so remove the obsolete short keys rather than only generating a new one alongside them.
       audit: |-
         To verify the RSA key modulus size:
 
@@ -386,18 +382,15 @@ queries:
       cisco.iosxe.aaa.newModelEnabled == true
     docs:
       desc: |
-        This check verifies that the AAA new model is enabled. The AAA new model (`aaa new-model`) is required to use TACACS+ or RADIUS for centralized authentication, authorization, and accounting.
+        This check verifies that the device is able to authenticate administrators against a central identity service rather than only against credentials stored on the box.
+
+        `aaa new-model` is the global switch that replaces the legacy per-line `login` and `login local` behavior with method lists. Nothing else in the AAA subsystem is available until it is set. The check requires the AAA new model to be enabled.
 
         **Why this matters**
 
-        Without the AAA new model enabled, the device cannot use centralized authentication services. If AAA new model is not enabled:
+        Without it, every administrator's access lives in the local user database of each individual router and switch. When an engineer leaves, someone has to remember to remove that account from several hundred devices, and the one that gets missed stays reachable with a working credential for as long as the device lives, which on network hardware is a decade. State-sponsored intrusion campaigns against Cisco routers have turned on exactly this: valid administrative credentials that were never revoked and never expired.
 
-        - The device relies solely on local authentication, which is difficult to manage at scale.
-        - Centralized access control through TACACS+ or RADIUS is not available.
-        - Audit trails for authentication events are incomplete.
-        - Compliance with security frameworks requiring centralized authentication cannot be achieved.
-
-        Enabling the AAA new model is the prerequisite for all AAA functionality.
+        Enabling the new model rewrites authentication on every line the moment the command is accepted, including the VTY session you are typing it from. If no local user exists and no default login list is defined, the next login attempt fails and recovery means a console cable. Create the local account and the default method list in the same configuration session, verify from a second window, and only then copy the configuration to startup.
       audit: |-
         To verify that the AAA new model is enabled:
 
@@ -453,17 +446,17 @@ queries:
       cisco.iosxe.aaa.loginEntries.length > 0
     docs:
       desc: |
-        This check verifies that AAA authentication login method lists are configured. AAA authentication login defines how users are authenticated when accessing the device.
+        This check verifies that a method list exists to decide how administrators logging in are authenticated.
+
+        With the AAA new model on, a line authenticates using a named method list, or using the list called `default` when none is named. `aaa authentication login default group tacacs+ local` is the usual form: try the TACACS+ servers first, fall back to the local database when they are unreachable. The check requires at least one login method list to be present.
 
         **Why this matters**
 
-        Without AAA authentication login configured, the device may allow access without proper authentication. If AAA login is not configured:
+        The new model with no login list is a half-configured state, and it is worse than either endpoint. Lines that previously prompted for a line password now behave according to rules nobody wrote, and depending on the release and the line the result ranges from a locked door to an unexpected prompt. Neither is something you want to discover during an outage.
 
-        - User authentication may not be enforced consistently.
-        - Centralized identity management cannot be leveraged.
-        - Audit trails for authentication events are incomplete.
+        More concretely, the method list is what routes authentication to TACACS+, and TACACS+ is what makes per-administrator identity, immediate revocation, and command authorization possible. Without it, everyone shares whatever is in the local database, and the accounting records name a device rather than a person.
 
-        Configuring AAA authentication login ensures proper authentication is enforced for all access methods.
+        Always terminate the list with `local`. A method list naming only the server group turns a TACACS+ outage or a broken WAN link into a device nobody can log into, which is the failure mode that pushes teams to abandon AAA entirely.
       audit: |-
         To verify that AAA authentication login method lists are configured:
 
@@ -523,17 +516,17 @@ queries:
       cisco.iosxe.aaa.accountingRecords.length > 0
     docs:
       desc: |
-        This check verifies that AAA accounting is configured to log user activity. Accounting records provide an audit trail of commands executed, sessions started, and system events.
+        This check verifies that administrative activity on the device is recorded to an external system.
+
+        `aaa accounting exec default start-stop group tacacs+` records session starts and stops, and `aaa accounting commands 15 default start-stop group tacacs+` records each privileged command as it is entered. Records leave the device as they are generated rather than at the end of the session. The check requires at least one accounting method list to be configured.
 
         **Why this matters**
 
-        Without AAA accounting, there is no record of administrative activity. If accounting is not configured:
+        When a route changes and a customer segment goes dark, the question is who typed what and when. Accounting is the only thing on the device that answers with a person's name attached. Configuration change logging records that a change happened; command accounting records the exact command line, the user, and the terminal it came from, forwarded off the box in real time.
 
-        - There is no forensic evidence of commands executed during a security incident.
-        - Compliance requirements for audit logging cannot be met.
-        - Accountability for privileged operations is lost.
+        That off-box property is what turns it into evidence. An attacker who reaches privileged EXEC can clear the local log buffer and purge the configuration archive, but they cannot retract records the TACACS+ server already holds. Emitting the record as the command is typed, rather than when the session closes, is what defeats an intruder who tidies up before logging off.
 
-        Enabling AAA accounting ensures that all activity is logged for audit and compliance.
+        Accounting depends on a reachable TACACS+ or RADIUS server, so confirm that records actually arrive after the next login rather than treating the configuration lines as proof the control works.
       audit: |-
         To verify that AAA accounting is configured:
 
@@ -590,17 +583,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all local user accounts use `secret` rather than `password` for credential storage. The `secret` keyword uses a one-way hash (MD5, SHA-256, or SCRYPT) while `password` uses reversible Type 7 encryption that is trivially decoded.
+        This check verifies that local account credentials are stored as one-way hashes rather than in a reversible form.
+
+        An account defined with `username admin password ...` stores the credential as Type 7, a reversible encoding. Defined with `username admin algorithm-type scrypt secret ...`, it stores a Type 9 hash instead. The check requires every local account on the device to use the secret form.
 
         **Why this matters**
 
-        Type 7 passwords can be decoded instantly using freely available tools. If users are configured with `password` instead of `secret`:
+        Type 7 is decoded, not cracked. The algorithm is a published XOR against a fixed key and web pages reverse it as fast as you can paste. Anyone who obtains the configuration, from a TFTP backup share, a network management platform's archive, a ticket attachment, or a read-only account allowed to run `show running-config`, walks away with working plaintext passwords for the accounts on that device. Because network engineers reuse credentials across a fleet, that single file frequently opens every device in it.
 
-        - Credentials can be recovered in plain text from the running configuration.
-        - Configuration backups expose all user passwords.
-        - An attacker with read access to the configuration obtains all credentials.
+        Type 9 scrypt is memory-hard and resists offline cracking well. Type 5 MD5, the older default for `secret`, resists it far less well but is still a hash rather than an encoding, so it is an acceptable fallback on releases without scrypt.
 
-        Using `secret` for all user accounts ensures that credentials are stored with a one-way hash.
+        Converting an account means deleting and recreating it, because IOS-XE will not hold both forms for one username. Have a second administrative account or console access ready first, so a session that drops between the two commands does not lock you out of the device.
       audit: |-
         To verify that local users use `secret` rather than `password`:
 
@@ -655,17 +648,17 @@ queries:
       cisco.iosxe.configuration.enableSecret.type == "secret"
     docs:
       desc: |
-        This check verifies that the privileged EXEC mode access is protected with `enable secret` rather than `enable password`. The `enable secret` uses a one-way hash, while `enable password` uses easily reversed Type 7 encryption.
+        This check verifies that the credential guarding privileged EXEC mode is stored as a hash rather than a reversible string.
+
+        IOS-XE accepts two commands for the same door. `enable password` writes a Type 7 value and `enable secret` writes a hash, Type 5 by default or Type 9 with `enable algorithm-type scrypt secret`. When both exist the secret takes precedence, but the password is still sitting in the configuration in recoverable form. The check requires privileged access to be governed by a secret.
 
         **Why this matters**
 
-        The enable password controls access to privileged EXEC mode, which grants full administrative control. If `enable password` is used instead of `enable secret`:
+        Privileged EXEC is total control of the device. From it an attacker rewrites access lists, adds accounts, turns off logging, changes routing so traffic detours through a host they own, and copies out the full configuration with every other credential the device holds. There is no lesser privilege level to fall back to and no second gate behind it.
 
-        - The privileged mode credential is stored with reversible encryption.
-        - An attacker can decode the password from the configuration.
-        - Full administrative access to the device is compromised.
+        A Type 7 enable password therefore means that anyone who can read the configuration owns the device. That set includes read-only operations staff whose accounts were only ever meant to display state, backup systems nobody audits, and whoever ends up with a stale config file years later.
 
-        Using `enable secret` ensures the privileged mode credential is protected with a one-way hash.
+        Remove `enable password` once the secret is in place rather than leaving it behind, and verify the new credential from a second session before saving to startup, because a mistyped one-way hash is one you will be fixing from the console.
       audit: |-
         To verify that privileged EXEC access uses `enable secret`:
 
@@ -720,17 +713,17 @@ queries:
       cisco.iosxe.configuration.service.passwordEncryptionEnabled == true
     docs:
       desc: |
-        This check verifies that the `service password-encryption` command is enabled. While this provides only Type 7 encryption (which is reversible), it prevents passwords from being visible in plain text when viewing the configuration.
+        This check verifies that plaintext passwords are obscured in the device configuration.
+
+        Several IOS-XE configuration elements, including line passwords, the BGP neighbor password, and authentication server keys, are stored exactly as typed unless `service password-encryption` is set. With it enabled, IOS-XE rewrites those values as Type 7 strings whenever the configuration is displayed or saved. The check requires the global `service password-encryption` command to be present.
 
         **Why this matters**
 
-        Without service password encryption, some passwords appear in clear text in the configuration. If password encryption is not enabled:
+        Router configurations travel widely. They are pasted into tickets, mailed to vendor support, archived by backup jobs, and committed to configuration management repositories. Every one of those copies is a credential store if the passwords in it are readable, and an attacker who reaches a backup share reaches the routing and management credentials for every device backed up to it.
 
-        - Passwords are visible to anyone who can view the running configuration.
-        - Shoulder-surfing during configuration review exposes credentials.
-        - Configuration backups contain clear-text passwords.
+        Type 7 is not encryption and should not be treated as such. The algorithm is a published XOR against a fixed key, and decoders have been available for over two decades, so anyone who obtains the configuration recovers the original strings in seconds. What `service password-encryption` buys is protection against casual reading: the operator running `show running-config` on a shared screen, the screenshot in a ticket, the over-the-shoulder glance during a change window.
 
-        Enabling service password encryption provides a basic layer of protection against casual observation.
+        Treat it as a floor, not a control. Local accounts belong under `username ... secret` and privileged access under `enable secret`, both of which are one-way hashes rather than reversible encoding, and both are covered by companion checks in this policy.
       audit: |-
         To verify that service password encryption is enabled:
 
@@ -782,17 +775,17 @@ queries:
       cisco.iosxe.ip.httpEnabled == false
     docs:
       desc: |
-        This check verifies that the HTTP server is disabled. HTTP transmits all data in clear text, making it unsuitable for device management.
+        This check verifies that the device is not serving its web management interface over an unencrypted transport.
+
+        The embedded HTTP server on IOS-XE answers on TCP port 80 and exposes administrative operations authenticated by whatever `ip http authentication` names. It is turned off with `no ip http server`. The check requires the HTTP server to be disabled.
 
         **Why this matters**
 
-        The HTTP server provides a web-based management interface over an unencrypted connection. If HTTP is enabled:
+        Every request to that server carries its credential in a plaintext header and every response carries configuration data back the same way. An attacker with any position on the path reads the administrative password out of a single request and replays it. That is the same exposure telnet has, on a port that perimeter filters and monitoring rules are far less likely to be watching, because nobody expects a router to be a web server.
 
-        - All management traffic including credentials is transmitted in clear text.
-        - Sessions can be hijacked through traffic interception.
-        - The HTTP service increases the attack surface with potential web vulnerabilities.
+        The interface is also a productive bug target. Cisco advisories include authentication bypasses and path-handling flaws in the IOS-XE web UI that permitted unauthenticated configuration changes, and the implant campaign tracked as CVE-2023-20198 in 2023 turned exactly this interface into full device compromise on internet-facing IOS-XE routers. Devices whose owners never used the web UI were taken over through it because it was simply running.
 
-        Disabling HTTP and using only HTTPS ensures that all web-based management is encrypted.
+        If a web interface is genuinely required by a management platform, run the TLS listener with `ip http secure-server`, keep the cleartext one off, and restrict who can reach either with `ip http access-class`.
       audit: |-
         To verify that the HTTP server is disabled:
 
@@ -844,16 +837,17 @@ queries:
       cisco.iosxe.ip.httpsEnabled == true
     docs:
       desc: |
-        This check verifies that the HTTPS server is enabled for secure web-based management. HTTPS provides TLS-encrypted management access when a web interface is required.
+        This check verifies that where the device serves a web management interface, that interface is protected by TLS.
+
+        `ip http secure-server` starts the encrypted listener on TCP port 443 using the device's certificate. It is independent of the cleartext listener, so a device can have neither, either, or both running. The check requires the TLS listener to be enabled.
 
         **Why this matters**
 
-        If web-based management is needed, HTTPS must be used to encrypt all traffic. Without HTTPS:
+        Several things reach into IOS-XE over the web transport rather than the CLI: RESTCONF, application hosting workflows, and network management platforms that push configuration through it. If TLS is off and those tools still have to work, they get pointed at the cleartext listener and the credential they carry crosses the network readable. An attacker on the path does not need to break anything; they read the authorization header and replay it against the device.
 
-        - Web-based management is either unavailable or relies on unencrypted HTTP.
-        - Compliance requirements for encrypted management interfaces cannot be met.
+        The certificate IOS-XE generates for itself is not verified by anything, so a client configured to ignore certificate warnings remains interceptable. Install a certificate from an authority the management tooling actually trusts, and keep the listener reachable only from the management network with `ip http access-class`, because a TLS-protected administrative interface exposed to the internet is still an administrative interface exposed to the internet.
 
-        Enabling HTTPS ensures that web-based management uses encrypted communications.
+        Where no web-based management is used at all, the stronger position is to run neither listener. On those devices this expectation is better exempted than satisfied by starting a service nothing needs.
       audit: |-
         To verify that the HTTPS server is enabled:
 
@@ -905,17 +899,17 @@ queries:
       cisco.iosxe.cdp.enabled == false
     docs:
       desc: |
-        This check verifies that Cisco Discovery Protocol (CDP) is disabled. CDP broadcasts detailed device information that can be exploited for network reconnaissance.
+        This check verifies that the device is not announcing its own identity and software details to everything on its directly attached segments.
+
+        Cisco Discovery Protocol, or CDP, is on by default in IOS-XE and multicasts a frame out every enabled interface roughly every 60 seconds. Each frame carries the hostname, a management IP address, the hardware platform, the full software version string, the local port, and often the VTP domain and native VLAN. `no cdp run` turns it off globally. The check requires CDP to be disabled.
 
         **Why this matters**
 
-        CDP operates at Layer 2 and sends information in clear text including hostname, IP address, platform, and software version. If CDP is not disabled:
+        An attacker who gains any foothold on an access port, whether a compromised printer, an unattended conference room jack, or a hijacked IP phone, does not need to scan the network. They listen for one minute and learn the exact software train the router is running, which turns vulnerability selection into a lookup against published advisories rather than a noisy probe that might be noticed. The native VLAN and VTP details in the same frame are the starting point for VLAN hopping.
 
-        - Detailed device information is broadcast to all directly connected devices.
-        - Attackers can passively collect network topology and software version data.
-        - This information enables targeted attacks against specific platform vulnerabilities.
+        CDP frames are unauthenticated and handled by the control plane, so forged neighbor announcements sent at volume have historically been usable to exhaust memory on the receiving device.
 
-        Disabling CDP prevents unnecessary information disclosure.
+        CDP is not always removable. Cisco IP phones use it to learn the voice VLAN and negotiate power, and some topology and monitoring products depend on it. Where phones are attached, disable CDP per interface on the ports that do not need it and confirm with the voice team before making the change globally.
       audit: |-
         To verify that CDP is disabled globally:
 
@@ -969,16 +963,17 @@ queries:
       cisco.iosxe.bootp.enabled == false
     docs:
       desc: |
-        This check verifies that the Bootstrap Protocol (BOOTP) service is disabled. BOOTP is a legacy protocol for network bootstrapping that is rarely needed and increases the attack surface.
+        This check verifies that the device is not answering bootstrap requests from hosts on its own segments.
+
+        The BOOTP responder is enabled by default in IOS-XE and answers the legacy bootstrap requests that predate DHCP, handing out an address and pointing the client at a boot image to fetch over TFTP. `no ip bootp server` disables the responder and `ip dhcp bootp ignore` makes the DHCP service drop BOOTP requests. The check requires the BOOTP service to be off.
 
         **Why this matters**
 
-        The BOOTP service allows the device to act as a BOOTP server. If enabled unnecessarily:
+        A device answering bootstrap requests is a device that can tell another device where to get its operating system. On any segment where something still boots over the network, an attacker who gets the router to answer, or who exploits the fact that it answers at all, points a booting client at an image of their choosing. That is a full compromise of the client, delivered by a piece of infrastructure the client has every reason to trust.
 
-        - The service increases the attack surface with an unused network service.
-        - It can be exploited for network reconnaissance or denial-of-service attacks.
+        Even where nothing network boots, the responder is a UDP listener that nobody monitors on a device that is patched once every few years. Advisories have covered crafted-packet crashes in the BOOTP and DHCP relay paths, and a crash on a router is a site outage rather than a single service restart.
 
-        Disabling BOOTP removes an unnecessary service and reduces the attack surface.
+        Almost nothing modern uses BOOTP. Before disabling it, check for network-booted appliances and older phone deployments that still depend on it, then confirm nothing lost its address after the change.
       audit: |-
         To verify that the BOOTP service is disabled:
 
@@ -1030,17 +1025,17 @@ queries:
       cisco.iosxe.ip.sourceRouteEnabled == false
     docs:
       desc: |
-        This check verifies that IP source routing is disabled. Source routing allows a sender to specify the route a packet takes through the network, which can be abused to bypass security controls.
+        This check verifies that the router refuses packets that carry their own routing instructions.
+
+        The IPv4 loose and strict source route options let a sender list the hops a packet must traverse, overriding the router's own forwarding decision. IOS-XE honors those options by default, and `no ip source-route` stops it from processing them. The check requires source routing to be disabled.
 
         **Why this matters**
 
-        IP source routing enables attackers to specify routing paths that circumvent firewalls, ACLs, and other security controls. If source routing is enabled:
+        Source routing lets an attacker choose the path, and choosing the path is how you get around controls that assume packets arrive from where the routing table says they should. A packet source-routed through an interface on the trusted side of a filter arrives looking like it originated inside. Return traffic follows the recorded route back to the sender, which means the technique also works with a forged source address: the attacker spoofs an internal address and the record-route option still brings the answer to them. That defeats address-based trust, and address-based trust is what most infrastructure access lists are built on.
 
-        - Attackers can route packets through paths that bypass security controls.
-        - Spoofed packets can be directed to reach internal networks.
-        - Network access controls can be circumvented.
+        It is also a reconnaissance tool. Loose source routing through chosen intermediate addresses maps reachability behind a perimeter that ordinary probes cannot see past.
 
-        Disabling source routing prevents attackers from manipulating packet routing paths.
+        There is essentially no legitimate use left. The options were designed for debugging a network that no longer exists, and most operators filter them at the edge in addition to disabling processing on each device. Do both, since a device deeper in the network may still honor what the edge let through.
       audit: |-
         To verify that IP source routing is disabled:
 
@@ -1092,16 +1087,17 @@ queries:
       cisco.iosxe.configuration.service.padEnabled == false
     docs:
       desc: |
-        This check verifies that the X.25 Packet Assembler/Disassembler (PAD) service is disabled. PAD is a legacy service for X.25 networks that is no longer needed in modern networks and increases the attack surface.
+        This check verifies that the device is not listening for X.25 terminal connections.
+
+        The packet assembler and disassembler service lets a device accept X.25 sessions and hand them to a terminal line. IOS-XE enables it by default for historical reasons and `no service pad` removes it. The check requires the service to be off.
 
         **Why this matters**
 
-        The PAD service is a legacy protocol that has no place in modern network environments. If PAD is enabled:
+        X.25 has been gone from commercial networks for well over a decade, so the honest reason to remove this is that it is code answering on a device where nobody would ever notice it answering. No monitoring rule covers it, no baseline includes it, and no operator would recognize a PAD session in a connection table as anomalous. A listener with no owner and no observer is precisely what a long-dwell intruder looks for when choosing where to sit.
 
-        - An unnecessary service is exposed that could be exploited.
-        - The attack surface is increased with a rarely monitored legacy service.
+        The deeper problem is maintenance. Legacy protocol handlers in IOS-XE receive very little scrutiny compared with SSH or the web server, they are rarely fuzzed, and the platform they run on is patched every few years at best. A parsing flaw in that code path stays exploitable for a very long time on hardware that is expected to run for a decade.
 
-        Disabling PAD removes an unnecessary legacy service.
+        Turning the service off has no operational cost on any network built this century. It belongs with BOOTP and the small servers in the handful of default-on services worth clearing out during initial hardening.
       audit: |-
         To verify that the PAD service is disabled:
 
@@ -1153,17 +1149,17 @@ queries:
       cisco.iosxe.ntp.authenticate == true
     docs:
       desc: |
-        This check verifies that NTP authentication is enabled to ensure the device only synchronizes time with trusted NTP servers.
+        This check verifies that the device only accepts a time update from a server that can prove which server it is.
+
+        `ntp authenticate` turns verification on, `ntp authentication-key` defines the shared key, `ntp trusted-key` marks which keys are acceptable, and each `ntp server` statement must reference its key number. All four parts are needed for the control to do anything. The check requires NTP authentication to be enabled.
 
         **Why this matters**
 
-        Without NTP authentication, an attacker can manipulate the device's clock through NTP spoofing. If NTP authentication is not enabled:
+        Unauthenticated NTP accepts time from whoever answers first. An attacker on the path, or anyone able to spoof the server's address toward the router, sets the clock to whatever they like, and the clock is load-bearing in more places than operators expect.
 
-        - Log timestamps become unreliable, undermining forensic investigations.
-        - Certificate validation can be bypassed with manipulated time.
-        - Time-sensitive security mechanisms can be compromised.
+        Moving it forward expires certificates that were valid, breaking IKE and TLS sessions the device depends on. Moving it backward revives a certificate that has been revoked or a key lifetime in a key chain that had already ended. Moving it sideways scrambles the timestamps on every log message the device emits, which is the cheapest way for an intruder to make their activity impossible to line up against firewall and server logs during an investigation.
 
-        Enabling NTP authentication ensures the device only accepts time updates from verified sources.
+        Enabling authentication without matching the key number and value exactly at the server end leaves the device rejecting every update and drifting silently, which is worse than the state you started from. Confirm the peer actually synchronizes after the change.
       audit: |-
         To verify that NTP authentication is enabled:
 
@@ -1220,17 +1216,17 @@ queries:
       cisco.iosxe.ntp.servers.length > 0
     docs:
       desc: |
-        This check verifies that at least one NTP server is configured. Accurate time is essential for log correlation, certificate validation, and security event analysis.
+        This check verifies that the device has an authoritative time source to synchronize its clock against.
+
+        A router with no `ntp server` statement runs on its own hardware clock, which on this class of device drifts by seconds a day and comes back at a meaningless value after a power loss on units without a battery-backed calendar. The check requires at least one NTP server to be configured.
 
         **Why this matters**
 
-        Without NTP servers configured, the device clock drifts over time. If NTP servers are not configured:
+        Correlation is the whole point. An investigation that has to line up router syslog against firewall logs, authentication records, and endpoint telemetry depends on all of them agreeing about when things happened. A device drifting by minutes turns a clear sequence of events into an ambiguous one, and the analyst cannot tell whether the router saw the traffic before or after the server did.
 
-        - Log timestamps are inaccurate, making incident investigation unreliable.
-        - Certificate expiration checks may malfunction.
-        - Event correlation across multiple devices is impossible.
+        Time also gates security functions on the device itself. Certificate validity windows for IKE and the TLS management listener, key lifetimes in the key chains used by routing protocol authentication, and time-based access lists all evaluate against the local clock. A wrong clock fails them open or closed with no message that explains why, which is a fault that can sit undiagnosed for months.
 
-        Configuring NTP servers ensures accurate, synchronized time.
+        Configure more than one server, drawn from sources that do not share a single upstream, so one unreachable peer does not leave the device unsynchronized. Then authenticate them, which a companion check in this policy covers.
       audit: |-
         To verify that NTP servers are configured:
 
@@ -1283,17 +1279,17 @@ queries:
       cisco.iosxe.logging.configurationChangesLoggingEnabled == true
     docs:
       desc: |
-        This check verifies that logging of configuration changes is enabled. Configuration change logging records all modifications to the device configuration, providing an audit trail of who changed what and when.
+        This check verifies that changes to the device configuration are recorded as they are made.
+
+        The configuration change logger is enabled under `archive` with `log config` followed by `logging enable`. Once running, IOS-XE records each configuration command with the user, the session, and the time, readable with `show archive log config all` and forwardable to syslog. The check requires configuration change logging to be enabled.
 
         **Why this matters**
 
-        Without configuration change logging, modifications to the device go unrecorded. If change logging is not enabled:
+        Most network outages are self-inflicted, and the first question after one is what changed. Without this log the answer has to be reconstructed by diffing a configuration backup taken at some unknown earlier point, which shows the net result and says nothing about the sequence or the author.
 
-        - There is no record of configuration modifications.
-        - Unauthorized changes cannot be detected.
-        - Compliance requirements for change management cannot be met.
+        For an intrusion the gap is worse. An attacker with privileged access adds a local account, opens a hole in an access list, or repoints logging somewhere harmless, then leaves. Nothing on the device records those individual commands. A configuration diff taken weeks later shows the account exists but not when it appeared or from which session, and that is the difference between scoping an incident and guessing at it.
 
-        Enabling configuration change logging provides visibility into all configuration modifications.
+        Send the records off the device as well. Anything held only in the local archive can be cleared by whoever reaches privileged EXEC, so pair this with a remote syslog destination and, where AAA is in place, with command accounting to a TACACS+ server.
       audit: |-
         To verify that configuration change logging is enabled:
 
@@ -1347,17 +1343,17 @@ queries:
       cisco.iosxe.logging.hosts.length > 0
     docs:
       desc: |
-        This check verifies that at least one remote logging host is configured. Sending logs to a remote server ensures data is preserved even if the device is compromised.
+        This check verifies that the device's log messages are delivered to a system outside the device.
+
+        `logging host` names a syslog destination, `logging trap` sets which severities are sent to it, and `logging source-interface` pins the source address so the collector sees a stable identity for the device. The check requires at least one remote logging host to be configured.
 
         **Why this matters**
 
-        Logs stored only on the device are vulnerable to loss or tampering. If remote logging hosts are not configured:
+        Local logging on IOS-XE is a circular memory buffer. It is small, it is overwritten continuously on a busy device, and it is emptied by a reload. On a router that is dropping and re-establishing sessions during an incident, the buffer can turn over in minutes, so the evidence of initial access is frequently gone before anyone logs in to look for it.
 
-        - Logs are lost when the device reboots or the buffer overflows.
-        - An attacker who compromises the device can erase local logs.
-        - Centralized log correlation is not possible.
+        It is also under the attacker's control. `clear logging` empties the buffer and leaves nothing behind to say it happened, which makes it a routine first step for anyone who knows the platform. A message that has already left the device cannot be recalled, so the copy at the collector is the only one worth relying on.
 
-        Configuring remote logging hosts ensures logs are preserved centrally.
+        Point the device at a collector that sits in a different trust zone from the network it is reporting on, and confirm the access lists along the path actually permit syslog, because a `logging host` that cannot be reached fails silently and looks configured.
       audit: |-
         To verify that remote logging hosts are configured:
 
@@ -1411,17 +1407,17 @@ queries:
       cisco.iosxe.logging.logUnsuccessfulLogin == true
     docs:
       desc: |
-        This check verifies that failed login attempts are logged. Logging failed authentications is essential for detecting brute-force attacks and unauthorized access attempts.
+        This check verifies that rejected authentication attempts against the device generate a log message.
+
+        `login on-failure log` makes IOS-XE emit a syslog record for each failed login, naming the username offered, the source address, and the line. It is off by default, so a device can be under sustained password guessing and report nothing at all. The check requires failed login logging to be enabled.
 
         **Why this matters**
 
-        Without failed login logging, suspicious authentication activity goes undetected. If failed login logging is not enabled:
+        Credential guessing against network devices is the quiet part of most infrastructure intrusions. It is slow, it comes from one address, and it disturbs no traffic. The only signal it produces is a stream of authentication failures, and if the device does not write them, there is no signal to detect.
 
-        - Brute-force attacks go undetected.
-        - There is no evidence of attempted unauthorized access.
-        - Real-time alerting on suspicious activity is not possible.
+        The absence also hides the moment that matters most. When guessing finally succeeds, the pattern that identifies it is a run of failures from an address followed by a success from that same address. With the failures unrecorded, the successful login looks exactly like an administrator arriving for work.
 
-        Enabling failed login logging captures authentication failures for security monitoring.
+        Turn on `login on-success log` alongside it, because the pair is what makes that pattern legible, and forward both to a remote collector so they outlive the device's buffer. Then consider `login block-for` to make guessing expensive rather than merely visible, and build its quiet-mode access list carefully, since a blocking period that does not exempt your management network locks your own operators out during exactly the wrong hour.
       audit: |-
         To verify that failed login logging is enabled:
 
@@ -1476,17 +1472,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that the default SNMP community strings "public" and "private" are not in use. These well-known defaults are the first values attackers try.
+        This check verifies that the device is not reachable over SNMP using the community strings that ship with every vendor's equipment.
+
+        A community string is the entire credential for SNMPv1 and v2c. `public` and `private` are the historical defaults, removed with `no snmp-server community public` and the equivalent for private. The check applies where an SNMP agent is running and requires neither default community to be configured.
 
         **Why this matters**
 
-        Default SNMP community strings are universally known and actively scanned for. If default communities are in use:
+        These two strings are the first thing every internet-wide scanner tries, and SNMP answers over UDP with no handshake, so the probe is a single packet and it leaves nothing in a connection table. With read access an attacker retrieves the interface list, the routing table, the ARP cache, the running software version, and on many IOS-XE releases the entire running configuration by way of a TFTP transfer the router performs on their behalf. That configuration holds the enable secret, the TACACS+ key, and every other credential on the device.
 
-        - Anyone can read device data using the "public" community.
-        - The "private" community may allow unauthorized configuration changes.
-        - Automated scanning tools will immediately exploit default strings.
+        Where a write community is left at `private`, the attacker skips the CLI entirely and changes the configuration through SNMP. This is not hypothetical; SNMP was the pivot in multiple documented state-actor campaigns against Cisco routers.
 
-        Removing default community strings and using unique values ensures SNMP access is restricted.
+        Renaming the community is a stopgap rather than a fix. Version 1 and 2c send the string in clear text on every poll, so anyone on the path collects the new one. The durable answer is SNMPv3 with both authentication and privacy, with community-based access retired once the polling platform supports it.
       audit: |-
         To verify that default SNMP community strings are not in use:
 
@@ -1547,16 +1543,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all SNMP community strings have ACLs applied to restrict which hosts can query the device via SNMP.
+        This check verifies that SNMP polling is accepted only from the management systems that are supposed to be polling.
+
+        Each `snmp-server community` statement takes a trailing access list number or name that limits which source addresses may use that community, as in `snmp-server community <string> RO 10`. The check applies where an SNMP agent is running with communities defined, and requires every community to carry an access list.
 
         **Why this matters**
 
-        SNMP without ACL restrictions allows any network host to query the device. If ACLs are not applied:
+        Because version 1 and 2c carry the community string in clear text, it is recoverable by anyone who can observe a poll: a compromised host on the management VLAN, a span port, or a device sitting in the path between the network management station and the router. Once they hold the string, the only thing left between them and the device's data is where they are permitted to send packets from.
 
-        - Any device on the network can query SNMP data.
-        - Write-access community strings allow remote configuration changes from any host.
+        An access list turns a stolen string into something that must be used from a specific address, forcing the attacker to compromise or spoof the monitoring station rather than replaying from wherever they happen to be. UDP source addresses are spoofable, so this is not absolute, but the response goes to the spoofed address and that removes most of the value for a read operation.
 
-        Applying ACLs restricts SNMP access to authorized management stations.
+        Build the list before you attach it and include every poller, including standby collectors and discovery tools that run only occasionally. Any server left out loses SNMP the moment the list is applied, and gaps in monitoring tend to be found late.
       audit: |-
         To verify that SNMP communities have ACLs applied:
 
@@ -1615,17 +1612,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all VTY lines are configured to accept only SSH as the transport protocol. Telnet transmits all data in clear text, including credentials.
+        This check verifies that remote administrative sessions can only arrive over an encrypted transport.
+
+        Each VTY line has an inbound transport setting, restricted with `transport input ssh` under `line vty 0 15`. IOS-XE will otherwise accept telnet on those lines. The check requires every VTY line to accept SSH and to refuse telnet.
 
         **Why this matters**
 
-        Telnet on VTY lines exposes management traffic to interception. If telnet is allowed:
+        Telnet puts the username, the password, the enable secret typed at the prompt, and every command and its output on the wire as readable text. Anyone with a tap point recovers the credentials by reading a single session, and tools have been reassembling telnet sessions into transcripts for thirty years. On a device that is itself a traffic aggregation point, the tap point is often the device sitting next to it in the rack.
 
-        - Usernames and passwords are transmitted unencrypted.
-        - Active sessions can be hijacked.
-        - Compliance with encrypted management requirements cannot be met.
+        The session can also be taken rather than merely read. Telnet has no integrity protection, so an attacker able to inject TCP segments appends commands into an authenticated session that the administrator never typed, and the router executes them at that administrator's privilege level.
 
-        Restricting VTY transport to SSH ensures all remote sessions are encrypted.
+        The number of VTY lines varies by platform and many chassis provide ranges above 15. Run `show line`, apply the setting to every range the device reports, and verify SSH login from a second session before closing the one you are working in, because new telnet connections are refused the instant the command is accepted.
       audit: |-
         To verify that VTY lines accept only SSH transport:
 
@@ -1686,17 +1683,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all VTY lines have an exec timeout configured. The exec timeout disconnects idle sessions to reduce the risk of unauthorized access through unattended terminals.
+        This check verifies that an idle remote administrative session is disconnected rather than left open indefinitely.
+
+        `exec-timeout 10 0` under `line vty 0 15` sets ten minutes of inactivity. The form `exec-timeout 0 0` explicitly means never, and that is the state this check is looking for the absence of. The check requires every VTY line to carry a nonzero idle timeout.
 
         **Why this matters**
 
-        Without an exec timeout, idle VTY sessions remain open indefinitely. If exec timeouts are not configured:
+        The session that stays open is the one nobody is watching. An engineer opens a terminal, gets pulled into a meeting, and leaves an authenticated privileged-EXEC session on an unlocked laptop in a shared office or a hotel lobby. Whoever sits down next has full control of a router without authenticating to anything.
 
-        - Forgotten sessions can be exploited by unauthorized users.
-        - Connection resources are consumed by idle sessions.
-        - Compliance requirements for session management cannot be met.
+        The same session is a target from the network side. A long-lived idle TCP connection to the router is available for hijacking by anyone able to inject into it, and an already-authenticated session skips the part of the attack that is hard.
 
-        Configuring exec timeouts on VTY lines ensures idle sessions are terminated.
+        Idle sessions also occupy VTY slots, and a device whose slots are all held by abandoned sessions is a device you cannot log into during an incident. Pair the timeout with `service tcp-keepalives-in`, which reaps the connections that died without closing rather than merely those a person stopped typing at.
+
+        Ten minutes is a reasonable balance. Aggressively short values interrupt legitimate work during change windows, and engineers respond by setting the timeout back to zero.
       audit: |-
         To verify that VTY lines have an exec timeout configured:
 
@@ -1751,16 +1750,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all VTY lines have an inbound access class (ACL) configured to restrict remote management access to authorized source IP addresses.
+        This check verifies that remote management connections are only accepted from the networks permitted to make them.
+
+        An inbound access class applied with `access-class 11 in` under `line vty 0 15` filters connection attempts before authentication happens at all. The check requires every VTY line to have an inbound access class.
 
         **Why this matters**
 
-        VTY lines without ACLs allow connection attempts from any source. If ACLs are not configured:
+        Without one, any host that can route a packet to any address on the device reaches the login prompt. That includes every user VLAN, every guest network, every site connected over an unfiltered WAN link, and on a badly placed device the internet. That reachability is what makes credential guessing practical: the attacker needs no privileged position, only a route.
 
-        - Any host can attempt brute-force attacks against the device.
-        - Management access cannot be restricted to trusted networks.
+        Filtering at the line rather than only on the interfaces is what makes the control hold. The device has many addresses and traffic to any of them terminates on the control plane, so an access list applied to one interface protects neither the loopback nor the address of a different interface. An access class on the line covers every path to the VTY at once.
 
-        Applying ACLs to VTY lines restricts access to authorized management stations.
+        This is the control most capable of locking you out of the device. It takes effect on the next connection, and if it omits the address you connect from, or names the wrong management subnet, the next login fails and recovery means the console port. Apply it with a session already open, verify a fresh connection from the management network succeeds, and only then save to startup.
       audit: |-
         To verify that VTY lines have an inbound access class configured:
 
@@ -1818,17 +1818,17 @@ queries:
       cisco.iosxe.auxLine.exec == false
     docs:
       desc: |
-        This check verifies that the auxiliary (AUX) line has exec mode disabled. The AUX port is typically used for modem connections and should not provide direct EXEC access, as it represents a potential backdoor.
+        This check verifies that the auxiliary port cannot be used to open a command-line session.
+
+        The auxiliary port on IOS-XE routers is a serial port intended for a dialup modem, and by default the line permits an EXEC session. `no exec` under `line aux 0` stops it from offering one. The check requires EXEC to be disabled on the auxiliary line.
 
         **Why this matters**
 
-        The AUX port provides a physical access path that bypasses network-based security controls. If exec is enabled on the AUX line:
+        The port has no owner. It was provisioned for out-of-band access to a site in an era when that meant a modem, the modem was removed at some point, and nobody has looked at the back of the chassis since. Where a modem is still attached, the device answers a phone call and offers a login prompt over a path that never crosses the firewall, appears in no network diagram, and generates no traffic anyone monitors.
 
-        - An attacker with physical access to the AUX port can gain CLI access.
-        - Modem connections to the AUX port can be used for unauthorized remote access.
-        - The AUX port bypasses network ACLs and firewall rules.
+        Even with nothing plugged in, a live EXEC on that line is an entry point for whoever has physical access to the rack. That includes contractors, facilities staff, and anyone who walks into an unlocked branch office closet, and a session opened there bypasses every access class configured on the VTY lines and every filter on the management path.
 
-        Disabling exec on the AUX line prevents it from being used as an entry point.
+        Disabling EXEC leaves the physical port present but inert. It does not affect the console port, so legitimate out-of-band recovery through a terminal server cabled to the console remains available, which is the supported way to do it.
       audit: |-
         To verify that the auxiliary line has exec disabled:
 
@@ -1881,16 +1881,17 @@ queries:
       cisco.iosxe.consoleLine.execTimeout > 0 * time.second
     docs:
       desc: |
-        This check verifies that the console line has an exec timeout configured to disconnect idle sessions automatically.
+        This check verifies that a session left open at the physical console is closed after a period of inactivity.
+
+        `exec-timeout 10 0` under `line con 0` sets ten minutes. The check requires the console line to carry a nonzero idle timeout.
 
         **Why this matters**
 
-        Without a console timeout, an idle session remains open indefinitely. If the console timeout is not set:
+        The console is the one path that no access list filters and no AAA outage can block, which is precisely why it deserves a timeout. An engineer working at the rack, or through a terminal server in the same cabinet, walks away and the authenticated session stays live for the next person at that keyboard to inherit.
 
-        - An unattended console connection can be used for unauthorized changes.
-        - Physical access security requirements cannot be met.
+        Console servers make this the common case rather than the rare one. Console ports in modern deployments are usually cabled to a network-reachable console server, so an abandoned console session is not protected by the door on the data center; it is protected only by who holds an account on that console server. A privileged EXEC session sitting idle there is a credential-free route onto the device for anyone who can open the right port.
 
-        Configuring a console exec timeout ensures idle sessions are terminated.
+        Set the timeout and treat it as complementary to physical control rather than a substitute for it. Because the console is your recovery path when an AAA method list or a VTY access class goes wrong, keep the value generous enough that a genuine recovery session is not dropped part way through the fix.
       audit: |-
         To verify that the console line has an exec timeout configured:
 
@@ -1943,17 +1944,17 @@ queries:
       cisco.iosxe.configuration.loginBanner != ""
     docs:
       desc: |
-        This check verifies that a login banner is configured. A login banner provides legal notice to users before they authenticate, which is essential for prosecuting unauthorized access.
+        This check verifies that a warning is presented to anyone connecting before they are offered the chance to authenticate.
+
+        `banner login ^...^` sets the text IOS-XE displays after the connection is established and immediately before the username prompt. It is delivered on every line type, console and VTY alike. The check requires the login banner to be non-empty.
 
         **Why this matters**
 
-        Without a login banner, there is no legal warning before access. If a login banner is not configured:
+        The purpose is legal and it is specific. Prosecutions and internal disciplinary actions for unauthorized access frequently turn on whether the person was on notice that the system was restricted and that their activity was recorded. A banner stating that the system is limited to authorized users and that use is monitored removes the argument that access appeared to be permitted. Guidance from the United States Department of Justice on network monitoring has long treated a consent banner as the mechanism that establishes that notice.
 
-        - Legal proceedings against unauthorized access may be weakened.
-        - Users are not informed of acceptable use policies or monitoring.
-        - Compliance requirements for access warnings cannot be met.
+        Write the text with care. A banner that names the device model, the site, the owning company, or the software release hands a scanner free reconnaissance before authentication, and welcoming wording has been argued in both directions in court. State that access is restricted and that activity is logged, and stop there.
 
-        Configuring a login banner ensures all users receive legal notice before accessing the device.
+        The login banner and the message-of-the-day banner appear at different points in the connection and a companion check in this policy covers the second, so configure both rather than treating either as covering the other.
       audit: |-
         To verify that a login banner is configured:
 
@@ -2005,16 +2006,17 @@ queries:
       cisco.iosxe.configuration.motdBanner != ""
     docs:
       desc: |
-        This check verifies that a Message of the Day (MOTD) banner is configured. The MOTD banner is displayed before login and serves as a general warning to all users.
+        This check verifies that a notice is shown to everyone who connects to the device, whether or not they go on to log in.
+
+        `banner motd ^...^` sets text that IOS-XE displays as soon as the connection is established, ahead of the login banner and the username prompt. The check requires the message-of-the-day banner to be non-empty.
 
         **Why this matters**
 
-        The MOTD banner provides an additional layer of legal notice and organizational messaging. If the MOTD banner is not configured:
+        The message-of-the-day banner is the first thing on the wire, which makes it the notice that reaches a connection which never authenticates. Someone who connects and disconnects, or whose access is refused before any credential is entered, has still been shown it. That is what makes it useful for establishing that a warning was given at the point of contact rather than only at the point of credential entry.
 
-        - Users connecting to the device receive no warning about authorized use.
-        - Legal requirements for displaying access warnings may not be met.
+        Operationally it also carries change-window and maintenance notices, which is what keeps two engineers from working on the same device at the same time during an incident. Many organizations rotate the text for the duration of planned work for exactly that reason.
 
-        Configuring a MOTD banner ensures users are notified of access policies.
+        Keep its reconnaissance value at zero. The banner is shown to anyone who can open a TCP connection, a scanner included, so it must not name the platform, the software release, the site address, the circuit identifier, or an on-call phone number. Restrict it to a statement that the system is restricted and monitored, and put operational detail somewhere that requires an authenticated session to read.
       audit: |-
         To verify that a Message of the Day banner is configured:
 
@@ -2068,17 +2070,17 @@ queries:
       cisco.iosxe.hostname.downcase != "switch"
     docs:
       desc: |
-        This check verifies that a unique, descriptive hostname is configured. A meaningful hostname is essential for identifying the device in logs, alerts, and management systems.
+        This check verifies that the device identifies itself by a name that is unique and meaningful within the estate.
+
+        `hostname <name>` sets it. IOS-XE ships as `Router` or `Switch` depending on the platform, and the check treats those two defaults as unconfigured along with an empty value. A hostname must be set and must not be either default.
 
         **Why this matters**
 
-        Without a unique hostname, the device uses a generic default name. If the hostname is not configured:
+        The hostname is the field that every log message, SNMP trap, flow record, and AAA accounting record is keyed on. When several devices in the same estate are all still called `Router`, the collector either merges their events into one apparent device or discards them as duplicates, and an investigation that needs to know which of forty branch routers saw the traffic cannot answer the question. Renaming the device later does not repair the records already collected under the wrong name.
 
-        - The device cannot be clearly identified in logs or management platforms.
-        - Log correlation across multiple devices is unreliable.
-        - Network topology documentation is incomplete.
+        The default name is also a signal to an attacker: this device was racked and never hardened. Equipment still carrying its shipping hostname reliably also still carries default community strings, no access class on the VTY lines, and whatever enable password the installation script left behind.
 
-        Setting a descriptive hostname ensures the device is identifiable across all workflows.
+        One dependency is worth knowing before changing it. The hostname combines with the domain name to form the fully qualified name that an RSA key pair is labeled with, so both must be set before `crypto key generate rsa` will run.
       audit: |-
         To verify that a unique, descriptive hostname is configured:
 
@@ -2130,17 +2132,17 @@ queries:
       cisco.iosxe.domainNames.length > 0
     docs:
       desc: |
-        This check verifies that a domain name is configured. A domain name is required for generating an FQDN, which is used for SSH key generation and certificate creation.
+        This check verifies that the device holds the domain component it needs in order to carry a cryptographic identity.
+
+        `ip domain name example.com` sets it. IOS-XE combines the hostname and the domain name into a fully qualified name and refuses to run `crypto key generate rsa` until both exist, because that name is what the key pair is labeled with. The check requires at least one domain name to be configured.
 
         **Why this matters**
 
-        Without a domain name, the device cannot generate an FQDN. If the domain name is not set:
+        The practical consequence is that a device with no domain name cannot have an RSA key pair, and a device with no RSA key pair cannot run SSH. Operators who hit this during a hardening pass often work around it by leaving telnet enabled until later, and later does not arrive. A missing domain name is therefore a common upstream cause of a device still being administered in clear text years after the decision was made to stop.
 
-        - SSH RSA key generation may fail.
-        - SSL/TLS certificate creation requires an FQDN.
-        - Device identification in DNS is not possible.
+        It matters for certificates for the same reason. The fully qualified name is what the device puts in a certificate request for the TLS management listener and for IKE, so a device without one cannot obtain a certificate that a client will validate against the address it connects to.
 
-        Configuring a domain name ensures the device can participate in secured communications.
+        Set the domain name to match what DNS actually resolves for the device. A key pair labeled with a name that corresponds to nothing makes host key verification and certificate troubleshooting considerably harder for whoever inherits the device.
       audit: |-
         To verify that a domain name is configured:
 
@@ -2192,16 +2194,17 @@ queries:
       cisco.iosxe.configuration.service.tcpKeepalivesInEnabled == true
     docs:
       desc: |
-        This check verifies that TCP keepalives for inbound sessions are enabled. TCP keepalives detect dead connections and clean up orphaned sessions that consume resources.
+        This check verifies that inbound management connections which have died without closing are detected and cleared.
+
+        `service tcp-keepalives-in` makes IOS-XE probe the far end of each incoming TCP session and tear the session down when the probes go unanswered. The check requires the service to be enabled.
 
         **Why this matters**
 
-        Without TCP keepalives, dead sessions persist indefinitely. If keepalives-in is not enabled:
+        A VTY session ends cleanly when the client sends a close. It does not end cleanly when a laptop battery dies, a wireless link drops, a VPN tunnel flaps, or an intermediate firewall silently discards its state entry. In every one of those cases the router still believes the session is live and continues to hold a VTY slot for it. With a small fixed number of slots, an afternoon of unstable connectivity is enough to fill them, and the symptom is administrators unable to log in to the device they need in order to fix the instability.
 
-        - Orphaned sessions consume VTY line resources, potentially blocking legitimate access.
-        - Dead sessions are not detected and cleaned up.
+        That is also the cheapest denial of service against the management plane. An attacker who opens sessions and then goes silent, never sending a close, holds slots for as long as the router will keep them, and without keepalives the router keeps them indefinitely.
 
-        Enabling TCP keepalives-in ensures dead inbound sessions are detected and removed.
+        An idle exec timeout does not cover this. It expires a session a person stopped typing at; keepalives detect a peer that is no longer there at all. Configure both, together with the outbound equivalent that a companion check in this policy covers.
       audit: |-
         To verify that TCP keepalives for inbound sessions are enabled:
 
@@ -2253,16 +2256,17 @@ queries:
       cisco.iosxe.configuration.service.tcpKeepalivesOutEnabled == true
     docs:
       desc: |
-        This check verifies that TCP keepalives for outbound sessions are enabled. TCP keepalives detect dead connections and clean up orphaned outbound sessions.
+        This check verifies that connections the device itself opened are torn down when the far end stops responding.
+
+        `service tcp-keepalives-out` applies the same probing to outgoing TCP sessions that the inbound service applies to incoming ones. The check requires the service to be enabled.
 
         **Why this matters**
 
-        Without TCP keepalives for outbound sessions, stale connections persist. If keepalives-out is not enabled:
+        The router originates more TCP than operators tend to remember: sessions to TACACS+ and RADIUS servers, syslog carried over TCP, BGP peerings, file transfers during a software upgrade, and outbound sessions to console servers. When one of those peers disappears without closing, the device keeps the socket and the memory behind it, and it keeps believing the destination is reachable.
 
-        - Dead outbound connections consume resources.
-        - The device may not detect when a remote peer has become unreachable.
+        The security consequence sits in the AAA path. A device that thinks it still has a working session to an authentication server behaves differently from one that knows the server is gone: the fallback to the local method list is delayed, and the window during which nobody can log in stretches out. On a device whose method list has no local fallback at all, that window is an outage with no way in except the console.
 
-        Enabling TCP keepalives-out ensures dead outbound sessions are detected and removed.
+        Stale outbound sockets also accumulate. Memory on a router is not generous, and sessions that are never reaped are a slow leak that surfaces as an unexplained reload months later, usually at the least convenient moment.
       audit: |-
         To verify that TCP keepalives for outbound sessions are enabled:
 
@@ -2316,16 +2320,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all BGP neighbors have MD5 authentication configured. BGP authentication prevents unauthorized peers from injecting routes.
+        This check verifies that each BGP peering will only come up with a peer that holds a shared secret.
+
+        `neighbor <address> password <value>` under `router bgp` enables TCP MD5 signing for that session, signing each segment of the peering with a key both ends must possess. The check applies where BGP neighbors are configured and requires every one of them to have a password set.
 
         **Why this matters**
 
-        Without BGP authentication, an attacker can establish rogue BGP sessions. If authentication is not configured:
+        BGP runs over an ordinary TCP session on port 179, and without signing that session is protected only by the peer's source address and the time-to-live of arriving packets. An attacker able to spoof the peer's address, or positioned on the path between the two routers, injects a segment into the established session. A forged reset drops the peering, and dropping a transit peering blackholes everything it was carrying. A forged update inserts a route, and a more specific prefix wins, so the attacker draws traffic for that prefix to equipment they control and reads or alters it before passing it along.
 
-        - Malicious routes can be injected, redirecting or black-holing traffic.
-        - BGP sessions can be disrupted through TCP reset attacks.
+        Signing is what makes the contents of the session attributable rather than merely its source address plausible.
 
-        Configuring authentication on BGP neighbors ensures only authorized peers can establish sessions.
+        MD5 here is old, and the keys are frequently weak and never rotated, so treat it as a floor and move to the TCP Authentication Option where both ends support it. Coordinate before applying it: the session stays down until both sides match, so this needs a maintenance window and the peer's operator on the call. Where neighbors belong to a peer group, set the key on the group so every member inherits it.
       audit: |-
         To verify that BGP neighbors have authentication configured:
 
@@ -2384,17 +2389,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all OSPF areas have authentication configured. OSPF authentication prevents unauthorized routers from injecting routes into the routing domain.
+        This check verifies that only routers holding a shared key can form adjacencies and inject routes into an OSPF area.
+
+        Authentication is enabled per area with `area <id> authentication message-digest` under `router ospf`, and each participating interface carries a key set with `ip ospf message-digest-key 1 md5 <key>`. The check applies where OSPF processes exist and requires every area to have either plain or message-digest authentication enabled.
 
         **Why this matters**
 
-        Without OSPF authentication, any device on the segment can participate in OSPF routing. If authentication is not configured:
+        OSPF forms adjacencies with whatever answers hellos on a segment. Without authentication, anything plugged into a routed VLAN becomes a router in your topology: an unused access port, a compromised server running a routing daemon, a laptop in a branch office. From there the attacker advertises itself as the best path to a prefix, the real routers install it, and traffic for that prefix arrives at them to be read and forwarded on with nobody the wiser.
 
-        - Rogue routers can inject false routes.
-        - OSPF adjacencies can be disrupted.
-        - Man-in-the-middle attacks via route injection are possible.
+        The same position lets them break the network rather than watch it. Advertising and withdrawing a link repeatedly forces continuous shortest-path recalculation on every router in the area, which on a large area is enough to disturb forwarding.
 
-        Configuring OSPF authentication ensures only authorized routers participate in the routing domain.
+        Message digest is materially stronger than the plain-text form, which puts the password in every hello and stops accidents rather than adversaries. Apply the interface keys throughout the area before enabling authentication on the area itself, because a router whose neighbors do not match drops adjacency at once, and losing adjacency in the backbone partitions the routing domain.
       audit: |-
         To verify that OSPF areas have authentication configured:
 

--- a/content/mondoo-cisco-iosxr-security.mql.yaml
+++ b/content/mondoo-cisco-iosxr-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-iosxr-security
     name: Mondoo Cisco IOS-XR Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -117,18 +117,17 @@ queries:
       cisco.iosxr.ssh.version == "v2"
     docs:
       desc: |
-        This check verifies that SSH version 2 is enforced on the device. SSH version 1 contains known cryptographic vulnerabilities and must not be used for secure management access.
+        This check verifies that remote management sessions negotiate only the modern SSH protocol.
+
+        IOS-XR runs an SSH server that can be told which protocol generations it will accept. The `ssh server v2` command in configuration mode restricts the server to SSH version 2 and refuses version 1 negotiation outright. Like every IOS-XR configuration change it stages into a target configuration and does nothing until `commit` runs. The check requires the SSH server to report version 2.
 
         **Why this matters**
 
-        SSH version 1 has well-documented weaknesses including susceptibility to man-in-the-middle attacks and session hijacking. If SSH version 2 is not enforced:
+        SSH version 1 has a structurally broken integrity mechanism. It protects packets with a CRC-32 checksum rather than a keyed message authentication code, which lets an attacker on the path insert chosen ciphertext into an authenticated session and have the device act on it. Public tooling for that insertion attack has existed since 2001, and it needs no credentials, only a position between the operator and the router.
 
-        - Management sessions are vulnerable to cryptographic attacks present in SSH version 1.
-        - Session integrity cannot be guaranteed, allowing potential session hijacking.
-        - Compliance with modern security frameworks that require strong encryption cannot be met.
-        - Credential exposure risk increases due to weaker key exchange mechanisms.
+        A router is where that position is easiest to obtain, because management traffic to it crosses the same infrastructure the router controls. An attacker who lands a command inside an administrator's live session can add an account, redirect traffic, or open a path deeper into the network without ever guessing a password.
 
-        Enforcing SSH version 2 ensures that all remote management sessions use a secure, modern protocol with strong cryptographic protections.
+        Pair this with generating an RSA host key of adequate size and restricting the line templates to SSH transport, both covered by companion checks in this policy.
       audit: |-
         To verify that SSH version 2 is enforced:
 
@@ -178,17 +177,17 @@ queries:
       cisco.iosxr.ssh.timeout <= 120
     docs:
       desc: |
-        This check verifies that an SSH timeout is configured to limit how long an SSH connection may spend in user authentication before the device drops it. The timeout should be set to a reasonable value of 120 seconds or less to minimize the window available for authentication attempts.
+        This check verifies that half-open SSH connections are dropped instead of being allowed to sit in authentication indefinitely.
+
+        `ssh timeout` sets how many seconds an incoming SSH connection may spend completing user authentication before IOS-XR tears it down. The value is staged in configuration mode and applies once `commit` runs. The check requires a value greater than zero and no more than 120 seconds, the upper bound the platform accepts.
 
         **Why this matters**
 
-        Without an SSH timeout, connections can remain in the authentication phase indefinitely. If the timeout is not configured:
+        Every connection sitting in authentication occupies a slot in the SSH server's session table. That table is small on a router, far smaller than on a general-purpose server, and an attacker who opens connections and simply never sends credentials can fill it from a single host. Once it is full, legitimate administrators are refused, and on a device whose only remaining access path is a console cable in a locked facility that turns a nuisance into an outage somebody has to drive to.
 
-        - Attackers can hold unauthenticated connections open while probing or brute-forcing credentials.
-        - Resources are consumed by stalled connections, potentially blocking legitimate access.
-        - Compliance requirements for session management cannot be met.
+        A generous timeout also widens the window for slow credential guessing, since each attempt costs the attacker a longer-lived connection they never had to keep alive.
 
-        Configuring an SSH timeout ensures that connections that fail to authenticate promptly are dropped, reducing the attack surface. Disconnecting sessions that go idle after authentication requires an exec timeout on the console and line templates.
+        This bounds authentication only. Sessions that go idle after a successful login are cut by an exec timeout on the console and on the line templates, which a companion check in this policy covers.
       audit: |-
         To verify that an SSH timeout is configured:
 
@@ -239,17 +238,17 @@ queries:
       cisco.iosxr.routerPublicKey.modulusSize >= 2048
     docs:
       desc: |
-        This check verifies that the RSA key pair used for SSH has a modulus size of at least 2048 bits. Keys smaller than 2048 bits are considered cryptographically weak and vulnerable to brute-force attacks.
+        This check verifies that the host key identifying the device to SSH clients is strong enough to resist factoring.
+
+        IOS-XR generates its SSH host key with `crypto key generate rsa` from EXEC mode, which prompts for a modulus size. Unlike configuration commands, this one takes effect immediately and needs no `commit`. The check requires the router's public key to report a modulus of at least 2048 bits.
 
         **Why this matters**
 
-        RSA keys with fewer than 2048 bits can be factored with current computing resources. If the key size is insufficient:
+        The host key is what tells an administrator they reached the real router rather than something impersonating it. An attacker who recovers the private half can stand up a machine-in-the-middle that presents the genuine fingerprint, so the client raises no warning, and then collect the TACACS+ or local credentials the operator types into it. From there they hold whatever privileges that operator holds.
 
-        - The SSH host key can potentially be compromised, enabling man-in-the-middle attacks.
-        - Compliance with NIST and other standards requiring minimum 2048-bit RSA keys cannot be met.
-        - The overall security of all SSH sessions to the device is weakened.
+        A 1024-bit RSA modulus is within reach of well-resourced factoring effort and has been deprecated for that reason since NIST SP 800-131A, and a 768-bit modulus was factored publicly in 2009. Routers frequently still carry a key generated at install with whatever default the software of that era offered, and nothing about normal operation ever regenerates it.
 
-        Using RSA keys of at least 2048 bits ensures that SSH sessions are protected with adequate cryptographic strength.
+        Regenerating replaces the fingerprint clients have pinned, so update known-hosts entries on jump hosts and automation before you rotate, or scripted access breaks the moment the new key is live.
       audit: |-
         To verify the RSA key modulus size:
 
@@ -300,18 +299,17 @@ queries:
       cisco.iosxr.aaaAuthenticationLogin.length > 0
     docs:
       desc: |
-        This check verifies that AAA authentication login method lists are configured on the device. AAA authentication integrates the router with centralized identity management systems such as TACACS+ or RADIUS for scalable authentication.
+        This check verifies that administrative logins are resolved against a defined authentication method list.
+
+        IOS-XR decides who a user is through AAA method lists built with `aaa authentication login`, typically `aaa authentication login default group tacacs+ local`, which consults the TACACS+ servers first and the local database if they are unreachable. The list is staged in configuration mode and takes effect at `commit`. The check requires at least one login method list to exist.
 
         **Why this matters**
 
-        Without AAA authentication login configured, the device relies solely on local credentials, which are difficult to manage at scale. If AAA authentication is not configured:
+        IOS-XR has no `enable secret`; privilege comes from the task groups AAA binds to an identity. Without a login method list the identity half of that model is unanchored, and every access decision collapses onto whichever local accounts happen to exist on that one chassis.
 
-        - The device cannot integrate with centralized identity management.
-        - User authentication cannot be enforced consistently across the network.
-        - Audit trails for authentication events are incomplete.
-        - Compliance with security frameworks requiring centralized authentication cannot be achieved.
+        Locally defined accounts are exactly what state-sponsored campaigns against routing infrastructure have repeatedly harvested and reused, because they are created once during turn-up, shared across a team, never rotated, and often identical across a fleet. A centralized method list means a departing engineer loses access everywhere at once instead of remaining a valid login on hundreds of routers.
 
-        Configuring AAA authentication login ensures centralized, scalable authentication with comprehensive audit trails.
+        Always keep `local` as the final method. A list pointing only at servers that later become unreachable locks everyone out, so stage the change with `commit confirmed` and let the timer roll it back if your test session fails to authenticate.
       audit: |-
         To verify that AAA authentication login method lists are configured:
 
@@ -368,18 +366,17 @@ queries:
       cisco.iosxr.aaaAccounting.length > 0
     docs:
       desc: |
-        This check verifies that AAA accounting is configured to log user activity. Accounting records provide a detailed audit trail of commands executed, sessions started, and system events.
+        This check verifies that administrative activity on the device produces an audit record held off the box.
+
+        `aaa accounting exec default start-stop group tacacs+` records session starts and stops, and `aaa accounting commands default start-stop group tacacs+` records the individual commands run inside them. Both are staged in configuration mode and become active at `commit`. The check requires at least one accounting entry to be configured.
 
         **Why this matters**
 
-        Without AAA accounting, there is no record of what administrators have done on the device. If accounting is not configured:
+        Accounting is the only source that says which named person did something. Syslog reports that a configuration was committed and which line it arrived on, but without accounting it does not attach that to an identity, so a shared local account leaves an investigation holding a timestamp and nothing else.
 
-        - There is no forensic evidence of commands executed during a security incident.
-        - Compliance requirements for audit logging cannot be met.
-        - Accountability for privileged operations is lost.
-        - Investigating unauthorized changes becomes significantly harder.
+        The records also leave the device as they are generated. Someone who reaches an IOS-XR router with configuration rights can clear the local log buffer and shape what remains, but they cannot retract accounting records a TACACS+ server has already accepted. That asymmetry is the difference between reconstructing an intrusion and guessing at it.
 
-        Enabling AAA accounting ensures that all activity is logged and available for audit, investigation, and compliance reporting.
+        Command accounting on a busy device is chatty, and because IOS-XR stages changes before they apply, an operator's exploratory work generates records before anything is committed. Size the accounting server and its retention for that volume rather than turning command accounting off.
       audit: |-
         To verify that AAA accounting is configured:
 
@@ -429,18 +426,17 @@ queries:
       cisco.iosxr.aaaAuthorization.length > 0
     docs:
       desc: |
-        This check verifies that AAA authorization is configured to control which commands and resources users can access. Authorization enforces the principle of least privilege by limiting user actions based on their assigned role.
+        This check verifies that an authenticated operator is limited to the operations their role permits.
+
+        IOS-XR expresses privilege through task groups, which are sets of read, write, execute and debug permissions over named tasks, bound to a user group and then to a user. `aaa authorization exec default group tacacs+ local` and `aaa authorization commands default group tacacs+ local` determine which of those a session actually receives. Both are staged in configuration mode and take effect at `commit`. The check requires at least one authorization entry.
 
         **Why this matters**
 
-        Without AAA authorization, authenticated users may have unrestricted access to all commands. If authorization is not configured:
+        Without authorization, authentication becomes the entire access decision and anyone who gets in gets everything the platform can do. On a core router that includes rewriting routing policy, applying an access list that partitions a site, and switching off the logging that would have shown it happened.
 
-        - Users can execute commands beyond what their role requires.
-        - Separation of duties cannot be enforced.
-        - The principle of least privilege is not applied.
-        - Compliance with access control requirements cannot be met.
+        The realistic threat is usually not an outsider. It is a contractor, a monitoring account, or an automation credential handed interactive access because carving out a narrower scope was more work at the time. Any of those turning into a full-privilege session is a lateral movement path that starts inside the management network.
 
-        Configuring AAA authorization ensures that users can only perform operations appropriate to their role.
+        Define and assign the task groups before you enforce authorization. A method list applied over groups nobody has been assigned to will deny work that operators legitimately need to perform.
       audit: |-
         To verify that AAA authorization is configured:
 
@@ -490,17 +486,17 @@ queries:
       cisco.iosxr.lineAuthentication.length > 0
     docs:
       desc: |
-        This check verifies that line authentication is configured for console and VTY lines. Line authentication ensures that all access points to the device require proper credentials before granting access.
+        This check verifies that every physical and virtual access path into the device demands credentials.
+
+        Applying a method list with `login authentication` under `line console` and `line default` is what binds the console and the line templates serving remote sessions to AAA. A line with no method list applied does not inherit enforcement merely because AAA is configured globally. The commands are staged in configuration mode and take effect at `commit`. The check requires line authentication to be configured.
 
         **Why this matters**
 
-        Without line authentication, access points such as the console or VTY lines may allow unauthenticated access. If line authentication is not configured:
+        An unbound line is the one that gets missed. AAA is set up carefully for remote administration, the console is left as it was during turn-up, and anyone who reaches the rack finds an unauthenticated prompt with full platform access. In a shared cage, a carrier hotel, or a cabinet a landlord's contractor can open, that is a realistic path, and it produces no authentication record because no authentication took place.
 
-        - Console or remote access may be available without any credentials.
-        - Unauthorized users can gain access to the device through unprotected lines.
-        - Compliance requirements for access control cannot be met.
+        The same gap turns up on auxiliary lines and on named templates created for one purpose and never revisited.
 
-        Configuring line authentication on all lines ensures that every access method requires proper authentication.
+        Prove the console works before you depend on it. If the AAA servers become unreachable and the console method list carries no `local` fallback, the one access path that survives a network failure is the one you have just closed, and recovery then means a site visit.
       audit: |-
         To verify that line authentication is configured:
 
@@ -554,17 +550,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all local user accounts have encrypted passwords. Passwords stored with encryption type 0 (clear text) are visible in the device configuration and can be trivially compromised.
+        This check verifies that local account credentials are stored as one-way hashes rather than readable text.
+
+        IOS-XR records each local credential with a type marker showing how it was stored, and type 0 means the value sits in the configuration exactly as typed. `username <user> secret <password>` stores a hash instead: the device accepts clear-text input and keeps only the digest. The check requires every local user to carry a secret type other than 0 or unset.
 
         **Why this matters**
 
-        Clear-text passwords in the running configuration are exposed to anyone who can view the configuration. If passwords are not encrypted:
+        Router configurations are copied constantly. They go into change tickets, vendor support cases, nightly backup shares, and configuration management repositories, and every one of those copies is a credential file if the passwords in it are readable. An attacker who reaches a backup server never has to touch a router to collect logins for the whole fleet, and those logins usually work on more than the device they came from.
 
-        - Credentials are visible in plain text in configuration backups and show commands.
-        - Configuration files sent to support or stored in version control expose all passwords.
-        - An attacker who gains read access to the configuration immediately obtains all credentials.
+        `username <user> password ...` is not an equivalent. That form uses the reversible type 7 encoding, a published XOR against a fixed key with public decoders going back two decades. It hides a credential from a glance at a shared screen and from nothing else.
 
-        Ensuring all users have encrypted passwords protects credentials from exposure through configuration access.
+        Remove any leftover `password` entry once a secret is in place, or the weaker copy stays in the configuration alongside the hash and is the one an attacker uses.
       audit: |-
         To verify that all local users have encrypted passwords:
 
@@ -623,18 +619,17 @@ queries:
       cisco.iosxr.passwordPolicies.length > 0
     docs:
       desc: |
-        This check verifies that AAA password policies are configured to enforce password complexity and lifecycle requirements. Password policies define minimum length, character requirements, and expiration settings.
+        This check verifies that local credentials must satisfy defined strength and lifecycle rules.
+
+        `aaa password-policy <name>` creates a named policy carrying settings such as `min-length`, `min-char-change`, `special-char`, `numeric` and `lifetime days`. The policy does nothing until it is attached to an account with `username <user> password-policy <name>`, and neither step is live until `commit`. The check requires at least one password policy to exist.
 
         **Why this matters**
 
-        Without password policies, users can set weak or trivially guessable passwords. If password policies are not configured:
+        Local accounts on network devices are where weak passwords survive longest. They are created during turn-up under time pressure, frequently reused across a batch of chassis commissioned the same week, and then left untouched for the decade the hardware stays in service. Nothing in normal operation ever prompts a change.
 
-        - Passwords may not meet minimum length or complexity requirements.
-        - Password reuse cannot be prevented.
-        - Password expiration cannot be enforced.
-        - Compliance with password management requirements cannot be met.
+        An attacker who obtains one such credential from an old configuration backup, a departed contractor, or another compromised device gets to try it against every router in the estate. Guessing is cheap as well when the credential is short, because the local database is evaluated directly on the box with no external rate limiting beyond what the operator configured.
 
-        Configuring password policies ensures that all local accounts meet minimum security requirements for password strength.
+        The policy governs both the `password` and `secret` forms, so it is not a substitute for storing credentials as hashes. Pair it with secrets, which a companion check in this policy requires.
       audit: |-
         To verify that AAA password policies are configured:
 
@@ -699,17 +694,17 @@ queries:
       cisco.iosxr.type6.aesConfigState == "Enabled"
     docs:
       desc: |
-        This check verifies that Type 6 AES password encryption is enabled. Type 6 encryption uses AES to provide strong, reversible encryption for passwords stored in the configuration, replacing the weak Type 7 encryption.
+        This check verifies that configuration values that cannot be hashed are protected with strong encryption instead of a trivially decoded encoding.
+
+        Some values must be reproducible by the device to be usable, including TACACS+ and RADIUS shared secrets and routing protocol keys. IOS-XR stores these as Type 6, AES encryption under a master key held outside the configuration text. It is turned on with `password6 encryption aes` and a `commit`, and the master key is then created from EXEC mode with `key config-key password-encryption`. The check requires the Type 6 AES state to report as enabled.
 
         **Why this matters**
 
-        Type 7 encryption is trivially reversible and provides minimal protection. If Type 6 encryption is not enabled:
+        The alternative is Type 7, whose algorithm is a published XOR against a fixed key. Any configuration containing a Type 7 string yields the original value in the time it takes to paste it into a decoder, and configurations leave the device constantly through backups, tickets and support cases.
 
-        - Passwords in the configuration are protected only by weak, easily reversed encryption.
-        - An attacker with access to the configuration can decode all Type 7 passwords instantly.
-        - RADIUS and TACACS+ shared secrets in the configuration are inadequately protected.
+        The values at stake are shared keys, so recovering one from a single router often unlocks far more than that router. A TACACS+ shared secret lets an attacker impersonate the authentication server for every device that trusts it, turning one leaked backup into control over the fleet's login decisions.
 
-        Enabling Type 6 encryption ensures that passwords stored in the configuration are protected with AES encryption.
+        Record the master key securely before storing anything under it. If it is lost or changed, every existing Type 6 value becomes unrecoverable and each one has to be reconfigured by hand.
       audit: |-
         To verify that Type 6 AES password encryption is enabled:
 
@@ -767,18 +762,17 @@ queries:
       cisco.iosxr.ntp.authenticate == true
     docs:
       desc: |
-        This check verifies that NTP authentication is enabled to ensure the device only synchronizes time with trusted NTP servers. Without authentication, an attacker could manipulate the device's clock by spoofing NTP responses.
+        This check verifies that the device accepts clock updates only from time sources that prove their identity.
+
+        `ntp authenticate` turns on verification of NTP messages, working together with `ntp authentication-key`, `ntp trusted-key`, and a `key` reference on each `ntp server` line. Without that keying, authentication is switched on but nothing is trusted. All of it is staged in configuration mode and applies at `commit`. The check requires NTP authentication to be enabled.
 
         **Why this matters**
 
-        Accurate, trusted time is critical for security operations. If NTP authentication is not enabled:
+        NTP runs over UDP, so an attacker who can reach the management network can forge a reply that appears to come from the configured server without intercepting anything first. Moving a router's clock is a quiet way to ruin the record of an intrusion: log entries land at times that correlate with nothing, and an analyst comparing routers sees a timeline that will not reconcile.
 
-        - An attacker can manipulate the device clock through NTP spoofing attacks.
-        - Log timestamps become unreliable, undermining forensic investigations.
-        - Certificate validation can be bypassed with manipulated time.
-        - Time-sensitive security mechanisms such as OTP tokens can be compromised.
+        A shifted clock also disturbs controls that read time directly. Certificate validity windows, the send and accept lifetimes on the key chains protecting OSPF and BGP, and time-based access lists all decide from it, and a large enough step expires a key chain or reactivates one that was retired.
 
-        Enabling NTP authentication ensures the device only accepts time updates from verified, trusted sources.
+        MD5 is the practical floor rather than a strong choice. Use a stronger digest where your release and your time servers both support one, and set the same key and key number on the server or the device discards its updates.
       audit: |-
         To verify that NTP authentication is enabled:
 
@@ -830,17 +824,19 @@ queries:
       cisco.iosxr.ntp.servers.length > 0
     docs:
       desc: |
-        This check verifies that at least one NTP server is configured to maintain accurate time synchronization. Accurate time is essential for log correlation, certificate validation, and security event analysis.
+        This check verifies that the device keeps its clock synchronized against an external reference.
+
+        `ntp server <address>` points IOS-XR at a time source. The entry is staged in configuration mode and becomes active at `commit`. The check requires at least one NTP association to exist.
 
         **Why this matters**
 
-        Without NTP servers configured, the device clock will drift over time, leading to inaccurate timestamps. If NTP servers are not configured:
+        A router with no external reference runs on a free-running oscillator that drifts steadily. Within weeks it can sit minutes away from real time, and a chassis brought back after a long power loss can come up decades off, since it has no battery-backed clock to fall back on.
 
-        - Log timestamps are inaccurate, making incident investigation unreliable.
-        - Time-based security controls such as certificate expiration checks may malfunction.
-        - Correlation of events across multiple devices becomes impossible.
+        That breaks incident work first. Correlating a routing anomaly across a core router, an edge router and a firewall depends on their timestamps lining up, and if one is minutes adrift the order of events is unreadable and the wrong cause gets blamed. It equally breaks anything that reads the clock to make a decision, including certificate validity, key chain lifetimes on routing protocol authentication, and scheduled configuration jobs.
 
-        Configuring NTP servers ensures the device maintains accurate, synchronized time.
+        Configure at least two sources so one unreachable server does not leave the device unsynchronized, and prefer sources you operate over public pools for infrastructure this sensitive.
+
+        Synchronizing without authenticating the source leaves it spoofable, which a companion check in this policy addresses.
       audit: |-
         To verify that NTP servers are configured:
 
@@ -892,18 +888,17 @@ queries:
       cisco.iosxr.logging.enabled == true
     docs:
       desc: |
-        This check verifies that logging is enabled on the device. Logging is the foundation of security monitoring, providing records of system events, errors, and security-relevant activities.
+        This check verifies that the device produces a record of what happens on it.
+
+        IOS-XR sends log messages to several destinations, each with its own severity threshold: `logging console`, `logging monitor` for terminal sessions, `logging buffered` for the in-memory ring, and `logging trap` for remote syslog. Each is staged in configuration mode and takes effect at `commit`. The check requires logging to be active.
 
         **Why this matters**
 
-        Without logging enabled, the device generates no records of system activity. If logging is disabled:
+        Without logging there is no trace that a configuration was committed, that an interface went down, that authentication failed repeatedly, or that a BGP session flapped. An intrusion into a router is often visible only as that kind of trace, because someone who has compromised the management plane makes changes that look ordinary in isolation and only form a pattern when they can be read in sequence.
 
-        - Security events such as failed logins, configuration changes, and link state changes are not recorded.
-        - Incident response teams have no data to investigate security breaches.
-        - Compliance requirements for audit logging cannot be met.
-        - Operational issues cannot be diagnosed from historical data.
+        The absence hurts more here than on a server, where an endpoint agent, a package database, and filesystem timestamps each leave evidence independently. A router has almost none of that. If the log did not capture it, there is usually nothing else to reconstruct from.
 
-        Enabling logging ensures that the device records system events for security monitoring and troubleshooting.
+        Set severity thresholds per destination rather than sending everything everywhere. Console logging at debug severity on a busy router floods the console and slows the very session you would need for recovery.
       audit: |-
         To verify that logging is enabled:
 
@@ -955,18 +950,17 @@ queries:
       cisco.iosxr.runLoggingSyslogHosts.length > 0
     docs:
       desc: |
-        This check verifies that at least one remote syslog host is configured for centralized log collection. Sending logs to a remote server ensures that log data is preserved even if the device is compromised or restarted.
+        This check verifies that log records are copied to a collector the device itself does not control.
+
+        `logging <syslog-server-address>` adds a remote destination, usually paired with `logging source-interface` so records arrive with a stable source address regardless of the path they take. Both are staged in configuration mode and apply at `commit`. The check requires at least one remote syslog host.
 
         **Why this matters**
 
-        Logs stored only on the device are vulnerable to loss or tampering. If remote syslog hosts are not configured:
+        Logs kept only on the router are held by the very system an attacker is trying to hide activity on. Anyone with configuration rights on IOS-XR can clear the buffer, and even untouched it is a fixed-size ring that overwrites itself, so a burst of interface flaps can push the evidence of a login out of memory within minutes. A reload erases it entirely.
 
-        - Logs are lost when the device reboots or the log buffer overflows.
-        - An attacker who compromises the device can erase local logs to cover their tracks.
-        - Centralized log correlation across multiple devices is not possible.
-        - SIEM integration for real-time security monitoring cannot function.
+        Once a record has been accepted by a remote collector it is beyond the attacker's reach, and during an investigation that difference is decisive. Central collection is also the only way to see a pattern that spans devices, such as one source address failing authentication against a dozen routers in sequence, which no single device's log reveals.
 
-        Configuring remote syslog hosts ensures that logs are preserved in a centralized, tamper-resistant location.
+        Remote logging is plain UDP by default and carries operational detail about your network. Keep the collector inside the management network or a dedicated VRF rather than routing syslog across general infrastructure.
       audit: |-
         To verify that remote syslog hosts are configured:
 
@@ -1016,17 +1010,17 @@ queries:
       cisco.iosxr.runLogging.bufferLogLevel != ""
     docs:
       desc: |
-        This check verifies that logging to the local buffer is configured. Buffer logging provides a local cache of recent log messages that can be reviewed for troubleshooting and incident investigation.
+        This check verifies that recent events stay readable on the device itself.
+
+        `logging buffered <severity>` allocates an in-memory ring buffer and sets the lowest severity stored in it, for example `logging buffered informational`. The command is staged in configuration mode and takes effect at `commit`. The check requires a buffer severity level to be configured.
 
         **Why this matters**
 
-        Without buffer logging configured, there is no local log history available on the device. If buffer logging is not enabled:
+        The buffer is what you still have when the network is the problem. If routing has broken, an uplink is down, or the syslog collector is unreachable, remote records stop arriving exactly when they matter most, and the operator sitting on a console cable needs the device's own account of the last several minutes to work out what happened.
 
-        - Administrators cannot review recent events directly on the device.
-        - Troubleshooting connectivity issues that prevent access to remote syslog becomes difficult.
-        - There is no local log data available during network outages.
+        It also covers the gap that remote logging leaves. Syslog over UDP offers no delivery guarantee, so a burst during an incident can be dropped in transit with nothing to signal the loss, and the local copy is the only way to notice.
 
-        Configuring buffer logging ensures that recent log messages are available locally for review.
+        Treat it as a diagnostic window rather than a record of account. The buffer is a fixed size that overwrites its oldest entries, it does not survive a reload, and anyone with configuration access can clear it, which is why a companion check in this policy also requires a remote collector.
       audit: |-
         To verify that buffer logging is configured:
 
@@ -1080,18 +1074,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that the default SNMP community strings "public" and "private" are not in use. These well-known defaults are the first values attackers try when attempting to access SNMP-enabled devices.
+        This check verifies that the device is not reachable through community strings every scanner already knows.
+
+        A community string is the entire credential for SNMP version 1 and version 2c, and `snmp-server community public RO` and `snmp-server community private RW` are the values printed as examples in nearly every vendor document ever written. The check requires that no configured community is named `public` or `private`.
 
         **Why this matters**
 
-        Default SNMP community strings are universally known and are actively scanned for by attackers. If default community strings are in use:
+        Those two strings are the first thing internet-wide scanners try, and an attempt costs one UDP packet with no session and no handshake. A read community answers with the interface table, the ARP and routing tables, the platform and software version, and on many builds portions of the running configuration, which amounts to a map of the network drawn by the network itself.
 
-        - Anyone with network access can read device configuration and operational data using the "public" community.
-        - The "private" community may allow unauthorized configuration changes via SNMP write access.
-        - Automated scanning tools will immediately detect and exploit default community strings.
-        - Sensitive network topology and configuration information is exposed.
+        A write community is worse. It permits interface state changes, and on Cisco platforms the configuration copy MIB has historically been used to pull the running configuration to an attacker-controlled TFTP server or push a replacement back. SNMP has been a named component of state-actor campaigns against routing infrastructure for precisely this reason.
 
-        Removing default community strings and using unique, complex values ensures SNMP access is properly restricted.
+        Renaming the community is the minimum, not the fix. Restrict each one with an access list and move to SNMPv3 wherever the management platform supports it, both covered by companion checks in this policy.
       audit: |-
         To verify that default SNMP community strings are not in use:
 
@@ -1155,17 +1148,19 @@ queries:
       cisco.iosxr.runSnmpUsers.length > 0
     docs:
       desc: |
-        This check verifies that SNMPv3 users are configured. SNMPv3 provides authentication and encryption, unlike SNMPv1/v2c which transmit community strings in clear text.
+        This check verifies that monitoring access uses per-user credentials with authentication and encryption.
+
+        SNMPv3 replaces the shared community string with named users bound to a group and a security level. `snmp-server group <name> v3 priv` demands both authentication and privacy, and `snmp-server user <user> <group> v3 auth sha clear <auth-password> priv aes 128 clear <priv-password>` creates a user that signs its requests and encrypts the payload. Both are staged in configuration mode and apply at `commit`. The check requires at least one SNMPv3 user.
 
         **Why this matters**
 
-        SNMPv1 and SNMPv2c use community strings as the sole authentication mechanism, and these are sent in clear text. If SNMPv3 is not configured:
+        Versions 1 and 2c put the community string in clear text in every single packet. Anyone able to observe management traffic, whether from a span port, a compromised switch, or a link between sites, recovers the credential passively without transmitting anything, and there is no exchange to detect afterward.
 
-        - SNMP credentials are transmitted in plain text and can be captured by network sniffing.
-        - There is no per-user authentication or access control for SNMP operations.
-        - SNMP data can be viewed or modified by anyone who intercepts the community string.
+        The responses are readable too. SNMP replies carry interface names, addressing, neighbor tables and platform detail, so an observer assembles a topology map from traffic that looks exactly like ordinary monitoring.
 
-        Configuring SNMPv3 users ensures that SNMP communications are authenticated and encrypted.
+        Per-user credentials also make revocation possible at all. A shared community string cannot be withdrawn from one team without breaking every poller using it, so in practice it never changes.
+
+        Choose SHA for authentication and AES for privacy. The MD5 and DES options that SNMPv3 still permits do not deliver what the version exists to provide.
       audit: |-
         To verify that SNMPv3 users are configured:
 
@@ -1221,17 +1216,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all SNMP community strings have access control lists (ACLs) applied to restrict which IP addresses can query the device via SNMP. Without ACLs, any host with network connectivity can access the device using SNMP.
+        This check verifies that SNMP queries are answered only for the management stations you name.
+
+        An IOS-XR community definition carries an access list, as in `snmp-server community <string> RO IPv4 <acl-name>`, limiting the source addresses whose queries the agent will process. The list is built with `ipv4 access-list`, and both it and the community line stage in configuration mode until `commit`. The check requires every configured community to have an access list applied.
 
         **Why this matters**
 
-        SNMP without ACL restrictions allows any network host to query the device. If ACLs are not applied to community strings:
+        Without one, the credential is the only barrier, and it is a static string carried in clear text over UDP in every poll. Anyone who observes a poll, finds the string in a configuration backup, or guesses one of the handful of values organizations reuse can query the device from anywhere that routes to it.
 
-        - Any device on the network can query SNMP data, exposing configuration and operational information.
-        - Unauthorized SNMP polling can be used for reconnaissance.
-        - Write-access community strings without ACLs allow remote configuration changes from any host.
+        An access list breaks that reuse. A string recovered from one router's backup does not work from an attacker's vantage point, because the request never arrives from an address the agent will answer.
 
-        Applying ACLs to SNMP community strings restricts access to authorized management stations only.
+        It also removes most of the unauthenticated exposure, since untargeted scanning is dropped before the community string is evaluated at all.
+
+        Confirm the list covers every legitimate poller before committing. A list that omits one monitoring system leaves that system blind while everything else looks healthy, so apply it with `commit confirmed` and let the timer revert the change if you got it wrong.
       audit: |-
         To verify that SNMP communities have ACLs applied:
 
@@ -1284,17 +1281,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that a login banner is configured on the device. A login banner provides legal notice to users before they authenticate, which is a prerequisite for prosecuting unauthorized access in many jurisdictions.
+        This check verifies that a warning notice is presented before anyone authenticates to the device.
+
+        `banner login` sets the text shown at connection time, ahead of any credential prompt. On IOS-XR the command takes a delimiter character marking the start and end of the message rather than quotation marks, so the correct form is `banner login # Authorized access only. All activity is monitored and logged. #`. It is staged in configuration mode and appears after `commit`. The check requires a login banner whose text is not empty.
 
         **Why this matters**
 
-        Without a login banner, there is no legal warning presented before access. If a login banner is not configured:
+        The banner is a legal instrument rather than a technical control. Prosecutions under unauthorized-access statutes, and disciplinary action against insiders, often turn on whether the accused was on notice that access was restricted and that activity was recorded. A device that greets a connection with a bare username prompt hands the defense an argument that access looked open.
 
-        - Legal proceedings against unauthorized access may be weakened without a warning.
-        - Users are not informed of acceptable use policies or monitoring.
-        - Compliance with organizational and regulatory requirements for access warnings cannot be met.
+        Notice of monitoring matters separately. In several jurisdictions consent to session recording must be established before the session, and the banner is where that consent is given for command accounting and syslog to be usable as evidence later.
 
-        Configuring a login banner ensures that all users receive legal notice before accessing the device.
+        Keep anything useful to an attacker out of the text: no hostname, no platform, no software version, no operator contact detail, and no word of welcome. Have counsel supply the wording rather than copying another organization's.
       audit: |-
         To verify that a login banner is configured:
 
@@ -1344,17 +1341,19 @@ queries:
       cisco.iosxr.runConsoleExecTimeout.seconds > 0
     docs:
       desc: |
-        This check verifies that an exec timeout is configured for the console line. A console exec timeout ensures that idle console sessions are automatically disconnected, reducing the risk of unauthorized physical access.
+        This check verifies that an idle session on the physical console is disconnected rather than left logged in.
+
+        `exec-timeout <minutes> <seconds>` under `line console` sets how long an authenticated console session may sit without input before IOS-XR closes it, and a value of `0 0` disables the timeout entirely. The setting is staged in configuration mode and takes effect at `commit`. The check requires a non-zero timeout.
 
         **Why this matters**
 
-        Without a console exec timeout, an idle console session remains open indefinitely. If the timeout is not configured:
+        Console sessions outlive the person who opened them. A field engineer connects a laptop or a terminal server to finish a turn-up, gets called away, and the session stays authenticated at full privilege for as long as the cable is attached. Terminal servers make this durable, because the session persists across the engineer's own disconnection, so the next person who reaches that port lands in an authenticated prompt without logging in.
 
-        - An unattended console connection can be used to make unauthorized changes.
-        - Physical access security requirements cannot be met.
-        - Compliance requirements for session management are not fulfilled.
+        Whatever is done from that prompt is unattributable. It is recorded under the identity of whoever authenticated originally, which is exactly the situation command accounting exists to prevent.
 
-        Configuring a console exec timeout ensures that idle console sessions are terminated.
+        Physical access to the cabinet is a realistic assumption in shared cages, carrier hotels, and remote sites serviced by third-party technicians.
+
+        Ten minutes is a workable value. Set it so short that operators cannot finish a change and they will find ways to defeat it, and apply the same discipline to the line templates that serve remote sessions.
       audit: |-
         To verify that the console line has an exec timeout configured:
 
@@ -1406,17 +1405,17 @@ queries:
       cisco.iosxr.hostname.downcase != "ios"
     docs:
       desc: |
-        This check verifies that a unique, descriptive hostname is configured. A meaningful hostname is essential for identifying the device in logs, alerts, and management systems.
+        This check verifies that the device identifies itself by a name that distinguishes it from every other device.
+
+        `hostname <name>` sets the value carried in the CLI prompt and in the identifier attached to every syslog record and SNMP notification the device sends. It is staged in configuration mode and applies at `commit`. The check requires a hostname that is set and is not one of the generic values `router` or `ios`, compared without regard to case.
 
         **Why this matters**
 
-        Without a unique hostname, the device uses a generic default name that makes it difficult to manage effectively. If the hostname is not configured:
+        Identity is what makes a log usable. A collector receiving records from forty devices that all call themselves `router` produces a stream where nothing can be attributed, alerts cannot be routed to the owning team, and an investigation cannot establish which chassis a change was committed on. The failure shows up during an incident, when reconstructing the order of events across devices is the entire task.
 
-        - The device cannot be clearly identified in logs or management platforms.
-        - Log correlation and analysis across multiple devices is unreliable.
-        - Network topology documentation is incomplete or ambiguous.
+        Operator error is the other cost, and on a router it is expensive. An engineer with several sessions open who misreads an ambiguous prompt and commits an interface shutdown on the wrong device can black out a site, and recovering it may require someone physically present at the console.
 
-        Setting a descriptive hostname ensures the device is easily recognizable across all operational and security workflows.
+        Encode location, role and sequence in the name and keep the scheme consistent across the estate, so a name read off an alert tells you what you are about to log in to.
       audit: |-
         To verify that a unique, descriptive hostname is configured:
 
@@ -1465,17 +1464,17 @@ queries:
       cisco.iosxr.cdp.disabled == true
     docs:
       desc: |
-        This check verifies that Cisco Discovery Protocol (CDP) is disabled globally. CDP broadcasts detailed device information including hostname, IP address, platform, and IOS version to all directly connected devices, which can be exploited for network reconnaissance.
+        This check verifies that the device does not advertise its own identity and capabilities to whatever is plugged into it.
+
+        Cisco Discovery Protocol, or CDP, broadcasts hostname, platform, software version, the local interface, and frequently a management address to directly connected neighbors at layer 2. IOS-XR ships with it off, so it is present only where someone entered the global `cdp` command and committed it. `no cdp` followed by `commit` restores the default. The check requires CDP to be disabled.
 
         **Why this matters**
 
-        CDP operates at Layer 2 and sends information in clear text. If CDP is not disabled:
+        CDP frames are unauthenticated and unencrypted and go to a multicast address every device on the segment receives. Anyone who reaches a port, through a wall jack, an unused patch in a shared cage, or a compromised host on an attached switch, is handed the exact software release running on your router. That turns vulnerability research into a lookup, telling an attacker which published advisories apply before they send a single probe.
 
-        - Detailed device information is broadcast to all devices on the same network segment.
-        - Attackers can passively collect network topology, platform, and software version information.
-        - This information can be used to identify vulnerable devices and plan targeted attacks.
+        The advertised management address is just as useful, since it names the interface where SSH and SNMP actually listen rather than the address an untargeted scan would find first.
 
-        Disabling CDP prevents unnecessary information disclosure on the network.
+        Some link layer discovery is genuinely needed, for IP phones and for cable audits. Where that applies, enable it on the specific access interfaces that require it and leave it off globally rather than turning it on device-wide.
       audit: |-
         To verify that CDP is disabled globally:
 
@@ -1526,17 +1525,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that small servers (TCP and UDP) are disabled. Small servers such as echo, chargen, discard, and daytime are legacy diagnostic services that are rarely needed and can be exploited for denial-of-service attacks.
+        This check verifies that the legacy diagnostic services on the device are not answering.
+
+        The small servers are echo, discard, daytime and chargen, controlled on IOS-XR by `service ipv4 tcp-small-servers`, `service ipv4 udp-small-servers` and their IPv6 equivalents. Each carries a maximum server count, and removing them with the `no` form and a `commit` drives that count to zero. The check requires a maximum server count of zero for every small-server service.
 
         **Why this matters**
 
-        Small servers expose unnecessary network services that increase the attack surface. If small servers are enabled:
+        Chargen over UDP is a reflection amplifier. It answers a spoofed request with a stream of characters far larger than the request, so an attacker who forges a victim's address turns your router into a source of traffic aimed at someone else. Generating it also burns control-plane CPU on a device that has routing adjacencies to maintain, so the router degrades while being used as a weapon.
 
-        - They can be used as amplification vectors for DoS attacks.
-        - Legacy services may contain undiscovered vulnerabilities.
-        - Each enabled service increases the attack surface without providing operational value.
+        Echo and daytime provide an unauthenticated responder that confirms a live device and hints at what it is, useful to a scanner working out which addresses in a block are infrastructure.
 
-        Disabling small servers removes unnecessary services and reduces the attack surface.
+        None of these services have an operational purpose on a modern network. They date from an era of small trusted networks, so removing them costs nothing.
+
+        Confirm the change actually committed. Staged configuration is discarded if you leave configuration mode without a `commit`, and the services keep running.
       audit: |-
         To verify that small servers are disabled:
 
@@ -1592,17 +1593,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all VTY line templates are configured to allow only SSH as the transport input protocol. Telnet transmits all data including credentials in clear text, making it unsuitable for management access.
+        This check verifies that remote management sessions can arrive only over an encrypted transport.
+
+        IOS-XR configures terminal access through line templates rather than a numbered VTY range. `transport input ssh` under `line default`, or under a named `line template`, states which protocols that template accepts inbound. The change is staged until `commit`. The check requires every template serving VTY sessions to accept SSH and to refuse telnet.
 
         **Why this matters**
 
-        Telnet on VTY lines exposes management traffic to interception. If telnet is allowed:
+        Telnet carries the whole session in clear text, including the username and password typed at the start. An attacker able to observe management traffic anywhere along its path, from a span port, a compromised intermediate switch, or an inter-site link, reads the credential without transmitting a packet and leaves no trace of having done so.
 
-        - All management sessions including usernames and passwords are transmitted unencrypted.
-        - Active sessions can be hijacked through TCP session hijacking.
-        - Compliance with standards requiring encrypted management interfaces cannot be met.
+        The session is modifiable in flight as well. There is no integrity protection, so an attacker on the path can inject commands into an administrator's authenticated session, and on a router those commands run with whatever task groups that operator holds.
 
-        Restricting VTY transport to SSH only ensures that all remote management sessions are encrypted.
+        Because the credentials taken this way belong to the management plane, the outcome is not one compromised host but the ability to reroute, mirror or drop traffic for everything behind the device.
+
+        Removing telnet cuts off anyone still relying on it. Stage the change with `commit confirmed`, verify a fresh SSH session works, and only then run the final `commit`.
       audit: |-
         To verify that VTY line templates accept only SSH transport:
 
@@ -1664,17 +1667,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all VTY line templates have access control lists (ACLs) applied to restrict which IP addresses can establish remote management sessions. Without ACLs on VTY lines, any host with network connectivity can attempt to connect.
+        This check verifies that remote management sessions are accepted only from the addresses you designate.
+
+        An IOS-XR line template applies an inbound filter with `access-class ingress <acl-name>`, referencing a list built with `ipv4 access-list`. Under `line default` it governs every VTY session that template serves. Both the list and the template change stage in configuration mode until `commit`. The check requires an access class on every template serving VTY sessions.
 
         **Why this matters**
 
-        VTY lines without ACLs are open to connection attempts from any source. If ACLs are not configured:
+        Without one, the SSH port is reachable from everywhere the device's addresses are routable, and every host in that set can attempt authentication. That is what credential stuffing against network devices depends on: one password leaked from an old configuration backup, tried against the whole estate from anywhere.
 
-        - Any host on the network can attempt brute-force attacks against the device's authentication.
-        - The device is exposed to unauthorized access from untrusted networks.
-        - Management access cannot be restricted to authorized management stations.
+        The attempts cost something even when they fail. Each is handled by the route processor, and a sustained flood against SSH consumes control-plane CPU on the same processor that maintains routing adjacencies.
 
-        Applying ACLs to VTY lines ensures that only authorized management stations can establish remote sessions.
+        An access class also narrows who can exploit a future defect in the management path. These devices are patched rarely and stay in service for a decade, so a vulnerability disclosed in year three is often still present in year eight, and the filter keeps it unreachable.
+
+        Verify the list contains the address you are connected from and apply it with `commit confirmed`, so a mistake rolls back on its own instead of needing a console visit.
       audit: |-
         To verify that VTY line templates have ACLs applied:
 
@@ -1745,17 +1750,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all BGP neighbors have MD5 authentication configured. BGP session authentication prevents unauthorized peers from injecting routes or disrupting routing.
+        This check verifies that BGP sessions authenticate the peer before exchanging routes.
+
+        `password clear <value>` under a `neighbor` inside `router bgp` enables TCP MD5 authentication for that session, signing each TCP segment with a shared key that both ends must configure identically. The change is staged in configuration mode and takes effect at `commit`. The check requires every configured BGP neighbor to have a password.
 
         **Why this matters**
 
-        Without BGP authentication, an attacker can establish a rogue BGP session and inject malicious routes. If BGP neighbor authentication is not configured:
+        An unauthenticated BGP session will accept a TCP connection from anything that reaches port 179 with the expected source address and AS number. An attacker who achieves that, or who can spoof it, brings the session up and advertises prefixes that pull traffic through infrastructure they control, which is route hijacking performed from inside your own peering rather than from a distant network.
 
-        - An attacker can establish unauthorized BGP peering sessions.
-        - Malicious routes can be injected, causing traffic to be redirected or black-holed.
-        - BGP sessions can be disrupted through TCP reset attacks.
+        Even without establishing a session, an off-path attacker who guesses the connection four-tuple and a plausible sequence number can reset an existing one. Repeated resets cause route flapping, and dampening then withdraws the affected prefixes for far longer than the attack itself lasted, converting a spoofing attempt into an outage.
 
-        Configuring authentication on all BGP neighbors ensures that only authorized peers can establish sessions.
+        MD5 here is a floor rather than a strong algorithm. Prefer the TCP Authentication Option where both peers support it.
+
+        Adding a key resets the session and stops traffic through that peer until both sides match, so coordinate with the peer operator and use a maintenance window.
       audit: |-
         To verify that BGP neighbors have authentication configured:
 
@@ -1812,17 +1819,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all OSPF areas have authentication configured using either a key chain or message digest. OSPF authentication prevents unauthorized routers from injecting routes into the routing domain.
+        This check verifies that routers must prove their identity before they can join the interior routing domain.
+
+        IOS-XR authenticates OSPF through a key chain applied with `authentication keychain <name>` under an `area`, or through a message digest key. The key chain is built with `key chain`, a `key-string`, a `cryptographic-algorithm`, and send and accept lifetimes. All of it stages in configuration mode and applies at `commit`. The check requires every configured area to carry a key chain or a message digest key.
 
         **Why this matters**
 
-        Without OSPF authentication, any device on the network segment can participate in OSPF routing. If OSPF authentication is not configured:
+        Without authentication, any device that can send OSPF hellos on a participating segment forms an adjacency. There is no registration step and no operator approval, so a host plugged into the wrong port, or an attacker who has compromised a server on a routed VLAN, becomes a router as far as the topology is concerned.
 
-        - Rogue routers can inject false routes, causing traffic to be redirected.
-        - OSPF adjacencies can be disrupted, causing network outages.
-        - An attacker can perform man-in-the-middle attacks by advertising routes through their device.
+        From there it advertises a low-cost path to a prefix it does not own and receives the traffic for it, a machine-in-the-middle across an entire subnet obtained without touching any endpoint. Advertising and withdrawing links instead drives constant recomputation, and because OSPF reconverges the whole area on every change, modest forged flooding disrupts routing far beyond the attacker's segment.
 
-        Configuring OSPF area authentication ensures that only authorized routers can participate in the OSPF routing domain.
+        Prefer HMAC-SHA-256 where the release supports it and treat MD5 as the floor. Authentication must match on every router in the area, so stage it across all of them in one maintenance window or the adjacencies you are protecting will drop.
       audit: |-
         To verify that OSPF areas have authentication configured:
 

--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cisco-nxos-security
     name: Mondoo Cisco NX-OS Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -127,17 +127,17 @@ queries:
       cisco.nxos.ssh.algorithm.in(["rsa", "ecdsa"])
     docs:
       desc: |
-        This check verifies that the SSH key uses a strong algorithm such as RSA or ECDSA. DSA keys are considered cryptographically weak and should not be used.
+        This check verifies that the host key protecting remote administrative sessions is built on a cryptographically sound algorithm.
+
+        NX-OS ships with SSH enabled by default, so the host key is in service from the moment the switch has a management address, whether or not anyone reviewed it. The key comes from `ssh key rsa 2048` or `ssh key ecdsa 256`, and since it cannot be replaced while the daemon runs, regeneration means `no feature ssh`, the new `ssh key` command, then `feature ssh`. This check requires RSA or ECDSA and fails a DSA key.
 
         **Why this matters**
 
-        The SSH key algorithm determines the cryptographic strength of SSH sessions. If a weak algorithm like DSA is used:
+        DSA on NX-OS is capped at 1024 bits, which is within reach of well funded attackers. Worse, a DSA signature leaks the private key outright if the per-signature random value is ever reused or partially predictable, a failure mode that has recovered real keys from real devices.
 
-        - The SSH host key is more vulnerable to compromise.
-        - Compliance with modern cryptographic standards cannot be met.
-        - Clients configured to reject weak algorithms cannot connect.
+        Recovering the host key lets an attacker impersonate the switch. They answer the operator's SSH connection with the stolen key, trigger no warning, capture the TACACS+ or local password typed into the prompt, and relay the session onward so the operator sees a normal login.
 
-        Using RSA or ECDSA ensures SSH sessions are protected with strong cryptographic algorithms.
+        Modern OpenSSH clients also refuse `ssh-dss` unless it is re-enabled by hand, so a DSA key usually breaks automation before anyone notices it is weak. Regeneration drops every session, so keep console access available.
       audit: |-
         To verify that the SSH key uses a strong algorithm:
 
@@ -208,16 +208,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that RSA SSH keys have a modulus of at least 2048 bits. Keys smaller than 2048 bits are considered cryptographically weak.
+        This check verifies that the RSA host key used for SSH is long enough to resist factoring.
+
+        Key length is fixed at generation time by `ssh key rsa 2048` or a larger modulus and cannot be extended in place. NX-OS accepts moduli well below 2048 bits, and switches commissioned years ago often still carry a 1024-bit key produced by the initial setup script. This check applies only when the algorithm is RSA and requires at least 2048 bits.
 
         **Why this matters**
 
-        RSA keys with fewer than 2048 bits can be factored with current computing resources. If the key size is insufficient:
+        Public factoring efforts have broken 768-bit RSA, and 1024 bits is widely treated as within reach of state-level resources. A switch installed in 2016 and still forwarding production traffic today has given an adversary a decade of improving hardware against a key that never changed.
 
-        - The SSH host key can potentially be compromised.
-        - Compliance with NIST and other standards requiring minimum 2048-bit keys cannot be met.
+        An attacker who factors the host key never has to touch the switch again. They sit on the management path, answer as the switch, present the correct fingerprint so no client warning appears, harvest the administrator password, and pass the session through to the real device.
 
-        Using RSA keys of at least 2048 bits ensures adequate cryptographic strength for SSH sessions.
+        Replacing the key requires `no feature ssh`, then `ssh key rsa 2048 force`, then `feature ssh`, which disconnects every SSH session including your own. Run it from the console and expect every client to report a changed host key.
       audit: |-
         To verify the SSH RSA key modulus size:
 
@@ -278,17 +279,17 @@ queries:
       cisco.nxos.sshLoginAttemptsLimit <= 3
     docs:
       desc: |
-        This check verifies that the SSH login attempts limit is configured to restrict the number of failed authentication attempts. The limit should be 3 or fewer to mitigate brute-force attacks.
+        This check verifies that the SSH server allows only a small number of password guesses per connection.
+
+        `ssh login-attempts` sets how many authentication failures NX-OS tolerates inside a single SSH connection before it drops the session. The NX-OS default is 3, which passes. This check requires a value of at least 1 and no more than 3, so a value of 0, which removes the limit, and any value above 3 both fail.
 
         **Why this matters**
 
-        Without a login attempts limit, attackers can make unlimited authentication attempts. If the limit is not configured:
+        Password guessing against a switch is cheap and nearly free of consequence. What costs the attacker time is the TCP handshake and key exchange for each connection, and a generous per-connection allowance amortizes that cost across many guesses. A low limit removes exactly that economy.
 
-        - Brute-force password attacks can proceed indefinitely.
-        - Dictionary attacks against user accounts are not throttled.
-        - The device is more susceptible to credential-guessing attacks.
+        The wordlists used against network gear are short and effective. They lead with vendor defaults and with the account names that accumulate on switches over the years, so a run that gets ten guesses per connection often succeeds where a run limited to three does not.
 
-        Configuring an SSH login attempts limit slows down brute-force attacks.
+        A per-connection cap does nothing against an attacker who simply reconnects, so treat it as one half of the control. Pair it with the login blocking covered by a companion check in this policy, which enforces a lockout across connections, and with an inbound access class on the VTY lines.
       audit: |-
         To verify that an SSH login attempts limit is configured:
 
@@ -342,18 +343,17 @@ queries:
       cisco.nxos.runAaaAuthenticationLogin.length > 0
     docs:
       desc: |
-        This check verifies that AAA authentication login method lists are configured. AAA authentication enables centralized identity management through TACACS+ or RADIUS servers.
+        This check verifies that logins are authenticated against a centrally managed identity source rather than only the switch's own user database.
+
+        `aaa authentication login default group <server-group> local` points the default method list at a TACACS+ or RADIUS server group and keeps the local database as a fallback. This check requires at least one `aaa authentication login` method list to be present.
 
         **Why this matters**
 
-        Without AAA authentication configured, the device relies solely on local credentials. If AAA is not configured:
+        Local accounts on a data center switch are the accounts nobody deprovisions. An engineer leaves, the identity provider disables their corporate account within the hour, and the `username` entry survives untouched in the running configuration of forty Nexus switches. Stale network device credentials have been a repeated entry point in state-sponsored campaigns against Cisco infrastructure precisely because nothing expires them.
 
-        - Centralized identity management cannot be leveraged.
-        - User authentication is not enforced consistently across the network.
-        - Audit trails for authentication events are incomplete.
-        - Compliance with security frameworks requiring centralized authentication cannot be met.
+        Central authentication also produces the record local login cannot. TACACS+ logs the identity behind each session and, with command accounting, each command typed, so a change is attributable to a person rather than a shared account.
 
-        Configuring AAA authentication login ensures centralized, scalable authentication.
+        Configure this defensively, because it can lock operators out. If the method list names only servers that become unreachable, nobody logs in and recovery means a password recovery procedure at the console. Keep `local` as the final method and set `aaa authentication login console local`.
       audit: |-
         To verify that AAA authentication login method lists are configured:
 
@@ -415,16 +415,17 @@ queries:
       cisco.nxos.runAaaGroupsServerRadius.length > 0
     docs:
       desc: |
-        This check verifies that at least one AAA group server (TACACS+ or RADIUS) is configured. AAA group servers define the external authentication servers used for centralized identity management.
+        This check verifies that the switch actually has an external authentication server group to send login requests to.
+
+        A method list is only a pointer. The group behind it is built by enabling `feature tacacs+`, defining the servers, and grouping them with `aaa group server tacacs+ <group-name>`, or by using the predefined `radius` group that holds all globally configured RADIUS servers. This check passes when at least one TACACS+ or RADIUS server group exists.
 
         **Why this matters**
 
-        Without AAA group servers, the device cannot delegate authentication to centralized servers. If no group servers are configured:
+        NX-OS rejects every TACACS+ command while the feature is disabled, so half-finished rollouts are common here. The result is a switch whose method list references a group that was never created. Authentication silently falls through to the local database while a configuration review sees the method list and concludes the device is centrally managed.
 
-        - Authentication fallback to centralized servers is not possible.
-        - Centralized user management, access control, and auditing cannot be implemented.
+        That gap matters most during an incident. The account you believe was revoked in the identity provider still works on the switch, and the accounting trail you expect to reconstruct the change from was never produced, because no server ever received the requests.
 
-        Configuring AAA group servers enables centralized authentication and authorization.
+        Define more than one server in the group, since a single authentication server turns a routine reboot into a fleet-wide login outage, and place the servers in the management VRF so authentication does not depend on the routed data path.
       audit: |-
         To verify that AAA group servers are configured:
 
@@ -485,17 +486,17 @@ queries:
       cisco.nxos.passwordStrengthCheck == true
     docs:
       desc: |
-        This check verifies that password strength checking is enabled. When enabled, NX-OS validates that passwords meet minimum complexity requirements before accepting them.
+        This check verifies that the switch refuses a weak password at the moment an operator tries to set one.
+
+        `password strength-check` turns on the built-in NX-OS validator, which rejects a new password that is shorter than eight characters, that lacks an uppercase letter, a lowercase letter, a digit, or a special character, that repeats characters consecutively, or that is a recognizable dictionary word. This check requires the feature to be enabled.
 
         **Why this matters**
 
-        Without password strength checking, users can set weak or trivially guessable passwords. If strength checking is disabled:
+        With the validator off, NX-OS accepts anything, and the passwords that end up on switches are the ones typed during a late build window: the hostname, the site code, the vendor name with a digit appended. Those lead every wordlist aimed at network gear.
 
-        - Short or simple passwords can be configured.
-        - Common dictionary words can be used as passwords.
-        - The overall security posture of the device is weakened.
+        Enforcement at the point of entry carries more weight on a switch than on a server, because there is no password expiry driving a later correction and no endpoint agent to flag the weak value afterward. Whatever is set during the build is very likely still set five years later.
 
-        Enabling password strength checking ensures all passwords meet minimum complexity requirements.
+        Note the limit. The validator runs only when a password is set, so existing accounts keep whatever they have until each is reset. Do that sweep after enabling it, and pair it with the minimum passphrase length enforced by a companion check in this policy.
       audit: |-
         To verify that password strength checking is enabled:
 
@@ -550,17 +551,17 @@ queries:
       cisco.nxos.encryptionService.masterKeyConfigured == true
     docs:
       desc: |
-        This check verifies that the encryption service is enabled with a master key configured. The encryption service provides Type 6 AES encryption for passwords stored in the configuration, replacing weak Type 7 encryption.
+        This check verifies that secrets stored in the configuration are protected by a device master key rather than a reversible encoding.
+
+        NX-OS Type 6 encryption applies AES to stored secrets using a master key deliberately kept outside the configuration file. `key config-key ascii` prompts for that key interactively, and `feature password encryption aes` moves the supported secrets, notably RADIUS and TACACS+ shared keys, to Type 6. This check requires both the service enabled and a master key present.
 
         **Why this matters**
 
-        Without the encryption service, passwords in the configuration are protected only by easily reversed Type 7 encryption. If the encryption service is not enabled:
+        The TACACS+ shared key is the highest value secret on the switch. Anyone holding it decrypts captured TACACS+ traffic, which carries the credentials of every administrator who logged in through it and every command they ran. It also lets them stand up a server the switch trusts for authentication decisions.
 
-        - RADIUS and TACACS+ shared secrets are inadequately protected.
-        - An attacker with configuration access can decode all Type 7 passwords.
-        - Compliance with encryption requirements cannot be met.
+        Without Type 6, those keys sit in the running configuration as Type 7 strings. Type 7 is a published XOR against a fixed key with decoders freely available for over twenty years. Configurations travel constantly: nightly TFTP backups, ticket attachments, vendor support cases, configuration management repositories. Every copy is a credential store.
 
-        Enabling the encryption service with a master key ensures strong AES encryption for stored passwords.
+        Treat the master key as a separate secret with its own custody. It is not written to the configuration and not carried by `copy running-config startup-config`, so restoring onto a replacement supervisor means setting it first or re-entering every secret by hand.
       audit: |-
         To verify that the encryption service is enabled with a master key:
 
@@ -623,17 +624,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that all local user accounts have encrypted credentials. Credentials stored with encryption type 0 (clear text) are visible in the device configuration.
+        This check verifies that no local account stores its password in readable form.
+
+        When an operator runs `username <user> password <password> role <role>`, the password is typed in the clear and NX-OS hashes it before writing the line. A credential with encryption type 0 is stored as literal text instead, which happens when a line already carrying a type 0 marker is pasted in or written by provisioning tooling. This check requires every local credential to use a type other than 0.
 
         **Why this matters**
 
-        Clear-text credentials in the configuration are exposed to anyone who can view it. If credentials are not encrypted:
+        A type 0 password is a live credential in every place the configuration ends up. That is the nightly backup share, the diff attached to a change ticket, the git repository the network team uses for configuration drift, and the text file an engineer saved while troubleshooting. Read access to any one of them is enough.
 
-        - Passwords are visible in plain text in show commands and configuration backups.
-        - An attacker with read access to the configuration obtains all credentials.
-        - Configuration files in version control or backups expose passwords.
+        Network credentials are also reused across the fleet more often than any team admits, so one type 0 line frequently yields the `network-admin` password that works on every switch in the data center.
 
-        Ensuring all users have encrypted credentials protects them from exposure.
+        Editing the stored string does not fix it. The encryption type only changes when the password is set again, so reset the affected accounts with a fresh strong password, verify with `show running-config | include ^username`, and persist with `copy running-config startup-config`.
       audit: |-
         To verify that all local users have encrypted credentials:
 
@@ -693,17 +694,17 @@ queries:
       cisco.nxos.passphraseLength.minLength >= 8
     docs:
       desc: |
-        This check verifies that the minimum passphrase length is set to at least 8 characters. Short passwords are significantly easier to crack through brute-force or dictionary attacks.
+        This check verifies that a floor is enforced on how short a local account password may be.
+
+        `userpassphrase min-length` sets that floor, and it is normally paired with an upper bound, as in `userpassphrase min-length 15 max-length 127`. NX-OS applies it when a password is set, refusing anything shorter. This check requires a configured minimum of at least 8 characters.
 
         **Why this matters**
 
-        Without an adequate minimum length, users can create trivially short passwords. If the minimum length is too low:
+        Length is the one password property that reliably costs an attacker time. Character classes and substitutions barely slow a modern cracking rig, but each additional character multiplies the search space. An eight character password recovered from a captured hash falls in hours on commodity GPUs; a fifteen character one does not fall at all by that route.
 
-        - Short passwords are vulnerable to brute-force attacks.
-        - Password security policies cannot be enforced.
-        - Compliance with password length requirements cannot be met.
+        Online guessing against the switch matters more day to day, and short passwords lose there too, because a password short enough to be typed quickly at a console is usually one memorable enough to appear in a wordlist.
 
-        Setting a minimum passphrase length of at least 8 characters (15+ recommended) ensures passwords have adequate complexity.
+        Eight is the floor this check enforces, not the number to configure. Fifteen or more is the sensible setting for a device whose accounts are rarely rotated and whose lifetime is measured in years. Pair it with `password strength-check`, which covers composition rather than length, and remember that the limit binds only on passwords set after it is configured, so existing short passwords need an explicit reset.
       audit: |-
         To verify that the minimum passphrase length is configured:
 
@@ -758,17 +759,17 @@ queries:
       cisco.nxos.systemLogin.attempts > 0
     docs:
       desc: |
-        This check verifies that the system login block feature is configured to temporarily block login attempts after a series of failures. This mitigates brute-force attacks by introducing a lockout period.
+        This check verifies that repeated failed logins temporarily shut an attacker out of the device.
+
+        `system login block-for 60 attempts 3 within 60` puts NX-OS into quiet mode, refusing further login attempts for sixty seconds once three failures occur inside a sixty second window. `system login quiet-mode access-class` names an ACL of hosts that remain permitted while quiet mode is active. This check requires both a non-zero block period and a non-zero attempt count.
 
         **Why this matters**
 
-        Without login blocking, attackers can make unlimited rapid authentication attempts. If login blocking is not configured:
+        A per-connection attempt cap barely slows a password guesser, because reconnecting resets the count. Quiet mode attacks the reconnect itself, and that changes the arithmetic completely: a rate of thousands of guesses per hour drops to a handful per minute, which is the difference between a wordlist finishing overnight and never finishing at all.
 
-        - Brute-force attacks proceed without any throttling.
-        - Automated credential-guessing tools can operate at full speed.
-        - The device is more susceptible to password-cracking attacks.
+        It also converts a quiet attack into a loud one. The transition into quiet mode is a distinct syslog event, so a brute-force attempt that would otherwise blend into ordinary failed-login noise becomes a single alertable message on the collector.
 
-        Configuring system login blocking introduces a delay after failed attempts, significantly slowing brute-force attacks.
+        Quiet mode blocks everyone it applies to, including you, which an attacker can trigger deliberately to keep operators off the switch during a larger action. Configure `system login quiet-mode access-class` to exempt your management subnet, keep console access available, and save the configuration with `copy running-config startup-config`.
       audit: |-
         To verify that the system login block feature is configured:
 
@@ -831,17 +832,19 @@ queries:
       cisco.nxos.ntp.servers.length > 0
     docs:
       desc: |
-        This check verifies that at least one NTP server is configured. Accurate time synchronization is essential for log correlation, certificate validation, and security event analysis.
+        This check verifies that the switch keeps its clock synchronized to an authoritative time source.
+
+        `ntp server <address> use-vrf management` points the switch at a time server reachable over the management VRF, which keeps synchronization independent of the routed data path. This check requires at least one NTP server to be configured.
 
         **Why this matters**
 
-        Without NTP servers, the device clock drifts over time. If NTP is not configured:
+        A Nexus switch that was never given a time source free-runs from whatever the clock held at boot. The drift is slow enough to go unnoticed and large enough to matter, and it degrades every syslog line the switch emits and every accounting record it sends to TACACS+.
 
-        - Log timestamps are inaccurate, making incident investigation unreliable.
-        - Certificate expiration checks may malfunction.
-        - Event correlation across devices is impossible.
+        Correlation is most of the work during an incident, and correlation is what a wrong clock destroys. When the switch reports an interface event at 03:14 and the firewall reports the connection at 03:31, there is no way to establish which caused which, and the timeline that would have identified the entry point never assembles.
 
-        Configuring NTP servers ensures accurate, synchronized time.
+        Time also gates certificate validation, so a switch running a year behind will happily accept a certificate that expired months ago.
+
+        Configure more than one server, and consider `ntp authenticate` with `ntp authentication-key` and `ntp trusted-key` so an attacker on the management segment cannot move the clock and reshape the evidence.
       audit: |-
         To verify that NTP servers are configured:
 
@@ -896,16 +899,17 @@ queries:
       cisco.nxos.clock.timezone != ""
     docs:
       desc: |
-        This check verifies that a timezone is configured on the device. A properly configured timezone ensures log timestamps are meaningful and correlate correctly with events in other systems.
+        This check verifies that the switch stamps its output with a declared, unambiguous local time reference.
+
+        `clock timezone EST -5 0` names the zone and its offset from UTC, and `clock summer-time` handles seasonal adjustment where it applies. This check requires a timezone to be configured.
 
         **Why this matters**
 
-        Without a timezone configured, log timestamps default to UTC which may not align with local operations. If the timezone is not set:
+        With no timezone set, the switch reports time with no zone the reader can rely on, and the assumption each person makes about that value differs. The operator reading `show logging` at the console assumes local time. The analyst reading the same event on the collector assumes UTC. One of them is wrong by several hours and neither knows it.
 
-        - Log analysis is complicated by unclear time references.
-        - Correlation with physical events or local schedules is difficult.
+        That cost lands exactly when time is most expensive. Reconstructing an intrusion means aligning switch events against firewall logs, badge records, and change tickets, and an unlabeled hour of skew is enough to place the switch event on the wrong side of the change that caused it.
 
-        Configuring the timezone ensures timestamps are clear and operationally relevant.
+        Fleet consistency matters more than the specific zone. Standardizing on UTC across every device is a perfectly good answer, and so is local time, but it needs to be the configured answer rather than the absence of one. Apply the same choice everywhere, and save it with `copy running-config startup-config` so a reload does not quietly revert one switch out of forty.
       audit: |-
         To verify that a timezone is configured:
 
@@ -960,17 +964,19 @@ queries:
       cisco.nxos.logging.remoteServers.length > 0
     docs:
       desc: |
-        This check verifies that remote logging is enabled and at least one remote syslog server is configured. Sending logs to a remote server preserves data even if the device is compromised.
+        This check verifies that the switch's log stream is copied off the box as it is produced.
+
+        `logging server <syslog-server-ip> 6 use-vrf management` sends messages at the chosen severity to a collector over the management VRF. This check requires remote logging to be enabled and at least one server to be configured.
 
         **Why this matters**
 
-        Logs stored only on the device are vulnerable to loss or tampering. If remote logging is not configured:
+        The on-box log is memory. It is bounded, it wraps under any real volume, and it is gone at reload, so a switch that logs only locally has an evidence window of hours and nothing at all after the reboot that so often follows an incident.
 
-        - Logs are lost when the device reboots.
-        - An attacker who compromises the device can erase local logs.
-        - Centralized log correlation and SIEM integration is not possible.
+        It is also fully under the control of whoever holds the switch. An attacker with `network-admin` runs `clear logging logfile` and the record of how they arrived disappears. Implant campaigns against Cisco network devices have gone further and modified the device so that it stops reporting the attacker's own activity, which is only detectable when an off-box copy exists to compare against.
 
-        Configuring remote logging ensures logs are preserved centrally.
+        Off-box logs are the one record the intruder on the switch cannot edit after the fact, which is what makes them the record worth having.
+
+        Send to a collector reachable in the management VRF so logging survives the data plane problems you most want logged, and alert on a switch that stops reporting.
       audit: |-
         To verify that remote logging servers are configured:
 
@@ -1026,16 +1032,17 @@ queries:
       cisco.nxos.logging.timestampFormat == "MicroSeconds"
     docs:
       desc: |
-        This check verifies that logging timestamps use millisecond or microsecond precision. Higher precision timestamps improve the accuracy of log correlation and forensic analysis.
+        This check verifies that log entries carry enough timestamp precision to order events that occur close together.
+
+        `logging timestamp milliseconds` raises the resolution of syslog timestamps from the NX-OS default of whole seconds. Microsecond resolution is also available. This check passes on millisecond or microsecond precision and fails on second-level timestamps.
 
         **Why this matters**
 
-        Second-level timestamps may not provide sufficient granularity for correlating events. If timestamps lack precision:
+        A switch produces its most important output in bursts. A single link failure emits interface down, protocol adjacency loss, MAC table churn, and route withdrawal within the same second. At second resolution all of those lines carry an identical timestamp and land in whatever order the collector happened to write them.
 
-        - Events occurring within the same second cannot be properly ordered.
-        - Forensic analysis of rapid event sequences is impaired.
+        In an investigation the ordering is the finding. Whether the ACL change preceded the traffic or followed it, whether the adjacency dropped before or after the interface, whether the spanning tree topology change caused the MAC moves or resulted from them: each of those questions is answered by sequence, and second-level stamps discard the sequence exactly where the events cluster.
 
-        Configuring millisecond or microsecond timestamps ensures precise event ordering.
+        Precision is not accuracy. Millisecond timestamps on a switch with no time source are precisely wrong, so treat this as one half of a pair with the NTP requirement enforced by a companion check in this policy. Set it in configuration mode and persist it with `copy running-config startup-config`.
       audit: |-
         To verify that logging timestamps use high precision:
 
@@ -1089,17 +1096,17 @@ queries:
       cisco.nxos.logging.srcInterfaceName != ""
     docs:
       desc: |
-        This check verifies that a source interface is configured for logging. Setting a consistent source interface ensures that syslog messages always originate from the same IP address, simplifying log management and ACL configuration on syslog servers.
+        This check verifies that syslog messages always leave the switch from one predictable address.
+
+        `logging source-interface mgmt0` pins the source address of outbound syslog to a chosen interface. Without it, NX-OS sources each message from whichever interface the route to the collector happens to select, and a Nexus switch typically owns many addresses across SVIs, loopbacks, and the management port. This check requires a source interface to be set.
 
         **Why this matters**
 
-        Without a source interface, syslog messages may originate from different IP addresses depending on the routing path. If the source interface is not set:
+        A collector identifies a device by the address the messages arrive from. When a routing change or a management path failover shifts that address, the same switch begins reporting as a new host. Its parsers do not match, its alert rules do not fire, and the historical timeline for that switch simply stops, which is the moment an operator is most likely to conclude the device is quiet and therefore healthy.
 
-        - Syslog server ACLs must permit multiple source addresses.
-        - Log correlation by source IP is unreliable.
-        - Syslog messages may be dropped if the egress interface changes.
+        The sharper failure is silent loss. Syslog collectors are normally restricted to a list of known senders, so messages arriving from an unexpected address are dropped at the collector's filter. The switch reports nothing wrong, because syslog over UDP is never acknowledged.
 
-        Configuring a source interface ensures consistent, reliable log delivery.
+        Choose an interface that stays up independently of the data path, typically `mgmt0` or a loopback, make sure the collector permits that address, and confirm the switch is still landing in the collector after the change rather than assuming it.
       audit: |-
         To verify that a logging source interface is configured:
 
@@ -1154,17 +1161,19 @@ queries:
       cisco.nxos.snmp.communities.none(name == "private")
     docs:
       desc: |
-        This check verifies that the default SNMP community strings "public" and "private" are not in use. These well-known defaults are the first values attackers try.
+        This check verifies that the switch does not answer to the SNMP community strings every scanner tries first.
+
+        Community strings are removed with `no snmp-server community public` and `no snmp-server community private` and replaced with an unpredictable value scoped to a role, as in `snmp-server community <unique-string> group network-operator`. This check fails when a community named `public` or `private` exists.
 
         **Why this matters**
 
-        Default SNMP community strings are universally known and actively scanned for. If defaults are used:
+        SNMP v1 and v2c carry the community string in the clear over UDP, and `public` and `private` are the values every vendor documents. Scanners test them continuously, so a switch left with defaults is found automatically rather than targeted.
 
-        - Anyone can read device data using "public".
-        - "private" may allow unauthorized configuration changes.
-        - Automated scanning tools will immediately exploit default strings.
+        Read access alone maps the environment. A walk with `public` returns the interface inventory, ARP and MAC tables, routing neighbors, and the running software version with its known vulnerabilities, which is often enough to fingerprint the whole fabric from one device.
 
-        Removing default community strings ensures SNMP access is properly restricted.
+        Write access through `private` is direct control. An attacker changes configuration through SNMP, and on Cisco platforms can drive a configuration copy to a TFTP server they operate, which hands them the full running configuration including the credentials in it.
+
+        Renaming the community is not the fix, only the first step. The replacement string still crosses the wire in plaintext, so restrict it with an ACL and move monitoring to SNMPv3 with enforced privacy, both covered by companion checks in this policy.
       audit: |-
         To verify that default SNMP community strings are not in use:
 
@@ -1220,17 +1229,19 @@ queries:
       cisco.nxos.snmp.settings.encryptionEnforced == true
     docs:
       desc: |
-        This check verifies that SNMPv3 encryption is enforced globally for all SNMP users. Enforcing encryption ensures that all SNMP communications use authentication and privacy (encryption).
+        This check verifies that every SNMPv3 user is required to authenticate and encrypt, with no per-user exception.
+
+        SNMPv3 users are created individually, as in `snmp-server user <username> network-operator auth sha <auth-password> priv aes-128 <priv-password>`, and each one can be created without privacy. `snmp-server globalEnforcePriv` makes encryption mandatory across all of them. This check requires that global enforcement to be in place.
 
         **Why this matters**
 
-        Without global encryption enforcement, individual SNMP users may be configured without encryption. If encryption is not enforced:
+        SNMPv3 offers three levels of protection and only the strongest encrypts the payload. Leaving the choice to each user definition means the security of the whole management interface is set by whichever user was created most carelessly, usually the one added quickly to onboard a new monitoring tool.
 
-        - SNMP credentials and data can be transmitted in clear text.
-        - Individual users may accidentally be configured without encryption.
-        - Compliance with standards requiring encrypted management protocols cannot be met.
+        An unencrypted SNMPv3 session is readable by anyone on the management path. The walk itself is the reconnaissance prize: interface inventory, address assignments, neighbor relationships, and platform versions, delivered in clean structured form.
 
-        Enforcing SNMPv3 encryption globally ensures all SNMP communications are authenticated and encrypted.
+        The authentication digest travels with those packets too, so a captured session also gives the attacker material for an offline attack against the user's authentication password, and a recovered password is reusable against every switch that shares it.
+
+        Inventory your pollers before enabling this. Any SNMPv3 user defined without a privacy password stops working immediately, and monitoring that still relies on v2c community strings should be migrated to SNMPv3 first rather than discovered as an outage.
       audit: |-
         To verify that SNMPv3 encryption is enforced globally:
 
@@ -1293,16 +1304,17 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all SNMP community strings have IPv4 or IPv6 ACLs applied to restrict which hosts can query the device.
+        This check verifies that SNMP polling is accepted only from named management stations.
+
+        An ACL listing the authorized pollers is bound to each community with `snmp-server community <community> use-ipv4acl <acl>`, and the ACL must exist before it is referenced. This check requires every configured community to carry an IPv4 or IPv6 ACL, and passes on a switch that defines no communities at all.
 
         **Why this matters**
 
-        SNMP without ACL restrictions allows any network host to query the device. If ACLs are not applied:
+        A community string is a bearer token sent in cleartext UDP. Anyone who captures one packet on the management path holds it, and so does anyone who guesses a predictable value. Without an ACL, holding the string means querying the switch from anywhere that can route to it; with one, a stolen string is usable only from an address already inside your management network.
 
-        - Any device on the network can query SNMP data.
-        - Unauthorized SNMP polling exposes configuration and operational information.
+        What that query returns is worth protecting. A full walk yields the interface inventory, ARP and MAC tables, routing adjacencies, and the software version, which is the reconnaissance an attacker performs before choosing where to move next.
 
-        Applying ACLs restricts SNMP access to authorized management stations.
+        Be honest about the limit. UDP source addresses are spoofable and the string still crosses the wire in the clear, so treat this as a stopgap while SNMPv3 is rolled out. Enumerate every poller first, because any station left out loses visibility of the switch immediately.
       audit: |-
         To verify that SNMP communities have ACLs applied:
 
@@ -1361,17 +1373,19 @@ queries:
       cisco.nxos.boot.poapEnabled == false
     docs:
       desc: |
-        This check verifies that Power-On Auto Provisioning (POAP) is disabled. POAP automatically downloads and executes a configuration script when the switch boots without a startup configuration, which can be exploited to load a malicious configuration.
+        This check verifies that the switch will not fetch and execute a configuration script from the network when it boots without one.
+
+        Power-On Auto Provisioning is the NX-OS zero-touch build path. A Nexus switch that boots with no startup configuration broadcasts DHCP, takes a script and image location from the options it receives, downloads them, and runs the script with full administrative rights. `no boot poap enable` turns that off, and this check requires it disabled.
 
         **Why this matters**
 
-        POAP can be exploited if an attacker sets up a rogue DHCP/TFTP server on the network. If POAP is enabled:
+        The entire trust model is the DHCP server, and the switch trusts whichever server answers first. On a data center fabric that can be any host an attacker has already compromised, and winning a DHCP race against a distant server is not a difficult problem.
 
-        - An attacker can serve a malicious configuration or script to the device during boot.
-        - The device can be reconfigured without authentication during the provisioning process.
-        - A compromised device can be reprovisioned with an attacker-controlled configuration.
+        The window opens more often than teams expect. A supervisor replacement, an RMA unit racked from the shelf, or a `write erase` and reload during troubleshooting all leave the switch with no startup configuration and POAP ready to run.
 
-        Disabling POAP prevents unauthorized auto-provisioning during device boot.
+        The outcome is total, because the script runs as the switch's own provisioning process. It can install attacker accounts, point AAA at a server they operate, mirror a production VLAN to a port they can reach, or load an image of their choosing.
+
+        If you genuinely build with POAP, keep it enabled only through the build, then run `no boot poap enable` and `copy running-config startup-config` before the switch carries production traffic.
       audit: |-
         To verify that POAP is disabled:
 
@@ -1426,17 +1440,19 @@ queries:
       cisco.nxos.copp.profile != ""
     docs:
       desc: |
-        This check verifies that Control Plane Policing (CoPP) is configured with a profile other than "lenient." CoPP protects the control plane from denial-of-service attacks by rate-limiting traffic destined to the CPU.
+        This check verifies that traffic punted to the switch's supervisor CPU is rate limited by something tighter than the most permissive policy available.
+
+        Control Plane Policing classifies traffic destined for the CPU and polices each class. NX-OS offers strict, moderate, lenient, and dense profiles, normally chosen by the initial setup script and changeable later with `copp profile strict`. This check fails an empty profile and the lenient profile, so strict, moderate, and dense all pass.
 
         **Why this matters**
 
-        The "lenient" CoPP profile provides minimal protection. If the CoPP profile is too permissive:
+        The data plane of a Nexus switch forwards in hardware at line rate. The control plane is an ordinary CPU orders of magnitude slower, and everything punted to it competes for the same cycles: BGP keepalives, OSPF hellos, ARP resolution, and the SSH session an operator would use to intervene.
 
-        - The control plane is vulnerable to denial-of-service attacks.
-        - Excessive traffic can overwhelm the CPU, causing routing protocol failures.
-        - Management access may become unavailable during an attack.
+        An attacker does not need volume to reach that CPU, only the right packets. A stream with an expiring TTL, traffic toward unresolved addresses that forces ARP glean, or a flood of management protocol requests all bypass the hardware fast path by design.
 
-        Using a strict or moderate CoPP profile ensures the control plane is adequately protected.
+        When the CPU saturates, routing adjacencies time out first. The switch withdraws its routes, so the outage propagates well beyond the device under attack, and the management session you need for recovery is queued behind the flood.
+
+        Tightening the profile can drop traffic that was previously tolerated, so change it in a maintenance window and watch the per-class drop counters.
       audit: |-
         To verify that CoPP uses a non-lenient profile:
 
@@ -1492,17 +1508,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that VTY lines have an exec timeout configured to disconnect idle sessions. The exec timeout reduces the risk of unauthorized access through unattended terminals.
+        This check verifies that idle remote administrative sessions are closed rather than left open indefinitely.
+
+        `exec-timeout` under `line vty` sets the idle period in minutes after which NX-OS disconnects a session. The NX-OS default is 30 minutes, which passes. A value of 0 disables the timeout entirely and fails. Because the default is not printed in the abbreviated configuration, confirm the effective value with `show running-config all | section "line vty"`.
 
         **Why this matters**
 
-        Without an exec timeout, idle VTY sessions remain open indefinitely. If exec timeouts are not configured:
+        An abandoned VTY session is an authenticated shell with `network-admin` rights waiting on somebody's screen, meaning the ability to shut an uplink, add an SPAN session, or install an account with no further authentication.
 
-        - Forgotten sessions can be exploited by unauthorized users.
-        - Connection resources are consumed by idle sessions.
-        - Compliance requirements for session management cannot be met.
+        The realistic path is not a stranger at a desk. It is a jump host where the engineer stays logged in, a terminal multiplexer that survives the laptop closing, or a workstation compromised by unrelated malware, where the attacker inherits a live switch session rather than needing credentials at all.
 
-        Configuring exec timeouts on VTY lines ensures idle sessions are terminated.
+        Sessions also accumulate. NX-OS caps concurrent VTY sessions, and stale ones hold those slots, so the operator who needs to log in during an outage is refused.
+
+        Choose a value that fits real work rather than the smallest number available. Nine or ten minutes is common, while an aggressive timeout drops operators mid-change and invites keepalive workarounds that defeat the control.
       audit: |-
         To verify that VTY lines have an exec timeout configured:
 
@@ -1559,16 +1577,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that the console line has an exec timeout configured to disconnect idle sessions automatically.
+        This check verifies that a session left open on the physical console does not stay authenticated indefinitely.
+
+        `exec-timeout` under `line console` disconnects an idle console session after the configured number of minutes. The NX-OS default is 30 minutes and passes, while `exec-timeout 0` disables the timeout and fails. The default does not appear in the abbreviated configuration, so verify it with `show running-config all | section "line console"`.
 
         **Why this matters**
 
-        Without a console timeout, an idle session remains open indefinitely. If the timeout is not set:
+        The console is treated as physically trusted because reaching it needs a cable. In practice that cable usually terminates on a terminal server, which is itself a network device with its own management interface and its own weaknesses. An attacker who reaches it does not land at a login prompt, they land in whatever session was left running on the switch.
 
-        - An unattended console connection can be used for unauthorized changes.
-        - Physical access security requirements cannot be met.
+        Data center floors are not closed rooms either. Vendor engineers, cabling contractors, and colocation staff pass racks routinely, and a console left at a live prompt needs no credential at all.
 
-        Configuring a console exec timeout ensures idle console sessions are terminated.
+        The console is also where AAA fallback delivers a local login, which makes a stale session there a bypass of the entire management plane rather than one more way in.
+
+        Keep it short enough to matter but long enough for real console work, since the console is the recovery path you depend on if a VTY access class or an AAA change removes remote access.
       audit: |-
         To verify that the console line has an exec timeout configured:
 
@@ -1625,16 +1646,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that VTY lines have inbound ACLs configured to restrict which IP addresses can establish remote management sessions.
+        This check verifies that remote management sessions are accepted only from approved source addresses.
+
+        An inbound access class applied under `line vty`, as in `access-class VTY-MGMT in`, filters SSH connections before authentication is attempted. This check requires every VTY line to carry an inbound access class.
 
         **Why this matters**
 
-        VTY lines without ACLs allow connection attempts from any source. If ACLs are not configured:
+        Without one, the SSH daemon answers anything that can route to any address the switch owns, and a Nexus switch owns many: the management port, every loopback, and an address on every SVI it routes for. A switch acting as default gateway for a server VLAN therefore offers its management plane to every host in that VLAN, including a compromised application server.
 
-        - Any host can attempt brute-force attacks against the device.
-        - Management access cannot be restricted to trusted networks.
+        Filtering ahead of authentication also removes the switch from opportunistic target lists. Password guessing stops at the ACL rather than the login prompt, and a flaw in the SSH implementation itself is unreachable from an address that never gets a TCP session.
 
-        Applying ACLs to VTY lines restricts access to authorized management stations.
+        This is the control most likely to lock you out. The access class takes effect the moment it is applied and can drop the session you are typing in. Build and verify the ACL first, keep a console session open, apply it, confirm a fresh SSH connection from a permitted station, and only then run `copy running-config startup-config`. Saving before verifying removes the reload as an escape route.
       audit: |-
         To verify that VTY lines have an inbound ACL configured:
 
@@ -1694,17 +1716,17 @@ queries:
       cisco.nxos.motdBanner != ""
     docs:
       desc: |
-        This check verifies that a Message of the Day (MOTD) banner is configured. The MOTD banner provides legal notice to users before authentication.
+        This check verifies that anyone connecting to the switch is shown a warning before they authenticate.
+
+        `banner motd` sets the text NX-OS presents at connection time, ahead of the username prompt, using a delimiter character to mark the start and end of the message. This check requires the banner text to be non-empty.
 
         **Why this matters**
 
-        Without a MOTD banner, there is no legal warning before access. If the banner is not configured:
+        This banner is a legal instrument rather than a technical control, and it is the one control on this list whose value is realized in a courtroom or a disciplinary hearing. Action under unauthorized access statutes generally turns on whether the person was on notice that the system was restricted, and a switch that greets a stranger with a bare login prompt supports the argument that access appeared open.
 
-        - Legal proceedings against unauthorized access may be weakened.
-        - Users are not informed of acceptable use policies.
-        - Compliance requirements for access warnings cannot be met.
+        Placement is what makes it work. A notice shown only after login has no bearing on someone who never intended to log in, which is why the message has to arrive at connection time, before credentials are requested.
 
-        Configuring a MOTD banner ensures users receive legal notice before accessing the device.
+        Keep the text free of anything useful to an attacker. Hostname, model, site, department, and support contacts are all reconnaissance, and welcoming language undercuts the notice itself. State that use is restricted, that activity is monitored and logged, and have your legal team supply the exact wording so the same text is deployed fleet-wide.
       audit: |-
         To verify that a Message of the Day banner is configured:
 
@@ -1758,16 +1780,17 @@ queries:
       cisco.nxos.execBanner != ""
     docs:
       desc: |
-        This check verifies that an exec banner is configured. The exec banner is displayed after successful authentication and can provide additional security reminders or policy information.
+        This check verifies that a policy notice is presented to users once they have successfully authenticated.
+
+        `banner exec` sets text that NX-OS prints immediately after login, just before the first prompt, delimited the same way as the message of the day banner. This check requires the banner text to be non-empty.
 
         **Why this matters**
 
-        The exec banner provides an opportunity to display post-login security reminders. If not configured:
+        The pre-login banner addresses strangers. This one addresses the people who belong here, and on a data center switch that audience causes most of the real damage. The engineer who shuts the wrong uplink or applies a change meant for a lab spine is working from an unremarkable prompt on a device that looks like forty others.
 
-        - Users are not reminded of security policies after login.
-        - There is no post-authentication notice about monitoring or acceptable use.
+        Use it to say what only an authenticated operator needs to know: that the session and the commands in it are recorded through TACACS+ accounting, that the device is under change control, and what class of device this is. A distinctive marker on production spines is read in the second before a disruptive command is typed, which is the moment it can still change the outcome.
 
-        Configuring an exec banner reinforces security awareness after authentication.
+        Recognize what it is not. An attacker sees this text only after they already have a session, so it works alongside the pre-authentication banner rather than in place of it. Keep it brief and free of details that would help someone who should not be reading it.
       audit: |-
         To verify that an exec banner is configured:
 
@@ -1823,17 +1846,19 @@ queries:
       cisco.nxos.hostname.downcase != "nexus"
     docs:
       desc: |
-        This check verifies that a unique, descriptive hostname is configured. A meaningful hostname is essential for identifying the device in logs, alerts, and management systems.
+        This check verifies that the switch identifies itself by a name unique to it.
+
+        `hostname <unique-descriptive-name>` sets the value that appears in the CLI prompt, in every syslog message the switch emits, in its CDP and LLDP advertisements, and in the SSH session banner. A factory Nexus answers to `switch`, and many are left at `nexus` after a partial build. This check requires a non-empty hostname and rejects the literal values `switch` and `nexus`.
 
         **Why this matters**
 
-        Without a unique hostname, the device uses a generic default name. If the hostname is not configured:
+        Syslog identifies the sender by hostname, so a collector receiving from forty devices that all call themselves `switch` merges them into one unusable stream. The interface that flapped, the ACL that changed, and the login that failed all become events without a device, and the reconstruction an incident depends on cannot be built.
 
-        - The device cannot be identified in logs or management platforms.
-        - Log correlation across multiple devices is unreliable.
-        - Network topology documentation is incomplete.
+        The prompt is also the last verification an operator performs before a disruptive command. A window showing `switch#` could be any device in the fabric, and that ambiguity is how a change lands on the wrong Nexus during a maintenance window.
 
-        Setting a descriptive hostname ensures the device is identifiable across all workflows.
+        A factory hostname signals something to an attacker too: a device still carrying its default name advertises that nobody finished a build checklist on it, which reliably predicts default community strings and untouched credentials nearby.
+
+        Name it for role and location and apply the same convention fleet-wide.
       audit: |-
         To verify that a unique, descriptive hostname is configured:
 
@@ -1887,16 +1912,19 @@ queries:
       cisco.nxos.ip.sourceRouteEnabled == false
     docs:
       desc: |
-        This check verifies that IP source routing is disabled. Source routing allows a sender to specify the route a packet takes, which can be abused to bypass security controls.
+        This check verifies that the switch ignores packets that try to dictate their own forwarding path.
+
+        The IP loose and strict source route options let a sender list hops a packet must traverse, overriding the forwarding decision the network would otherwise make. `no ip source-route` makes the switch discard them. Because the setting is not printed in the abbreviated configuration, confirm it with `show running-config all | include ip source-route`. This check requires source routing disabled.
 
         **Why this matters**
 
-        IP source routing enables attackers to specify routing paths that circumvent firewalls and ACLs. If source routing is enabled:
+        Firewall and ACL placement rests on an assumption about which paths traffic can take. Source routing breaks that assumption directly, letting an attacker steer a packet through the switch and out an interface that no filter inspects, reaching a segment the topology was designed to keep unreachable.
 
-        - Attackers can route packets through paths that bypass security controls.
-        - Spoofed packets can reach internal networks.
+        The return path is the sharper problem. Replies follow the source route in reverse, so an attacker who spoofs a trusted internal address still receives the answers. That turns blind spoofing, which is mostly useless, into a working two-way session under a borrowed identity.
 
-        Disabling source routing prevents attackers from manipulating packet routing paths.
+        The same options serve as a reconnaissance tool, letting an outsider probe internal reachability and map segments they cannot route to directly.
+
+        There is effectively no legitimate production use left. The mechanism was deprecated in practice decades ago precisely because its abuse cases outnumbered its uses, so disable it globally and save the configuration.
       audit: |-
         To verify that IP source routing is disabled:
 
@@ -1952,16 +1980,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that IP directed broadcast is disabled on all interfaces. Directed broadcasts can be used as amplification vectors for denial-of-service attacks (Smurf attacks).
+        This check verifies that no interface will convert a unicast packet addressed to a subnet broadcast into an actual broadcast on that subnet.
+
+        `no ip directed-broadcast` under each routed interface stops that translation. This check requires it disabled on every interface, so a single interface that still permits it fails the check.
 
         **Why this matters**
 
-        IP directed broadcasts allow a single packet to be broadcast to all hosts on a subnet. If directed broadcast is enabled:
+        Directed broadcast is the amplifier in a Smurf attack. One spoofed ICMP echo sent to a subnet's broadcast address becomes one reply from every live host on that segment, and because the source was forged, all of those replies converge on a victim who never sent anything. The amplification factor is simply the number of responding hosts.
 
-        - The interface can be used as a Smurf attack amplifier.
-        - Denial-of-service attacks can be amplified through the device.
+        A data center switch makes this considerably worse than a campus router does. A server VLAN holds hundreds of active hosts behind high speed uplinks, so a modest inbound stream becomes an outbound flood large enough to saturate whatever the attacker aims it at, and the traffic leaves from your address space.
 
-        Disabling directed broadcast on all interfaces prevents amplification attacks.
+        The same mechanism doubles as a host census. One probe returns a reply per responding host, handing an attacker the live inventory of a segment they cannot otherwise enumerate.
+
+        Fix every routed interface rather than the first one flagged, verify with `show running-config interface`, and persist the change with `copy running-config startup-config`.
       audit: |-
         To verify that IP directed broadcast is disabled on all interfaces:
 
@@ -2022,16 +2053,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all BGP neighbors have MD5 authentication configured. BGP authentication prevents unauthorized peers from injecting routes.
+        This check verifies that BGP sessions authenticate the peer before exchanging routes.
+
+        With `feature bgp` enabled, each neighbor under `router bgp` takes a `password <shared-secret>` that turns on TCP MD5 signing for the session. This check applies when BGP is configured and requires every neighbor to carry a password.
 
         **Why this matters**
 
-        Without BGP authentication, an attacker can establish rogue BGP sessions. If authentication is not configured:
+        BGP believes what its peer tells it. An unauthenticated neighbor statement accepts a session from anything reaching the right address with the right autonomous system number, so an attacker who can source traffic from the peer's address becomes a trusted routing source.
 
-        - Malicious routes can be injected, redirecting or black-holing traffic.
-        - BGP sessions can be disrupted through TCP reset attacks.
+        What follows is not a routing bug, it is a tap. The attacker announces a more specific prefix for a production subnet, the switch prefers it, and traffic destined for your servers arrives at a next hop they control, to be recorded or modified before being forwarded on so nothing appears broken. A withdrawal instead blackholes the same traffic outright.
 
-        Configuring authentication on BGP neighbors ensures only authorized peers establish sessions.
+        MD5 signing also blunts the blind TCP reset: without it, an attacker who lands a plausible sequence number tears the session down and forces a reconvergence.
+
+        Coordinate with the peer operator first. Setting a password on an established neighbor drops the session until both ends match, so routing through that peer stops. Confirm recovery with `show bgp sessions`.
       audit: |-
         To verify that BGP neighbors have authentication configured:
 
@@ -2097,17 +2131,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that BGP neighbor change logging is enabled. Logging BGP peer state changes provides visibility into routing stability and potential security events.
+        This check verifies that BGP peer state transitions are recorded as they happen.
+
+        `log-neighbor-changes` under `router bgp <as-number>` makes NX-OS emit a syslog message each time a neighbor enters or leaves the established state. This check applies when BGP is configured and requires the setting on every BGP instance.
 
         **Why this matters**
 
-        Without BGP neighbor change logging, routing disruptions may go unnoticed. If logging is not enabled:
+        A BGP session dropping is one of the few switch events that is always significant. It means routes were withdrawn and traffic moved somewhere else, and on a data center fabric that is either an outage or the early shape of one.
 
-        - BGP session flaps and resets are not recorded.
-        - Unauthorized BGP peering attempts are not logged.
-        - Routing stability issues cannot be diagnosed from historical data.
+        Without the log line the evidence is transient. `show bgp` reports the state right now, so an adjacency that dropped for eleven seconds at two in the morning and recovered leaves nothing behind. The application team's latency spike has no explanation on the network side, and the flapping peer keeps flapping.
 
-        Enabling BGP log neighbor changes ensures routing events are captured for monitoring and troubleshooting.
+        The pattern of transitions is also the security signal. An attacker probing the BGP port, attempting a session from a spoofed source, or running a reset attack against an established peer produces a characteristic burst of state changes that is visible only if state changes are logged.
+
+        Pair it with remote logging, since messages held only in the on-box buffer are lost at reload and can be cleared by anyone with `network-admin`. Alert on transition frequency rather than on each event.
       audit: |-
         To verify that BGP neighbor change logging is enabled:
 
@@ -2168,17 +2204,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that all OSPF interfaces have authentication configured using either MD5 or a key chain. OSPF authentication prevents unauthorized routers from injecting routes.
+        This check verifies that OSPF accepts routing information only from routers that prove they hold a shared key.
+
+        Authentication is set per interface, either with `ip ospf authentication message-digest` alongside `ip ospf message-digest-key 1 md5 <key>`, or by referencing a key chain with `ip ospf authentication key-chain <keychain-name>`. This check applies when OSPF is configured and requires every OSPF interface to carry one of the two.
 
         **Why this matters**
 
-        Without OSPF authentication, any device on the segment can participate in OSPF routing. If authentication is not configured:
+        OSPF forms an adjacency with whatever answers a hello on the segment. On an unauthenticated interface that means any host on the VLAN can become a router: a server running a rogue routing daemon, a compromised hypervisor, or a laptop plugged into a live port.
 
-        - Rogue routers can inject false routes.
-        - OSPF adjacencies can be disrupted.
-        - Man-in-the-middle attacks via route injection are possible.
+        Once adjacent, the attacker advertises a low cost route to a prefix they want and its traffic starts arriving at them. Because they can forward it onward, the result is a transparent interception that no application notices.
 
-        Configuring OSPF interface authentication ensures only authorized routers participate in the routing domain.
+        The destructive version needs less finesse. Flooding the area with churning link state advertisements forces every router in it to recompute continuously, and the instability spreads well past the segment the attacker reached.
+
+        Prefer a key chain over a static digest key, because key chains support rotation without tearing the adjacency down. Enabling authentication on a live interface drops the adjacency until the neighbor matches, so schedule it with the neighboring device and verify with `show ip ospf neighbors`.
       audit: |-
         To verify that OSPF interfaces use authentication:
 


### PR DESCRIPTION
Rewrites the `docs.desc` prose for every check in the three Cisco network device policies to match the description standard in `content/CLAUDE.md`.

## Why

All 94 descriptions shared the same three defects. Each opened by restating its own title, each rendered the "Why this matters" body as a bullet list, and each closed with a paragraph that restated the opener ("Enabling AAA accounting ensures that all activity is logged for audit and compliance."). The bodies leaned on "reduces the attack surface" and "compliance requirements cannot be met" without naming a control, which is true of every check in the repo and therefore tells the reader nothing.

The rewrites lead with the security capability rather than the config key, name the command the operator actually types in that platform's own CLI syntax, say what an attacker concretely does without the control, and close by naming what to pair the check with or when it legitimately should not be applied.

## Per-policy counts

| Policy | Checks | Descriptions rewritten | Left as-is | Version |
|---|---|---|---|---|
| `content/mondoo-cisco-iosxe-security.mql.yaml` | 36 | 36 | 0 | 1.0.3 → 1.0.4 |
| `content/mondoo-cisco-iosxr-security.mql.yaml` | 27 | 27 | 0 | 1.0.3 → 1.0.4 |
| `content/mondoo-cisco-nxos-security.mql.yaml` | 31 | 31 | 0 | 1.0.3 → 1.0.4 |
| **Total** | **94** | **94** | **0** | |

No description already met the standard, so none were left alone.

## Three operating systems, not one

These are genuinely different platforms and the prose now reflects that. Where the same control objective exists on all three, the syntax, the defaults and the operational model differ, and each description states its own platform's correctly.

- **IOS-XE** — classic IOS CLI, changes live immediately in the running config and persist via `copy running-config startup-config`. `service password-encryption`, `enable secret`, `ip ssh version 2`, `aaa new-model`, `no ip http server`, `no cdp run`, `line vty 0 15` with `transport input ssh` and `access-class`.
- **IOS-XR** — two-stage configuration where nothing takes effect until `commit`, and `commit confirmed` is called out on the four controls capable of locking an operator out. Line templates rather than `line vty 0 15`, `access-class ingress`, no `enable secret` because privilege is task-group based through AAA, Type 6 AES via `password6 encryption aes`, and CDP correctly described as off by default on this platform.
- **NX-OS** — feature-based enablement, SSH on by default and telnet off, which is the inverse of IOS. `copp profile strict|moderate|lenient|dense`, POAP boot provisioning, `ssh login-attempts`, `system login block-for`, `userpassphrase min-length`.

No description is byte-identical to one in a sibling policy.

## Example

`mondoo-cisco-nxos-security-poap-disabled`, before:

> This check verifies that Power-On Auto Provisioning (POAP) is disabled. POAP automatically downloads and executes a configuration script when the switch boots without a startup configuration, which can be exploited to load a malicious configuration.
>
> **Why this matters**
>
> POAP can be exploited if an attacker sets up a rogue DHCP/TFTP server on the network. If POAP is enabled:
>
> - An attacker can serve a malicious configuration or script to the device during boot.
> - The device can be reconfigured without authentication during the provisioning process.
> - A compromised device can be reprovisioned with an attacker-controlled configuration.
>
> Disabling POAP prevents unauthorized auto-provisioning during device boot.

After:

> This check verifies that the switch will not fetch and execute a configuration script from the network when it boots without one.
>
> Power-On Auto Provisioning is the NX-OS zero-touch build path. A Nexus switch that boots with no startup configuration broadcasts DHCP, takes a script and image location from the DHCP options it receives, downloads them, and runs the script with full administrative rights. `no boot poap enable` turns that behavior off, and this check requires it disabled.
>
> **Why this matters**
>
> The entire trust model is the DHCP server, and the switch trusts whichever server answers first. On a data center fabric that can be any host an attacker has already compromised, and winning a DHCP race against a distant server is not a difficult problem.
>
> The window opens more often than teams expect. A supervisor module replacement, an RMA unit racked from the shelf, or a `write erase` and reload during troubleshooting all leave the switch with no startup configuration and POAP ready to run.
>
> The outcome is total, because the script executes as the switch's own provisioning process. It can install accounts the attacker controls, point AAA at a server they operate, mirror a production VLAN to a port they can reach, or load an image of their choosing.
>
> If you genuinely build with POAP, keep it enabled only through the build, then run `no boot poap enable` and `copy running-config startup-config` before the switch carries production traffic.

## Validation

| Gate | Result |
|---|---|
| `cnspec policy lint` on all three | `valid policy bundle(s)` |
| `typos` on all three | no output, exit 0 |
| `go test ./internal/bundle/...` | `ok` |
| Descriptions not starting with `This check` | 0 of 94 |
| Descriptions missing `**Why this matters**` | 0 of 94 |
| Descriptions with more than one `**Why this matters**` | 0 of 94 |
| `**Risk mitigation**` headings | 0 |
| `—` / `–` / ` -- ` | 0 |
| MQL accessor paths in prose | 0 |
| Bullet lists in prose | 0 of 94, down from 94 of 94 |
| Byte-identical descriptions across the three policies | 0 |

## Diff scope is prose only

No `mql`, `filters`, `tags`, `impact`, `props`, `title`, `audit`, or `remediation` changed anywhere in this PR.

Proved structurally rather than by reading the diff: each bundle was parsed at `origin/main` and at this branch's tip, every `docs.desc` and every `policies[].version` was replaced with a placeholder, and the resulting trees were compared.

```
content/mondoo-cisco-iosxe-security.mql.yaml       structural-equal: True
content/mondoo-cisco-iosxr-security.mql.yaml       structural-equal: True
content/mondoo-cisco-nxos-security.mql.yaml        structural-equal: True
```

Every remaining difference is confined to description text and the three patch-level version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
