### PR TITLE
🐛 validation: stop the drift report crying wolf

### DIFF
--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -117,6 +117,11 @@ jobs:
           found=$(gh issue list --state all --label validation-drift \
             --search "$title in:title" --json number,state \
             --jq '.[0] | if . then "\(.number) \(.state)" else "" end')
+          # `$found` is either empty or exactly "<number> <STATE>", and STATE is
+          # GitHub's `IssueState` GraphQL enum, whose only members are OPEN and
+          # CLOSED. The two branches below are therefore exhaustive rather than
+          # assuming a shape: a third value cannot appear without a breaking
+          # change to the schema gh compiles against.
           number=${found%% *}
           state=${found##* }
 

--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -13,6 +13,11 @@ name: Validator Upstream Drift
 ## needs a person to decide whether the content or the pin is wrong. So the job
 ## writes a table into one long-lived issue and never fails the build.
 ##
+## The issue exists only on the weeks it has something to say. A quiet week
+## closes it and opens nothing; drift reopens the same issue with a fresh table.
+## An open issue therefore means a pin needs a look, which is the only reading
+## under which the label stays worth subscribing to.
+##
 ## `validation-dependency-updates.yaml` runs an hour before this and opens a
 ## pull request per *kind* of pin that moved, so most rows below have a pull
 ## request behind them -- shared with the other rows of their kind, because
@@ -48,6 +53,7 @@ jobs:
           python-version: "3.12"
 
       - name: Check pinned versions against upstream
+        id: drift
         env:
           # ~45 api.github.com calls per run. Unauthenticated that shares a
           # 60/hour budget with the whole runner IP, and a throttled run would
@@ -55,12 +61,29 @@ jobs:
           # all-clear. With this token the limit is 5,000/hour.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          python3 content/validation/upstream/check.py \
+            --format markdown --json-out /tmp/pins.json > /tmp/table.md
+
+          # What makes this week's report worth a person's attention. `behind`
+          # is the obvious one. `unstamped` means a pin could not be read out of
+          # the file that declares it, so the checker is broken and silence
+          # would be a false all-clear. The other three states are not: an
+          # `unchecked` row is a network blip, `manual` is permanent by
+          # construction, and `current` is the whole point.
+          actionable=$(jq '[.[] | select(.state == "behind" or .state == "unstamped")] | length' /tmp/pins.json)
+          total=$(jq 'length' /tmp/pins.json)
+          echo "actionable=$actionable" >> "$GITHUB_OUTPUT"
+
           {
             echo "Each of these pins decides what the remediation and IaC-variant"
             echo "validators check against. \`BEHIND\` is not automatically a bug — it"
             echo "is a prompt to look."
             echo
-            python3 content/validation/upstream/check.py --format markdown
+            echo "**$actionable of $total pins need a look this week.** Every other row is"
+            echo "here for context: the report is the whole picture, not just the diff."
+            echo
+            cat /tmp/table.md
             echo
             echo "Most of these already have a pull request: the weekly"
             echo "\`Bump validation dependencies\` workflow opens one per *kind* of pin"
@@ -81,19 +104,44 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          ACTIONABLE: ${{ steps.drift.outputs.actionable }}
         run: |
           set -euo pipefail
           gh label create validation-drift --force \
             --color B7791F \
             --description "Remediation validation broke without a content change"
           title="Validator upstream pins: weekly drift report"
-          existing=$(gh issue list --state open --label validation-drift \
-            --search "$title in:title" --json number --jq '.[0].number // empty')
+          # `--state all`, because a week with nothing behind closes this issue
+          # rather than leaving a stale table open. Finding the closed one is
+          # what lets the next drift reopen it instead of opening a second.
+          found=$(gh issue list --state all --label validation-drift \
+            --search "$title in:title" --json number,state \
+            --jq '.[0] | if . then "\(.number) \(.state)" else "" end')
+          number=${found%% *}
+          state=${found##* }
+
+          # An open issue that says nothing needs doing is worse than no issue:
+          # week after week it trains everyone to skip the label, and then the
+          # week something really is behind reads the same as the fifty before
+          # it. The all-clear is the absence of an open issue.
+          if [ "$ACTIONABLE" -eq 0 ]; then
+            if [ -n "$found" ] && [ "$state" = "OPEN" ]; then
+              gh issue comment "$number" --body \
+                "Every watched pin is current. Closing; the weekly run reopens this issue with a fresh table the next time one falls behind."
+              gh issue close "$number"
+            fi
+            echo "nothing behind — no issue opened"
+            exit 0
+          fi
+
           # One long-lived issue whose body is replaced each week: the table is a
           # snapshot of right now, so appending weekly comments would bury the
           # current state under stale ones.
-          if [ -n "$existing" ]; then
-            gh issue edit "$existing" --body-file /tmp/drift.md
+          if [ -n "$found" ]; then
+            gh issue edit "$number" --body-file /tmp/drift.md
+            if [ "$state" = "CLOSED" ]; then
+              gh issue reopen "$number"
+            fi
           else
             gh issue create --title "$title" --body-file /tmp/drift.md --label validation-drift
           fi

--- a/content/validation/upstream/check.py
+++ b/content/validation/upstream/check.py
@@ -20,6 +20,7 @@
 #   python3 content/validation/upstream/check.py
 #   python3 content/validation/upstream/check.py --format markdown
 #   python3 content/validation/upstream/check.py --format json
+#   python3 content/validation/upstream/check.py --format markdown --json-out pins.json
 #   python3 content/validation/upstream/check.py --exit-code   # 1 if behind
 
 import argparse
@@ -93,6 +94,12 @@ def main() -> None:
     )
     parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     parser.add_argument(
+        "--json-out",
+        metavar="PATH",
+        help="also write the JSON form to PATH, so one run can render a report and "
+             "answer 'is anything behind' without asking every upstream twice",
+    )
+    parser.add_argument(
         "--exit-code",
         action="store_true",
         help="exit 1 when any pin is behind (default: always exit 0, this is a report)",
@@ -100,6 +107,9 @@ def main() -> None:
     args = parser.parse_args()
 
     pins = discover()
+
+    if args.json_out:
+        Path(args.json_out).write_text(render_json(pins) + "\n")
 
     if args.format == "json":
         print(render_json(pins))

--- a/content/validation/upstream/pins.py
+++ b/content/validation/upstream/pins.py
@@ -90,6 +90,46 @@ def as_token(value: object) -> str:
     return text if UPSTREAM_TOKEN.fullmatch(text) else "unknown"
 
 
+def is_prerelease(version: str) -> bool:
+    """True for a version carrying a pre-release marker.
+
+    Semver puts the marker after a hyphen (`2.0.0-beta2`); RubyGems puts it in
+    a dotted segment (`0.27.0.beta4`). Both reduce to "something past the
+    numeric prefix contains a letter", which is also exactly how
+    `Gem::Version#prerelease?` decides. Every released version this module
+    resolves today is digits and dots, so nothing legitimate trips it.
+    """
+    return bool(re.search(r"[A-Za-z]", version.strip().lstrip("vV")))
+
+
+def stable_token(value: object) -> str:
+    """`as_token`, but a pre-release is not a version a pin may be moved to.
+
+    The registries disagree about whether "latest" hides a pre-release.
+    rubygems.org's `gems/<name>.json`, npm's `latest` dist-tag, PyPI's
+    `info.version` and GitHub's `releases/latest` all exclude one; the Terraform
+    registry's `version` field does not. Rather than remember which is which at
+    every call site, every version resolver ends here, and a pre-release comes
+    back as "unknown" -- the same fail-safe `as_token` already applies to a
+    value it cannot parse, and it reads in the report as "could not reach
+    upstream" rather than as a bump someone should make.
+    """
+    token = as_token(value)
+    return "unknown" if token != "unknown" and is_prerelease(token) else token
+
+
+def newest_stable(versions: list[str]) -> str:
+    """The highest non-pre-release entry of a registry's version list.
+
+    Ordering is by numeric component rather than by the list's own order: the
+    Terraform registry does not document a sort, and a backported patch
+    released after a newer minor would otherwise read as the newest thing
+    published and report a current pin as behind.
+    """
+    stable = [v for v in versions if v and not is_prerelease(v)]
+    return max(stable, key=lambda v: tuple(int(n) for n in re.findall(r"\d+", v)), default="")
+
+
 def fetch_json(url: str) -> dict | list | None:
     headers = {"User-Agent": USER_AGENT}
     # Compare the parsed hostname, never a substring of the URL: `"…" in url`
@@ -121,45 +161,68 @@ def latest_github_release(repo: str) -> str:
     data = fetch_json(f"https://api.github.com/repos/{repo}/releases/latest")
     if not isinstance(data, dict) or not data.get("tag_name"):
         return "unknown"
-    return as_token(str(data["tag_name"]).lstrip("v"))
+    return stable_token(str(data["tag_name"]).lstrip("v"))
 
 
 def latest_pypi(pkg: str) -> str:
     data = fetch_json(f"https://pypi.org/pypi/{pkg}/json")
     if not isinstance(data, dict):
         return "unknown"
-    return as_token(data.get("info", {}).get("version", "unknown"))
+    return stable_token(data.get("info", {}).get("version", "unknown"))
 
 
 def latest_rubygem(gem: str) -> str:
     data = fetch_json(f"https://rubygems.org/api/v1/gems/{gem}.json")
     if not isinstance(data, dict):
         return "unknown"
-    return as_token(data.get("version", "unknown"))
+    return stable_token(data.get("version", "unknown"))
 
 
 def latest_gitlab_release(project: str) -> str:
     """Latest release of a GitLab-hosted project. glab lives on gitlab.com and
-    the GitHub mirror publishes no releases, so `releases/latest` there 404s."""
-    data = fetch_json(f"https://gitlab.com/api/v4/projects/{project}/releases?per_page=1")
-    if not isinstance(data, list) or not data:
+    the GitHub mirror publishes no releases, so `releases/latest` there 404s.
+
+    GitLab has no "exclude pre-releases" flag on this endpoint and returns
+    releases newest-first, so a page is fetched and the first stable tag taken
+    rather than whatever happens to sit at the top.
+    """
+    data = fetch_json(f"https://gitlab.com/api/v4/projects/{project}/releases?per_page=20")
+    if not isinstance(data, list):
         return "unknown"
-    return as_token(str(data[0].get("tag_name", "unknown")).lstrip("v"))
+    for release in data:
+        tag = stable_token(str(release.get("tag_name", "")).lstrip("v"))
+        if tag != "unknown":
+            return tag
+    return "unknown"
 
 
 def latest_npm(pkg: str) -> str:
     data = fetch_json(f"https://registry.npmjs.org/{pkg}/latest")
     if not isinstance(data, dict):
         return "unknown"
-    return as_token(data.get("version", "unknown"))
+    return stable_token(data.get("version", "unknown"))
 
 
 def latest_terraform_provider(source: str) -> str:
-    """Latest published version of a Terraform provider, e.g. `hashicorp/aws`."""
+    """Latest *released* version of a Terraform provider, e.g. `hashicorp/aws`.
+
+    The registry's top-level `version` is the newest thing published, including
+    a pre-release, and it is the one resolver here whose upstream works that
+    way. `aliyun/alicloud` reads `2.0.0-beta2` there while its newest release is
+    `1.289.0`, which turned a perfectly current `~> 1.288` pin into a BEHIND row
+    proposing a `~> 2.0` constraint that no released provider satisfies. The
+    same response carries the full `versions` list, so the newest stable entry
+    costs no extra request.
+    """
     data = fetch_json(f"https://registry.terraform.io/v1/providers/{source}")
     if not isinstance(data, dict):
         return "unknown"
-    return as_token(data.get("version", "unknown"))
+    versions = data.get("versions")
+    if isinstance(versions, list):
+        newest = newest_stable([str(v) for v in versions])
+        if newest:
+            return stable_token(newest)
+    return stable_token(data.get("version", "unknown"))
 
 
 def latest_okta_spec_release() -> str:
@@ -422,18 +485,60 @@ def _entry_pattern(key: str, source: str) -> str:
 
 
 def constraint_for(version: str) -> str:
-    """The `~>` constraint this repo would write for a released provider version.
+    """The `~>` constraint this repo writes when a provider outgrows its pin.
 
-    `~> 5.0` floats across every 5.x release, so a provider only outgrows its
-    constraint on a *major* bump. Below 1.0 the minor is the breaking axis and
-    `~> 0.111` floats only across 0.111.x, so a 0.x provider outgrows it on a
-    minor bump. This reproduces every constraint currently in PROVIDER_MAP.
+    House style is the floor of the release's own line: `~> 6.0` for 6.60.0,
+    `~> 0.14` for a 0.14.x. It is only consulted for a provider whose current
+    constraint can no longer resolve the newest release, so what it produces is
+    always the *next* line rather than a restatement of the current one.
     """
     parts = version.split(".")
     if len(parts) < 2:
         return f"~> {version}"
     major, minor = parts[0], parts[1]
     return f"~> 0.{minor}" if major == "0" else f"~> {major}.0"
+
+
+def constraint_admits(constraint: str, version: str) -> bool:
+    """Whether a `~>` constraint already resolves to `version`.
+
+    This is the question the report needs answered, and it is not the same as
+    "is the constraint spelled the way `constraint_for` would spell it today".
+    Terraform's pessimistic operator lets only the rightmost component the
+    constraint names increment, so `~> 6.0` covers all of 6.x, `~> 1.288` covers
+    every 1.x from 1.288 up, and `~> 1.0.4` stops at 1.1.0.
+
+    `alicloud` is why the distinction matters. Its `~> 1.288` is a deliberate
+    pin with a comment in `terraform.py` explaining it: the 2.x line is
+    beta-only, and `~> 2.0` resolved to nothing at all. Comparing constraint
+    text reported that pin behind every week and had the auto-bump workflow
+    offering to reinstate the exact constraint someone had already removed for
+    cause. Asking whether the pin resolves 1.289.0 answers "no action needed".
+
+    The same rule means a 0.x provider reports current until its 1.0: `~> 0.14`
+    genuinely does resolve 0.15, so rewriting it to `~> 0.15` changes which
+    provider Terraform selects not at all.
+    """
+    m = re.fullmatch(r"~>\s*(\d+(?:\.\d+)*)", constraint.strip())
+    if not m:
+        return False
+    bound = [int(p) for p in m.group(1).split(".")]
+    actual = [int(p) for p in re.findall(r"\d+", version)]
+    if not actual:
+        return False
+
+    # Everything left of the rightmost named component is frozen, so the
+    # exclusive ceiling is that neighbour incremented. A one-component
+    # constraint freezes nothing and has no ceiling.
+    ceiling = bound[:-2] + [bound[-2] + 1] if len(bound) > 1 else None
+    width = max(len(bound), len(actual), len(ceiling or []))
+
+    def pad(v: list[int]) -> list[int]:
+        return v + [0] * (width - len(v))
+
+    if pad(actual) < pad(bound):
+        return False
+    return ceiling is None or pad(actual) < pad(ceiling)
 
 
 def check_terraform_pins() -> list[Pin]:
@@ -462,14 +567,22 @@ def check_terraform_pins() -> list[Pin]:
             files=[TERRAFORM_VALIDATOR],
         ))
 
-    # Provider entries hold a `~>` constraint, not a version, so the comparison
-    # is constraint-to-constraint: hashicorp/aws at 6.60.0 makes `~> 5.0` behind
-    # and `~> 6.0` current, while 6.61.0 leaves `~> 6.0` alone.
+    # Provider entries hold a `~>` constraint, not a version, so a pin is behind
+    # when the newest release is one the constraint cannot resolve -- not when
+    # the constraint is merely spelled differently to what this repo would write
+    # from scratch. hashicorp/aws at 6.60.0 leaves `~> 6.0` alone and makes
+    # `~> 5.0` behind; aliyun/alicloud at 1.289.0 leaves the deliberate
+    # `~> 1.288` alone, which comparing constraint text did not.
     for key, (source, constraint) in _parse_pair_map(text, "PROVIDER_MAP").items():
         version = latest_terraform_provider(source)
+        if version == "unknown":
+            latest = "unknown"
+        elif constraint_admits(constraint, version):
+            latest = constraint
+        else:
+            latest = constraint_for(version)
         out.append(Pin(
-            f"terraform-provider-{key}", "terraform-provider", constraint,
-            constraint_for(version) if version != "unknown" else "unknown",
+            f"terraform-provider-{key}", "terraform-provider", constraint, latest,
             f"{source} {version}",
             apply=make_apply(_entry_pattern(key, source)),
             files=[TERRAFORM_VALIDATOR],


### PR DESCRIPTION
Fixes the three complaints against #3436.

### A quiet week no longer opens an issue

The report was published unconditionally, so a week where every pin was current still produced an issue whose only content was fifty `ok` rows. An open issue that says nothing needs doing trains everyone to skip the label, and then the week something really is behind reads the same as the fifty before it.

The issue is now opened only when a pin is `behind` or `unstamped`, and a clean week closes the existing one with a comment rather than leaving a stale table open. Drift reopens the same issue, so the long-lived-issue design is unchanged.

`unstamped` counts as actionable on purpose: it means a pin could not be read out of the file that declares it, so the checker itself is broken and silence would be a false all-clear. `unchecked` is a network blip and `manual` is permanent, so neither is.

All six branches were exercised against a stubbed `gh`:

| behind | existing issue | result |
| --- | --- | --- |
| 0 | none | nothing |
| 0 | open | comment + close |
| 0 | closed | nothing |
| >0 | none | create |
| >0 | open | edit body |
| >0 | closed | edit body + reopen |

### No pin is reported behind a pre-release

The registries disagree about whether "latest" hides one. rubygems.org's `gems/<name>.json`, npm's `latest` dist-tag, PyPI's `info.version` and GitHub's `releases/latest` all exclude a pre-release; the Terraform registry's `version` field does not. Rather than remember which is which per call site, every version resolver now ends in `stable_token`, and a pre-release comes back as `unknown`.

### `~> 1.288` is not behind `~> 2.0`

`aliyun/alicloud` publishes `2.0.0-beta2` as its newest version, which the checker turned into a `~> 2.0` upstream and reported the pin behind. That constraint resolves to nothing at all, the 2.x line being beta-only, which is exactly why `terraform.py` already carries a commented, deliberate `~> 1.288`. So the report proposed reinstating the constraint someone had removed for cause, and `validation-dependency-updates.yaml` would have opened the pull request for it.

Terraform's pessimistic operator lets only the rightmost named component increment, so `~> 1.288` covers every 1.x from 1.288 up and does resolve the current 1.289.0. `constraint_admits` asks that question instead of comparing constraint text, and `constraint_for` is now consulted only for a provider that has genuinely outgrown its line.

A side effect worth flagging: a 0.x provider now reports current until its 1.0. `~> 0.14` really does resolve 0.15, so the weekly PR rewriting it to `~> 0.15` changed which provider Terraform selected not at all.

### Verification

Run against the live registries, not mocks:

- `terraform-provider-alicloud` moves from `BEHIND` / `~> 2.0` to `ok` / `~> 1.288`.
- The other 23 provider rows are unchanged, as are the tflint rulesets, linters, CLIs and specs.
- The three genuinely behind pins still report: cookstyle `8.6.10 -> 8.7.6`, and the slack and portainer spec SHAs.
- `bump.py --all --dry-run` now offers only cookstyle; it no longer offers the alicloud constraint.
- `constraint_admits` covered for floor, ceiling, three-component pins, 0.x, and a non-pessimistic constraint it should refuse to interpret.
- Both `run:` blocks are shellcheck-clean.

### Not changed: cookstyle

The third complaint on #3436 was that the cookstyle row reports a pre-release that is not on rubygems. It reproduces as accurate, so nothing here suppresses it. `8.7.6` is tagged `v8.7.6` upstream, published on rubygems.org on 2026-06-24, `prerelease: false`, `yanked: false`; it installs with the workflow's own `gem install cookstyle -v 8.7.6` and runs clean on a recipe. `latest_rubygem` was already pre-release-safe, verified against `ruby-lsp`, which reads `0.26.10` from that endpoint while `0.27.0.beta4` is its newest push. The `stable_token` guard added here is belt-and-braces for that resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
