### PR TITLE
✨ nextdns: add bypass, safe browsing, dynamic dns, and log domain checks

### DIFF
--- a/content/mondoo-nextdns-security.mql.yaml
+++ b/content/mondoo-nextdns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-nextdns-security
     name: Mondoo NextDNS Security
-    version: 1.0.3
+    version: 1.1.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -38,15 +38,22 @@ policies:
           - uid: mondoo-nextdns-security-ai-threat-detection-enabled
           - uid: mondoo-nextdns-security-cryptojacking-protection-enabled
           - uid: mondoo-nextdns-security-dga-protection-enabled
+          - uid: mondoo-nextdns-security-google-safe-browsing-enabled
           - uid: mondoo-nextdns-security-idn-homograph-protection-enabled
           - uid: mondoo-nextdns-security-typosquatting-protection-enabled
           - uid: mondoo-nextdns-security-nrd-blocking-enabled
+          - uid: mondoo-nextdns-security-dynamic-dns-blocking-enabled
           - uid: mondoo-nextdns-security-csam-blocking-enabled
           - uid: mondoo-nextdns-security-parked-domain-blocking-enabled
+      - title: Filtering Integrity
+        filters: asset.platform == "nextdns-profile"
+        checks:
+          - uid: mondoo-nextdns-security-bypass-method-blocking-enabled
       - title: Logging and Visibility
         filters: asset.platform == "nextdns-profile"
         checks:
           - uid: mondoo-nextdns-security-query-logging-enabled
+          - uid: mondoo-nextdns-security-query-log-domains-retained
     scoring_system: average
 queries:
   # ==========================================
@@ -412,6 +419,76 @@ queries:
       - url: https://nextdns.github.io/api/#security
         title: NextDNS API — Security
 
+  - uid: mondoo-nextdns-security-google-safe-browsing-enabled
+    title: Ensure NextDNS Google Safe Browsing is enabled
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-5-4-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      nextdns.profile.security.googleSafeBrowsing == true
+    docs:
+      desc: |
+        This check verifies that the Google Safe Browsing blocklist is applied to the profile alongside the NextDNS feeds.
+
+        Google Safe Browsing is the list that Chrome, Safari, Firefox, and Android consult before loading a page, assembled from Google's own crawling of the web and from reports sent back by browser installations. NextDNS applies the same list at the resolver, so a name on it is refused before any client opens a connection to it. NextDNS calls the toggle **Google Safe Browsing** on the Security tab of a profile, and this check requires it to be on.
+
+        **Why this matters**
+
+        How much a blocklist catches depends on what its operator can see, and Google sees an unusual amount. It crawls continuously and receives reports from billions of browser installations, so a phishing page is frequently listed within hours of going live, sometimes before a threat intelligence feed has picked the domain up at all. Running both sources means a name has to be missing from both before it resolves.
+
+        Enforcing the list at the resolver also reaches everything the browser check cannot. Safe Browsing protects a user only inside a browser that implements it and has not had it switched off. It does nothing for a link opened from a mail client, nothing for a chat application rendering a preview, nothing for a script fetching a URL, and nothing at all for a device that has no browser. The resolver applies the same list to every client on the profile no matter what software asked.
+
+        The list is aimed at web pages rather than domains, so it occasionally flags a name whose content has since changed or which shares hosting with something that was flagged. Review a block before acting on it, and where the name is genuinely needed add it to the profile's Allowlist tab rather than turning the source off for every client.
+      audit: |
+        To verify that Google Safe Browsing is enabled from the NextDNS dashboard:
+
+        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+        2. Open the **Security** tab.
+        3. Inspect the **Google Safe Browsing** toggle.
+
+        If the toggle is on, the check passes. If it is off, the check fails.
+
+        To verify via the NextDNS API, inspect `googleSafeBrowsing`:
+
+        ```bash
+        curl -s https://api.nextdns.io/profiles/<profile-id>/security \
+          -H "X-Api-Key: $NEXTDNS_API_KEY"
+        ```
+      remediation:
+        - id: console
+          desc: |
+            To enable Google Safe Browsing from the NextDNS dashboard:
+
+            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+            2. Open the **Security** tab.
+            3. Turn on **Google Safe Browsing**.
+        - id: api
+          desc: |
+            To enable Google Safe Browsing using the NextDNS API:
+
+            ```bash
+            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/security \
+              -H "X-Api-Key: $NEXTDNS_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"googleSafeBrowsing": true}'
+            ```
+    refs:
+      - url: https://nextdns.github.io/api/#security
+        title: NextDNS API — Security
+
   - uid: mondoo-nextdns-security-idn-homograph-protection-enabled
     title: Ensure NextDNS IDN homograph protection is enabled
     impact: 70
