### PR TITLE
📝 panos: rewrite check descriptions to the prose standard

### DIFF
--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 2.0.3
+    version: 2.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -119,18 +119,19 @@ queries:
     mql: panos.system.avVersion != ""
     docs:
       desc: |
-        This check verifies that antivirus content is installed on the device. Antivirus content provides the signature database used to identify known malware, viruses, and trojans as they traverse the network.
+        This check verifies that the firewall has antivirus content installed.
+
+        Antivirus content is a separate update stream from the Applications and Threats package. It carries the malware signatures the antivirus profile uses to inspect files moving over HTTP, SMTP, IMAP, POP3, FTP, and SMB, and it is released on a much faster cadence than threat content. The installed version is listed as the Antivirus package under Device > Dynamic Updates, and this check requires it to be present rather than blank.
 
         **Why this matters**
 
-        Without antivirus content installed, the firewall cannot inspect files and traffic for known malware. If antivirus content is missing:
+        File inspection sits between a user clicking a link and a payload landing on their disk. Without antivirus content, an attacker delivering a commodity loader over a web download or a mail attachment needs no evasion at all; the sample can be years old and widely detected everywhere else and it still crosses the perimeter, because the appliance has nothing to match it against.
 
-        - Malicious files can pass through the firewall undetected, potentially infecting endpoints and servers.
-        - Email attachments carrying malware will not be scanned or blocked.
-        - Web downloads containing trojans or viruses will reach end users without inspection.
-        - The firewall loses its ability to act as a network-level malware prevention tool.
+        Because the antivirus package updates on its own schedule and under its own entitlement, it can be missing while threat content is perfectly current. Administrators who confirm the Applications and Threats version looks recent frequently never notice that the antivirus slot is empty.
 
-        Maintaining current antivirus content ensures the firewall can identify and block known malware before it reaches internal systems.
+        The failure is also asymmetric in the direction that matters least for alerting. No signatures means no antivirus log entries, so the absence of detections reads as the absence of malware.
+
+        Devices deployed purely as internal segmentation firewalls that never carry file transfers gain less from this content, though the download costs nothing and leaves the option open. Note that these signatures only inspect traffic on rules that actually reference an antivirus profile or a profile group, so pair this check with the rule-level profile checks in this policy.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -202,18 +203,19 @@ queries:
     mql: panos.system.appVersion != ""
     docs:
       desc: |
-        This check verifies that application identification content (App-ID) is installed on the device. App-ID content enables the firewall to identify applications regardless of port, protocol, or encryption.
+        This check verifies that the firewall has application identification content installed.
+
+        Application content is the decoder and signature set that lets the firewall name the application behind a session instead of inferring it from the port number. It ships in the same Applications and Threats package as threat content, and the installed version is shown under Device > Dynamic Updates. This check requires an application content version to be present.
 
         **Why this matters**
 
-        Without current application content, the firewall cannot accurately identify applications traversing the network. If App-ID content is missing:
+        Without this content, every rule that names an application stops matching what its author intended. Traffic falls through to whatever rule matches next, and in most rulebases that is either a broad allow near the bottom or the interzone default deny. The first outcome silently widens access; the second causes an outage. Neither is what the rule says.
 
-        - Security policies fall back to port-based rules, which are easily circumvented by applications that use non-standard ports.
-        - Administrators lose visibility into what applications are running on the network.
-        - Application-level QoS and traffic shaping policies cannot function correctly.
-        - Risk assessment becomes unreliable because the firewall cannot distinguish between legitimate and risky applications.
+        The decoders are also what makes threat inspection work. Security profiles operate on the decoded application stream, so an unidentified application means files inside it are not extracted, URLs inside it are not categorized, and the session is inspected far more shallowly than the attached profiles imply.
 
-        Keeping application content up to date ensures the firewall can enforce application-aware security policies and provide accurate network visibility.
+        For an attacker, a firewall without application content has been reduced to port matching. Tunneling a command-and-control channel over 443 or 53 stops requiring any real effort, because nothing left on the device distinguishes it from the legitimate traffic sharing that port.
+
+        Newly staged appliances report no content until their first update completes. Because application and threat content ride the same package, this check failing alongside the threat content check almost always points at update connectivity rather than at two separate problems.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -289,19 +291,20 @@ queries:
         where(feature.downcase.contains("dns") && expired == "no").
         length > 0
     docs:
-      desc: |-
-        This check verifies that an active DNS Security license is installed on the device. The DNS Security subscription enables DNS-layer threat analysis powered by machine learning and global threat intelligence.
+      desc: |
+        This check verifies that the firewall carries an active DNS Security subscription.
+
+        DNS Security adds a real-time cloud lookup on the domains the firewall observes in DNS queries, classifying them against categories such as command and control, malware, dynamic DNS, newly registered domains, and algorithmically generated names. It is switched on through the DNS policies of an Anti-Spyware profile, and its entitlement is listed under Device > Licenses, where this check requires an entry for the DNS feature that is not expired.
 
         **Why this matters**
 
-        Attackers increasingly leverage DNS for command-and-control communication and data exfiltration because DNS traffic is often allowed through firewalls without inspection. Without an active DNS Security license:
+        DNS is the one protocol allowed out of nearly every network, which is precisely why malware uses it for rendezvous and for exfiltration. A beacon resolving a fresh domain every few minutes produces no unusual pattern at the transport layer; the only distinguishing feature is the domain itself.
 
-        - Malware on internal systems can communicate with command-and-control servers via DNS queries without detection.
-        - Data exfiltration through DNS tunneling goes unidentified.
-        - Domain generation algorithm (DGA) patterns used by malware families are not flagged.
-        - The firewall misses an entire layer of threat detection that complements traditional traffic inspection.
+        Domain generation algorithms exist to defeat blocklists, cycling through thousands of candidate names so no static list keeps up. Cloud-side analysis is what makes them tractable, because classification happens against a live feed rather than against content downloaded hours ago.
 
-        DNS Security provides an additional layer of protection by analyzing DNS traffic for malicious activity, catching threats that might bypass other security controls.
+        DNS tunneling is the exfiltration case. Data encoded into query labels leaves as a stream of ordinary lookups to a nameserver the attacker controls, and without query-level analysis nothing in the session log looks wrong.
+
+        This control only sees queries that traverse the firewall, so environments where endpoints reach an external resolver over encrypted DNS or use a third-party service directly need those paths blocked or redirected first. Configure sinkholing in the Anti-Spyware profile as well, so a matched domain resolves somewhere the infected host can actually be identified.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -369,18 +372,19 @@ queries:
     mql: panos.licenses.where(expired == "yes") == []
     docs:
       desc: |
-        This check verifies that no licenses on the PAN-OS device are expired. Expired licenses directly impact the device's ability to protect the network against current threats.
+        This check verifies that no subscription on the firewall has expired.
+
+        PAN-OS keeps a license entry for every subscription and capability on the device, each with its own expiry date, and marks entries past that date as expired. The full list is visible under Device > Licenses, and this check requires that none of those entries carry an expired status.
 
         **Why this matters**
 
-        When licenses expire, the security capabilities they enable begin to degrade immediately. If any licenses are expired:
+        Subscriptions do not fail loudly when they lapse. The feature usually keeps running on whatever content it last downloaded, so the device continues to inspect traffic, continues to write logs, and continues to look healthy while its view of the threat landscape is frozen on the day the subscription ended. Every vulnerability disclosed after that date is invisible to it.
 
-        - The device stops receiving threat intelligence and signature updates, leaving it blind to newly discovered threats.
-        - Advanced security features may be disabled entirely or operate in a limited mode with reduced effectiveness.
-        - The organization may fall out of compliance with frameworks that require active security subscriptions.
-        - Protection gaps widen over time as new vulnerabilities and attack techniques emerge without corresponding updates.
+        That gap is valuable to an attacker precisely because it is quiet. Exploitation of newly disclosed edge-device vulnerabilities is now measured in days, and a firewall running content from three months ago will not recognize any of it.
 
-        Organizations must maintain active licenses to ensure continuous protection against evolving threats.
+        Expiry is also rarely limited to one feature. Subscriptions are commonly bought as a bundle with a shared renewal date, so a missed renewal takes threat prevention, URL filtering, WildFire, and DNS Security out together, removing several independent layers at once rather than one.
+
+        Some entries cover perpetual capabilities or evaluation features that were never meant to be renewed, and those will fail this check without representing a real gap. Review the list and remove licenses the organization has deliberately let go, rather than leaving expired entries in place where they mask a renewal that genuinely was missed.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -449,18 +453,19 @@ queries:
     mql: panos.system.operationalMode.downcase == "normal"
     docs:
       desc: |
-        This check verifies that the PAN-OS device is operating in normal mode rather than maintenance or other non-operational states. The operational mode reflects the overall health and readiness of the firewall.
+        This check verifies that the firewall is running in normal operational mode.
+
+        PAN-OS reports an operational mode describing which runtime the system booted into. Normal mode is the state in which the dataplane forwards traffic and the security policy is enforced; other states, such as maintenance mode or a partially initialized boot, mean the system is not doing that work. The mode appears in the General Information section of the Dashboard and in the output of `show system info`, and this check requires it to be normal.
 
         **Why this matters**
 
-        A device not in normal operational mode cannot reliably protect the network. If the device is in a non-normal state:
+        A firewall that is not in normal mode is not a firewall. Depending on the platform and the deployment, traffic either stops at the device, which blacks out every site behind it, or passes without inspection, which quietly removes the perimeter while every upstream dashboard still shows the appliance as present. The second failure is worse than the outage nobody misses.
 
-        - The firewall may not be processing traffic or enforcing security policies, leaving the network unprotected.
-        - Network traffic may be blocked entirely, causing a service interruption.
-        - The device may be stuck in maintenance mode due to configuration problems that require immediate attention.
-        - Underlying hardware failures may be present that compromise the device's reliability.
+        Maintenance mode in particular is a recovery state reached after a failed content install, a corrupted configuration, or a disk problem. It offers console access and image recovery, and it does not run the security policy. A device sitting in maintenance mode since an unattended reboot has been out of the enforcement path for however long that reboot went unnoticed.
 
