### PR TITLE
✨ validation: cover the upstream pin resolvers with offline tests

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -316,3 +316,24 @@ jobs:
 
       - name: Validate chef remediation blocks
         run: python3 content/validation/remediation/code/chef.py --github-actions
+
+  # The pin resolvers that decide what every job above validates against.
+  # They run on a schedule from validation-dependency-updates.yaml, where a
+  # wrong answer is a pull request bumping a pin to a version that does not
+  # exist -- so the only place to catch one is here, on the change that
+  # introduces it. Recorded payloads, no network, no tooling.
+  upstream-resolvers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Test the upstream pin resolvers
+        run: make test/content/upstream/unit

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ VALIDATION := content/validation
 .PHONY: test/content/remediation test/content/remediation/terraform test/content/remediation/cloudformation
 .PHONY: test/content/remediation/bicep test/content/remediation/ansible test/content/remediation/powershell
 .PHONY: test/content/remediation/bash test/content/remediation/chef
-.PHONY: test/content/commands test/content/upstream
+.PHONY: test/content/commands test/content/upstream test/content/upstream/unit
 
 # The checks that run with nothing installed but Go and cnspec. Two groups are
 # deliberately left out, each for its own reason:
@@ -268,6 +268,13 @@ test/content/commands:
 # reports only, never fails the build.
 test/content/upstream:
 	python3 $(VALIDATION)/upstream/check.py --format markdown
+
+# The resolvers behind that report, against recorded upstream payloads. Offline
+# and fast, and the one part of this that does fail the build: a resolver that
+# reads an index wrongly opens a pull request bumping a pin to a version that
+# does not exist.
+test/content/upstream/unit:
+	python3 -m unittest discover -s $(VALIDATION)/upstream -p "*_test.py"
 
 .PHONY: test/lint/staticcheck
 test/lint/staticcheck:

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -90,6 +90,7 @@ Run the one that covers what you touched.
 | `make test/content/remediation/terraform` | one of them (also `/cloudformation`, `/bicep`, `/ansible`, `/powershell`, `/bash`, `/chef`) | that language's linter |
 | `make test/content/commands` | CLI and API calls; `CLOUD=aws` scopes it | that cloud's CLI |
 | `make test/content/upstream` | which pins are behind | network |
+| `make test/content/upstream/unit` | the pin resolvers, against recorded payloads | none |
 | `make test/content/spelling` | `typos` over the repo | `brew install typos-cli` |
 
 Linters the remediation code validators need: `tflint`, `cfn-lint`, the Bicep CLI, `ansible-lint`, `pwsh`, `shellcheck`, `cookstyle`. Each validator prints an install hint and exits non-zero when its linter is missing, so you never get a silent pass.
@@ -331,7 +332,8 @@ Things to know when touching this:
 
 - **A bump is never applied without review.** The tooling does the mechanical half; whether a red CI run means the pin is wrong or the content is remains a judgement call. Closing a bump pull request is a valid answer, and the branch reopens when upstream moves again.
 - **A CLI's version and its checksum can never move apart.** The bumper re-downloads the artifact using the URL read back out of the workflow's own `curl` line and recomputes the digest, so it hashes exactly what CI fetches. `--verify-checksums` re-derives all of them at their *current* pins.