@@ -628,6 +705,78 @@ queries:
       - url: https://nextdns.github.io/api/#security
         title: NextDNS API — Security
 
+  - uid: mondoo-nextdns-security-dynamic-dns-blocking-enabled
+    title: Ensure NextDNS dynamic DNS hostname blocking is enabled
+    impact: 65
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-308-a-5-ii-b-security-awareness-training-and-tools-protection-from-malicious-software
+      compliance/iso-27001-2022: iso-27001-2022-a-8-7
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-de-cm-4
+      compliance/nist-csf-2: nist-csf-2-de-cm-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-si-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-14-2
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-5-2-1
+      compliance/soc2-2017: soc2-control-cc6-8-4
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      nextdns.profile.security.ddns == true
+    docs:
+      desc: |
+        This check verifies that hostnames served by dynamic DNS providers are blocked for the profile.
+
+        A dynamic DNS provider hands out a name underneath a domain it owns and lets whoever claimed it repoint that name at any address, at any moment, usually free of charge and with no identity check. NextDNS calls the toggle **Block Dynamic DNS Hostnames** on the Security tab of a profile, and this check requires it to be on.
+
+        **Why this matters**
+
+        That combination is why so much attacker infrastructure lives on one. A command-and-control name costs nothing, leaves no registrar record tying it to anyone, and can be moved to fresh hosting the moment the current address is seized or blocked, so an implant keeps reaching its operator with no update pushed to it. Remote access trojans have shipped with dynamic DNS naming as their default for two decades, and commodity malware families still do.
+
+        The same properties make it the quickest way to stand up a phishing or payload page. A hostname is resolving within a minute of being claimed, and it inherits a parent domain that has existed for years, so it slips past the age heuristics that catch a freshly registered name. Newly registered domain blocking does not cover this, because the domain is not new.
+
+        Blocking is done by provider, so nothing underneath the provider's domain resolves. That is what makes the control effective and also what makes it blunt: home routers, IP cameras, and remote access appliances use these hostnames legitimately, and a small site reaching an office over one will stop working the moment this is turned on.
+
+        NextDNS keeps each provider's own website and its address update endpoint reachable, so devices that depend on one can still refresh their record. Where a business genuinely needs to reach a specific dynamic DNS hostname, add that one name to the profile's Allowlist tab rather than leaving the whole category resolving.
+      audit: |
+        To verify that dynamic DNS hostname blocking is enabled from the NextDNS dashboard:
+
+        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+        2. Open the **Security** tab.
+        3. Inspect the **Block Dynamic DNS Hostnames** toggle.
+
+        If the toggle is on, the check passes. If it is off, the check fails.
+
+        To verify via the NextDNS API, inspect `ddns`:
+
+        ```bash
+        curl -s https://api.nextdns.io/profiles/<profile-id>/security \
+          -H "X-Api-Key: $NEXTDNS_API_KEY"
+        ```
+      remediation:
+        - id: console
+          desc: |
+            To enable dynamic DNS hostname blocking from the NextDNS dashboard:
+
+            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+            2. Open the **Security** tab.
+            3. Turn on **Block Dynamic DNS Hostnames**.
+        - id: api
+          desc: |
+            To enable dynamic DNS hostname blocking using the NextDNS API:
+
+            ```bash
+            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/security \
+              -H "X-Api-Key: $NEXTDNS_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"ddns": true}'
+            ```
+    refs:
+      - url: https://nextdns.github.io/api/#security
+        title: NextDNS API — Security
+
   - uid: mondoo-nextdns-security-csam-blocking-enabled
     title: Ensure NextDNS child sexual abuse material blocking is enabled
     impact: 60