-        Devices should operate in normal mode to provide continuous security protection for network traffic.
+        The mode is also a signal about hardware. Appliances that fail power-on diagnostics or lose a dataplane processor often come up degraded rather than refusing to boot, so an unexpected operational mode is frequently the first visible symptom of a failing device.
+
+        Firewalls deliberately placed in FIPS-CC mode, or being rebuilt during a maintenance window, will fail this check by design; confirm the mode against the change record before treating it as an incident. Pair the check with out-of-band console access, because a device found in maintenance mode cannot be recovered over the network.
       audit: |
         ### Audit via the PAN-OS CLI
 
@@ -531,18 +536,19 @@ queries:
     mql: panos.system.threatVersion != ""
     docs:
       desc: |
-        This check verifies that threat prevention content is installed on the device. Threat content includes the signatures, rules, and intelligence the firewall uses to detect and block network attacks.
+        This check verifies that the firewall has threat prevention content installed.
+
+        Threat content is the signature package behind vulnerability protection, anti-spyware, and the rest of the intrusion prevention engine. It arrives through the Applications and Threats update, and the installed version is shown under Device > Dynamic Updates and in the Dashboard's General Information panel. This check requires a threat content version to be present rather than blank.
 
         **Why this matters**
 
-        Without current threat prevention content, the firewall loses its core ability to detect and block attacks. If threat content is missing:
+        An appliance with no threat content still matches traffic against the security policy, but the profiles attached to those rules have nothing to compare packets against. An attacker sending a known exploit for an unpatched mail server, load balancer, or VPN appliance behind the firewall gets a clean pass, and the traffic log records an allowed session rather than a blocked threat.
 
-        - Known threats pass through the firewall undetected because there are no signatures to match against.
-        - The intrusion prevention system (IPS) has no rules to block exploit attempts.
-        - Known vulnerability exploits and attack techniques cannot be identified or stopped.
-        - Behavioral analysis and heuristics for detecting unknown threats are unavailable.
+        The gap is invisible from the outside. Rules still show vulnerability and anti-spyware profiles attached, threat logs still exist, and the only difference is that they stay empty. Teams reading a quiet threat log as evidence that nothing is attacking them will not question it until an endpoint is already compromised.
 
-        Maintaining up-to-date threat content is fundamental to the firewall's security function and should be verified regularly.
+        Missing content usually means the device cannot reach the update servers, that the subscription lapsed, or that a scheduled download completed while the install step failed. Each of those is silent, so the absence tends to persist for weeks.
+
+        A firewall that has just been factory reset or newly staged will legitimately report no content until its first update runs. Pair this check with the license checks in this policy, because downloads stop the moment the underlying subscription expires even though the last installed version stays on disk and keeps this check passing.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -621,18 +627,19 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active Threat Prevention license is installed on the device. Threat Prevention is the core security subscription that enables intrusion prevention, anti-spyware, and vulnerability protection.
+        This check verifies that the firewall carries an active Threat Prevention subscription.
+
+        Threat Prevention entitles the device to vulnerability protection, anti-spyware, and antivirus signatures, along with the ongoing Applications and Threats content stream that keeps them current. Its status is listed under Device > Licenses, and this check requires an entry for the threat feature that is not expired.
 
         **Why this matters**
 
-        Without an active Threat Prevention subscription, the firewall operates in a significantly degraded security state. If this license is missing or expired:
+        This subscription is what turns the appliance from a stateful firewall into an intrusion prevention system. Without it the device still decides which sessions are allowed, but it stops looking inside the ones it allows. An exploit aimed at an internet-facing web server, a database driver, or an unpatched VPN concentrator behind the firewall crosses as ordinary permitted traffic.
 
-        - Intrusion prevention and detection capabilities are disabled, allowing exploit attempts to pass through.
-        - Spyware, command-and-control traffic, and data exfiltration go undetected.
-        - Known software vulnerabilities cannot be defended against at the network layer.
-        - Threat detection signatures stop receiving updates, leaving the firewall blind to new attack techniques.
+        The subscription is also the gate on content downloads. When it lapses the installed signatures stay in place and keep matching, so the device appears to be working; it simply never learns anything new again. The result is a control whose effectiveness decays a little every day without producing a single alert about it.
 
-        Threat Prevention is considered a core security subscription and should be maintained on all production firewalls to protect against the vast majority of network threats.
+        Anti-spyware belongs to the same subscription and covers the outbound half of an intrusion. Losing it means command-and-control beacons, DNS-based exfiltration, and known botnet traffic leaving the network stop being flagged, which removes the detection most likely to catch a compromise that began somewhere the firewall could not see.
+
+        This is the one subscription essentially every production firewall needs, so a device that fails this check and is not a lab unit should be handled as a licensing incident rather than a configuration finding. The entitlement on its own inspects nothing until the corresponding profiles are attached to security rules.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -707,19 +714,19 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active URL Filtering license is installed on the device. URL Filtering enables the firewall to categorize and control web traffic based on site reputation and content category.
+        This check verifies that the firewall carries an active URL Filtering subscription.
+
+        URL Filtering supplies the categorization database and the cloud lookup service that classify web destinations, along with credential submission detection and the ability to act on a site's risk score. Its status is listed under Device > Licenses, and this check requires an entry for the URL feature that is not expired.
 
         **Why this matters**
 
-        Without an active URL Filtering license, the firewall cannot inspect or control web traffic at the URL level. If this license is missing or expired:
+        Phishing is a delivery problem before it is an endpoint problem, and a categorized web destination is the last place to stop it in transit. Without the subscription, a credential-harvesting domain registered an hour ago resolves and loads for every user behind the firewall, and the only remaining defense is the recipient noticing.
 
-        - Users can access known malicious websites that deliver malware or host exploit kits.
-        - Phishing sites are not detected or blocked, increasing the risk of credential theft.
-        - Administrators cannot enforce acceptable use policies based on website content categories.
-        - The URL categorization database stops receiving updates, reducing the accuracy of web traffic classification.
-        - Risk-based reputation scoring is unavailable, preventing informed policy decisions about borderline sites.
+        Category lookup is also how the firewall recognizes command-and-control and payload staging over ordinary HTTPS. Attackers deliberately host second-stage payloads on hosting and file-sharing services that no port or application rule would ever block, because the traffic is genuinely web traffic to a genuinely popular provider. Categorization and reputation are the signal that separates them.
 
-        URL Filtering is essential for protecting users from web-based threats, enforcing acceptable use policies, and preventing phishing attacks.
+        Credential phishing prevention depends on this subscription too. Losing it removes the control that notices a corporate password being typed into an uncategorized or newly seen site, which is the most direct precursor to an account takeover there is.
+
+        Without the subscription the device falls back to a small set of built-in categories, so some rules keep working and the loss is partial rather than total, which is exactly why it goes unnoticed. Pair this check with the rule-level URL filtering check, since the database is only consulted for traffic on rules that carry a URL filtering profile.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -788,18 +795,19 @@ queries:
     mql: panos.system.wildfireVersion != ""
     docs:
       desc: |
-        This check verifies that WildFire threat intelligence content is installed on the device. WildFire content delivers signatures generated from cloud-based sandbox analysis of unknown files observed across Palo Alto Networks' global sensor network.
+        This check verifies that the firewall has WildFire content installed.
+
+        WildFire content is the fast-turnaround signature feed generated from cloud sandbox verdicts across Palo Alto Networks' customer base. Where antivirus content is a daily package, WildFire signatures are published within minutes of a sample being convicted, which closes the window between a new payload appearing somewhere in the world and this firewall being able to recognize it. The installed version is listed as the WildFire package under Device > Dynamic Updates, and this check requires it to be present.
 
         **Why this matters**
 
-        Without WildFire content, the firewall cannot benefit from cloud-based threat intelligence and advanced malware analysis. If WildFire content is missing:
+        Attackers routinely recompile or repack a payload for each campaign so that no existing signature matches. The value of this feed is that the first victim's submission produces a verdict every other firewall can enforce almost immediately. A device without the feed is permanently in the position of the first victim.
 
-        - Unknown files that have been analyzed and identified as malicious in the cloud will not be blocked locally.
-        - The firewall loses access to near real-time signature updates derived from global threat intelligence.
-        - Previously unknown malware and zero-day threats cannot be detected using WildFire-generated signatures.
-        - Advanced persistent threats that rely on novel malware go unidentified at the network perimeter.
+        Targeted intrusions are where that matters most. A bespoke loader written for one organization will never appear in a daily antivirus package, and the only signal available at the perimeter is the sandbox verdict on the sample itself.
 
-        WildFire content ensures the firewall can leverage cloud-based threat intelligence to prevent sophisticated attacks that evade traditional signature-based detection.
+        Without the content installed, the appliance can still forward files for analysis when a WildFire profile is attached, but it cannot act on any verdict it did not produce locally. That turns a preventive control into a reporting one.
+
+        This feed is only useful alongside the WildFire subscription and a WildFire Analysis profile attached to the rules carrying file traffic. A current content version on a device with no such profiles changes nothing about what reaches users.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -878,18 +886,19 @@ queries:
         length > 0
     docs:
       desc: |
-        This check verifies that an active WildFire license is installed on the device. WildFire provides cloud-based sandbox analysis and machine learning to detect and prevent previously unknown malware and zero-day exploits.
+        This check verifies that the firewall carries an active WildFire subscription.
+
+        WildFire is the cloud sandbox service. The subscription entitles the device to forward unknown files and links for detonation and to receive the resulting verdicts as signatures on a minutes-scale feed rather than the daily antivirus cadence. Its status is listed under Device > Licenses, and this check requires an entry for the WildFire feature that is not expired.
 
         **Why this matters**
 
-        Without an active WildFire license, the firewall cannot submit unknown files for cloud-based analysis or receive WildFire-generated threat intelligence. If this license is missing or expired:
+        Signature-based inspection only recognizes what has been seen before, and an attacker's cheapest evasion is making sure their payload has not been. Repacking a commodity loader for each target defeats the antivirus package outright. Sandbox analysis is the control designed for that case, because it judges a sample by what it does rather than by what it looks like.
 
-        - Previously unknown malware and zero-day exploits pass through the firewall undetected.
-        - Unknown files cannot be submitted to the WildFire cloud for sandbox analysis across multiple virtual environments.
-        - Machine learning-based threat detection is unavailable, reducing the firewall's ability to identify novel attacks.
-        - The firewall loses access to global threat intelligence derived from millions of sensors worldwide.
+        Without the subscription, unknown files are simply forwarded. There is no detonation, no verdict, and no signature, so the first anyone learns that a file was malicious is from the endpoint it landed on.
 