-- **Terraform provider entries hold a constraint, not a version.** `~> 5.0` floats across all of 5.x, so a provider only outgrows it on a major; below 1.0 the minor is the breaking axis, so `~> 0.111` outgrows on a minor. A provider major bump is a content migration, not a dependency bump.
+- **Terraform provider entries hold a constraint, not a version.** A pin is behind when the newest release is one the constraint cannot resolve, not when it is spelled differently to what this repo would write from scratch. Terraform's pessimistic operator lets only the rightmost named component increment, so `~> 5.0` floats across all of 5.x, `~> 0.111` across the rest of 0.x, and a deliberately narrow `~> 1.288` across every later 1.x. A provider major bump is a content migration, not a dependency bump.
+- **Only *released* versions become constraints.** The Terraform Registry's `version` field is the newest version *published*, prereleases included, and terraform will not select a prerelease for a `~>` constraint, so a constraint derived from one resolves to nothing at all. That shipped twice: `aliyun/alicloud` published a 2.0 beta while its released line was 1.x, the bump proposed `~> 2.0`, and tflint never noticed because it does not resolve versions. Every resolver now ends in `stable_token`, and the Terraform one reads the registry's version list rather than that field. Both rules are covered by `make test/content/upstream/unit`.
 - **Grammars are not string bumps.** The pin records which tool produced the checked-in JSON, so it moves by installing that tool and re-running the dump script. `--all` reports them as skipped rather than pretending.
 - **`upstream/dump/vercel.py` is the one place a version is written twice** (its `VERCEL_VERSION` constant and the JSON's `_meta`). `bump.py --sync-dump-pins` pulls the constant back into line after a regeneration.
 

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -94,9 +94,11 @@ PROVIDER_MAP = {
     # `~> 2.0` matched no released version: the registry carries 2.0.0-beta1 and
     # 2.0.0-beta2 and nothing else in that line, so terraform could not resolve
     # the provider at all. tflint never noticed because it does not resolve
-    # versions. Current stable is 1.288.0, so the pin holds the 1.x line on
-    # purpose rather than by preference. Revisit it once 2.x has a stable
-    # release, otherwise the mirror keeps resolving to 1.x indefinitely.
+    # versions. The pin holds the 1.x line on purpose rather than by
+    # preference, and stays narrow to say so. `~> 1.288` still floats across
+    # every later 1.x, so `upstream/pins.py` asks whether the constraint
+    # resolves the newest release rather than whether it is spelled the way
+    # that file would spell it, and proposes 2.x only once 2.x has one.
     "alicloud": ("aliyun/alicloud", "~> 1.288"),
     "clickhouse": ("ClickHouse/clickhouse", "~> 3.0"),
     "cloudflare": ("cloudflare/cloudflare", "~> 5.0"),

--- a/content/validation/upstream/pins_test.py
+++ b/content/validation/upstream/pins_test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+"""Unit tests for the pin resolvers.
+
+Every resolver here reads an upstream index and turns it into the string this
+repo pins, so the failure mode is not a crash: it is a bump that looks
+reasonable and is wrong. A version nothing resolves to, or a pin reported as
+behind itself. Both have shipped, twice each, and the only reader downstream is
+whoever reviews the pull request the weekly workflow opens.
+
+These resolvers otherwise run on a schedule only, so a defect introduced here
+is not observable until that run. The tests are offline -- anything that would
+reach a registry patches `fetch_json` with a recorded payload -- so they cost
+nothing and run on every pull request that touches `content/`.
+
+    make test/content/upstream/unit
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pins
+
+
+class StableTokenTest(unittest.TestCase):
+    """A pre-release is never a version a pin may be moved to."""
+
+    def test_recognises_the_two_spellings(self):
+        # Semver puts the marker after a hyphen; RubyGems puts it in a dotted
+        # segment. Both are "something past the numeric prefix has a letter".
+        self.assertTrue(pins.is_prerelease("2.0.0-beta2"))
+        self.assertTrue(pins.is_prerelease("0.27.0.beta4"))
+        self.assertTrue(pins.is_prerelease("1.0.0-rc1"))
+
+    def test_a_release_is_not_a_prerelease(self):
+        self.assertFalse(pins.is_prerelease("1.289.0"))
+        # A leading v is stripped before the test, so a tag is not misread as
+        # a pre-release on the strength of its own prefix.
+        self.assertFalse(pins.is_prerelease("v1.2.3"))
+
+    def test_prerelease_resolves_to_unknown(self):
+        # "unknown" is the same fail-safe an unparseable value already gets: it
+        # reports as unchecked, which opens no pull request.
+        self.assertEqual(pins.stable_token("2.0.0-beta2"), "unknown")
+        self.assertEqual(pins.stable_token("1.289.0"), "1.289.0")
+
+    def test_every_resolver_ends_in_stable_token(self):
+        # The registries disagree about whether "latest" hides a pre-release,
+        # so the rule is applied at the resolver rather than remembered per
+        # upstream. One recorded pre-release payload per resolver.
+        for resolver, payload, arg in [
+            (pins.latest_github_release, {"tag_name": "v9.0.0-beta.1"}, "owner/repo"),
+            (pins.latest_pypi, {"info": {"version": "2.0.0b1"}}, "pkg"),
+            (pins.latest_rubygem, {"version": "0.27.0.beta4"}, "gem"),
+            (pins.latest_npm, {"version": "5.0.0-next.3"}, "pkg"),
+        ]:
+            with self.subTest(resolver=resolver.__name__):
+                with mock.patch.object(pins, "fetch_json", return_value=payload):
+                    self.assertEqual(resolver(arg), "unknown")
+
+
+class NewestStableTest(unittest.TestCase):
+    """Picking a release out of a registry's version list."""
+
+    def test_orders_numerically_not_lexically(self):
+        # The lists arrive sorted, but sorted as strings, which puts 1.9.0
+        # above 1.289.0 and would report a current pin behind.
+        self.assertEqual(pins.newest_stable(["1.10.0", "1.289.0", "1.9.0"]), "1.289.0")
+
+    def test_skips_prereleases(self):
+        self.assertEqual(
+            pins.newest_stable(["1.288.0", "1.289.0", "2.0.0-beta1", "2.0.0-beta2"]),
+            "1.289.0",
+        )
+
+    def test_nothing_stable_is_empty(self):
+        self.assertEqual(pins.newest_stable(["2.0.0-beta1"]), "")
+        self.assertEqual(pins.newest_stable([]), "")
+
+
+class LatestTerraformProviderTest(unittest.TestCase):
+    """The registry's `version` field is the newest version *published*."""
+
+    def resolve(self, payload: object) -> str:
+        with mock.patch.object(pins, "fetch_json", return_value=payload):
+            return pins.latest_terraform_provider("aliyun/alicloud")
+
+    def test_ignores_prereleases(self):
+        # aliyun/alicloud as the registry served it in August 2026: a 2.0 beta
+        # published while the released line was still 1.x. Taking `version`
+        # verbatim produced `~> 2.0`, which matches no released version, so
+        # terraform could not resolve the provider at all. tflint never noticed,
+        # because it does not resolve versions. The full `versions` list rides
+        # along on the same response, so reading it costs no extra request.
+        self.assertEqual(
+            self.resolve({
+                "version": "2.0.0-beta2",
+                "versions": ["1.287.0", "1.288.0", "1.289.0", "2.0.0-beta1", "2.0.0-beta2"],
+            }),
+            "1.289.0",
+        )
+
+    def test_orders_the_list_numerically(self):
+        self.assertEqual(
+            self.resolve({"version": "1.9.0", "versions": ["1.10.0", "1.289.0", "1.9.0"]}),
+            "1.289.0",
+        )
+
+    def test_falls_back_to_the_version_field(self):
+        # A registry response carrying no list still resolves, and still only
+        # through `stable_token`.
+        self.assertEqual(self.resolve({"version": "1.5.0"}), "1.5.0")
+
+    def test_prerelease_only_provider_is_unknown(self):
+        # Nothing to pin to. Reported as unchecked, which opens no pull request
+        # -- the right answer for a provider with no release at all.
+        self.assertEqual(
+            self.resolve({"version": "2.0.0-beta1", "versions": ["2.0.0-beta1"]}),
+            "unknown",
+        )
+
+    def test_unreachable_registry_is_unknown(self):
+        self.assertEqual(self.resolve(None), "unknown")
+
+
+class LatestGitLabReleaseTest(unittest.TestCase):
+    """GitLab has no "exclude pre-releases" flag on the releases endpoint."""
+
+    def resolve(self, payload: object) -> str:
+        with mock.patch.object(pins, "fetch_json", return_value=payload):
+            return pins.latest_gitlab_release("group%2Fproject")
+
+    def test_takes_the_first_stable_tag_not_the_first_tag(self):
+        # Releases come back newest-first, so a pre-release at the top would be
+        # the answer if the page were not scanned.
+        self.assertEqual(
+            self.resolve([{"tag_name": "v1.65.0-rc1"}, {"tag_name": "v1.64.0"}]),
+            "1.64.0",
+        )
+
+    def test_a_page_with_no_release_is_unknown(self):
+        self.assertEqual(self.resolve([{"tag_name": "v1.0.0-rc1"}]), "unknown")
+        self.assertEqual(self.resolve([]), "unknown")
+
+
+class ConstraintAdmitsTest(unittest.TestCase):
+    """A `~>` pin is behind when it cannot resolve the newest release."""
+
+    def test_narrow_pin_still_floats_across_its_line(self):
+        # The regression. `~> 1.288` covers every 1.x from 1.288 up, so 1.289.0
+        # needs no action. Comparing constraint *text* instead reported the pin
+        # behind the `~> 1.0` this repo writes from scratch, and had the bump
+        # workflow offering to loosen a constraint that is narrow on purpose.
+        self.assertTrue(pins.constraint_admits("~> 1.288", "1.289.0"))
+        self.assertTrue(pins.constraint_admits("~> 6.0", "6.60.0"))
+
+    def test_a_new_major_outgrows_the_pin(self):
+        self.assertFalse(pins.constraint_admits("~> 1.288", "2.0.0"))
+        self.assertFalse(pins.constraint_admits("~> 5.0", "6.60.0"))
+
+    def test_only_the_rightmost_named_component_increments(self):
+        # `~> 1.0.4` names a patch, so it stops at 1.1.0.
+        self.assertTrue(pins.constraint_admits("~> 1.0.4", "1.0.9"))
+        self.assertFalse(pins.constraint_admits("~> 1.0.4", "1.1.0"))
+
+    def test_a_zero_x_pin_holds_until_one_point_oh(self):
+        # `~> 0.111` really does resolve 0.112.0, so rewriting it to `~> 0.112`
+        # would change which provider terraform selects not at all. It outgrows
+        # at 1.0 and not before.
+        self.assertTrue(pins.constraint_admits("~> 0.111", "0.112.0"))
+        self.assertFalse(pins.constraint_admits("~> 0.111", "1.0.0"))
+
+    def test_a_release_below_the_floor_is_not_admitted(self):
+        self.assertFalse(pins.constraint_admits("~> 1.288", "1.287.0"))
+
+    def test_a_constraint_this_cannot_parse_is_not_admitted(self):
+        # Anything but `~>` falls through to `constraint_for`, which is the
+        # conservative direction: it reports rather than staying quiet.
+        self.assertFalse(pins.constraint_admits(">= 1.0", "1.2.3"))
+
+
+class CheckTerraformPinsTest(unittest.TestCase):
+    """The provider rows the weekly bump workflow reads."""
+
+    SOURCE = '''
+TFLINT_PLUGIN_MAP = {
+}
+
+PROVIDER_MAP = {
+    "alicloud": ("aliyun/alicloud", "~> 1.288"),
+    "aws": ("hashicorp/aws", "~> 5.0"),
+    "stackit": ("stackitcloud/stackit", "~> 0.111"),
+    "time": ("hashicorp/time", "~> 0.14"),
+    "unreleased": ("vendor/unreleased", "~> 1.0"),
+}
+'''
+
+    UPSTREAM = {
+        "aliyun/alicloud": "1.289.0",
+        "hashicorp/aws": "6.60.0",
+        "stackitcloud/stackit": "0.112.0",
+        "hashicorp/time": "1.0.0",
+        "vendor/unreleased": "unknown",
+    }
+
+    def states(self, upstream: dict[str, str] | None = None) -> dict[str, tuple[str, str]]:
+        versions = upstream or self.UPSTREAM
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "terraform.py"
+            path.write_text(self.SOURCE)
+            with mock.patch.object(pins, "TERRAFORM_VALIDATOR", path), \
+                 mock.patch.object(pins, "latest_terraform_provider", versions.get):
+                return {p.name: (p.state, p.latest) for p in pins.check_terraform_pins()}
+
+    def test_narrow_pin_is_current(self):
+        # The whole point of the narrowed alicloud pin: it holds the 1.x line
+        # while 2.x is beta-only, and reopens nothing meanwhile.
+        self.assertEqual(
+            self.states()["terraform-provider-alicloud"], ("current", "~> 1.288")
+        )
+
+    def test_narrow_pin_still_bumps_once_the_next_line_releases(self):
+        # And the pin is not simply pinned forever: a real 2.0.0 outgrows it.
+        upstream = {**self.UPSTREAM, "aliyun/alicloud": "2.0.0"}
+        self.assertEqual(
+            self.states(upstream)["terraform-provider-alicloud"], ("behind", "~> 2.0")
+        )
+
+    def test_a_genuinely_outgrown_pin_still_reports(self):
+        self.assertEqual(self.states()["terraform-provider-aws"], ("behind", "~> 6.0"))
+
+    def test_zero_x_pin_is_current_within_its_line(self):
+        self.assertEqual(
+            self.states()["terraform-provider-stackit"], ("current", "~> 0.111")
+        )
+
+    def test_zero_x_pin_outgrows_at_one_point_oh(self):
+        self.assertEqual(self.states()["terraform-provider-time"], ("behind", "~> 1.0"))
+
+    def test_an_unresolvable_provider_opens_no_bump(self):
+        # "unchecked" rather than "behind": there is no version to move to, and
+        # a row that cannot be resolved must not be turned into a pull request.
+        self.assertEqual(
+            self.states()["terraform-provider-unreleased"], ("unchecked", "unknown")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This opened as the fix for the `terraform-provider-alicloud ~> 2.0` bump proposed in #3434. #3438 landed that fix first and more broadly, so this branch is rebased down to the half it did not bring: the coverage.

## What changed in the rebase

#3438 fixes both defects this branch targeted, by different mechanisms, so every line it added to `upstream/pins.py` is gone:

| this branch proposed | what shipped in #3438 |
|---|---|
| `RELEASED_VERSION` regex in `latest_terraform_provider` | `is_prerelease` / `stable_token` at **every** resolver, plus `newest_stable` over the registry's version list |
| `tracks_same_line`, comparing release lines | `constraint_admits`, asking whether the constraint resolves the release |

The second pair are not the same question, and they disagree: `~> 0.111` is spelled for the 0.111 line but genuinely resolves 0.112.0, so `stackit` is **current** under what shipped and would have been **behind** under this branch. #3438's is the better question and it is merged, so this branch now tests it rather than replacing it.

## What remains

#3438 rewrote 153 lines of `pins.py` with no test at all, and these resolvers run on a schedule only. A wrong answer there is not a crash and not a red build; it is a plausible-looking pull request bumping a pin to a version that does not exist, with the reviewer as the only check. That has shipped twice for this one provider: #3313 merged the bad bump and #3367 reverted it.

`pins_test.py` covers both defects against recorded payloads, so it needs no network and no tooling:

- a pre-release never becomes a version a pin may move to, at every resolver rather than only the Terraform one;
- the registry's version list is read numerically, so `1.289.0` sorts above `1.9.0` and a beta-only line resolves to `unknown`;
- a `~>` pin is behind when it cannot resolve the newest release, so the deliberate `~> 1.288` is current at 1.289.0 and behind at 2.0.0.

The `upstream-resolvers` job runs them on every pull request touching `content/**`, which is where a defect in this code is introduced and the only place it can be caught before the schedule turns it into a bump.

## Verification

Both tests were confirmed to fail against the code they guard, by reintroducing each defect:

```
restore the `version`-field read      -> 3 failures, incl. '2.0.0-beta1' != 'unknown'
restore constraint-text comparison    -> 2 failures, incl. ('behind', '~> 1.0') != ('current', '~> 1.288')
```

The second is the original bug reproduced exactly.

Live, against `registry.terraform.io`, all 29 provider pins report current:

```
current   terraform-provider-alicloud    ~> 1.288 -> ~> 1.288  (aliyun/alicloud 1.289.0)
current   terraform-provider-stackit     ~> 0.111 -> ~> 0.111  (stackitcloud/stackit 0.112.0)
current   terraform-provider-aws         ~> 6.0   -> ~> 6.0    (hashicorp/aws 6.60.0)
```

```
make test/content/upstream/unit     # 26 tests, no network, no tooling
```

## Two prose corrections

Both described the mechanism this branch had proposed rather than the one #3438 shipped:

- the `alicloud` comment in `terraform.py`;
- the validation README's claim that `~> 0.111` outgrows its pin on a minor. It does not. That constraint resolves every later 0.x and holds until 1.0, which is what `constraint_admits` implements.

Closes #3434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