@@ -773,6 +922,81 @@ queries:
         title: NextDNS API — Security
 
   # ==========================================
+  # Filtering Integrity
+  # ==========================================
+  - uid: mondoo-nextdns-security-bypass-method-blocking-enabled
+    title: Ensure NextDNS bypass method blocking is enabled
+    impact: 75
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-uem-02
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-23
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-pt-4
+      compliance/nist-csf-2: nist-csf-2-pr-ir-01
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-7
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a02
+      compliance/pci-dss-4: pcidss-requirement-1-2-5
+      compliance/soc2-2017: soc2-control-cc6-6-1
+      compliance/vda-isa-5: vda-isa-5-5-2-3
+    mql: |
+      nextdns.profile.parentalControl.blockBypass == true
+    docs:
+      desc: |
+        This check verifies that the services used to route around the profile's filtering are blocked.
+
+        A device is protected only for as long as it keeps asking NextDNS. A commercial VPN, a web proxy, the Tor network, or a third-party encrypted DNS resolver each moves name resolution somewhere the profile cannot see, and every other control on the profile stops applying to that device the moment one is in use. NextDNS calls the toggle **Block Bypass Methods** on the Parental Control tab of a profile, and this check requires it to be on.
+
+        **Why this matters**
+
+        Installing a free VPN app on a managed phone takes under a minute and moves all of its name resolution off the resolver. Nothing breaks, nobody is prompted, and the profile keeps reporting healthy, because it is no longer being asked anything. A device that has left looks exactly like a device that is quiet, which is why this rarely gets noticed until someone goes looking for a specific query and finds the whole device missing from the logs.
+
+        It is not only deliberate evasion. Browsers and applications ship their own encrypted DNS endpoints and will use them ahead of the system resolver in some configurations, so a device can leave the profile because of a default nobody chose. Refusing the well-known endpoints pushes those clients back onto the system resolver, where the profile applies again.
+
+        The same escape is available to malware. An implant that resolves its operator's domain through a public encrypted DNS endpoint sidesteps every blocklist on the profile, and because the query never reaches the resolver it leaves no trace in the logs either. Denying the names those endpoints live at closes that path without needing anything installed on the endpoint.
+
+        This is a DNS-layer control and only reaches what resolves by name. A VPN client configured with a hardcoded address, a laptop tethered to a phone, and Tor bridges are all outside its reach, and the blocked list does not cover every provider that exists. Pair it with device management that governs which VPN profiles and DNS configurations can be installed in the first place.
+      audit: |
+        To verify that bypass method blocking is enabled from the NextDNS dashboard:
+
+        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+        2. Open the **Parental Control** tab.
+        3. Inspect the **Block Bypass Methods** toggle.
+
+        If the toggle is on, the check passes. If it is off, the check fails.
+
+        To verify via the NextDNS API, inspect `blockBypass`:
+
+        ```bash
+        curl -s https://api.nextdns.io/profiles/<profile-id>/parentalControl \
+          -H "X-Api-Key: $NEXTDNS_API_KEY"
+        ```
+      remediation:
+        - id: console
+          desc: |
+            To enable bypass method blocking from the NextDNS dashboard:
+
+            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+            2. Open the **Parental Control** tab.
+            3. Turn on **Block Bypass Methods**.
+        - id: api
+          desc: |
+            To enable bypass method blocking using the NextDNS API:
+
+            ```bash
+            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/parentalControl \
+              -H "X-Api-Key: $NEXTDNS_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"blockBypass": true}'
+            ```
+    refs:
+      - url: https://nextdns.github.io/api/#profile
+        title: NextDNS API — Profile
+
+  # ==========================================
   # Logging and Visibility
   # ==========================================
   - uid: mondoo-nextdns-security-query-logging-enabled