-        WildFire is critical for protecting against sophisticated, targeted attacks and zero-day exploits that traditional signature-based detection cannot identify.
+        The subscription also feeds the fast signature channel the rest of the fleet depends on. A device without it gains nothing from convictions produced elsewhere, so a payload already caught at another site keeps working here.
+
+        Analysis forwards file content to the cloud service, so organizations with data residency constraints should route to a regional cloud or an on-premises appliance rather than dropping the subscription. As with the other entitlements, it does nothing until a WildFire Analysis profile is attached to the rules carrying file traffic.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -965,18 +974,19 @@ queries:
     mql: panos.zones.all(zoneProfile != "")
     docs:
       desc: |
-        This check verifies that every security zone has a zone protection profile assigned. Zone protection profiles defend against flood attacks, reconnaissance attempts, and packet-based attacks at the zone level.
+        This check verifies that every security zone has a zone protection profile applied.
+
+        A zone protection profile sets the flood thresholds, reconnaissance detection, and packet-based attack protections that apply to traffic arriving on any interface in that zone. Profiles are built under Network > Network Profiles > Zone Protection and attached to a zone under Network > Zones, and this check requires every zone to name one.
 
         **Why this matters**
 
-        Without a zone protection profile, a zone has no protection against network-layer attacks targeting the firewall or traversing through it. If zone protection profiles are missing:
+        Zone protection acts before the security policy does, on traffic that has not yet matched a rule. That makes it the only control covering a SYN flood aimed at the firewall itself, and the scanning and sweeping that precede a targeted attack. A rulebase, however tight, does not help when the resource being exhausted is the session table.
 
-        - SYN, UDP, ICMP, and other flood attacks can overwhelm the firewall or downstream systems.
-        - Reconnaissance techniques such as port scans and host sweeps go undetected.
-        - Malformed packets and packet-based attacks (IP spoofing, fragmented packets) are not dropped.
-        - The firewall cannot enforce rate limiting or connection thresholds for the zone.
+        Reconnaissance detection is the part most often missed. Port scans and host sweeps against an internet-facing zone are a reliable early indicator that something specific is being planned, and without a profile they generate no event at all, so the first sign of the intrusion is the intrusion.
 
-        Assigning a zone protection profile to every zone ensures a baseline level of network-layer defense across the entire firewall.
+        Packet-based attack protection covers the older but still effective malformed-packet techniques: spoofed source addresses, overlapping fragments, and IP options used to slip past inspection. These are dropped at the zone level or not at all.
+
+        Thresholds, not attachment, are the hard part of this control. A profile with flood limits set below the site's real peak throughput drops legitimate traffic during a busy period, so baseline the zone before committing values and set the alert threshold well below the drop threshold, ensuring the first indication is a log entry rather than an outage.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1053,18 +1063,19 @@ queries:
     mql: panos.zones.all(enablePacketBufferProtection == true)
     docs:
       desc: |
-        This check verifies that packet buffer protection is enabled on all security zones. Packet buffer protection prevents a single session or source from consuming an excessive share of the firewall's packet buffer resources.
+        This check verifies that packet buffer protection is enabled on every security zone.
+
+        Packet buffer protection watches the firewall's dataplane buffers and, when utilization crosses a threshold, identifies and then throttles or blocks the individual sessions and source addresses responsible. The global thresholds live under Device > Setup > Session, and the per-zone toggle that puts them into effect is on each zone under Network > Zones. This check requires that toggle to be on.
 
         **Why this matters**
 
-        Without packet buffer protection, a single abusive session can exhaust the firewall's packet buffers, causing traffic drops across all zones and effectively creating a denial-of-service condition. If packet buffer protection is disabled:
+        Packet buffers are a finite dataplane resource shared across every zone on the appliance. A single abusive source anywhere on the device can therefore starve traffic everywhere on it, and without per-zone enforcement the blast radius of one hostile session is the whole firewall.
 
-        - A single high-volume session can monopolize packet buffer resources, starving other traffic.
-        - Denial-of-service attacks targeting one zone can degrade performance across the entire firewall.
-        - Legitimate traffic in other zones may be dropped due to buffer exhaustion from an unrelated attack.
-        - The firewall has no mechanism to isolate resource consumption by zone or session.
+        This is cheap to mount and hard to attribute. The traffic need not be malformed or even unusually large in aggregate; it only needs to be shaped so buffers fill faster than they drain. From the operator's side the symptom is packet loss on unrelated interfaces, which sends the investigation toward the network rather than toward the source.
 
-        Enabling packet buffer protection ensures fair resource allocation and prevents localized attacks from impacting the entire firewall.
+        Enforcement is also what makes the event visible. With protection enabled the firewall names the offending session and source in its logs, turning an ambiguous performance complaint into an actionable incident.
+
+        The global thresholds ship with values that are conservative for the platform, so review them against the real traffic profile before relying on the control; on a heavily loaded device an aggressive block threshold can terminate legitimate long-lived sessions. This is resource protection rather than a substitute for the flood thresholds in a zone protection profile, and the two are meant to be configured together.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1139,18 +1150,19 @@ queries:
     mql: panos.zones.all(logSetting != "")
     docs:
       desc: |
-        This check verifies that all security zones have a log forwarding setting configured. Log forwarding ensures zone-level events are sent to external logging infrastructure for analysis and retention.
+        This check verifies that every security zone has a log forwarding profile attached.
+
+        The log setting on a zone determines where events raised by that zone's protection profile, such as flood detections and reconnaissance alerts, are sent. Forwarding profiles are defined under Objects > Log Forwarding and selected on each zone under Network > Zones, and this check requires every zone to name one.
 
         **Why this matters**
 
-        Without log forwarding configured on zones, zone protection events are only stored locally and may be lost during high-volume events or device failures. If log forwarding is missing:
+        Local log storage on a firewall is a small circular buffer. During exactly the event these logs exist to record, a flood or a sweep generating entries at high rate, the buffer rolls over fastest and the earliest records go first. The entries describing how an attack started are the ones lost soonest.
 
-        - Zone protection events (floods, scans, packet-based attacks) are not forwarded to SIEM or log management systems.
-        - Security teams lose visibility into network-layer attacks targeting specific zones.
-        - Incident response is hindered because historical zone event data may not be available.
-        - Compliance requirements for log retention and centralized monitoring cannot be met.
+        Off-box forwarding is also what survives the device. If the firewall is rebooted to recover from the incident, replaced, or compromised, anything held only in local storage goes with it, and an attacker with administrative access on the appliance can clear those logs deliberately.
 
-        Configuring log forwarding on all zones ensures that security events are captured, correlated, and available for investigation.
+        Correlation is the other half. Zone events are most useful next to endpoint and identity data in a log platform, because a host sweep from an internal address only becomes interesting once it is tied to the workstation that started it.
+
+        Zones carrying only low-value internal traffic may reasonably forward at a higher severity threshold rather than not at all, which is a filter decision inside the forwarding profile rather than a reason to leave the zone unset. Note that a forwarding profile does nothing on a zone that has no zone protection profile generating events in the first place.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1227,19 +1239,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that no security rules allow all applications, services, sources, and destinations — commonly known as "allow any/any" rules. These rules effectively bypass the firewall's security controls.
+        This check verifies that no enabled security rule allows every application, service, source, and destination at once.
+
+        A rule of that shape permits all traffic between all addresses with no application or port constraint. Rules are administered under Policies > Security, and this check requires that no enabled rule with an allow action has all four of those fields set to any.
 
         **Why this matters**
 
-        An allow-any rule permits all traffic through the firewall without restriction, defeating the purpose of having a next-generation firewall. If allow-any rules exist:
+        A rule like this ends the security policy for everything it matches. Because rules are evaluated in order and the first match wins, an allow-any rule placed high in the rulebase silently voids every specific rule beneath it, including the ones an audit will read and approve.
 
-        - All traffic passes through without application identification, threat inspection, or access control.
-        - Attackers can use any protocol, port, or application to communicate through the firewall.
-        - Lateral movement within the network is unrestricted.
-        - The firewall provides no security value for traffic matching these rules.
-        - Compliance frameworks universally require least-privilege access controls.
+        For an attacker who has landed anywhere behind the firewall, this is the difference between a segmented network and a flat one. Lateral movement to any host, on any port, in any direction is permitted, and the traffic log shows every step of it as policy compliant.
 
-        Security rules should follow the principle of least privilege, explicitly defining allowed applications, services, and address ranges.
+        These rules almost always arrive as a temporary measure. Someone opens one during a migration or to break an outage at 2am, the immediate problem goes away, and the rule survives because nothing ever fails afterward to prompt its removal. The absence of complaints is the reason it stays.
+
+        Where a broad rule is genuinely needed, narrow at least one dimension and attach security profiles so the traffic is still inspected, then record an explicit review date. A rule matching this shape with a deny action is the intended default-deny form and is not what this check looks for.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1326,19 +1338,19 @@ queries:
         all(applications.none(_ == "any"))
     docs:
       desc: |
-        This check verifies that all enabled allow rules use specific App-ID applications rather than "any". App-ID is a core capability of Palo Alto Networks next-generation firewalls that identifies applications regardless of port, protocol, or encryption.
+        This check verifies that enabled allow rules identify traffic by application rather than permitting any application.
+
+        Setting a rule's application to any means the firewall permits whatever it finds on the allowed ports without regard to what the session actually carries. The field is on the Application tab of each rule under Policies > Security, and this check requires that no enabled allow rule leaves it set to any.
 
         **Why this matters**
 
-        Rules with the application set to "any" fall back to port-based matching, which provides significantly weaker security. If rules do not use App-ID:
+        Port numbers are a convention, not a control. An attacker who wants an outbound channel from a compromised host picks 443 because it is open everywhere, and a rule allowing any application on 443 cannot tell a browser session from an SSH tunnel, a remote access tool, or an implant beaconing over TLS.
 
-        - Applications using non-standard ports or tunneling through allowed ports bypass security controls.
-        - The firewall cannot distinguish between legitimate and malicious applications on the same port.
-        - Evasive applications that hop between ports cannot be identified or controlled.
-        - Visibility into actual application usage on the network is lost.
-        - The primary differentiating capability of a next-generation firewall goes unused.
+        The same weakness runs inbound. A rule intended to publish a web service but written to allow any application accepts whatever protocol a client chooses to speak to that port, which turns a narrow exposure into whatever the backend happens to answer.
 
