### PR TITLE
🐛 cisco: fail the NX-OS CoPP check when no policing is applied

### DIFF
--- a/content/mondoo-cisco-nxos-security.mql.yaml
+++ b/content/mondoo-cisco-nxos-security.mql.yaml
@@ -1436,13 +1436,12 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-6
     mql: |
-      cisco.nxos.copp.profile != "lenient"
-      cisco.nxos.copp.profile != ""
+      cisco.nxos.copp.profile.in(["strict", "moderate", "dense"])
     docs:
       desc: |
-        This check verifies that the switch has not been left with the weakest available protection for traffic reaching its supervisor CPU.
+        This check verifies that the switch polices traffic reaching its supervisor CPU, and has not been left with the weakest available protection.
 
-        Control Plane Policing classifies traffic destined for the CPU and polices each class. NX-OS offers strict, moderate, lenient, and dense profiles, normally chosen by the initial setup script and changeable later with `copp profile strict`. This check fails only when the profile is empty or set to lenient, so strict, moderate, and dense pass. So does `copp profile skip`, which installs no policing at all, and a switch in that state needs a real profile applied regardless of what this check reports.
+        Control Plane Policing classifies traffic destined for the CPU and polices each class. NX-OS accepts strict, moderate, lenient, dense, and skip for `copp profile`, normally chosen by the initial setup script and changeable later with `copp profile strict`. The check passes only on strict, moderate, or dense. It fails on lenient, the weakest profile; on skip, which installs no policing at all; and on a switch with no `copp profile` line in its running configuration.
 
         **Why this matters**
 
@@ -1454,7 +1453,7 @@ queries:
 
         Tightening the profile can drop traffic that was previously tolerated, so change it in a maintenance window and watch the per-class drop counters.
       audit: |-
-        To verify that CoPP uses a non-lenient profile:
+        To verify that CoPP uses a protective profile:
 
         1. Open an authenticated session to the device CLI.
         2. Display the active CoPP profile:
@@ -1463,7 +1462,7 @@ queries:
            show copp status
            ```
 
-        The device passes when the active CoPP profile is `strict`, `moderate`, or `dense`. A `lenient` profile or no profile is a failing result.
+        The device passes when the active CoPP profile is `strict`, `moderate`, or `dense`. A `lenient` profile, a `skip` profile, or no configured profile at all is a failing result.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
Fixes #3419.

`mondoo-cisco-nxos-security-copp-profile-strict` excluded only `lenient` and the empty string, so it passed on the states that mean the control is *absent* rather than merely weak.

```diff
- cisco.nxos.copp.profile != "lenient"
- cisco.nxos.copp.profile != ""
+ cisco.nxos.copp.profile.in(["strict", "moderate", "dense"])
```

### Two passing states, not one

The report covers `copp profile skip`. There is a second one it did not.

`cisco.nxos.copp` is nullable: the provider's `copp()` returns null when `show running-config | include copp` produces no rows, which is what a switch with no `copp profile` line looks like. Under MQL's three-valued logic `null != "lenient"` evaluates true, so both assertions passed on a device that was never configured at all.

Verified against the runtime rather than assumed:

| `copp profile` | `profile` | before | after |
|---|---|---|---|
| `strict` | `"strict"` | pass | pass |
| `moderate` | `"moderate"` | pass | pass |
| `dense` | `"dense"` | pass | pass |
| `lenient` | `"lenient"` | **fail** | **fail** |
| `skip` | `"skip"` | **pass** ❌ | **fail** ✅ |
| *(absent)* | `null` | **pass** ❌ | **fail** ✅ |

The allowlist closes both because `.in()` on null returns `false`, not null — checked directly:

```
$ mql run local -c 'asset.labels["nope"] != "lenient"'
[ok]
$ mql run local -c 'asset.labels["nope"].in(["strict","moderate","dense"])'
[failed]  expected: == true   actual: false
```

That asymmetry is the whole reason the allowlist is the right shape here, beyond fail-closed behavior on future profile values: a denylist built from `!=` cannot reject a null, because `null != anything` is true.

The textfsm template is `^copp profile\s+${PROFILE}$`, with `PROFILE` as `(\S+)`, so `skip` is captured verbatim and reaches the check as `"skip"` — it is not filtered out upstream.

### Docs

The description previously recorded the gap as accepted behavior ("So does `copp profile skip`, which installs no policing at all, and a switch in that state needs a real profile applied regardless of what this check reports"). That sentence and the audit steps now describe what the check enforces. The `impact`, `uid`, title and compliance tags are unchanged.

### Test plan

- [x] `cnspec policy lint ./content` — valid policy bundle(s)
- [x] Confirmed the lint actually type-checks this resource by planting `cisco.nxos.copp.bogusFieldXYZ`, which failed with `cannot find field 'bogusFieldXYZ' in cisco.nxos.coppConfig` — so the passing lint is meaningful and not a skipped provider
- [x] All six profile states evaluated against both the old and new expressions (table above)
- [x] `typos` clean

There are no NX-OS fixtures under `content/validation` — that harness covers IaC variants only — so the evaluation above is the available verification.

### Not in this PR

The truncated `cisco.nxos.coppConfig.profile` doc noted in the issue lives in `mondoohq/mql-enterprise-providers`, so it needs its own PR there. Cause is a blank `//` inserted mid-sentence when a long one-line comment was split into the required title/description form, cutting the title at `strict (most aggressive` and leaving the description opening with `the default), moderate, ...`.