@@ -842,6 +1066,78 @@ queries:
               -H "X-Api-Key: $NEXTDNS_API_KEY" \
               -H "Content-Type: application/json" \
               -d '{"enabled": true}'
+            ```
+    refs:
+      - url: https://nextdns.github.io/api/#settings
+        title: NextDNS API — Settings
+
+  - uid: mondoo-nextdns-security-query-log-domains-retained
+    title: Ensure NextDNS query logs retain the queried domains
+    impact: 55
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
+      compliance/dora: dora-art-10
+      compliance/hipaa: hipaa-security-ss164-312-b-audit-controls
+      compliance/iso-27001-2022: iso-27001-2022-a-8-15
+      compliance/nis-2: nis-2-21-2-b
+      compliance/nist-csf-1: nist-csf-1-pr-pt-1
+      compliance/nist-csf-2: nist-csf-2-pr-ps-04
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-au-3
+      compliance/nist-sp-800-171: nist-sp-800-171--3-3-1
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a09
+      compliance/pci-dss-4: pcidss-requirement-10-2-2
+      compliance/soc2-2017: soc2-control-cc7-2-1
+      compliance/vda-isa-5: vda-isa-5-5-2-4
+    mql: |
+      nextdns.profile.settings.logsDropDomain == false
+    docs:
+      desc: |
+        This check verifies that the name a client asked for is written to the profile's query logs rather than redacted out of them.
+
+        NextDNS can keep a query log while discarding the domain from every entry, leaving the time, the device, and whether the answer was blocked, but not what was asked for. NextDNS calls the toggle **Log domains** on the Settings tab of a profile, and this check requires it to be on.
+
+        **Why this matters**
+
+        The domain is the only field in a DNS record that answers a question. Without it the log says a device made forty thousand requests and that three hundred were refused, and it cannot say which name was reached for, which control refused it, or whether anyone on the network ever contacted the indicator that was published this morning. Logging is on, storage is being consumed, and no investigation can begin.
+
+        That gap is close to invisible until it matters. The profile reports logging as enabled, the dashboard still draws its charts of blocked and allowed counts, and the setting reads like a privacy refinement rather than the removal of the record's contents. It is usually discovered during an incident, which is the worst possible moment to learn that the evidence was never written.
+
+        Keeping the name is also what makes the rest of the profile auditable. Judging whether a blocklist is too aggressive, confirming that a control is firing at all, and deciding whether a device needs an entry on the Allowlist tab all depend on reading back the specific names involved.
+
+        Where DNS logging is legally constrained, the field to give up is the client address rather than the domain. Dropping the client address removes what identifies a person while leaving a log that can still say what was reached for on the network, and a shorter retention period limits the exposure either way. If the names themselves genuinely cannot be held, turn logging off rather than keeping a record that answers nothing.
+      audit: |
+        To verify that queried domains are retained in the logs from the NextDNS dashboard:
+
+        1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+        2. Open the **Settings** tab.
+        3. Inspect the **Log domains** toggle under the logging options.
+
+        If the toggle is on, the check passes. If it is off, the check fails.
+
+        To verify via the NextDNS API, inspect `logs.drop.domain` under settings, which must be `false`:
+
+        ```bash
+        curl -s https://api.nextdns.io/profiles/<profile-id>/settings \
+          -H "X-Api-Key: $NEXTDNS_API_KEY"
+        ```
+      remediation:
+        - id: console
+          desc: |
+            To retain queried domains in the logs from the NextDNS dashboard:
+
+            1. Sign in to the [NextDNS dashboard](https://my.nextdns.io) and select the profile.
+            2. Open the **Settings** tab.
+            3. Turn on **Log domains**, and set retention and storage location to match your privacy requirements.
+        - id: api
+          desc: |
+            To retain queried domains in the logs using the NextDNS API:
+
+            ```bash
+            curl -X PATCH https://api.nextdns.io/profiles/<profile-id>/settings/logs \
+              -H "X-Api-Key: $NEXTDNS_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"drop": {"domain": false}}'
             ```
     refs:
       - url: https://nextdns.github.io/api/#settings


### PR DESCRIPTION
Fixes #3422

Adds four checks to `content/mondoo-nextdns-security.mql.yaml`, taking it from 11 to 15. Every field was verified against the installed provider schema at `~/.config/mondoo/providers/nextdns/nextdns.resources.json` and against the provider source in `providers/nextdns/resources/profile.go`, and every API path and body against [the NextDNS API docs](https://nextdns.github.io/api/). Policy version 1.0.3 to 1.1.0, a MINOR bump because this adds capability.

A new **Filtering Integrity** group is added, which is the third area the policy's own `docs.desc` already claims to cover and had no checks for.

## Checks added

| uid | impact | anchored to | mql |
|---|---|---|---|
| `mondoo-nextdns-security-bypass-method-blocking-enabled` | 75 | `mondoo-nextdns-security-dns-rebinding-protection-enabled` (75) | `nextdns.profile.parentalControl.blockBypass == true` |
| `mondoo-nextdns-security-google-safe-browsing-enabled` | 70 | `mondoo-nextdns-security-dga-protection-enabled` (70) | `nextdns.profile.security.googleSafeBrowsing == true` |
| `mondoo-nextdns-security-dynamic-dns-blocking-enabled` | 65 | `mondoo-nextdns-security-nrd-blocking-enabled` (65) | `nextdns.profile.security.ddns == true` |
| `mondoo-nextdns-security-query-log-domains-retained` | 55 | `mondoo-nextdns-security-query-logging-enabled` (55) | `nextdns.profile.settings.logsDropDomain == false` |

Bypass method blocking sits at 75 rather than 80 because it is enforcement of the other controls rather than a control in its own right, which puts it just under the threat intelligence feeds check. The log domain check inherits the logging check's 55 because it is the same objective: a profile that drops the domain reports logging as enabled while writing records that name nothing, so the existing check passes on a log no one can investigate.

## Compliance tags

Every tag was resolved by reading the control text in `cnspec-enterprise-policies/frameworks/`, not copied from a neighbouring check. Each uid below was grep-verified to exist under its framework's `controls:`.

### `bypass-method-blocking-enabled`

| framework | control uid | control title | control text |
|---|---|---|---|
| bsi-sys-1-5 | `false` | | Module scope is virtualization only; no control addresses DNS filtering, proxies, or endpoint network paths |
| csa-cloud-controls-matrix-4 | `cloud-controls-matrix-4-uem-02` | Application and Service Approval | "Define, document, apply and evaluate a list of approved services, applications and sources of applications (stores) acceptable for use by endpoints when accessing or storing organization-managed data." |
| dora | `dora-art-9` | Article 9 - Protection and Prevention | "minimise the impact of ICT risk on ICT systems through the deployment of appropriate ICT security tools, policies and procedures" |
| hipaa | `false` | | No standard addresses circumvention of network filtering; §164.312(a)(1), §164.312(e)(1) and §164.310(b) were each considered and rejected as stretches |
| iso-27001-2022 | `iso-27001-2022-a-8-23` | Annex A 8.23 Web filtering | Blocking the anonymizing-proxy and alternate-resolver category is the web filtering control |
| nis-2 | `nis-2-21-2-e` | Article 21.2 e) | "Security in network and information systems acquisition, development and maintenance" |
| nist-csf-1 | `nist-csf-1-pr-pt-4` | PR.PT-4 | "Communications and control networks are protected" |
| nist-csf-2 | `nist-csf-2-pr-ir-01` | PR.IR-01 | "Networks and environments are protected from unauthorized logical access and usage" |
| nist-sp-800-53-rev5 | `nist-sp-800-53-rev5-sc-7` | Boundary Protection | "Connect to external networks or systems only through managed interfaces consisting of boundary protection devices" |
| nist-sp-800-171 | `nist-sp-800-171--3-13-1` | Monitor, control, and protect communications at the external boundaries and key internal boundaries | "Restricting or prohibiting interfaces in organizational systems includes restricting external web communications traffic to designated managed interfaces" |
| owasp-top-10-2025 | `owasp-top-10-2025-a02` | A02:2025 Security Misconfiguration | |
| pci-dss-4 | `pcidss-requirement-1-2-5` | Requirement 1.2.5 | "Unauthorized network traffic (services, protocols, or packets destined for specific ports) cannot enter or leave the network." |
| soc2-2017 | `soc2-control-cc6-6-1` | CC6.6.1 Restricts Access | "The types of activities that can occur through a communication channel (for example, FTP site, router port) are restricted." |
| vda-isa-5 | `vda-isa-5-5-2-3` | 5.2.3 To what extent are IT systems protected against malware? | "Measures to prevent protection software from being deactivated or altered by users are defined and implemented." |

This check deliberately does **not** reuse the `sc-21` mapping of the neighbouring DNS rebinding check. SC-21 is DNSSEC validation of resolver responses and has nothing to do with anti-circumvention. For the same reason PCI 1.3.2 was rejected: it is a deny-by-default egress control, and a bypass blocklist is allow-by-default with targeted denies.

### `google-safe-browsing-enabled` and `dynamic-dns-blocking-enabled`

Both are network-layer malicious-code blocklists and share their mappings, except on PCI DSS where they split.

| framework | control uid | control title | control text |
|---|---|---|---|
| bsi-sys-1-5 | `false` | | Virtualization-only module, no malware or content-filtering control |
| csa-cloud-controls-matrix-4 | `cloud-controls-matrix-4-tvm-02` | Malware Protection Policy and Procedures | "policies and procedures to protect against malware on managed assets" |
| dora | `dora-art-9` | Article 9 - Protection and Prevention | "deployment of appropriate ICT security tools, policies and procedures" |
| hipaa | `hipaa-security-ss164-308-a-5-ii-b-…-protection-from-malicious-software` | §164.308(a)(5)(ii)(B) Protection from Malicious Software | "Procedures for guarding against, detecting, and reporting malicious software." |
| iso-27001-2022 | `iso-27001-2022-a-8-7` | Annex A 8.7 Protection against malware | |
| nis-2 | `nis-2-21-2-e` | Article 21.2 e) | "Security in network and information systems acquisition, development and maintenance" |
| nist-csf-1 | `nist-csf-1-de-cm-4` | DE.CM-4 | "Malicious code is detected" |
| nist-csf-2 | `nist-csf-2-de-cm-01` | DE.CM-01 | "Networks and network services are monitored to find potentially adverse events" |
| nist-sp-800-53-rev5 | `nist-sp-800-53-rev5-si-3` | Malicious Code Protection | "Implement malicious code protection mechanisms at system entry and exit points to detect and eradicate malicious code" |
| nist-sp-800-171 | `nist-sp-800-171--3-14-2` | Provide protection from malicious code at designated locations | "Malicious code protection mechanisms include anti-virus signature definitions and reputation-based technologies" |
| owasp-top-10-2025 | `owasp-top-10-2025-a02` | A02:2025 Security Misconfiguration | |
| soc2-2017 | `soc2-control-cc6-8-4` | CC6.8.4 Uses Antivirus and Anti-Malware Software | "Antivirus and anti-malware software is implemented and maintained to provide for the interception or detection and remediation of malware." |
| vda-isa-5 | `vda-isa-5-5-2-3` | 5.2.3 To what extent are IT systems protected against malware? | "Data transferred by central gateways (e.g. e-mail, internet, third-party networks) is automatically inspected by means of protection software." |

PCI DSS splits the two:

- Google Safe Browsing maps to `pcidss-requirement-5-4-1`, "Processes and automated mechanisms are in place to detect and protect personnel against phishing attacks." Safe Browsing is the canonical phishing blocklist and 5.4.1's guidance names blocking phishing before it reaches personnel as the intended mechanism.
- Dynamic DNS blocking maps to `pcidss-requirement-5-2-1`, "Automated mechanisms are implemented to prevent systems from becoming an attack vector for malware." That is command-and-control channel denial rather than user-facing phishing.

### `query-log-domains-retained`

| framework | control uid | control title | control text |
|---|---|---|---|
| bsi-sys-1-5 | `false` | | A6 Protokollierung is scoped to the operational state and network connections of the virtual infrastructure, not DNS record content |
| csa-cloud-controls-matrix-4 | `cloud-controls-matrix-4-log-08` | Log Records | "Generate audit records containing relevant security information." |
| dora | `dora-art-10` | Article 10 - Detection | "detection capabilities to promptly identify anomalies, in particular cyber-attacks and system intrusions" |
| hipaa | `hipaa-security-ss164-312-b-audit-controls` | §164.312(b) Audit Controls | "mechanisms that record and examine activity in information systems that contain or use electronic protected health information" |
| iso-27001-2022 | `iso-27001-2022-a-8-15` | Annex A 8.15 Logging | |
| nis-2 | `nis-2-21-2-b` | Article 21.2 b) Incident handling | Art. 6(8) defines incident handling as actions to "prevent, detect, analyse" an incident |
| nist-csf-1 | `nist-csf-1-pr-pt-1` | PR.PT-1 | "Audit/log records are determined, documented, implemented, and reviewed in accordance with policy" |
| nist-csf-2 | `nist-csf-2-pr-ps-04` | PR.PS-04 | "Log records are generated and made available for continuous monitoring" |
| nist-sp-800-53-rev5 | `nist-sp-800-53-rev5-au-3` | Content of Audit Records | "Ensure that audit records contain information that establishes the following:" |
| nist-sp-800-171 | `nist-sp-800-171--3-3-1` | Create and retain system audit logs to enable monitoring, analysis, investigation and reporting | "Audit record content that may be necessary to satisfy this requirement includes time stamps, source and destination addresses, event descriptions" |
| owasp-top-10-2025 | `owasp-top-10-2025-a09` | A09:2025 Logging and Alerting Failures | |
| pci-dss-4 | `pcidss-requirement-10-2-2` | Requirement 10.2.2 | "Audit logs record the following details for each auditable event: Identity or name of affected data, system component, resource, or service (for example, name and protocol)." |
| soc2-2017 | `soc2-control-cc7-2-1` | CC7.2.1 Implements Detection Policies, Procedures, and Tools | "detection tools are implemented on Infrastructure and software to identify anomalies in the operation or unusual activity on systems" |
| vda-isa-5 | `vda-isa-5-5-2-4` | 5.2.4 To what extent are event logs recorded and analyzed? | "Event logs support the traceability of events in case of a security incident. This requires that events necessary to determine the causes are recorded and stored." |

This check maps to **AU-3 Content of Audit Records** rather than the AU-12 used by the sibling `query-logging-enabled` check. AU-12 is correct for "is logging on"; this check asks whether the record is complete, which is a different control. On CSA it likewise takes `log-08` (Log Records) rather than the sibling's `log-07` (Logging Scope). Two caveats worth recording: 800-53 rev5 in this repo carries base controls only, so SC-7(7) split tunneling and the other enhancements are not mappable, and the 2017 SOC 2 TSC has no audit-record-content control at all, so CC7.2.1 is a category-level rather than element-level fit and is the only defensible anchor available.

## What was deliberately not added

**`profileSetup.dnscrypt`, the issue's number one priority.** The field cannot express what the issue wants, and a check on it would be worse than no check. It is typed `string`, and `providers/nextdns/resources/profile.go` passes the API's `setup.dnscrypt` straight through. That value is the profile's DNSCrypt **stamp**, an `sdns://` connection string NextDNS generates for every profile from its ID and publishes on the profile's own setup page. It is not a toggle and there is no state in which it is absent, so `dnscrypt != empty` would pass on every profile in existence while asserting nothing. The issue's underlying concern is real and is addressed by the bypass method blocking check instead, which is the setting NextDNS actually exposes for keeping devices on the resolver.