-        Specifying applications by App-ID ensures the firewall identifies and controls traffic based on the actual application, not just the port number.
+        Application matching also gates the rest of the inspection stack. The decoders that extract files, URLs, and credentials operate on an identified application, so a rule matching by port alone inspects the session far more shallowly than the profiles attached to it suggest.
+
+        Legitimate exceptions exist: a proprietary protocol with no application signature has to fall back to a service definition, and those rules should use a custom application or a tightly scoped service and address pair rather than being left open. When tightening an existing rule, build the application list from the traffic already logged against it, since guessing tends to break something that only runs once a month.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1417,18 +1429,19 @@ queries:
         )
     docs:
       desc: |
-        This check verifies that all enabled allow rules have at least one security profile or a security profile group attached. Security profiles enable threat inspection on allowed traffic.
+        This check verifies that enabled allow rules apply threat inspection through a security profile or profile group.
+
+        Profiles are what cause allowed traffic to be examined for exploits, malware, and spyware; a rule without one permits the session and inspects nothing. The setting is on the Actions tab of each rule under Policies > Security, and this check requires an enabled allow rule to name either a profile group or at least one of the antivirus, anti-spyware, and vulnerability protection profiles.
 
         **Why this matters**
 
-        An allow rule without security profiles permits traffic through without any threat inspection. If security profiles are missing from allow rules:
+        Subscriptions and content on the device do nothing on their own. A firewall with current signatures and every license active still passes an exploit untouched if the rule that admitted the session has no profile attached, and nothing warns that this is happening.
 
-        - Malware, exploits, and command-and-control traffic pass through the firewall uninspected.
-        - The firewall functions as a simple stateful firewall rather than a next-generation firewall.
-        - Known vulnerabilities cannot be detected or blocked in allowed traffic.
-        - Spyware and botnet communications are not identified.
+        This is the most common way a next-generation firewall ends up operating as a stateful packet filter. Rules get written for connectivity first, the traffic flows, and the profile field is left empty because nothing about the rule's behavior suggests it should not be.
 
-        Attaching security profiles (Antivirus, Anti-Spyware, Vulnerability Protection) or a security profile group to every allow rule ensures that all permitted traffic is inspected for threats.
+        For an attacker the consequence is direct. Exploiting a vulnerable internal service means getting the exploit to it, and a rule without vulnerability protection does exactly that, delivering the payload to a host that may be months behind on patching.
+
+        Inspection adds load, so on very high throughput rules carrying traffic that is already inspected elsewhere a deliberately reduced profile group is a reasonable trade. Prefer a shared profile group over per-rule profiles, so a policy change propagates in one place instead of being reapplied rule by rule.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1512,19 +1525,19 @@ queries:
         all(urlFilteringProfile != "" || profileGroup != "")
     docs:
       desc: |
-        This check verifies that all enabled allow rules have a URL filtering profile or security profile group attached. URL filtering inspects web traffic to block access to malicious, phishing, and inappropriate websites.
+        This check verifies that enabled allow rules apply URL filtering to the web traffic they permit.
+
+        A URL filtering profile classifies each web destination a session reaches and acts on the category, and it takes effect only on the rules that reference it. The setting is on the Actions tab of each rule under Policies > Security, and this check requires an enabled allow rule to name either a URL filtering profile or a profile group containing one.
 
         **Why this matters**
 
-        Without URL filtering on allow rules, users and systems can access known malicious websites through the firewall without any inspection or control. If URL filtering is missing:
+        Outbound web access is the path a phishing click takes and the path the payload comes back on. A rule permitting it without categorization cannot distinguish a business application from a credential-harvesting page registered an hour ago, so the browser loads both.
 
-        - Users can reach phishing sites designed to steal credentials.
-        - Drive-by download sites that distribute malware are not blocked.
-        - Command-and-control traffic using HTTP/HTTPS to known malicious URLs passes through.
-        - Acceptable use policies cannot be enforced at the firewall level.
-        - Credential phishing protection, which detects corporate credentials submitted to untrusted sites, is unavailable.
+        It is also the return channel for an established compromise. Command and control over HTTPS is indistinguishable from ordinary browsing at the session level; the destination's category and reputation are the only remaining signal, and a rule without a profile never asks for them.
 
-        Applying URL filtering to allow rules provides critical protection against web-based threats and enforces organizational web access policies.
+        Because blocked-category logging lives in the profile, a rule without one produces no record of where users actually went. Reconstructing an incident afterward then depends entirely on endpoint telemetry that may not exist.
+
+        This applies to rules carrying general web traffic; a rule scoped to one internal service on a fixed address gains little from categorization and can reasonably omit it. URL filtering also only sees what it can read, so pair it with decryption on the rules where inspecting HTTPS is permitted, or classification falls back to the certificate name alone.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1596,19 +1609,19 @@ queries:
         all(logEnd == true)
     docs:
       desc: |
-        This check verifies that all enabled security rules have session-end logging turned on. Session-end logs capture the complete picture of each network session including bytes transferred, duration, and threat verdicts.
+        This check verifies that enabled security rules log at session end.
+
+        Session-end logging writes one record per session after it closes, carrying the application, the byte and packet counts in each direction, the duration, the user, and the action taken. The option is on the Actions tab of each rule under Policies > Security, and this check requires it on every enabled rule.
 
         **Why this matters**
 
-        Without session-end logging, the firewall processes traffic but does not record what happened. If logging is disabled:
+        Traffic logs are the primary evidence a firewall produces. Without them an investigation cannot establish whether a host ever talked to a given address, how much data left, or when it started, and all three questions come up in the first hour of an incident.
 
-        - Security teams have no record of network sessions for forensic analysis.
-        - Threat detection and incident response are severely hampered by lack of traffic data.
-        - Compliance requirements for audit logging cannot be met.
-        - Anomaly detection systems that rely on traffic logs cannot function.
-        - There is no way to verify whether security policies are being applied correctly.
+        Session end is the record carrying the byte counts, which is what makes exfiltration visible. A session-start log shows that a connection happened; only the session-end record shows that four gigabytes went out over it.
 
-        Session-end logging is the primary source of traffic visibility and should be enabled on every security rule.
+        Deny rules matter as much as allow rules here. Blocked traffic is the signal that something is scanning, misconfigured, or already compromised and probing for a way out, and a deny rule that does not log turns that signal into silence.
+
+        The usual reason logging gets disabled is volume on a very chatty rule, and the right answer is to filter or sample in the forwarding profile rather than to stop generating the record. Where a rule must genuinely stay quiet, document why, and confirm that retention on the receiving system is long enough for the logs to still exist when someone comes to read them.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1675,18 +1688,19 @@ queries:
     mql: panos.securityRules.none(disabled == true)
     docs:
       desc: |
-        This check verifies that no disabled security rules remain in the rulebase. Disabled rules add complexity to the configuration without providing any security function.
+        This check verifies that the security rulebase contains no disabled rules.
+
+        A disabled rule stays in the configuration and in the displayed rule order but is skipped during evaluation. Rules are enabled and disabled under Policies > Security, and this check requires that none of them are left in the disabled state.
 
         **Why this matters**
 
-        Disabled rules in the rulebase indicate stale configuration that has not been properly cleaned up. If disabled rules remain:
+        Disabled rules make the rulebase harder to read correctly, and rule order is the whole of the policy's meaning. Anyone reviewing the configuration has to mentally filter out inactive entries to work out what actually matches first, and reviews run against a longer, noisier list find fewer real problems.
 
-        - The rulebase becomes harder to audit and review, increasing the chance of misconfiguration.
-        - Disabled rules may be accidentally re-enabled, potentially creating security gaps.
-        - Compliance auditors may flag disabled rules as evidence of poor configuration management.
-        - Rule order and intent become unclear when disabled rules are interspersed with active rules.
+        Re-enablement is the specific hazard. A rule disabled two years ago for a decommissioned application may reference address objects that have since been reused for something else entirely, so switching it back on grants access nobody intended, to a system nobody was thinking about.
 
-        Disabled rules should be removed from the configuration or documented with a clear justification for temporary retention.
+        Disabled rules also distort the tools people use to reason about the policy. Rule usage and hit-count data has nothing to say about a rule that never evaluates, so the normal signal for identifying dead policy fails on exactly the entries that are already dead.
+
+        Short-lived disablement during a change window is legitimate, and a rule kept disabled as a documented rollback path is defensible; both should carry a description saying so and a date. Everything else belongs in version control rather than in the running configuration.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1763,18 +1777,19 @@ queries:
         all(wildFireAnalysisProfile != "" || profileGroup != "")
     docs:
       desc: |
-        This check verifies that all enabled allow rules have a WildFire Analysis profile or security profile group attached. WildFire provides cloud-based sandbox analysis to detect zero-day malware and advanced persistent threats.
+        This check verifies that enabled allow rules forward unknown files for sandbox analysis.
+
+        A WildFire Analysis profile tells the firewall which file types on a rule to submit to the sandbox when no existing verdict applies. It is selected on the Actions tab of each rule under Policies > Security, and this check requires an enabled allow rule to name either that profile or a profile group containing one.
 
         **Why this matters**
 
-        Without a WildFire Analysis profile on allow rules, unknown files pass through the firewall without being submitted for cloud-based analysis. If WildFire analysis is not applied:
+        Antivirus signatures only cover samples that have been seen. The files worth worrying about most, a loader built for this target or repacked for this campaign, are by construction the ones no signature matches, and sandbox analysis is the only control on the device that can reach a verdict about them.
 
-        - Zero-day malware and previously unknown threats are not detected.
-        - Files are not submitted to the WildFire cloud for sandbox detonation and behavioral analysis.
-        - The firewall cannot benefit from machine learning-based threat classification.
-        - Newly discovered threats from the global WildFire network cannot generate signatures for local enforcement.
+        Without a profile attached, those files are delivered. The firewall had them in hand, decoded, on a rule it was inspecting, and passed them through because nothing instructed it to ask. The verdict that would have identified the sample is never produced.
 
-        Applying a WildFire Analysis profile to all allow rules ensures that unknown files are analyzed in the cloud and threats are identified even when no signature exists.
+        Submission also protects everyone else. A conviction generated from one organization's sample becomes a signature the whole fleet enforces within minutes, so a device that never submits is both unprotected and a gap in the shared feed.
+
+        Sandboxing sends file content to the analysis cloud, so rules carrying regulated or highly sensitive data may need a regional cloud or an on-premises analysis appliance instead. Verdicts also arrive after the file has been forwarded, so pair this with the antivirus profile, which blocks inline, rather than treating sandbox analysis as the only file control.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1849,18 +1864,19 @@ queries:
         all(managementProfile != "")
     docs:
       desc: |