**`profileSecurity.tlds`.** It is a list rather than a boolean, and no assertion over it holds up. A non-empty test is satisfied by one arbitrary entry and asserts no security property, and a specific TLD list is an opinion that goes stale as abuse rates move between namespaces. The abuse this control targets is already covered by the threat intelligence feeds, newly registered domain, and parked domain checks the policy has.

**`logsRetention` and `logsLocation`.** Retention would require picking a threshold in seconds, and the API's representation of unlimited retention could not be confirmed without a live account, so a `>=` assertion risks failing the most retentive configuration there is. Storage location is a data residency decision where both values are correct for different regulatory regimes, and encoding one as secure would be wrong for half of the policy's users.

**`logsDropIp`.** Unlike dropping the domain, dropping the client address is a genuine privacy improvement that leaves the log able to answer what was reached for on the network. Requiring it off would take the wrong side of a real trade. The new log domain check says so explicitly and points readers at the client address as the field to give up when DNS logging is legally constrained.

**`blockPageEnabled`.** Agreed that it is not worth a check. The block page changes what a user sees after a domain has already been refused, and showing it for HTTPS sites requires installing the NextDNS root CA. Nothing about it changes whether a name resolves.

**`profilePrivacy` as a whole.** `disguisedTrackers`, `natives`, and `blocklists` are tracker and advertising controls rather than security controls, so they belong in a privacy-scoped policy rather than this one. Left for a separate change.