-        This check verifies that all active Layer 3 ethernet interfaces have an interface management profile configured. Management profiles control which management services (HTTP, HTTPS, SSH, SNMP, ping) are accessible on each interface.
+        This check verifies that active Layer 3 interfaces carry an explicit interface management profile.
+
+        An interface management profile lists which management services, among ping, SSH, HTTPS, SNMP, response pages, and User-ID, may be reached on the dataplane interfaces referencing it. Profiles are built under Network > Network Profiles > Interface Mgmt and attached on the Advanced tab of each interface under Network > Interfaces, and this check requires every Layer 3 interface that is up to name one.
 
         **Why this matters**
 
-        PAN-OS dataplane interfaces allow no management services unless a management profile explicitly enables them, so a missing profile does not expose services on its own. The value of assigning a profile to every active interface is making that deny posture explicit and auditable. If management profiles are not configured:
+        A dataplane interface with no profile already denies management services, so the absence of one is not itself an exposure. What it costs is intent. Nothing in the configuration states that management on that interface is meant to be closed, so a reviewer cannot tell a deliberate deny from an oversight, and neither can the next administrator who needs to add ping for a monitoring system.
 
-        - There is no explicit, reviewable statement of which management protocols are allowed on each interface.
-        - Audits cannot confirm that management access on untrusted interfaces is denied by design rather than by omission.
-        - Administrators may later attach permissive profiles without a baseline that distinguishes trusted from untrusted interfaces.
-        - Profiles that enable services without permitted IP restrictions expand the firewall's management plane attack surface.
+        That ambiguity is where real exposure enters. The Palo Alto management plane has been the target of mass-exploited pre-authentication vulnerabilities more than once, and the incidents that ended badly involved interfaces reachable from untrusted networks. Profiles are the record of which interfaces those are, and without a baseline separating trusted from untrusted, permissive profiles get attached to the wrong ones.
 
-        Configuring a management profile on every active Layer 3 interface ensures explicit control over which management services are permitted, following the principle of least privilege.
+        Profiles are also where permitted source addresses are set. One that enables HTTPS or SSH with no address list turns the interface into an open management endpoint for anyone who can route to it, which is the first thing to look for when reviewing the profiles that already exist.
+
+        Attaching a profile named for a deny-everything baseline to internet-facing and untrusted interfaces makes the intent explicit and cheap to audit. Management access belongs on the dedicated management interface on an out-of-band network wherever the deployment allows it, with dataplane management reserved for cases that genuinely have no alternative.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -1943,19 +1959,19 @@ queries:
         none(enableDhcp == true)
     docs:
       desc: |
-        This check verifies that no Layer 3 ethernet interfaces are configured to obtain their IP address via DHCP. Firewalls should use static addressing for predictability and to prevent DHCP-based attacks.
+        This check verifies that Layer 3 interfaces use static addressing rather than DHCP.
+
+        Setting a Layer 3 interface to DHCP client makes the firewall request its address, mask, gateway, and optionally a default route from whatever server answers on that segment. The address type is on the IPv4 tab of each interface under Network > Interfaces, and this check requires that no Layer 3 interface is configured as a DHCP client.
 
         **Why this matters**
 
-        DHCP-assigned addresses on a firewall introduce unpredictability and potential security risks. If interfaces use DHCP:
+        DHCP has no authentication. Anything on the segment can answer a request and the client takes the first reply, so an attacker with a foothold on that network can hand the firewall a gateway address they control and receive traffic the firewall then forwards to them. On a perimeter interface that is an interception primitive requiring no access to the firewall at all.
 
-        - A rogue DHCP server could assign incorrect addresses, redirecting or intercepting traffic.
-        - IP address changes could break routing, VPN tunnels, and NAT policies that reference specific addresses.
-        - DNS and management systems may lose connectivity to the firewall if its address changes.
-        - DHCP lease expiration during operation could cause a brief service interruption.
-        - Security policies referencing interface addresses may become invalid after an address change.
+        The default route option is the sharper edge of the same problem. A DHCP client interface can accept a route from the server, letting an untrusted party influence where the firewall sends traffic for destinations it has no specific route for.
 
-        Static addressing ensures predictable, reliable firewall operation and eliminates DHCP-related attack vectors.
+        The availability cost is separate and just as real. VPN peers, NAT rules, address objects, and remote monitoring all reference the interface address, and a lease renewal that returns a different one breaks them at once, usually outside a change window and without an obvious cause.
+
+        Small branch and consumer-broadband deployments are the legitimate exception, where the upstream provider offers nothing but DHCP. In those cases decline the default route from the server and configure a static one instead, and restrict what the interface accepts to the minimum the link requires.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2027,18 +2043,19 @@ queries:
         all(zone != "")
     docs:
       desc: |
-        This check verifies that all active Layer 3 ethernet interfaces are assigned to a security zone. Interfaces not assigned to a zone cannot have security policies applied to their traffic.
+        This check verifies that active Layer 3 interfaces belong to a security zone.
+
+        Zones are what the security policy matches on, since every rule names a source and destination zone, so an interface outside every zone is outside the policy. The assignment is on the Config tab of each interface under Network > Interfaces, and this check requires every Layer 3 interface that is up to name a zone.
 
         **Why this matters**
 
-        An interface without a zone assignment operates outside the firewall's security policy framework. If interfaces are not assigned to zones:
+        PAN-OS drops traffic on an interface with no zone, so the immediate effect is an availability one. The link is up, the address is configured, the cable is right, and nothing passes. This is a common cause of an interface that looks healthy at every layer and still carries no traffic.
 
-        - Traffic on those interfaces cannot be matched by any security policy rule.
-        - No threat inspection, access control, or logging applies to traffic on unzoned interfaces.
-        - The interface effectively creates a gap in the firewall's security perimeter.
-        - Zone-based protections (zone protection profiles, DoS protection) do not apply.
+        The security cost appears when the omission gets fixed carelessly. Under time pressure the quickest way to make traffic flow is to drop the interface into an existing zone that already has permissive rules, which extends whatever trust that zone carries to a segment nobody assessed for it.
 
-        Every active Layer 3 interface must be assigned to a security zone to ensure all traffic is subject to the firewall's security policies.
+        Zone membership also determines which network-layer protections apply. Zone protection profiles, packet buffer protection, and DoS protection are all bound to a zone, so an unzoned interface sits outside those controls as well as outside the rulebase.
+
+        Interfaces that are genuinely unused should be administratively disabled rather than left up without a zone, which removes them from this check and from the configuration's ambiguity at the same time. When adding a zone to bring an interface into service, create one scoped to that segment rather than reusing an existing zone for convenience.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2112,19 +2129,19 @@ queries:
         all(version.in(["ikev2", "ikev2-preferred"]))
     docs:
       desc: |
-        This check verifies that all enabled IKE gateways use IKEv2 or IKEv2-preferred mode. IKEv2 provides significant security and performance improvements over IKEv1.
+        This check verifies that enabled IKE gateways negotiate with IKEv2.
+
+        The version setting on an IKE gateway selects IKEv1, IKEv2, or IKEv2 with a fallback to IKEv1 for peers that cannot do better. It is on the General tab of each gateway under Network > Network Profiles > IKE Gateways, and this check requires enabled gateways to be set to IKEv2 or to the IKEv2-preferred mode.
 
         **Why this matters**
 
-        IKEv1 has known security weaknesses and is considered a legacy protocol. If IKE gateways use IKEv1:
+        IKEv1 is a 1998 protocol whose weaknesses are structural rather than implementation defects. Its aggressive mode exposes the identity payload and a hash derived from the pre-shared key in cleartext on the wire, which gives a passive observer everything needed to grind that key offline at their own pace.
 
-        - The key exchange is vulnerable to known attacks against IKEv1's design, including offline dictionary attacks in aggressive mode.
-        - IKEv1 lacks built-in NAT traversal, requiring additional configuration.
-        - Dead peer detection and error handling are less robust than in IKEv2.
-        - IKEv2 supports stronger authentication methods including EAP and asymmetric authentication.
-        - IKEv1 requires more round trips to establish a security association, increasing latency.
+        IKEv2 removes the exposure by protecting identities in every exchange and by making the responder prove liveness before committing state, which also blunts the half-open flooding attacks IKEv1 responders are vulnerable to.
 
-        Migrating to IKEv2 improves both security and tunnel establishment performance.
+        The operational half matters on a perimeter device. IKEv2 has built-in liveness detection and NAT traversal and rekeys without tearing the tunnel down, so tunnels recover from a transient outage instead of staying black-holed until someone notices, and mobility support keeps a tunnel up across an address change on a dynamic link.
+
+        The IKEv2-preferred setting exists for the real constraint here, which is a peer that cannot be upgraded. It is a migration state rather than a destination: it silently falls back to IKEv1 with all of its weaknesses, so track which gateways are actually negotiating down and finish the migration instead of leaving the fallback as the permanent configuration.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2196,19 +2213,19 @@ queries:
         all(authType == "certificate")
     docs:
       desc: |
-        This check verifies that all enabled IKE gateways use certificate-based authentication rather than pre-shared keys. Certificate authentication provides stronger identity verification and better key management.
+        This check verifies that enabled IKE gateways authenticate peers with certificates rather than pre-shared keys.
+
+        An IKE gateway authenticates either with a pre-shared key typed into both ends or with a certificate validated against a configured certificate profile. The method is set on the General tab of each gateway under Network > Network Profiles > IKE Gateways, and this check requires enabled gateways to use certificate authentication.
 
         **Why this matters**
 
-        Pre-shared keys (PSKs) are a weaker form of authentication that introduce operational and security risks. If IKE gateways use pre-shared keys:
+        A pre-shared key is a password that two devices share and that people have to move between them. In practice it is chosen by whoever built the tunnel, sent over email or chat to the other party, written into a runbook, and reused across sites because keeping them distinct is work. Any one of those steps is enough for it to leak.
 
-        - PSKs are often weak, reused across multiple tunnels, or shared insecurely between administrators.
-        - Rotating pre-shared keys requires coordinated changes on both ends of every tunnel.
-        - Compromised pre-shared keys allow an attacker to establish unauthorized VPN tunnels.
-        - IKEv1 aggressive mode with PSKs is vulnerable to offline brute-force attacks against the key.
-        - There is no revocation mechanism for compromised pre-shared keys — every tunnel using the key must be reconfigured.
+        Once it leaks, an attacker who can reach the gateway brings up a tunnel as the legitimate peer and appears inside the network at whatever zone that tunnel terminates in. The gateway cannot tell the difference, because knowledge of the key is the entire identity claim.
 
-        Certificate-based authentication leverages PKI infrastructure for stronger identity verification, automated rotation, and centralized revocation.
+        Recovery is the part that hurts. There is no revocation for a shared secret, so a suspected compromise means coordinating a simultaneous change with every peer that used the key, and keys reused across sites all have to move at once. Certificates turn that into a revocation list update.
+
+        Certificate authentication depends on a working PKI: a certificate profile that genuinely validates the chain, a revocation source the firewall can reach, and monitoring for expiry, since an expired peer certificate takes the tunnel down. Where a partner cannot support certificates, use a long random key unique to that tunnel and rotate it on a schedule.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2288,18 +2305,19 @@ queries:
         )
     docs:
       desc: |
-        This check verifies that all enabled IKE gateways have dead peer detection (DPD) enabled. DPD detects when a VPN peer becomes unreachable and cleans up the associated security associations.
+        This check verifies that enabled IKE gateways detect when a peer stops responding.
+
+        The mechanism differs by version. IKEv1 gateways use dead peer detection, IKEv2 gateways use the liveness check, and gateways set to IKEv2-preferred need both because either version may end up in use. The settings are under Advanced Options on each gateway under Network > Network Profiles > IKE Gateways, and this check requires the mechanism matching the gateway's configured version to be enabled.
 
         **Why this matters**
 
-        Without dead peer detection, the firewall cannot detect when a VPN peer has become unreachable. If DPD is disabled:
+        IPsec has no notion of a connection that closes. When a peer reboots, loses power, or is cut off upstream, its security associations simply stop being answered, and without an active probe the local end never learns this. It keeps encrypting into a tunnel that no longer terminates anywhere.
 
-        - Stale IKE and IPsec security associations persist, consuming system resources.
-        - Traffic continues to be sent into a dead tunnel, resulting in packet loss.
-        - Failover to backup tunnels or paths does not occur because the primary tunnel appears active.
-        - The firewall cannot distinguish between a temporary network interruption and a permanent peer failure.
+        The visible symptom is a tunnel that shows as up while nothing traverses it. Traffic is routed into it and disappears, monitoring reports the tunnel as healthy, and the outage gets diagnosed as an application problem on the far side because the network layer insists everything is fine.
 
-        Enabling DPD ensures timely detection of failed peers and allows the firewall to clean up stale tunnels and trigger failover mechanisms.
+        Failover depends entirely on this signal. A backup tunnel or an alternate path is only taken once the primary is known to be down, so without liveness detection the redundancy that was designed and paid for never engages.
+
+        Stale security associations also accumulate on the gateway, consuming resources and, when the peer returns, causing rekey collisions that stop the tunnel from re-establishing cleanly until the old entries time out. Set the probe interval against the link's real characteristics, since intervals that are too aggressive on a high-latency or lossy path tear down a tunnel that is merely slow.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2372,18 +2390,19 @@ queries:
         none(ikev1ExchangeMode == "aggressive")
     docs:
       desc: |
-        This check verifies that no IKEv1 gateways use aggressive mode for key exchange. Aggressive mode transmits identity information in cleartext and is vulnerable to offline attacks.
+        This check verifies that IKEv1 gateways negotiate in main mode rather than aggressive mode.
+
+        IKEv1 phase 1 can run as a six-message main mode exchange or a three-message aggressive mode exchange. The exchange mode is set under Advanced Options on each gateway under Network > Network Profiles > IKE Gateways, and this check requires that no enabled gateway capable of IKEv1 is set to aggressive.
 
         **Why this matters**
 
-        IKEv1 aggressive mode reduces the number of exchanges needed to establish a security association but does so at the cost of security. If aggressive mode is used:
+        Aggressive mode sends the initiator's identity and a hash computed over the pre-shared key before any encryption is established. Anyone who can capture that single exchange, or who simply sends one packet to the gateway and records the reply, walks away with material they can attack offline for as long as they like, at whatever rate their hardware allows.
 
-        - The initiator's identity (ID payload) is sent in cleartext in the first message, exposing it to eavesdroppers.
-        - Pre-shared key hashes are transmitted in a way that enables offline brute-force attacks.
-        - An attacker who captures the aggressive mode exchange can mount an offline dictionary attack against the pre-shared key.
-        - The reduced number of round trips means fewer opportunities for the peers to verify each other's identity.
+        That last part is what separates it from an online guessing attack. There is no lockout, no rate limit, and no log entry on the firewall for the millions of attempts, because none of them touch the firewall. A key that would take years to guess over the network falls in hours against a GPU.
 
-        IKEv1 gateways should use main mode, which protects identity information through encryption. Better yet, migrate to IKEv2 which does not have this vulnerability.
+        The recovered key is rarely just a credential for that one tunnel. Because pre-shared keys get reused across gateways, cracking a single aggressive mode exchange frequently yields access to several tunnels, and the attacker arrives as a trusted peer inside whichever zone they terminate in.
+
+        Aggressive mode exists to support peers with dynamic addresses that cannot be identified by IP before the exchange begins. Certificate authentication solves that constraint better, identifying the peer without exposing anything derived from a shared secret. Where aggressive mode genuinely cannot be avoided, treat the key as public and move the gateway to IKEv2 as the actual fix.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2455,18 +2474,19 @@ queries:
         all(antiReplay == true)
     docs:
       desc: |
-        This check verifies that all enabled IPsec tunnels have anti-replay protection enabled. Anti-replay protection prevents attackers from capturing and re-injecting encrypted packets into a VPN tunnel.
+        This check verifies that enabled IPsec tunnels discard replayed packets.
+
+        Anti-replay tracks the sequence numbers on arriving ESP packets against a sliding window and drops anything outside it or already seen. The option is among the advanced settings of each tunnel under Network > IPSec Tunnels, and this check requires it on every enabled tunnel.
 
         **Why this matters**
 
-        Without anti-replay protection, an attacker who can capture packets on the wire can replay them into the tunnel. If anti-replay is disabled:
+        Encryption stops an observer from reading a packet; it does nothing to stop them from sending it again. Without replay protection an attacker who can capture ciphertext on the path can inject those exact packets back into the tunnel later, and the receiving end decrypts and processes them as authentic, because cryptographically they are.
 
-        - An attacker can capture encrypted VPN packets and retransmit them to trigger duplicate actions on the remote system.
-        - Replay attacks can be used to manipulate stateful applications by re-submitting previously valid transactions.
-        - Denial-of-service conditions can be created by replaying large volumes of captured traffic.
-        - The integrity guarantee of the IPsec tunnel is weakened because packets can be injected without detection.
+        What that buys depends on what the tunnel carries. Replayed application traffic can re-trigger operations meant to happen once, and on links carrying control or telemetry protocols it lets an attacker resubmit a stale state update without ever needing to read or forge anything.
 
-        Anti-replay uses a sliding window of sequence numbers to detect and discard replayed packets, maintaining the integrity of the tunnel.
+        It is also a cheap denial of service. Flooding replayed packets forces the far end to decrypt and authenticate every one before discarding it, spending the expensive part of the work on traffic that was never going to be accepted.
+
+        Replay protection is on by default and is normally switched off deliberately, most often to work around out-of-order delivery on a multipath or heavily load-balanced link that pushes packets outside the window. Widening the replay window is the better answer there; if it must stay off, confirm the underlying path is one an attacker can neither observe nor inject on.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2537,18 +2557,19 @@ queries:
         all(enableTunnelMonitor == true)
     docs:
       desc: |
-        This check verifies that all enabled IPsec tunnels have tunnel monitoring configured. Tunnel monitoring probes the remote end of the tunnel and triggers failover when connectivity is lost.
+        This check verifies that enabled IPsec tunnels are monitored for end-to-end reachability.
+
+        Tunnel monitoring sends probes through the tunnel to an address on the far side and takes a configured action, either waiting for recovery or failing over, when those probes stop being answered. It is configured per tunnel under Network > IPSec Tunnels, and this check requires it on every enabled tunnel.
 
         **Why this matters**
 
-        Without tunnel monitoring, the firewall cannot detect when an IPsec tunnel has silently failed. If tunnel monitoring is disabled:
+        Tunnel monitoring answers a different question from peer liveness detection. Liveness checks confirm the peer gateway is still talking IKE; monitoring confirms that traffic placed in the tunnel actually arrives somewhere useful. A tunnel can be negotiated, established, and completely broken at the same time, when a routing change, a proxy identifier mismatch, or a firewall on the far side quietly discards whatever comes out of it.
 
-        - Traffic continues to be routed into a failed tunnel, resulting in packet loss.
-        - Failover to backup tunnels or alternate paths does not occur automatically.
-        - Network outages persist until the tunnel failure is manually detected and addressed.
-        - Service-level agreements may be violated due to extended undetected tunnel downtime.
+        That state is the hard one to diagnose. Every status display shows the tunnel up, so the investigation starts at the application and works backward, and the outage lasts as long as it takes someone to think of testing the path itself.
 
-        Tunnel monitoring continuously verifies tunnel reachability and can automatically trigger failover actions, ensuring high availability of VPN connectivity.
+        Monitoring is also what drives automatic failover on a route pointing at the tunnel interface. Without it the route stays installed and traffic keeps being sent into a path that does not work, so a designed-in backup link never takes over.
+
+        The monitored destination has to be chosen with care. An address that is reachable but not representative, or one behind a device that drops the probe protocol, produces either false confidence or a tunnel that flaps. Pick a host on the far side whose availability actually stands in for the service the tunnel exists to carry.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2625,19 +2646,19 @@ queries:
         all(decryptionProfile != "")
     docs:
       desc: |
-        This check verifies that all enabled decryption rules with a decrypt action have a decryption profile attached. Decryption profiles enforce TLS protocol standards and certificate validation requirements on decrypted sessions.
+        This check verifies that enabled decryption rules with a decrypt action apply a decryption profile.
+
+        A decryption profile sets the rules for the sessions being decrypted: the minimum TLS version, the permitted cipher suites and key exchange algorithms, and what to do about expired, untrusted, or unsupported certificates. Profiles live under Objects > Decryption > Decryption Profile and are attached on the Options tab of each rule under Policies > Decryption, where this check requires every enabled decrypt rule to name one.
 
         **Why this matters**
 