## Validation

- `cnspec policy lint content/mondoo-nextdns-security.mql.yaml` → `valid policy bundle(s)`, no warnings.
- `cnspec policy lint ./content` → `valid policy bundle(s)`. The two `terraform.resources` standalone-function warnings are pre-existing and unrelated.
- `typos` → no output, exit 0. No allowlist file was touched.
- `go test ./internal/bundle/...` → `ok`.
- `python3 content/validation/remediation/code/bash.py` → exit 0, all fifteen NextDNS snippets `[PASS]`.
- Group registration verified programmatically by parsing the bundle: all 15 queries appear in a group's `checks:` list, including all 4 new ones, with none unregistered.
- `desc`, `audit` and `remediation` verified non-empty on all four new checks, each with `console` and `api` remediation entries.
- Prose gate over the four new descriptions verified programmatically: each starts with `This check`, each has exactly one `**Why this matters**`, none has `**Risk mitigation**`, no em dashes or en dashes anywhere in `desc`, `audit` or `remediation`, no bullet lists in `desc`, and no `nextdns.*` accessor path in `desc`.
- Every one of the 33 distinct control uids assigned was grep-verified to exist under its framework's `controls:` in `cnspec-enterprise-policies/frameworks/`.
- **No existing check was modified.** The bundle was parsed at `origin/main` and at this tip and every pre-existing uid's `mql`, `title`, `impact`, `tags`, `docs` and `refs` compared: zero differences. The diff is 297 insertions and 1 deletion, and that deletion is the `version:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