-        Without a decryption profile, decrypted traffic is not validated against TLS security best practices. If decryption profiles are missing:
+        When the firewall decrypts a session it becomes the TLS client for the real server, and the security of that outbound connection is now the firewall's decision rather than the browser's. Without a profile that decision defaults to accepting far more than any modern client would: obsolete protocol versions, weak ciphers, and certificates that fail validation.
 
-        - Sessions using weak or deprecated TLS versions (SSLv3, TLS 1.0) are not blocked.
-        - Connections with untrusted or expired certificates are permitted.
-        - Weak cipher suites that provide inadequate encryption are allowed.
-        - Certificate chain validation failures are not enforced, enabling man-in-the-middle attacks.
-        - The firewall decrypts traffic without enforcing any standards on the TLS session itself.
+        The result is worse than not decrypting at all. The user's browser sees a valid certificate issued by the firewall and shows a lock, so every signal the endpoint would have used to warn them is replaced by a reassuring one, while the connection the firewall actually made to the server was never validated. An attacker intercepting beyond the firewall is invisible to both ends.
 
-        A decryption profile ensures that decrypted sessions meet minimum security standards for TLS version, cipher strength, and certificate validity.
+        Certificate handling is the specific setting to review. A profile that blocks untrusted issuers and expired certificates is what preserves the warning the user would otherwise have received; without it, decryption strips the endpoint's ability to detect exactly the attack decryption was deployed to find.
+
+        Blocking on validation failure will break sites that are genuinely misconfigured, so plan for an exception process and for applications that pin certificates and cannot be decrypted at all. Those belong on a no-decrypt rule with a profile of their own rather than being accommodated by loosening the profile covering everything else.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2710,19 +2731,19 @@ queries:
         all(logFailedTlsHandshakes == true)
     docs:
       desc: |
-        This check verifies that all enabled decryption rules log failed TLS handshakes. Failed TLS handshakes can indicate attacks, misconfigurations, or applications that do not properly support decryption.
+        This check verifies that enabled decryption rules log unsuccessful TLS handshakes.
+
+        When a session fails to negotiate, PAN-OS can record the attempt together with the reason it failed. The option is on the Options tab of each rule under Policies > Decryption, and this check requires it on every enabled decryption rule.
 
         **Why this matters**
 
-        Without logging failed TLS handshakes, administrators have no visibility into decryption failures. If TLS failure logging is disabled:
+        Handshake failures are the visible edge of both attacks and breakage, and they are the one place the two look alike. Without the record, a client that pins its certificate and a client whose session is being tampered with in transit produce identical evidence: none.
 
-        - Man-in-the-middle or downgrade attacks that cause handshake failures go undetected.
-        - Applications or clients that do not support decryption are not identified for troubleshooting.
-        - Certificate pinning failures that indicate potential security issues are not logged.
-        - Trends in TLS failures that could indicate a broader attack or misconfiguration are invisible.
-        - Compliance requirements for monitoring encrypted traffic cannot be met.
+        The operational case is what usually gets this enabled. Decryption deployments fail on a long tail of applications that pin certificates, require client certificates, or speak a TLS variant the profile rejects, and each one presents to the user as a generic connection error. The failure log is the only artifact naming the application and the reason, which is the difference between adding a targeted exception and switching decryption off for a whole subnet.
 
-        Logging failed TLS handshakes provides essential visibility for troubleshooting decryption issues and detecting potential attacks.
+        The security case is thinner but real. A rise in validation failures against a destination that normally succeeds is what interception upstream of the firewall looks like, and downgrade attempts appear here as negotiation failures rather than as sessions.
+
+        This does generate volume, particularly in the first weeks of a decryption rollout, so send it to a forwarding profile rather than relying on local storage, and expect to spend time on exceptions before the rate settles.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2794,18 +2815,19 @@ queries:
         all(staticRoutes.any(destination == "0.0.0.0/0"))
     docs:
       desc: |
-        This check verifies that all virtual routers have a default route (0.0.0.0/0) configured. A missing default route typically indicates a routing misconfiguration that can cause traffic to be silently dropped.
+        This check verifies that every virtual router has a statically configured default route.
+
+        A default route of 0.0.0.0/0 is the entry a router uses for destinations no other route covers. Static routes are configured per virtual router under Network > Virtual Routers, and this check requires each virtual router to have one with that destination.
 
         **Why this matters**
 
-        Without a default route, the virtual router has no path for traffic destined to networks not explicitly listed in the routing table. If a default route is missing:
+        A router with no default route discards traffic for anything not explicitly in its table, and it does so silently. No failure surfaces that points at the routing table, so the symptom presented to users is that some destinations work and others hang, which sends the investigation toward DNS or the application long before anyone opens the router configuration.
 
-        - Traffic to unknown destinations is silently dropped rather than forwarded to a gateway.
-        - Internet-bound traffic fails if no specific route covers the destination.
-        - VPN or inter-zone traffic may fail for destinations not covered by specific routes.
-        - Routing failures can be difficult to diagnose when there is no default path.
+        On a firewall this failure also cuts against the device's own services. Content updates, license checks, cloud lookups for URL and DNS categorization, and log forwarding to an off-box collector all originate from the firewall and all depend on a path to destinations outside its directly connected networks. A missing default route degrades the security controls themselves, not just transit traffic.
 
-        A properly configured default route ensures that all traffic has a forwarding path, preventing silent routing failures. In environments using dynamic routing protocols, the default route may be learned dynamically — in that case, verify the dynamic routing configuration is correct.
+        Recovery from an unreachable firewall is the availability concern behind this. Losing the return path to the management network means losing the way in to fix it, which is why an out-of-band console path matters on a device whose routing can be changed remotely.
+
+        Virtual routers that learn their default route from OSPF, BGP, or a dynamic path monitor are correctly configured and will still fail this check, because it looks only at static routes. Confirm which model each virtual router uses before acting, and note that a virtual router deliberately confined to a set of internal networks may legitimately have no default route at all.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2880,18 +2902,19 @@ queries:
         all(ospfAreas.all(interfaces().all(authProfile != "")))
     docs:
       desc: |
-        This check verifies that all OSPF interfaces have an authentication profile configured. OSPF authentication prevents unauthorized routers from injecting malicious routing information into the network.
+        This check verifies that OSPF interfaces require authentication before forming an adjacency.
+
+        An OSPF authentication profile carries a password or an MD5 key that neighbors must present for their packets to be accepted. Profiles are defined in the OSPF configuration of each virtual router under Network > Virtual Routers and referenced by the interfaces in each area, where this check requires every OSPF-enabled interface to name one.
 
         **Why this matters**
 
-        Without authentication, any device on a shared network segment can participate in OSPF and inject arbitrary routes. An attacker who gains access to a network segment running OSPF can:
+        Unauthenticated OSPF accepts routing information from anything on the segment. An attacker with any foothold on a network where OSPF runs, whether a compromised host, a switch port in an unlocked closet, or a virtual machine on the wrong VLAN, can form an adjacency with the firewall and begin advertising routes to it.
 
-        - Inject false routes to redirect traffic through attacker-controlled systems for interception.
-        - Advertise more-specific routes to black-hole traffic, causing denial of service.
-        - Manipulate routing tables to bypass security zones and firewall policies.
-        - Perform man-in-the-middle attacks by rerouting traffic through a compromised host.
+        What that buys is traffic redirection. Advertising a more specific route for a subnet the attacker cares about pulls that traffic through a host they control, where they can read it, modify it, and forward it on so the interception stays invisible from both endpoints. Routing manipulation at the firewall is especially valuable, because it can steer traffic around the zones the security policy depends on.
 
-        Configuring OSPF authentication ensures that only authorized routers can exchange routing information, protecting the integrity of the routing domain.
+        The same primitive works as a denial of service. Advertising a route and then dropping what arrives black-holes a subnet, and because the firewall's routing table is genuinely correct according to the protocol, the outage looks like a network failure rather than an attack.
+
+        Authentication here is a secret shared between neighbors, so it needs to be distinct per area or link and rotated like any other credential; the older simple password type sends it in cleartext and should not be used. Even on a point-to-point link the firewall fully controls, configuring it costs one profile and outlives the assumption about who can reach that link.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -2967,18 +2990,19 @@ queries:
         all(ospfAreas.all(virtualLinks().all(authProfile != "")))
     docs:
       desc: |
-        This check verifies that all OSPF virtual links have an authentication profile configured. Virtual links connect non-contiguous OSPF areas through a transit area, and without authentication they are vulnerable to route manipulation.
+        This check verifies that OSPF virtual links require authentication.
+
+        A virtual link is a logical adjacency carrying backbone traffic across a transit area, used when an area has no direct attachment to area 0. Virtual links are configured per area in the OSPF settings of a virtual router under Network > Virtual Routers, and this check requires each of them to reference an authentication profile.
 
         **Why this matters**
 
-        OSPF virtual links traverse non-backbone areas to maintain connectivity with Area 0. Because they pass through intermediate areas, they are particularly exposed to attack:
+        A virtual link is a backbone adjacency, and the routers it passes through are not part of it. Every device along the transit area can see its packets and can send packets appearing to come from the far end, so the set of parties able to interfere with the link is far larger than the set that was meant to be in the backbone at all.
 
-        - An attacker in the transit area can spoof virtual link packets to inject routes into the backbone.
-        - Unauthenticated virtual links allow unauthorized adjacency formation, enabling route poisoning.
-        - Compromised routing in the backbone area (Area 0) affects the entire OSPF domain.
-        - Virtual link spoofing can be used to partition the network, causing widespread routing failures.
+        That difference is what makes an unauthenticated virtual link worse than an unauthenticated ordinary interface. A route injected into area 0 propagates to the entire OSPF domain rather than to one segment, so a single spoofed advertisement can redirect or black-hole traffic between sites that have no other relationship to the compromised area.
 
-        Authentication on virtual links ensures that only trusted routers can form adjacencies across transit areas, protecting the backbone from unauthorized route injection.
+        Virtual links are also easy to overlook. They are configured somewhere different from interface settings, they are usually added once during a topology fix and never revisited, and an authentication standard applied to interfaces frequently misses them entirely.
+
+        A virtual link is a workaround for an area that lost its backbone attachment, and the durable fix is normally to restore direct connectivity rather than to keep the link. While one exists, authenticate it under the same key management as the rest of the domain, and remember the transit area's own interfaces need authentication too, since the virtual link's traffic depends on the routing through them.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -3054,18 +3078,19 @@ queries:
         all(ospf.rfc1583 == false)
     docs:
       desc: |
-        This check verifies that OSPF RFC 1583 compatibility mode is disabled on all virtual routers. RFC 1583 has known deficiencies in external route preference calculation that were corrected in RFC 2328.
+        This check verifies that RFC 1583 compatibility is turned off in OSPF.
+
+        RFC 1583 compatibility restores the older route preference rules for choosing among external routes to the same destination, which RFC 2328 replaced because the original rules could produce persistent routing loops. The setting is in the OSPF configuration of each virtual router under Network > Virtual Routers, and this check requires it to be disabled.
 
         **Why this matters**
 
-        RFC 1583 compatibility mode uses an older algorithm for selecting among multiple AS-external LSA routes to the same destination. This can be exploited to cause security issues:
+        The problem the newer rules fix is that different routers applying the older preference algorithm to the same set of external advertisements can each choose a next hop pointing at the other. Traffic then circulates between them until its time to live expires, consuming bandwidth on every link in the loop.
 
-        - An attacker advertising external routes can exploit the weaker path selection to redirect traffic through a malicious router.
-        - The RFC 1583 algorithm can create forwarding loops when multiple ASBR routers advertise routes to the same external destination.
-        - Routing loops can be leveraged to cause denial of service or to intercept traffic.
-        - Mixed RFC 1583 and RFC 2328 behavior in the same OSPF domain causes unpredictable route selection.
+        Anyone able to inject external routes can arrange this deliberately. Advertising the same destination from two points with the right cost relationship turns a routing subtlety into an amplifier: a small amount of traffic sent into the loop occupies the path repeatedly, and the resulting outage reads as congestion rather than as an attack.
 
-        Disabling RFC 1583 compatibility ensures the firewall uses the more secure RFC 2328 route selection algorithm, reducing the risk of route manipulation attacks.
+        The preference rules also decide which advertisement wins when several routers offer a path to the same external prefix, so an attacker able to influence that choice can pull traffic toward a route they control. The older algorithm leaves more room to do it.
+
+        Compatibility mode has to be set consistently across the whole OSPF domain, because a mixed setting is what actually produces the inconsistent choices. Where a legacy device requires it, treat the setting as a constraint to be tracked and retired with that device, and limit the interim risk by authenticating the domain so external routes can only come from routers that belong in it.
       audit: |
         ### Audit via the PAN-OS web interface
 
@@ -3136,18 +3161,19 @@ queries:
         all(ospf.rejectDefaultRoute == true)
     docs:
       desc: |
-        This check verifies that OSPF is configured to reject default routes learned from OSPF neighbors. A firewall should use explicitly configured default routes rather than accepting them dynamically via OSPF.
+        This check verifies that OSPF is configured to reject default routes learned from neighbors.
+
+        With this option set, the virtual router will not install a 0.0.0.0/0 route received in an OSPF advertisement. It is in the OSPF configuration of each virtual router under Network > Virtual Routers, and this check requires it to be enabled.
 
         **Why this matters**
 
-        Accepting a default route via OSPF means any OSPF neighbor can advertise itself as the gateway of last resort, potentially hijacking all traffic that does not match a more specific route:
+        The default route is the single most valuable entry in a routing table, because it decides where everything unmatched goes. Accepting one from OSPF means any router able to form an adjacency can nominate itself as the destination for all traffic the firewall has no specific route for, which on a perimeter device is most of what passes through it.
 
-        - A compromised or rogue router can advertise a default route to redirect all traffic through attacker-controlled infrastructure.
-        - An accidental default route advertisement from a misconfigured neighbor can cause traffic to flow through an unintended path, bypassing security controls.
-        - Accepting dynamic default routes undermines the principle of explicit routing, where the firewall administrator controls the forwarding path for unknown destinations.
-        - Traffic redirected via a spoofed default route can be intercepted, modified, or dropped.
+        Redirecting that traffic is a complete interception. It leaves the firewall exactly as it arrived, reaches a host the attacker controls, and can be forwarded on to the real destination afterward, so neither sender nor receiver sees anything unusual and the firewall's own logs show a normal allowed session.
 
-        Rejecting default routes via OSPF ensures the firewall only uses administratively configured default routes, maintaining control over the forwarding path for traffic to unknown destinations.
+        The accidental case is more common than the attack and just as damaging. A misconfigured router redistributing a default route into OSPF can pull a site's entire outbound traffic through a link that was never sized for it, or through a path bypassing the inspection points the design depends on.
+
+        A firewall's default route should be a deliberate, statically configured decision, which is what the default route check in this policy looks for. Where a design genuinely requires a dynamically learned default, use a route filter that accepts it only from one specific, authenticated neighbor rather than accepting it from the protocol at large.
       audit: |
         ### Audit via the PAN-OS web interface
 


### PR DESCRIPTION
Rewrites all 36 check descriptions in `content/mondoo-panos-security.mql.yaml` to the `docs.desc` standard in `content/CLAUDE.md`.

Every description in this policy shared the same shape: a one-line opener, a bullet list under **Why this matters**, and a closing sentence restating the opener. None of them told the reader where in the PAN-OS web interface the setting lives, so a failing check gave no starting point. The rewrite replaces the bullets with prose about what an attacker concretely does, names the administration location, and ends with the legitimate exceptions instead of a restatement.

## Before / after

| | Before | After |
|---|---|---|
| Checks rewritten | 0 | 36 of 36 |
| Descriptions using bullet lists | 36 | 0 |
| Descriptions naming a PAN-OS web interface location | 0 | 36 |
| Descriptions ending by restating the opener | 36 | 0 |
| Descriptions with an exception / pairing paragraph | 1 | 36 |
| Em dashes, en dashes, ` -- ` | 3 | 0 |
| Parenthetical asides | 14 | 0 |

Sibling checks that previously differed only by a noun swap are now differentiated on what actually separates them. `ike-dead-peer-detection` and `ipsec-tunnel-monitoring` now explain that liveness checks confirm the peer still speaks IKE while tunnel monitoring confirms traffic placed in the tunnel arrives somewhere useful. The four content-installed checks explain their separate update streams and cadences rather than repeating "content is missing". The five license checks each lead with the distinct capability the subscription gates.

## Example

`mondoo-panos-security-ike-no-aggressive-mode`

**Before**

> This check verifies that no IKEv1 gateways use aggressive mode for key exchange. Aggressive mode transmits identity information in cleartext and is vulnerable to offline attacks.
>
> **Why this matters**
>
> IKEv1 aggressive mode reduces the number of exchanges needed to establish a security association but does so at the cost of security. If aggressive mode is used:
>
> - The initiator's identity (ID payload) is sent in cleartext in the first message, exposing it to eavesdroppers.
> - Pre-shared key hashes are transmitted in a way that enables offline brute-force attacks.
> - An attacker who captures the aggressive mode exchange can mount an offline dictionary attack against the pre-shared key.
> - The reduced number of round trips means fewer opportunities for the peers to verify each other's identity.
>
> IKEv1 gateways should use main mode, which protects identity information through encryption. Better yet, migrate to IKEv2 which does not have this vulnerability.

**After**

> This check verifies that IKEv1 gateways negotiate in main mode rather than aggressive mode.
>
> IKEv1 phase 1 can run as a six-message main mode exchange or a three-message aggressive mode exchange. The exchange mode is set under Advanced Options on each gateway under Network > Network Profiles > IKE Gateways, and this check requires that no enabled gateway capable of IKEv1 is set to aggressive.
>
> **Why this matters**
>
> Aggressive mode sends the initiator's identity and a hash computed over the pre-shared key before any encryption is established. Anyone who can capture that single exchange, or who simply sends one packet to the gateway and records the reply, walks away with material they can attack offline for as long as they like, at whatever rate their hardware allows.
>
> That last part is what separates it from an online guessing attack. There is no lockout, no rate limit, and no log entry on the firewall for the millions of attempts, because none of them touch the firewall. A key that would take years to guess over the network falls in hours against a GPU.
>
> The recovered key is rarely just a credential for that one tunnel. Because pre-shared keys get reused across gateways, cracking a single aggressive mode exchange frequently yields access to several tunnels, and the attacker arrives as a trusted peer inside whichever zone they terminate in.
>
> Aggressive mode exists to support peers with dynamic addresses that cannot be identified by IP before the exchange begins. Certificate authentication solves that constraint better, identifying the peer without exposing anything derived from a shared secret. Where aggressive mode genuinely cannot be avoided, treat the key as public and move the gateway to IKEv2 as the actual fix.

## No behavior changed

**No `mql`, `filters`, `tags`, `impact`, `props`, `title`, `audit`, or `remediation` was modified.** Only `docs.desc` and the policy `version` changed, and the version moved one PATCH level from 2.0.3 to 2.0.4.

This is proven structurally rather than by reading the diff. The bundle is parsed at `origin/main` and at this commit, every `docs.desc` and `policies[].version` is replaced with a placeholder, and the resulting trees are compared:

```
EQUAL: True
```

## Validation

| Gate | Result |
|---|---|
| `cnspec policy lint content/mondoo-panos-security.mql.yaml` | `valid policy bundle(s)` |
| `typos` | no output |
| `go test ./internal/bundle/...` | `ok  go.mondoo.com/cnspec/v13/internal/bundle  1.427s` |
| Descriptions not starting with `This check` | 0 / 36 |
| Descriptions missing `**Why this matters**`, or with more than one | 0 / 36 |
| `**Risk mitigation**` headings | 0 |
| Em dashes, en dashes, ` -- ` | 0 |
| MQL accessor paths in prose | 0 |
| Bullet or numbered list lines | 0 |
| Byte-identical sibling descriptions | 0 |
| Parentheses in prose | 0 |

Interface locations were written against the PAN-OS provider schema in `~/.config/mondoo/providers/panos/panos.resources.json` and against each check's existing `audit` block, so the prose and the audit steps point at the same place. The schema also confirms every string field on these resources is non-optional, which is why the `field != ""` comparisons throughout this policy are genuine non-empty tests rather than the null-unsafe form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
