### PR TITLE
📝 alibaba: rewrite check descriptions in prose

### DIFF
--- a/content/mondoo-alibaba-security.mql.yaml
+++ b/content/mondoo-alibaba-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-alibaba-security
     name: Mondoo Alibaba Cloud Security
-    version: 1.2.0
+    version: 1.2.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -140,18 +140,17 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that every RAM user who can sign in to the Alibaba Cloud console has a multi-factor authentication (MFA) device bound to their identity. By default a RAM user created with a logon profile can authenticate with a password alone, so a single leaked or guessed password grants full interactive access.
+        This check verifies that interactive sign-in to the Alibaba Cloud console is protected by a second authentication factor for every RAM user who holds a logon profile.
+
+        A RAM user created with a logon profile can authenticate with a password alone by default, so the account's only barrier is a secret that can be phished, reused, or guessed. Multi-factor authentication (MFA) binds a virtual MFA device or a U2F security key to the identity so a password on its own no longer produces a session. Bind the device in the RAM console under **Identities** > **Users** on the affected user's **Authentication** tab, or with `aliyun ram CreateVirtualMFADevice` followed by `aliyun ram BindMFADevice`. Binding a device is only half the control: enforce MFA at sign-in by attaching an MFA-required condition through the account's security settings, otherwise the device exists but is never demanded.
 
         **Why this matters**
 
-        - **Password compromise is common:** Phishing, credential stuffing, and reused passwords are among the most frequent initial-access techniques; a second factor blocks account takeover even when the password is known.
-        - **Console access is high value:** Interactive console sessions can reach every service the user is authorized for, so an unprotected console login is a direct path to broad account access.
-        - **Privilege concentration:** RAM users often carry standing permissions, so protecting their sign-in materially reduces the account's overall attack surface.
+        Phishing, credential stuffing, and password reuse are among the most frequent initial-access techniques in use today. A second factor blocks account takeover even in the case where the attacker already holds a working password, because the attacker must also compromise a physical or virtual device that never leaves the user's possession.
 
-        **Risk mitigation**
+        Console sessions are unusually valuable. An interactive session can reach every service the user is authorized for, so an unprotected console login is a direct path to broad account access rather than a foothold in one service. RAM users frequently carry standing permissions that were granted once and never reviewed, which concentrates that value further.
 
-        - **Blocks single-factor takeover:** Requiring a device-bound second factor stops an attacker who only holds the password.
-        - **Raises attacker cost:** MFA forces adversaries to compromise a physical or virtual device in addition to a credential.
+        The check evaluates only users that have a logon profile. A programmatic identity that holds access keys but cannot sign in to the console is out of scope here; a companion check in this policy bounds the lifetime of those keys instead.
       audit: |
         ### Audit via Console
 
@@ -221,18 +220,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every Object Storage Service (OSS) bucket has server-side encryption configured so that objects are encrypted at rest. Without a bucket-level encryption rule, objects can be written in plaintext to the underlying storage.
+        This check verifies that every Object Storage Service (OSS) bucket applies a default server-side encryption rule, so object contents are encrypted at rest from the moment they are written.
+
+        Default encryption is a bucket-level setting administered under **Content Security** > **Server-side Encryption** in the OSS console, or with `aliyun oss bucket-encryption --method put`. The check requires that an encryption method is recorded for the bucket, either the service-managed `AES-256` keys or `KMS`. A bucket whose encryption method reads **None** fails. Declared in Terraform, the same setting is a `server_side_encryption_rule` block carrying an `sse_algorithm` value.
 
         **Why this matters**
 
-        - **Defense against storage-layer exposure:** Encryption at rest protects object contents if the underlying disks, backups, or storage media are ever accessed outside the service.
-        - **Regulatory expectation:** Many compliance regimes require that stored data, especially personal or cardholder data, is encrypted at rest.
-        - **Low-cost, high-coverage control:** A bucket-level default encryption rule transparently protects every object without changing application behavior.
+        Without a bucket-level rule, objects land on the underlying storage as plaintext. Anyone who reaches that storage outside the service reads them directly: a recovered disk, a restored backup, or a copy of the storage media yields file contents without a single OSS API call, so nothing appears in request logs and no credential is ever spent. An encryption rule turns that same material into ciphertext that is useless without the keys.
 
-        **Risk mitigation**
+        Encryption can also be requested per object at upload time, which means every SDK call, every pipeline, and every hand-run script has to remember to ask. A bucket default removes that dependency and guarantees objects are encrypted no matter which client wrote them, with no change to application behavior on read or write.
 
-        - **Reduces breach impact:** Encrypted objects are unreadable to an attacker who obtains raw storage without the keys.
-        - **Consistent coverage:** A default rule guarantees new objects are encrypted, eliminating gaps from per-object configuration mistakes.
+        Stored data that includes personal or cardholder information is expected to be encrypted at rest by most compliance regimes, so a bucket with no rule at all becomes an exception you must explain rather than a control you can evidence.
+
+        This check asserts that some encryption method is configured, not which one. A companion check in this policy goes further and requires `KMS` with a customer master key, which adds key access control and audit trail that the built-in `AES-256` keys cannot provide.
       audit: |
         ### Audit via Console
 
@@ -340,18 +340,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every active RAM user access key was created within the last 90 days. Access keys are long-lived programmatic credentials, and the longer a key remains valid the greater the window for it to be leaked, harvested from source control, or reused after an employee departs. Rotating keys on a fixed schedule caps that exposure window.
+        This check verifies that long-lived programmatic credentials are replaced on a fixed schedule, requiring every `Active` RAM user access key to have been created within the last 90 days.
+
+        An access key is a static secret with no expiry of its own, so its exposure window is bounded only by how often it is rotated. Rotate a key in the RAM console under **Identities** > **Users** on the user's **Authentication** tab by creating a new **AccessKey**, moving consumers onto it, then setting the old key to **Disabled** and deleting it once traffic has drained. The same sequence runs from the CLI with `aliyun ram CreateAccessKey`, `aliyun ram UpdateAccessKey --Status Inactive`, and `aliyun ram DeleteAccessKey`.
 
         **Why this matters**
 
-        - **Static secrets accumulate risk:** Unlike an interactive session, an access key does not expire on its own; a key that is years old may have been copied into scripts, CI systems, or laptops that are no longer trusted.
-        - **Leaked keys are a top breach vector:** Access keys are routinely exposed in public repositories, logs, and container images; frequent rotation invalidates a leaked key before an attacker can rely on it.
-        - **Departed users and stale automation:** A key that is never rotated outlives the context it was issued for, leaving credentials active long after the need for them ends.
+        Unlike an interactive session, an access key does not lapse on its own. A key that is years old has had years to be copied into scripts, CI systems, container images, and laptops that are no longer trusted, and nothing about the account's current state records where those copies went.
 
-        **Risk mitigation**
+        Leaked access keys are a leading breach vector. They surface routinely in public repositories, application logs, and published images, and automated scanners harvest them within minutes of exposure. Frequent rotation invalidates a leaked key before an attacker can build anything durable on it.
 
-        - **Caps the exposure window:** Regular rotation guarantees that any single leaked key becomes useless within a bounded period.
-        - **Forces credential hygiene:** A rotation policy surfaces unused and forgotten keys so they can be disabled and removed.
+        Rotation also forces credential hygiene. A key that is never rotated outlives the person or the automation it was issued for, so a departed employee or a decommissioned job leaves working credentials behind. A rotation cycle surfaces those forgotten keys so they can be disabled and removed rather than quietly renewed.
+
+        Keys already in the `Inactive` state are not evaluated, since a disabled key cannot authenticate. Disabling is a safe intermediate step during a rotation, but delete the old key once consumers have moved rather than leaving it parked.
       audit: |
         ### Audit via Console
 
@@ -419,18 +420,19 @@ queries:
     impact: 60
     docs:
       desc: |
-        This check ensures that the RAM account password policy requires a minimum password length of at least 14 characters. Longer passwords dramatically increase the effort required for brute-force and dictionary attacks, and a short minimum length is one of the most common weaknesses in credential policy.
+        This check verifies that the account-wide credential floor for RAM passwords is high enough to resist cracking, requiring a minimum password length of at least 14 characters.
+
+        The RAM account password policy governs every user in the account who authenticates with a password, so the minimum length set there is the shortest password anyone can choose. Set it in the RAM console under **Settings** > **Security Settings** > **Password Policy** by raising **Minimum Password Length** to 14 or greater, with `aliyun ram SetPasswordPolicy --MinimumPasswordLength 14`, or by declaring `minimum_password_length` on the Terraform account password policy resource.
 
         **Why this matters**
 
-        - **Length is the strongest single factor:** Each additional character multiplies the search space an attacker must cover, so length defeats offline cracking far more effectively than composition rules alone.
-        - **Default policies are weak:** The Alibaba Cloud default minimum length is below modern guidance, so accounts left at the default permit easily guessed passwords.
-        - **Console and API access share the policy:** A weak password floor exposes every RAM user who authenticates with a password.
+        Length is the strongest single lever available in password policy. Each additional character multiplies the search space an attacker must cover, so length defeats offline cracking far more effectively than composition rules do. A 14-character floor pushes an offline attack against a captured hash beyond practical reach for the tooling most attackers use.
 
-        **Risk mitigation**
+        The Alibaba Cloud default minimum sits below modern guidance, so an account that was never tuned permits passwords short enough to be guessed. Because the policy is set once at the account level, leaving it at the default is a silent decision rather than a visible one, and no individual user is in a position to correct it.
 
-        - **Raises brute-force cost:** A 14-character floor pushes offline cracking beyond practical reach for common attackers.
-        - **Consistent baseline:** Enforcing the minimum at the account level guarantees no user can set a short password.
+        Enforcing the floor centrally also removes the gap that guidance alone leaves behind. Every RAM user who authenticates with a password inherits the same baseline, with no reliance on anyone following a written standard.
+
+        Length is necessary but not sufficient on its own. Companion checks in this policy assert the character-class requirements and the failed-login lockout that complete the password policy.
       audit: |
         ### Audit via Console
 
@@ -525,18 +527,19 @@ queries:
     impact: 60
     docs:
       desc: |
-        This check ensures that the RAM account password policy requires all four character classes: uppercase letters, lowercase letters, numbers, and symbols. Requiring mixed character types widens the keyspace an attacker must search and blocks trivially guessable passwords built from a single class.
+        This check verifies that RAM passwords are drawn from the full character space rather than a small predictable alphabet, requiring all four character classes: uppercase letters, lowercase letters, numbers, and symbols.
+
+        The account password policy applies the requirement to every RAM user at the moment a password is set, so no user can opt out of it. Enable all four requirements in the RAM console under **Settings** > **Security Settings** > **Password Policy**, or set `--RequireUppercaseCharacters`, `--RequireLowercaseCharacters`, `--RequireNumbers`, and `--RequireSymbols` to `true` with `aliyun ram SetPasswordPolicy`. In Terraform the same four attributes appear on the account password policy resource as `require_uppercase_characters`, `require_lowercase_characters`, `require_numbers`, and `require_symbols`.
 
         **Why this matters**
 
-        - **Composition widens the keyspace:** Requiring every character class forces passwords out of small, predictable alphabets that fall quickly to dictionary and mask attacks.
-        - **Blocks weak patterns:** Without complexity rules, users default to lowercase words and simple number suffixes that automated cracking tools target first.
-        - **Applies account-wide:** The policy governs every RAM user, so a single misconfiguration weakens all password-based logins.
+        Requiring every character class forces passwords out of the narrow alphabets that fall first to dictionary and mask attacks. Cracking tools work outward from the cheapest keyspaces, and a lowercase-only password of any reasonable length is among the cheapest.
 
-        **Risk mitigation**
+        Without complexity rules, users converge on predictable shapes: a lowercase dictionary word with a digit or two appended, or a capitalized word ending in an exclamation mark. Those patterns are exactly what automated cracking rulesets model, so they offer far less real strength than their character count suggests.
 
-        - **Defeats low-effort guessing:** Mandatory mixed classes eliminate the weakest password patterns across the account.
-        - **Complements length:** Combined with a strong minimum length, complexity requirements push passwords beyond practical offline cracking.
+        The policy governs the whole account, which means a single missing requirement weakens every password-based login at once. There is no per-user compensating control that an administrator can apply afterward.
+
+        Complexity works alongside length rather than in place of it. Paired with the 14-character minimum asserted by a companion check in this policy, mandatory mixed classes push passwords past the point where offline cracking is worth an attacker's time.
       audit: |
         ### Audit via Console
 
@@ -650,18 +653,19 @@ queries:
     impact: 60
     docs:
       desc: |
-        This check ensures that the RAM account password policy locks an account after a small number of consecutive failed password attempts. A lockout threshold between 1 and 5 stops online password guessing while still allowing for occasional user error. A value of 0 disables the lockout entirely and permits unlimited guessing.
+        This check verifies that online password guessing against RAM accounts is throttled, requiring the account password policy to lock an account after between 1 and 5 consecutive failed attempts.
+
+        The lockout threshold is the brake on live authentication attempts. A value of `0` disables the lockout entirely and permits unlimited guessing, and a value above 5 leaves enough room for automated tooling to work through a candidate list. Set the number of password retries in the RAM console under **Settings** > **Security Settings** > **Password Policy**, with `aliyun ram SetPasswordPolicy`, or through `max_login_attempts` on the Terraform account password policy resource.
 
         **Why this matters**
 
-        - **Online guessing needs a brake:** Without a lockout, an attacker can attempt passwords repeatedly against a live login until one succeeds.
-        - **Disabled lockout is the default risk:** A policy that allows unlimited attempts turns every password-based account into a brute-force target.
-        - **Low thresholds contain automated attacks:** Locking after a handful of failures stops credential-stuffing tools that rely on high request volume.
+        Password strength is only one half of the defense against guessing. Without a lockout, an attacker can attempt candidate passwords against a live login endpoint indefinitely, and no amount of policy on password composition prevents the attempts themselves from being made.
 
-        **Risk mitigation**
+        A policy that allows unlimited attempts turns every password-based identity in the account into a standing brute-force target. Credential-stuffing tools depend on high request volume against many accounts at once, so a threshold in the low single digits removes the volume they need before a single reused password can be confirmed.
 
-        - **Throttles brute force:** A tight lockout threshold makes online password guessing impractical.
-        - **Signals attacks:** Repeated lockouts surface guessing attempts for investigation.
+        Lockouts also generate signal. Repeated lockouts across the account are visible evidence of a guessing campaign and give responders something concrete to investigate, where silent failed attempts would pass unnoticed.
+
+        Where occasional user error makes a tight threshold inconvenient, pair the lockout with multi-factor authentication rather than raising the limit. Loosening the threshold restores the attacker's request budget, while a second factor removes the value of a correctly guessed password outright.
       audit: |
         ### Audit via Console
 
@@ -764,18 +768,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no custom RAM policy grants full administrative access by allowing every action on every resource. An `Allow` statement whose `Action` is `*` and whose `Resource` is `*` or the fully wildcarded `acs:*:*:*:*` (whether written as a single string or inside a list, and with no `NotAction` or `NotResource` exception carved out) is equivalent to the built-in AdministratorAccess policy and hands the attached identity unrestricted control of the account.
+        This check verifies that least privilege holds in the account's custom permission set, ensuring that no custom RAM policy grants unrestricted control by allowing every action on every resource.
+
+        An `Allow` statement whose `Action` is `*` and whose `Resource` is `*` or the fully wildcarded `acs:*:*:*:*` is equivalent to the built-in AdministratorAccess policy and hands the attached identity total control of the account. The check treats the grant as full admin whether the wildcards are written as single strings or inside lists, and it accounts for a `NotAction` or `NotResource` exception that carves real scope back out. Scope an offending policy in the RAM console under **Permissions** > **Policies** by replacing the wildcards with the specific actions and resource ARNs the identity requires and saving a new version, or publish the scoped document with `aliyun ram CreatePolicyVersion --SetAsDefault true`.
 
         **Why this matters**
 
-        - **Wildcard grants defeat least privilege:** A single `*/*` allow statement bypasses every intended access boundary, so any identity carrying it can reach every service and resource.
-        - **Custom policies escape review:** Broad permissions embedded in a custom policy are easy to overlook, unlike attaching the clearly named system administrator policy.
-        - **Blast radius on compromise:** If an identity with full-admin custom permissions is compromised, the attacker inherits total account control.
+        A single wildcard allow statement bypasses every access boundary the rest of the permission model was designed to draw. Any identity carrying it reaches every service and every resource in the account regardless of what the surrounding policies say.
 
-        **Risk mitigation**
+        Broad permissions buried in a custom policy document also escape review in a way that a named system policy does not. Attaching AdministratorAccess is a visible act that an approver can question; a custom policy with an innocuous name that happens to contain `"Action": "*"` reads as ordinary until someone opens the document.
 
-        - **Contains compromise:** Scoping permissions to required actions and resources limits what a stolen credential can do.
-        - **Enforces intentional access:** Removing wildcard grants forces each permission to be justified against a real need.
+        The consequence on compromise is total. A stolen credential or a hijacked session belonging to such an identity inherits unrestricted account control, with no boundary left to contain lateral movement.
+
+        Only custom policies are evaluated, so an account that defines none passes with nothing to assess. Where genuine account-wide administration is required, grant it through the named system policy so the privilege is obvious to anyone reviewing the attachment.
       audit: |
         ### Audit via Console
 
@@ -842,18 +847,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every RAM user with a console logon profile has signed in within the last 90 days. A user who can log in but has not done so recently represents standing access that is no longer being used, and dormant accounts are a favored target because their misuse is unlikely to be noticed.
+        This check verifies that console access is actively used rather than merely retained, requiring every RAM user with a logon profile to have signed in within the last 90 days.
+
+        A logon profile is what makes a RAM user able to authenticate interactively. When that profile exists but no sign-in has occurred in 90 days, or has never occurred at all, the account represents standing access that nobody currently depends on. Review the **Last Logon** time in the RAM console under **Identities** > **Users**. Where the access is no longer needed, delete the logon profile with `aliyun ram DeleteLoginProfile` to remove console access, or remove the identity entirely with `aliyun ram DeleteUser` once its credentials and policy attachments are cleared.
 
         **Why this matters**
 
-        - **Dormant access is unmonitored access:** An account that nobody actively uses can be compromised and operated for a long time before anyone notices.
-        - **Orphaned accounts linger:** Users who have changed roles or left the organization often retain console access that was never revoked.
-        - **Standing credentials expand attack surface:** Every enabled login that is not needed is an additional entry point an attacker can target.
+        Dormant access is unmonitored access. When a legitimate owner never signs in, there is nobody positioned to notice that someone else has, so an attacker who takes over an idle account can operate inside it for a long time before any human raises a question.
 
-        **Risk mitigation**
+        Orphaned accounts accumulate quietly. Staff change roles, contracts end, and short-lived project access is granted and forgotten, yet the console login usually survives all of it because revoking access is nobody's explicit task.
 
-        - **Removes unused entry points:** Disabling or deprovisioning inactive users shrinks the set of credentials an attacker can abuse.
-        - **Surfaces stale identities:** Flagging inactivity drives a regular review of who still needs access.
+        Every enabled login that is not needed is another entry point that has to be defended, monitored, and covered by password and MFA policy. Removing unused logins shrinks that surface directly rather than adding another control on top of it.
+
+        Deleting the logon profile removes interactive access while leaving the identity and its programmatic credentials intact, which is the right move when automation still authenticates as that user. Users with no logon profile at all are out of scope for this check.
       audit: |
         ### Audit via Console
 
@@ -922,18 +928,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that no Object Storage Service (OSS) bucket is exposed through a `public-read` or `public-read-write` access control list (ACL). A public ACL lets anonymous callers on the internet list and download bucket objects, and `public-read-write` additionally lets them upload and overwrite objects. A bucket whose public ACL is neutralized by an enabled Block Public Access setting is not treated as exposed, because Block Public Access overrides the ACL.
+        This check verifies that no Object Storage Service (OSS) bucket hands anonymous callers access through its access control list (ACL).
+
+        An OSS bucket ACL takes one of three values, and two of them are public. The check fails a bucket set to `public-read` or `public-read-write` and passes one set to `private`. The setting lives under **Access Control** > **Access Control List** in the OSS console and can be corrected with `aliyun oss set-acl oss://<bucket-name> private -b`.
 
         **Why this matters**
 
-        - **Direct data exposure:** A `public-read` bucket serves every object to anyone who knows or guesses the bucket URL, with no authentication.
-        - **Unauthenticated writes:** A `public-read-write` bucket lets anyone add, replace, or delete objects, enabling data tampering, defacement, and hosting of malicious content on your namespace.
-        - **Broad blast radius:** Bucket-level ACLs apply to the whole bucket, so a single misconfiguration can expose large volumes of data at once.
+        A `public-read` bucket answers anonymous HTTP requests. Anyone who learns or guesses the bucket URL lists the objects and downloads all of them with ordinary GET requests, presenting no credentials and leaving nothing that ties the transfer to an identity. Bucket names surface in page source, mobile app bundles, and support tickets, and internet-wide scanners sweep for readable buckets continuously, so exposure is usually discovered by strangers before it is discovered by you.
 
-        **Risk mitigation**
+        A `public-read-write` bucket additionally accepts anonymous uploads and deletes. That lets an attacker replace assets your application serves, host malware or phishing content under your storage namespace and its reputation, destroy objects outright, or park bulk data at your expense.
 
-        - **Keeps data private by default:** A private ACL requires authenticated, authorized requests for every object.
-        - **Removes anonymous write paths:** Denying public write blocks tampering and abuse of your storage namespace.
+        Because the grant is made at the bucket level, one wrong value exposes everything the bucket holds at once, which is what turns a small configuration slip into a large disclosure.
+
+        A bucket with a public ACL still passes when Block Public Access is enabled, because that guardrail overrides the ACL and the objects are not actually reachable. Companion checks in this policy cover the guardrail itself and the bucket policy, which is a separate grant path that a private ACL does not close.
       audit: |
         ### Audit via Console
 
@@ -1035,18 +1042,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that every Object Storage Service (OSS) bucket has Block Public Access enabled. Block Public Access is an account- and bucket-level guardrail that overrides any ACL or bucket policy that would otherwise grant public access, so a bucket cannot be exposed to the internet even if an ACL or policy is misconfigured.
+        This check verifies that Block Public Access is turned on for every Object Storage Service (OSS) bucket, so no ACL or bucket policy can open the bucket to the internet.
+
+        Block Public Access is a guardrail available at both the account and the bucket level. While it is active, any grant that would expose objects publicly is ignored, whatever the ACL says and whatever principals a bucket policy names. It is enabled under **Access Control** > **Block Public Access** in the OSS console, and in Terraform through an `alicloud_oss_bucket_public_access_block` resource with `block_public_access = true`.
 
         **Why this matters**
 
-        - **Defense in depth:** Block Public Access acts as a backstop that neutralizes accidental public ACLs and bucket policies, so a single mistake does not expose data.
-        - **Prevents drift:** Even if a user or automation later sets a public ACL or policy, the guardrail keeps the bucket private.
-        - **Reduces exposure surface:** Buckets that never need public access are hardened against the most common storage-exposure mistake.
+        Public storage exposure is rarely the result of a deliberate decision. It comes from a bucket created with a `public-read` ACL to make one asset reachable, or a policy statement pasted in with a `Principal` of `*` because the narrower form was harder to write. Without the guardrail, either mistake takes effect the instant it is saved and the bucket starts serving objects to anonymous callers with nothing raising an objection.
 
-        **Risk mitigation**
+        Buckets also drift long after creation. New pipelines, new operators, and new automation edit access settings over the life of a bucket, and the guardrail keeps every one of those edits from producing an exposure rather than relying on each author to get access control right.
 
-        - **Overrides risky grants:** Public ACLs and policies are ignored while the guardrail is active.
-        - **Consistent baseline:** Enabling the block establishes a private-by-default posture across buckets.
+        For the large majority of buckets that never need anonymous access, the guardrail closes the single most common storage exposure mistake at essentially no operational cost.
+
+        This is a backstop, not a substitute for correct access control: the ACL and the bucket policy should be private on their own merits, and companion checks in this policy assert both. Buckets that intentionally serve content anonymously, such as those backing a public static website, cannot use the guardrail and should be excepted deliberately rather than left unblocked by omission.
       audit: |
         ### Audit via Console
 
@@ -1128,18 +1136,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that no Object Storage Service (OSS) bucket policy grants access to anonymous principals. In an OSS bucket policy an anonymous grant is expressed as a `Principal` of `*`, which allows unauthenticated callers on the internet to perform the granted actions regardless of the bucket ACL. A bucket whose wildcard-principal policy is neutralized by an enabled Block Public Access setting is not treated as exposed, because Block Public Access overrides the policy grant.
+        This check verifies that no Object Storage Service (OSS) bucket policy grants its permissions to unauthenticated callers.
+
+        In an OSS bucket policy an anonymous grant is written as a statement whose `Principal` is `*`. Everyone on the internet then holds whatever actions that statement allows. Policies are edited under **Access Control** > **Bucket Policy** in the OSS console, and replaced from a file with `aliyun oss bucket-policy --method put oss://<bucket-name> ./bucket-policy.json`. The fix is to name specific RAM identities in place of the wildcard rather than to remove access altogether.
 
         **Why this matters**
 
-        - **Bypasses authentication:** A statement that allows `Principal` `*` grants the listed actions to anyone, with no credentials required.
-        - **Easy to overlook:** Bucket policies are separate from the bucket ACL, so a private ACL can be silently undermined by a permissive policy.
-        - **High-value target:** Object storage frequently holds backups, logs, and application data that are attractive to attackers when reachable anonymously.
+        A wildcard principal removes authentication from the request path entirely. If the statement allows read actions, an attacker enumerates and downloads objects with no credential to steal and no key to rotate afterward. If it allows write or delete actions, the same anonymous caller overwrites or destroys the bucket's contents.
 
-        **Risk mitigation**
+        The policy grant is evaluated independently of the bucket ACL, so a bucket that reads **Private** on the access control page can still be fully open through a permissive statement on the next page over. That separation is exactly why the problem survives reviews that only inspect the ACL.
 
-        - **Requires authenticated access:** Removing anonymous grants forces every request to present valid credentials.
-        - **Closes a hidden exposure path:** Auditing policies alongside ACLs eliminates a common blind spot for public data access.
+        Object storage tends to accumulate database backups, application logs, and export files, which is precisely the material an attacker wants and precisely what makes an anonymously readable bucket worth scanning for.
+
+        A bucket with no policy at all passes, since there is no grant to worry about, and so does a bucket whose wildcard statement is neutralized by an enabled Block Public Access setting, because the guardrail overrides the policy grant. A companion check in this policy covers the bucket ACL, which is the other route to anonymous access.
       audit: |
         ### Audit via Console
 
@@ -1203,18 +1212,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every Object Storage Service (OSS) bucket's default server-side encryption uses the KMS algorithm backed by a customer master key (CMK), rather than the built-in AES-256 keys. A KMS CMK gives you control over key rotation, access policy, and disable/delete operations, and produces an auditable trail of key usage.
+        This check verifies that an Object Storage Service (OSS) bucket's default encryption is backed by a customer master key (CMK) you control in Key Management Service, rather than by the built-in `AES-256` keys the platform manages for you.
+
+        Both methods encrypt objects at rest. They differ in who holds the key. Select **KMS** and a specific CMK under **Content Security** > **Server-side Encryption** in the OSS console, or run `aliyun oss bucket-encryption --method put oss://<bucket-name> --sse-algorithm KMS --kms-masterkey-id <cmk-id>`. Against a live bucket the check requires both the `KMS` method and a key recorded on the bucket; a bucket showing **None** or **AES-256** fails.
 
         **Why this matters**
 
-        - **Customer-controlled keys:** A KMS CMK lets you govern who can use the key and revoke access, which the service-managed AES-256 keys do not allow.
-        - **Auditability:** KMS records every encrypt and decrypt operation, supporting investigation and compliance evidence.
-        - **Stronger separation of duties:** Key administration is separated from data access, limiting what a single compromised identity can reach.
+        With the service-managed keys there is no key policy to write, which sounds convenient until you need one. You cannot say which identities may decrypt, you cannot revoke that ability, and you cannot see when the key was used. A CMK gives you all three, and it splits the permission to read data in two: an identity now needs both bucket access and key access, so a single compromised RAM user or leaked access key no longer reaches object contents on its own.
 
-        **Risk mitigation**
+        KMS records every encrypt and decrypt operation against the key. That log is what turns "the bucket was reachable" into "these objects were actually decrypted, at these times, by this identity", which is the difference between speculating about an incident and scoping it.
 
-        - **Revocable access:** Disabling the CMK renders the bucket's objects unreadable, providing a fast containment control.
-        - **Governed key lifecycle:** Rotation and access policies for the CMK are managed centrally in KMS.
+        Disabling the CMK is also a containment control. It renders the bucket's objects unreadable immediately, without touching the bucket or its contents, while rotation and key lifecycle stay governed centrally in KMS.
+
+        This is the stricter of the two encryption checks in this policy. A bucket on `AES-256` still satisfies the companion requirement that encryption at rest be configured, and fails here only because the key is not yours to govern.
       audit: |
         ### Audit via Console
 
@@ -1319,18 +1329,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every Object Storage Service (OSS) bucket has access logging enabled so that requests against the bucket are recorded to a target bucket. Without access logs there is no record of who read, wrote, or deleted objects, which undermines detection and forensic investigation.
+        This check verifies that every Object Storage Service (OSS) bucket records the requests made against it, by writing access logs to a target bucket.
+
+        Access logging is switched on under **Log Management** > **Logging** in the OSS console, where you choose the bucket that will receive the log objects and a prefix for them. The equivalent commands are `aliyun oss logging --method put oss://<bucket-name> oss://<log-bucket-name>/log/` and, in Terraform, a `logging` block naming `target_bucket` and `target_prefix`. The check requires that a logging configuration exists on the bucket.
 
         **Why this matters**
 
-        - **Detection and investigation:** Access logs are the primary evidence for identifying unauthorized access, data exfiltration, and abuse.
-        - **Accountability:** Recorded requests attribute actions to callers, supporting incident response and audits.
-        - **Compliance expectation:** Many regimes require that access to data stores is logged and retained.
+        Reads are invisible without logs. An attacker holding a leaked access key, or an anonymous caller who found a publicly readable bucket, can download every object in it and leave no evidence that anything was taken. When the exposure is later discovered, there is no way to answer the question that actually matters, which is whether anyone used it. Teams routinely have to notify on the assumption that everything was read, because the alternative is unprovable.
 
-        **Risk mitigation**
+        Logs are also what make detection possible before that point. A single identity enumerating a bucket and pulling its entire contents looks nothing like normal application traffic, but only if the traffic is recorded somewhere it can be reviewed.
 
-        - **Enables timely detection:** Continuous logging surfaces anomalous access patterns for review.
-        - **Supports forensics:** Retained request logs let responders reconstruct what happened during an incident.
+        Recorded requests attribute each action to a caller, which supports both incident response and the audit and retention expectations that most compliance regimes place on access to data stores.
+
+        This check asserts that logging is configured with a target, not that the target is safe. Send logs to a dedicated bucket that the workloads writing to the source bucket cannot modify, with its own restrictive access control and a defined retention period, otherwise an attacker who reaches the source bucket also reaches the record of what they did.
       audit: |
         ### Audit via Console
 
@@ -1431,18 +1442,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every Object Storage Service (OSS) bucket has versioning enabled. With versioning, OSS retains previous versions of an object when it is overwritten or deleted, so data can be recovered after accidental changes, malicious deletion, or ransomware.
+        This check verifies that every Object Storage Service (OSS) bucket retains prior versions of its objects, so an overwrite or a delete is a recoverable event instead of a permanent one.
+
+        Versioning is set under **Redundancy for Fault Tolerance** > **Versioning** in the OSS console, with `aliyun oss bucket-versioning --method put oss://<bucket-name> enabled`, or through a Terraform `versioning` block with `status = "Enabled"`. The check requires the status to be `Enabled`; a bucket that never enabled versioning fails, and so does one that has suspended it.
 
         **Why this matters**
 
-        - **Recovery from deletion:** Versioning preserves prior object versions, allowing restoration after accidental or malicious deletes and overwrites.
-        - **Ransomware resilience:** An attacker who encrypts or overwrites objects cannot destroy the retained earlier versions without additional privileges.
-        - **Data integrity:** Historical versions provide a reliable point-in-time reference when investigating unexpected changes.
+        Without versioning, a write wins outright. A ransomware operator with valid write credentials reads each object, writes back an encrypted copy, and the original ceases to exist, so there is nothing to restore and nothing to negotiate over except the key. The same finality applies to ordinary accidents, such as a deploy that syncs an empty directory over a prefix or a script that recurses further than intended.
 
-        **Risk mitigation**
+        With versioning enabled, those writes and deletes leave the earlier object in place as a retained version. Destroying the history then takes a further, distinct privilege to remove specific versions, which is a permission most application identities have no reason to hold.
 
-        - **Restores lost data:** Earlier versions can be recovered when current objects are corrupted or removed.
-        - **Limits destructive impact:** Overwrites and deletes become recoverable events rather than permanent loss.
+        Retained versions also give investigations a point-in-time reference. When an object's contents look wrong, being able to see what it held before the change is what separates a confirmed tampering event from a suspicion.
+
+        Versioning retains data but does not restrict who can remove it, so pair it with RAM policies that withhold version deletion from the identities that write objects day to day. It also only covers changes made after it is enabled, so overwrites that already happened remain unrecoverable.
       audit: |
         ### Audit via Console
 
@@ -1553,18 +1565,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no security group permits inbound SSH (TCP port 22) from the entire internet (`0.0.0.0/0`). A rule counts as open whether it names `0.0.0.0/0` directly or references a prefix list that contains it, and whether it names the port exactly or a wider range that spans it. SSH exposed to the world invites brute-force and credential-stuffing attacks against every instance the group protects.
+        This check verifies that inbound SSH reachability is confined to trusted source ranges rather than the entire IPv4 internet.
+
+        A security group ingress rule decides which sources may open a TCP session to the instances the group protects. This check treats a rule as world-open whether it names `0.0.0.0/0` directly or references a prefix list that contains it, and whether it names port 22 exactly or a wider range that spans it, so a rule written as `1/1024` or as the all-ports `-1/-1` counts the same as `22/22`. Inbound rules live under **Network & Security** > **Security Groups** in the ECS console, and the check requires that no accepting ingress rule admits TCP port 22 from `0.0.0.0/0`.
 
         **Why this matters**
 
-        - **SSH is a top attack target:** Internet-facing SSH is continuously scanned and brute-forced by automated tooling.
-        - **Broad blast radius:** A security group rule applies to every instance it is attached to, so one open rule exposes many hosts.
-        - **Bypasses bastions:** World-open SSH defeats the purpose of jump hosts and VPN-gated administrative access.
+        Port 22 is one of the most heavily scanned ports on the internet. Automated tooling works through common account names and password lists continuously, so a newly opened rule draws login attempts within minutes and never stops drawing them.
 
-        **Risk mitigation**
+        Brute forcing is not the only path. Operators routinely reuse a single key pair or password across a fleet, so one credential recovered from a laptop, a build log, or an unrelated breach unlocks every host that accepts it. A world-open port 22 turns that reuse into direct account access with nothing else in the way.
 
-        - **Removes a standing attack surface:** Restricting source ranges eliminates untrusted inbound SSH.
-        - **Forces controlled access:** Administrative access is funneled through known networks or bastions.
+        The exposure is rarely limited to one machine. A security group rule applies to every instance attached to the group, so a single rule can put an entire tier online at once, and it defeats the jump hosts and VPN-gated administration built to funnel that traffic through known networks.
+
+        Restricting the source to a bastion address or an internal CIDR such as `10.0.0.0/8` is the fix, not moving SSH to a different port. This check looks only at IPv4 sources; a companion check in this policy covers the same administrative ports reached over IPv6.
       audit: |
         ### Audit via Console
 
@@ -1672,18 +1685,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no security group permits inbound RDP (TCP port 3389) from the entire internet (`0.0.0.0/0`). A rule counts as open whether it names `0.0.0.0/0` directly or references a prefix list that contains it, and whether it names the port exactly or a wider range that spans it. World-open RDP is a primary vector for ransomware and unauthorized remote desktop access.
+        This check verifies that Remote Desktop reachability is confined to trusted source ranges rather than being offered to the entire IPv4 internet.
+
+        Remote Desktop Protocol carries interactive Windows console sessions over TCP port 3389, and a security group ingress rule decides who may open one. The check treats a rule as world-open whether it names `0.0.0.0/0` directly or references a prefix list that contains it, and whether it names port 3389 exactly or a wider range that spans it. Inbound rules are edited per group under **Network & Security** > **Security Groups** in the ECS console, and the required state is that no accepting ingress rule admits TCP port 3389 from `0.0.0.0/0`.
 
         **Why this matters**
 
-        - **RDP is heavily targeted:** Exposed RDP is routinely scanned and brute-forced, and is a common ransomware entry point.
-        - **Broad blast radius:** A single open rule exposes every instance the security group protects.
-        - **Bypasses controlled access:** World-open RDP defeats VPN-gated or bastion-mediated administration.
+        Exposed RDP is the working front door for ransomware crews. Access brokers scan the whole address space for port 3389, spray credentials against what answers, and sell the sessions that succeed; the intrusion that follows arrives as a hands-on-keyboard operator rather than a worm, which is why encryption is usually preceded by days of quiet credential harvesting and backup deletion.
 
-        **Risk mitigation**
+        An interactive desktop session also hands the attacker the tooling already installed on the host. Domain-joined machines expose credential material to anyone holding a session, so a single reachable Windows instance frequently becomes the pivot into the rest of the estate.
 
-        - **Removes a standing attack surface:** Restricting source ranges eliminates untrusted inbound RDP.
-        - **Forces controlled access:** Remote desktop access is funneled through known networks.
+        One rule is enough to create that opening across a whole tier, because the rule applies to every instance the security group protects, and it nullifies the VPN-gated or bastion-mediated administration that was supposed to stand in front of them.
+
+        Where remote desktop genuinely must cross the internet, front it with a bastion or a VPN and scope `cidr_ip` to that path. This check evaluates IPv4 sources only; IPv6 exposure of the same port is covered by a companion check in this policy.
       audit: |
         ### Audit via Console
 
@@ -1791,18 +1805,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that no security group allows inbound access to all ports or all protocols from the entire internet (`0.0.0.0/0`). A rule counts as open whether it names `0.0.0.0/0` directly or references a prefix list that contains it. A fully open ingress rule exposes every service on every attached instance.
+        This check verifies that no security group grants the internet unrestricted ingress, meaning access to every port or over every protocol.
+
+        Ingress filtering is the whole purpose of a security group, and an all-ports or all-protocol rule sourced from the internet withdraws it. The check treats such a rule as world-open whether it names `0.0.0.0/0` directly or references a prefix list that contains it, and it recognizes the unrestricted forms the service accepts: an `ip_protocol` of `all`, and the port ranges `-1/-1` and `1/65535`. Rules are managed under **Network & Security** > **Security Groups** in the ECS console, and the required state is that none of these appears on an accepting inbound rule.
 
         **Why this matters**
 
-        - **Total exposure:** An all-ports or all-protocol world-open rule negates network-level protection entirely.
-        - **Broad blast radius:** Every instance the group protects becomes reachable on every port.
-        - **Masks other controls:** Such a rule renders more specific hardening moot.
+        This is the total negation of network-level filtering. Every listening service on every instance the group protects becomes reachable from any address on the internet: administrative daemons, database ports bound to the wrong interface, debug endpoints, management agents, and anything a colleague starts next week without telling anyone.
 
-        **Risk mitigation**
+        That reach includes services nobody deliberately published. An unrestricted rule needs no attacker skill to exploit, because there is nothing to bypass; discovery is a single port sweep, and whatever is listening is the attack surface.
 
-        - **Restores segmentation:** Removing the rule re-establishes least-exposure networking.
-        - **Limits reachable services:** Only intended ports and protocols remain accessible.
+        It also silently voids the rest of the hardening around it. Careful per-port rules elsewhere in the same group become decorative, and a review that reads those narrow rules can come away believing the tier is segmented when it is not.
+
+        Removing the rule and replacing it with explicit rules for the ports actually in use, such as `443/443` from an internal range, restores least-exposure networking. A public-facing listener remains legitimate, but it belongs in a rule naming that one port and protocol, not in a blanket grant.
       audit: |
         ### Audit via Console
 
@@ -1907,18 +1922,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that no security group permits inbound SSH (22) or RDP (3389) from the entire IPv6 internet (`::/0`). A rule counts as open whether it names `::/0` directly or references a prefix list that contains it, and whether it names the port exactly or a wider range that spans it. IPv6 exposure is easy to overlook when only IPv4 rules are reviewed, yet it grants the same reachability.
+        This check verifies that administrative ports are closed to the public IPv6 internet, not only to the public IPv4 internet.
+
+        Alibaba Cloud security groups carry IPv4 and IPv6 sources in separate fields, and a rule sourced from `::/0` reaches an instance exactly as a rule sourced from `0.0.0.0/0` does. The check looks for accepting inbound rules that expose SSH on port 22 or RDP on port 3389 to `::/0`, whether the rule names `::/0` directly or references a prefix list that contains it, and whether it names the port exactly or a wider range that spans it. Inbound rules are reviewed under **Network & Security** > **Security Groups** in the ECS console.
 
         **Why this matters**
 
-        - **IPv6 is often forgotten:** Teams frequently harden IPv4 rules while leaving equivalent IPv6 rules wide open.
-        - **Same attack surface:** World-open IPv6 admin ports are scanned and brute-forced just like IPv4.
-        - **Broad blast radius:** The rule applies to every instance the security group protects.
+        This is a review blind spot more than a configuration mistake. Teams audit their IPv4 rules, close port 22 to the world, record the finding as resolved, and never scroll to the IPv6 column, where an equivalent rule sits untouched. Tooling and runbooks written before dual-stack rollout reinforce the gap by only ever asking about `0.0.0.0/0`.
 
-        **Risk mitigation**
+        The reachability is identical. Scanning the full IPv6 space is impractical, but that is not how these hosts are found: addresses leak through DNS records, certificate transparency logs, outbound connections, and published inventory, and once an address is known the brute-force traffic against port 22 or 3389 looks exactly like the IPv4 case.
 
-        - **Closes the IPv6 gap:** Restricting `::/0` sources removes untrusted inbound administrative access over IPv6.
-        - **Consistent posture:** IPv6 and IPv4 rules enforce the same least-exposure policy.
+        The scope is the same too. The rule applies to every instance the security group protects, so the IPv6 half of the policy quietly exposes the same fleet the IPv4 half was hardened to protect.
+
+        Scope the source to a trusted IPv6 prefix such as `fd00::/8` instead of `::/0`. Instances with no IPv6 address assigned are not reachable through such a rule today, but the rule remains a standing exposure for the moment one is assigned, so it should be corrected rather than left as harmless.
       audit: |
         ### Audit via Console
 
@@ -2031,18 +2047,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that ECS instances are not directly reachable from the internet through a public IP or elastic IP combined with permissive security-group rules. Instances that must be reached from outside should sit behind a load balancer or NAT gateway rather than exposing the host directly.
+        This check verifies that ECS instances are not directly reachable from the internet, meaning they carry no public or elastic IP that permissive security-group rules leave open.
+
+        Direct exposure is the combination of two things: a routable address on the instance, either an assigned public IP or a bound elastic IP, and security-group rules that let outside traffic reach it. Both are managed in the ECS console, where an elastic IP is unbound from the instance and the attached security groups are tightened. Workloads that must serve external traffic belong behind a load balancer or a NAT gateway instead, so the address that faces the internet is not the host itself.
 
         **Why this matters**
 
-        - **Direct exposure widens attack surface:** A publicly reachable instance is scanned and probed continuously.
-        - **No intermediary controls:** Fronting services with load balancers or gateways adds a layer where filtering and monitoring occur.
-        - **Lateral movement risk:** A compromised internet-facing instance is a foothold into the private network.
+        A publicly addressed instance is discovered and probed continuously, and every service it runs is evaluated by whoever finds it. The host operating system, not a managed edge, becomes the thing that has to survive that traffic.
 
-        **Risk mitigation**
+        Fronting the workload with a load balancer or gateway reintroduces a layer where filtering, rate limiting, TLS termination, and request logging happen before anything reaches the instance. A directly exposed host has none of that, and an attack against it leaves evidence only in whatever the host itself records.
 
-        - **Reduces attack surface:** Removing direct public reachability forces traffic through controlled entry points.
-        - **Contains blast radius:** Private instances are not directly reachable by external attackers.
+        The consequence of compromise is also worse. An internet-facing instance still sits inside the private network, so a successful intrusion starts from a position with routes to internal subnets and internal services, turning an external hit into a foothold for lateral movement.
+
+        Some designs legitimately require a public address, such as a NAT instance or a bastion. Where that is true, the exposure should be one narrow, deliberately scoped path rather than a general-purpose host, and the security-group checks in this policy remain the control that keeps administrative ports closed.
       audit: |
         ### Audit via Console
 
@@ -2108,18 +2125,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that ECS disks are encrypted at rest. By default a disk is created unencrypted unless encryption is explicitly requested, leaving block storage contents readable if the underlying media is ever accessed.
+        This check verifies that block storage attached to ECS instances is encrypted at rest.
+
+        An ECS disk is created unencrypted unless encryption is explicitly requested, so the insecure state is the default rather than an act of misconfiguration. Encryption status is visible in the ECS console under **Storage & Snapshots** > **Disks** in the **Encryption** column, and the check requires it on every disk, system and data alike, since boot volumes hold credentials, keys, and application configuration just as attached volumes hold business data.
 
         **Why this matters**
 
-        - **Protects data on the block layer:** Encryption keeps disk contents unreadable outside the service.
-        - **Covers system and data disks:** Both boot and attached data volumes hold sensitive material.
-        - **Regulatory expectation:** Encryption of stored data is a common compliance requirement.
+        Encryption at the block layer means the stored bytes are meaningless outside the service. Without it, disk contents are readable to anyone who obtains the underlying media or a copy of the raw volume, and that copy is often produced by an ordinary snapshot or image operation rather than by physical access.
 
-        **Risk mitigation**
+        The protection is transparent to the workload. Encryption and decryption happen below the file system, so no application change, key handling code, or performance-sensitive rewrite is involved in turning it on.
 
-        - **Reduces breach impact:** Encrypted volumes are unreadable to an attacker who obtains raw storage.
-        - **Transparent protection:** Disk encryption requires no application changes.
+        Storing regulated data on unencrypted volumes also fails a control that appears in nearly every compliance regime an account is likely to be assessed against, so an unencrypted disk is usually both a real exposure and an audit finding.
+
+        Encryption is chosen at disk creation and cannot be toggled on an existing disk. Fixing a finding means taking a snapshot, creating a new encrypted disk from it, and attaching that in place of the original. A companion check in this policy goes further and asks that encrypted disks use a customer master key rather than a service-default key.
       audit: |
         ### Audit via Console
 
@@ -2210,18 +2228,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that encrypted ECS disks use a KMS customer master key (CMK) rather than relying solely on a service-default key. A customer-managed key gives the account control over key policy, rotation, and revocation.
+        This check verifies that encrypted ECS disks derive their protection from a Key Management Service customer master key, or CMK, rather than from a service-default key alone.
+
+        Encryption alone establishes that the data is unreadable outside the service; it says nothing about who controls the key. A customer master key moves that control into the account, where key policy, rotation, and revocation are administered and where key use is logged. The association is visible per disk in the ECS console under **Storage & Snapshots** > **Disks** as the **KMS Key ID**, and the check applies only to disks that already have encryption enabled.
 
         **Why this matters**
 
-        - **Key governance:** A CMK lets the account define who can use the key and audit its use.
-        - **Revocation control:** Disabling a CMK renders the associated volumes unreadable, a powerful containment lever.
-        - **Separation of duties:** Customer-managed keys separate data access from key administration.
+        A customer master key makes key usage governable. The account defines which principals may use the key, and every operation against it is auditable, so the question of who decrypted a volume and when has an answer.
 
-        **Risk mitigation**
+        Revocation becomes a real containment lever. Disabling a customer master key immediately renders every volume encrypted under it unreadable, which is an action worth having available during an active incident and which is not available when a service-default key is doing the work.
 
-        - **Stronger blast-radius control:** Key revocation immediately cuts access to data encrypted under the CMK.
-        - **Auditable key use:** CMK operations are logged and governed by key policy.
+        It also separates data access from key administration. A principal who can attach and read a disk is not automatically a principal who can govern the key protecting it, and that split is what makes the encryption a control rather than an implementation detail.
+
+        The KMS key is chosen at disk creation, so remediating an existing disk means snapshotting it and creating a replacement with `--KMSKeyId` set, or `kms_key_id` in the Terraform-declared form. Disks with no encryption at all are outside this check and are covered by a companion check in this policy.
       audit: |
         ### Audit via Console
 
@@ -2313,18 +2332,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every ECS instance with the metadata service enabled requires a session token to read instance metadata, the hardened access mode Alibaba Cloud provides in place of the default token-optional behavior. When tokens are optional, a plain HTTP GET to the metadata endpoint returns the credentials of the instance RAM role, so any server-side request forgery (SSRF) flaw in a workload on the instance can read those credentials. Requiring a token forces the caller to first obtain one with a separate request, which an SSRF payload generally cannot perform.
+        This check verifies that reading instance metadata requires a session token, the hardened access mode Alibaba Cloud offers in place of the default token-optional behavior.
+
+        Every ECS instance can reach a link-local metadata endpoint that returns its configuration and, critically, the temporary credentials of its attached instance RAM role. In the default mode a token is optional, so a plain HTTP GET to that endpoint returns those credentials. The hardened mode makes the caller obtain a token in a separate request first. The mode is set per instance in the ECS console under the instance metadata settings, or with `aliyun ecs ModifyInstanceMetadataOptions --HttpEndpoint enabled --HttpTokens required`, where `HttpEndpoint` is mandatory on the call and `enabled` keeps metadata reachable while the token requirement is added.
 
         **Why this matters**
 
-        - **SSRF-to-credential path:** With optional tokens, a single SSRF bug in an application on the instance hands an attacker the instance RAM role credentials with no authentication.
-        - **Inherited blast radius:** Those credentials carry whatever the attached instance RAM role grants, extending a single application flaw into account-wide access.
-        - **Defense independent of the application:** Requiring a token blocks the read at the metadata service itself, regardless of whether the application-layer SSRF is ever fixed.
+        Token-optional metadata turns any server-side request forgery flaw into credential theft. An application tricked into fetching an attacker-supplied URL fetches the metadata endpoint instead, and the response body is a working set of RAM role credentials, obtained with no authentication and no code execution on the host.
 
-        **Risk mitigation**
+        Those credentials carry whatever the instance RAM role grants. A defect in one web form therefore inherits the role's reach across the account, which is why this path so often converts a low-severity application bug into a full cloud compromise.
 
-        - **Closes the credential path:** A token-first handshake defeats the simple GET-based metadata read that SSRF relies on.
-        - **Limits credential theft:** Even a reachable metadata endpoint no longer yields credentials to an unauthenticated forged request.
+        Requiring a token moves the defense off the application. Server-side request forgery payloads generally cannot perform the separate token request that must precede the read, so the credential path closes at the metadata service whether or not the application flaw is ever found and fixed.
+
+        Instances with the metadata endpoint turned off entirely are already outside this risk and are not evaluated here. Requiring a token complements, and does not replace, keeping the instance RAM role scoped to the permissions the workload actually uses.
       audit: |
         ### Audit via Console
 
@@ -2434,18 +2454,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that ApsaraDB for RDS instances are reachable only over the internal network and are not assigned a public (Internet) connection endpoint. An instance with a public endpoint is directly addressable from the internet, dramatically widening its exposure to credential-guessing, exploitation of database vulnerabilities, and data exfiltration.
+        This check verifies that an ApsaraDB for RDS instance is reachable only over the internal network and is never given an Internet-facing connection endpoint.
+
+        An RDS instance can carry a second connection string in addition to its VPC endpoint, and that public endpoint puts the database listener directly on the internet. You manage it in the ApsaraDB for RDS console on the Database Connection page, where the public endpoint can be released, or with the `ReleaseInstancePublicConnection` API action. The check requires the instance to report a network type other than `Internet`.
 
         **Why this matters**
 
-        - **Direct internet reachability:** A public endpoint places the database listener on the public internet, where it is continuously scanned and probed by opportunistic and targeted attackers.
-        - **Reduced defense in depth:** Internal-only databases sit behind VPC boundaries and security groups; a public endpoint bypasses that layered isolation and leaves the IP allowlist as the only barrier.
-        - **Blast radius of a single misconfiguration:** If the allowlist is ever loosened or a credential leaks, a publicly reachable database can be reached and drained from anywhere in the world.
+        A public endpoint places the database listener on the public internet, where it is continuously scanned and probed by opportunistic and targeted attackers. Automated scanners sweep the address space for open database ports and start credential guessing against anything that answers, so exposure is measured in minutes rather than months.
 
-        **Risk mitigation**
+        Internal-only databases sit behind VPC boundaries and security groups. A public endpoint bypasses that layered isolation and leaves the IP allowlist as the only remaining barrier, so one loosened allowlist entry or one leaked credential is enough. A database that is only internally addressable must first be reached from inside the VPC; a publicly addressable one can be reached and drained from anywhere in the world.
 
-        - **Shrinks the attack surface:** Keeping the instance on the internal network removes it from internet-wide scanning and forces access through controlled network paths.
-        - **Enforces network segmentation:** Internal endpoints require attackers to first gain a foothold inside the VPC, preserving defense in depth.
+        Releasing the public endpoint therefore raises the cost of exploiting the database from harvesting a password to establishing a foothold inside your network.
+
+        Some workloads genuinely need access from outside Alibaba Cloud, such as a partner analytics tool or a one-time migration job. Where a public endpoint cannot be avoided, treat a tightly scoped whitelist and enforced transport encryption as mandatory compensating controls; companion checks in this policy cover both. This check evaluates the endpoint configuration only and asserts nothing about the strength of the credentials behind it.
       audit: |
         ### Audit via Console
 
@@ -2513,18 +2534,19 @@ queries:
     impact: 75
     docs:
       desc: |
-        This check ensures that ApsaraDB for RDS instances have SSL/TLS enabled so that client connections are encrypted in transit. Without SSL/TLS, credentials and query data travel between clients and the database in cleartext and can be intercepted on the network path.
+        This check verifies that client connections to an ApsaraDB for RDS instance are encrypted in transit with SSL/TLS.
+
+        ApsaraDB for RDS terminates TLS per connection endpoint and issues a certificate authority certificate that clients install to validate the server. You turn it on in the ApsaraDB for RDS console on the Data Security page under SSL, selecting the endpoint to protect and downloading the CA certificate for clients, or with the `ModifyDBInstanceSSL` API action passing `--SSLEnabled 1`. The check requires SSL to be enabled on the instance.
 
         **Why this matters**
 
-        - **Cleartext credentials and data:** Unencrypted database connections expose usernames, passwords, and query results to anyone able to observe the network traffic.
-        - **Man-in-the-middle risk:** Without server certificate validation, an attacker positioned on the path can impersonate the database or silently relay and modify traffic.
-        - **Regulatory expectation:** Many compliance regimes require that data, especially personal or cardholder data, is encrypted while in transit.
+        An unencrypted database session carries the login handshake, the SQL text, and every returned row in cleartext. Anything able to observe the network path, including a compromised host on a shared segment, a mirrored port, or an intermediate network device, reads the account password and then the data itself.
 
-        **Risk mitigation**
+        Encryption alone is not the whole benefit. Without server certificate validation, an attacker positioned on the path can impersonate the database endpoint, collect the credentials that clients present to it, and relay a modified session to the real instance without either side noticing.
 
-        - **Protects data on the wire:** SSL/TLS encrypts the session so intercepted traffic is unreadable.
-        - **Authenticates the endpoint:** Certificate-based TLS lets clients verify they are connected to the genuine database and not an impostor.
+        Many compliance regimes explicitly require that data in transit, and personal or cardholder data in particular, is protected by encryption between the application and the database.
+
+        Because SSL is configured per endpoint, an instance that exposes both an internal and a public connection string needs the setting applied to each one it uses. The check confirms that the server is configured for encrypted connections; it cannot see whether every client connection string actually requests SSL and trusts the CA, so plan the client rollout alongside the server change or connections will continue in cleartext against a TLS-capable server.
       audit: |
         ### Audit via Console
 
@@ -2591,18 +2613,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that ApsaraDB for RDS instances have Transparent Data Encryption (TDE) enabled so that database files are encrypted at rest. Without TDE, the underlying data files, logs, and backups are written unencrypted and are readable to anyone who obtains the raw storage.
+        This check verifies that an ApsaraDB for RDS instance encrypts its stored data with Transparent Data Encryption (TDE).
+
+        TDE encrypts and decrypts at the storage engine layer, so the relational data files, the redo and binary logs, and the backups derived from them are written as ciphertext while applications keep issuing ordinary SQL. You enable it in the ApsaraDB for RDS console on the Data Security page under TDE, choosing either a Key Management Service key or the service-managed key, or with the `ModifyDBInstanceTDE` API action passing `--TDEStatus Enabled`. In Terraform the equivalent is `tde_status` set to `Enabled` on the database instance.
 
         **Why this matters**
 
-        - **Defense against storage-layer exposure:** TDE protects data if the underlying disks, snapshots, or backups are ever accessed outside the database service.
-        - **Regulatory expectation:** Many compliance regimes require that stored data, especially personal or cardholder data, is encrypted at rest.
-        - **Transparent to applications:** TDE encrypts and decrypts at the storage engine level, so it protects data without requiring application changes.
+        Without TDE, every table the engine has written is recoverable from the raw storage. An operator who copies a snapshot, a support process that exports a disk image, or an attacker who gains access to the storage layer beneath the database can read the rows directly without ever authenticating to the instance or leaving a trace in its logs.
 
-        **Risk mitigation**
+        The exposure follows the data outward. Backups and exports inherit whatever protection the instance had, so an unencrypted instance produces unencrypted backup artifacts that are frequently stored and moved with far less scrutiny than the database itself.
 
-        - **Reduces breach impact:** Encrypted data files are unreadable to an attacker who obtains raw storage without the keys.
-        - **Protects backups:** Because encryption follows the data into backups, exported or leaked backup files remain protected.
+        Compliance regimes routinely require stored personal and cardholder data to be encrypted at rest, and the storage-engine placement of TDE satisfies that without a schema change or an application rewrite.
+
+        TDE protects data that has left the database process; it does nothing against an attacker who authenticates successfully, because the engine decrypts transparently for any valid session. Pair it with a scoped IP allowlist and enforced SSL so the encrypted store is not simultaneously an openly reachable one.
       audit: |
         ### Audit via Console
 
@@ -2703,18 +2726,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no ApsaraDB for RDS instance has an IP allowlist entry of `0.0.0.0/0`, which would permit connections from any source address on the internet. A world-open allowlist removes the network barrier in front of the database and leaves only credentials protecting it.
+        This check verifies that the network barrier in front of an ApsaraDB for RDS instance is scoped to known sources rather than opened to the entire internet.
+
+        Each RDS instance carries one or more whitelist groups that decide which source addresses may open a connection. You edit them in the ApsaraDB for RDS console on the Data Security page under Whitelist Settings, or with the `ModifySecurityIps` API action, and in Terraform through the `security_ips` argument on the database instance. The check fails an instance whose allowlist contains `0.0.0.0/0`, and it also rejects a bare `0.0.0.0` entry and any other range carrying a `/0` prefix length.
 
         **Why this matters**
 
-        - **World-open access:** An allowlist entry of `0.0.0.0/0` accepts connection attempts from every IP address, exposing the database to internet-wide scanning and brute-force attempts.
-        - **Single line of defense:** With the network barrier removed, only the database password stands between an attacker and the data.
-        - **Common breach vector:** Databases reachable from anywhere are routinely discovered and compromised through weak or leaked credentials.
+        An entry of `0.0.0.0/0` accepts connection attempts from every address on the internet. The database is then subject to the same continuous scanning, credential stuffing, and brute-force traffic that any exposed service receives, and each attempt is answered by the engine itself.
 
-        **Risk mitigation**
+        With the network control removed, the account password becomes the single thing standing between an attacker and the data. Databases reachable from anywhere are routinely discovered and compromised through a weak, reused, or previously leaked credential, and no other layer is left to catch the attempt.
 
-        - **Restores network segmentation:** Limiting the allowlist to specific trusted addresses forces connections through known, controlled sources.
-        - **Reduces exposure:** A tightly scoped allowlist keeps the database off the open internet even if a credential is compromised.
+        A scoped allowlist restores the second, independent barrier. An attacker must both hold a valid credential and originate from an address you deliberately permitted, which usually means first compromising something inside your own network.
+
+        The check passes an instance that reports no allowlist entries at all, since a group with no permitted sources grants no access. Replacing `0.0.0.0/0` with the specific application ranges is the fix; keeping the instance off a public endpoint entirely, which a companion check in this policy covers, is the stronger one.
       audit: |
         ### Audit via Console
 
@@ -2818,18 +2842,19 @@ queries:
     impact: 60
     docs:
       desc: |
-        This check ensures that ApsaraDB for RDS instances have release (deletion) protection enabled so that a production database cannot be destroyed by an accidental or malicious delete request. Without deletion protection, a single API call or console action can permanently remove the instance and its data.
+        This check verifies that an ApsaraDB for RDS instance is protected against being released by a single delete request.
+
+        Release protection is a lock held on the instance object itself. While it is set, the delete path is refused until an operator explicitly clears the lock, which turns a one-step destruction into a two-step one. You enable it in the ApsaraDB for RDS console on the Basic Information page under Release Protection, with the `ModifyDBInstanceDeletionProtection` API action passing `--DeletionProtection true`, or in Terraform by setting `deletion_protection` to `true`.
 
         **Why this matters**
 
-        - **Irreversible data loss:** Deleting a database instance removes its data; without a guardrail a mistaken or malicious request can cause an outage and permanent loss.
-        - **Availability impact:** Loss of a production database directly disrupts the applications and services that depend on it.
-        - **Insider and automation risk:** Broad delete permissions or misfiring automation can remove critical instances unless a protective lock is in place.
+        Releasing a database instance destroys the instance and the data it holds. There is no undo, so a mistyped instance identifier, a console click on the wrong row, or a deliberately destructive request from a compromised account causes permanent loss rather than a recoverable incident.
 
-        **Risk mitigation**
+        The immediate consequence is availability. Every application and downstream service bound to that instance stops working the moment it is released, and recovery depends entirely on whether a usable backup exists and how long a restore takes.
 
-        - **Prevents accidental destruction:** Deletion protection requires the lock to be explicitly removed before an instance can be deleted, blocking one-step mistakes.
-        - **Adds a deliberate safeguard:** The extra step gives operators a chance to catch and stop an unintended or unauthorized deletion.
+        Broad delete permissions and automation multiply the exposure. A misfiring pipeline, a Terraform run against the wrong workspace, or an insider with routine administrative rights can remove a production instance in a single call unless something refuses the call. Release protection is that refusal, and clearing it deliberately gives an operator the moment needed to notice that the target is production.
+
+        Short-lived instances created by tests or continuous integration are meant to be destroyed and should not carry the lock. This control guards the instance object, not the data inside it, so it is not a substitute for backups, retention settings, or restricting who holds delete permissions in the first place.
       audit: |
         ### Audit via Console
 
@@ -2934,18 +2959,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that ApsaraDB for PolarDB clusters have Transparent Data Encryption (TDE) enabled so that cluster data is encrypted at rest. Without TDE, the underlying data files and backups are stored unencrypted and are readable to anyone who obtains the raw storage.
+        This check verifies that an ApsaraDB for PolarDB cluster encrypts the data it holds in its shared storage layer using Transparent Data Encryption (TDE).
+
+        PolarDB separates compute from storage, so one distributed storage volume backs the primary node and every read-only node in the cluster. TDE encrypts that volume and the backups taken from it, transparently to the SQL the nodes serve. You enable it in the ApsaraDB for PolarDB console under Settings and Management on the TDE page, selecting a Key Management Service key or the service-managed key, or with the `ModifyDBClusterTDE` API action. That call accepts `Enable` as its `--TDEStatus` value while the cluster reports its state back as `Enabled`, which is also the value Terraform expects for `tde_status`.
 
         **Why this matters**
 
-        - **Defense against storage-layer exposure:** TDE protects cluster data if the underlying storage, snapshots, or backups are ever accessed outside the service.
-        - **Regulatory expectation:** Many compliance regimes require that stored data, especially personal or cardholder data, is encrypted at rest.
-        - **Transparent to applications:** TDE encrypts and decrypts at the storage engine level, protecting data without application changes.
+        Without TDE, the cluster's shared storage holds every page in the clear. Because that one volume serves the whole cluster, raw access to it yields the complete dataset at once rather than the contents of a single node, and it does so without authenticating to any database endpoint.
 
-        **Risk mitigation**
+        The same exposure travels into backups and exports, which inherit the encryption state of the cluster they came from. Unencrypted backup artifacts are copied, archived, and shared far more freely than a live cluster, so they are frequently where the data actually leaks.
 
-        - **Reduces breach impact:** Encrypted cluster data is unreadable to an attacker who obtains raw storage without the keys.
-        - **Protects backups:** Because encryption follows the data into backups, exported or leaked backup files remain protected.
+        Encryption at the storage layer also satisfies the at-rest requirements that most compliance regimes place on personal and cardholder data, without touching the application.
+
+        TDE defends against access beneath the database, not against a session that authenticates normally, since the engine decrypts for any valid connection. Combine it with a scoped cluster allowlist so the encrypted storage is not fronted by an openly reachable endpoint.
       audit: |
         ### Audit via Console
 
@@ -3049,18 +3075,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no ApsaraDB for PolarDB cluster has an access allowlist entry of `0.0.0.0/0`, which would permit connections from any source address on the internet. A world-open allowlist removes the network barrier in front of the cluster and leaves only credentials protecting it.
+        This check verifies that an ApsaraDB for PolarDB cluster admits connections only from source addresses you deliberately permitted.
+
+        A PolarDB cluster holds its permitted sources in named IP array groups rather than a single flat list, and every group is consulted when a client connects. You edit them in the ApsaraDB for PolarDB console under Settings and Management on the Whitelists page, or with the `ModifyDBClusterAccessWhitelist` API action, which takes the group name through `--DBClusterIPArrayName` alongside the addresses. In Terraform the same groups appear as `db_cluster_ip_array` blocks carrying a `security_ips` list. The check examines every group and fails the cluster if any of them contains `0.0.0.0/0`, a bare `0.0.0.0`, or any other range with a `/0` prefix length.
 
         **Why this matters**
 
-        - **World-open access:** An allowlist entry of `0.0.0.0/0` accepts connection attempts from every IP address, exposing the cluster to internet-wide scanning and brute-force attempts.
-        - **Single line of defense:** With the network barrier removed, only the database password stands between an attacker and the data.
-        - **Common breach vector:** Clusters reachable from anywhere are routinely discovered and compromised through weak or leaked credentials.
+        A group opened to `0.0.0.0/0` accepts connection attempts from every address on the internet, and the cluster endpoint then absorbs the continuous scanning and brute-force traffic that any exposed database service attracts.
 
-        **Risk mitigation**
+        With that barrier gone, the database password is the only control left. Clusters reachable from anywhere are routinely found and compromised through a weak or previously leaked credential, and nothing else is positioned to stop the attempt.
 
-        - **Restores network segmentation:** Limiting the allowlist to specific trusted addresses forces connections through known, controlled sources.
-        - **Reduces exposure:** A tightly scoped allowlist keeps the cluster off the open internet even if a credential is compromised.
+        Because the permitted sources are split across several named groups, an otherwise careful configuration is easy to undermine: one temporary group added during a migration and never cleaned up reopens the cluster even though the main group is correct. Reviewing every group, not just the default one, is the point of the check.
+
+        The check passes a cluster that reports no allowlist entries at all, since a group permitting no sources grants no access. Scoping the groups to the application ranges restores a second, independent barrier that an attacker must clear before a credential is worth anything.
       audit: |
         ### Audit via Console
 
@@ -3181,18 +3208,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that every ApsaraDB for Redis (Tair) instance enforces password authentication. Redis instances can be placed in a password-free access mode that lets any client inside the VPC connect without presenting credentials, so a single foothold on an adjacent host grants direct read/write access to the cached data.
+        This check verifies that an ApsaraDB for Redis or Tair instance demands a password from every client instead of accepting anonymous connections.
+
+        Redis instances support a password-free access mode that waives authentication for clients arriving from inside the VPC, so reaching the port becomes sufficient to use the datastore. You turn it off in the ApsaraDB for Redis console on the Instance Information page by disabling password-free access, or with the `ModifyInstanceVpcAuthMode` API action setting `--VpcAuthMode Open`. In Terraform the same setting is `vpc_auth_mode` on the instance.
 
         **Why this matters**
 
-        - **Password-free access removes the last control:** When authentication is disabled, network reachability is the only barrier; any compromised workload, container, or peered network in the VPC can read and modify every key.
-        - **Caches hold sensitive data:** Redis frequently stores session tokens, credentials, and personal data, so unauthenticated access is a direct path to account takeover and data theft.
-        - **Lateral movement is amplified:** An attacker who lands anywhere in the VPC can pivot straight into the datastore without needing to steal a credential first.
+        When authentication is waived, network reachability is the whole of the access control. Any compromised workload, container, function, or peered network that can route to the instance reads and modifies every key, issues administrative commands, and can flush the entire keyspace without presenting anything at all.
 
-        **Risk mitigation**
+        Redis is rarely holding disposable data. Session tokens, API credentials, rate-limit state, queued jobs, and cached personal records are common contents, so anonymous read access converts directly into account takeover and anonymous write access converts into application logic that can be steered.
 
-        - **Requires a credential to connect:** Enforcing authentication blocks anonymous clients even when they can reach the instance over the network.
-        - **Contains lateral movement:** A compromised neighbor must also obtain the instance password before it can touch the data.
+        The effect on an intrusion is to erase a step. An attacker who lands anywhere in the VPC normally has to find and steal a credential before touching a datastore; with password-free access the pivot is immediate, and it leaves no failed-authentication trail for anyone to notice.
+
+        The Terraform-declared form of this check accepts an omitted `vpc_auth_mode`, because password-free access has to be selected deliberately rather than inherited. Requiring a password is a floor, not a boundary: keep the instance in a VPC with TLS enabled and rotate the password after any suspected exposure, since a single shared secret protects the whole keyspace.
       audit: |
         ### Audit via Console
 
@@ -3295,18 +3323,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every ApsaraDB for Redis (Tair) instance encrypts client connections with TLS and is deployed in a VPC rather than the legacy classic network. Traffic to a Redis instance without TLS travels in plaintext, and classic-network instances share a flat address space with other tenants' resources, widening the exposure of the datastore.
+        This check verifies that an ApsaraDB for Redis or Tair instance encrypts client traffic with TLS and sits inside a VPC rather than on the legacy classic network.
+
+        The two settings are administered separately. TLS is turned on in the ApsaraDB for Redis console under SSL Settings, or with the `ModifyInstanceSSL` API action passing `--SSLEnabled Enable`, which Terraform expresses as `ssl_enable` set to `Enable`. Moving a classic-network instance into a VPC is a distinct operation, offered in the console as Switch to VPC and performed through `SwitchNetwork`. The check requires TLS to be on and the reported network type to be `VPC`.
 
         **Why this matters**
 
-        - **Plaintext traffic is interceptable:** Without TLS, credentials and cached data can be read or tampered with by anything able to observe the connection path.
-        - **Classic networks lack isolation:** The classic network offers none of the segmentation, security group, and routing controls of a VPC, so the instance is reachable across a much broader boundary.
-        - **Defense in depth:** Encrypting transit and confining the instance to a VPC combine network isolation with cryptographic protection of the wire.
+        The Redis wire protocol is text based, so an unencrypted session exposes the authentication command, every key name, and every value to anything able to observe the connection path. The same position allows an observer to inject commands into the stream rather than only to read it.
 
-        **Risk mitigation**
+        The classic network offers none of the segmentation, security group, and routing controls that a VPC provides. An instance left there sits in a flat address space alongside unrelated resources, so the set of hosts that can even attempt a connection is far larger than the set you intended, and the tools that would normally narrow it do not apply.
 
-        - **Protects data on the wire:** TLS prevents eavesdropping and manipulation of Redis traffic in transit.
-        - **Shrinks the reachable surface:** A VPC deployment lets security groups and routing restrict which workloads can reach the instance.
+        Applied together the two settings cover different halves of the same problem: the VPC decides who can reach the port, and TLS decides what they learn if they do.
+
+        Network type is fixed at creation and changed only by migrating the instance, so this is a planned operation rather than a toggle. The Terraform-declared form asserts only `ssl_enable`, since a configuration that assigns a `vswitch_id` is already placing the instance in a VPC.
       audit: |
         ### Audit via Console
 
@@ -3409,18 +3438,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every ApsaraDB for Redis (Tair) instance has transparent data encryption (TDE) enabled so that persisted data is encrypted at rest. Without TDE, the instance's data files and backups are written to the underlying storage in plaintext.
+        This check verifies that an ApsaraDB for Redis or Tair instance encrypts the data it persists to disk using transparent data encryption (TDE).
+
+        Redis is often thought of as memory only, but the service writes the keyspace to durable storage for persistence and backup, and those files are plaintext unless TDE is on. You enable it in the ApsaraDB for Redis console on the Data Security page under TDE, selecting or creating the Key Management Service key to use, or with the `ModifyInstanceTDE` API action passing `--TDEStatus Enabled`. Terraform expresses the same state as `tde_status` set to `Enabled`.
 
         **Why this matters**
 
-        - **Protects data at rest:** TDE encrypts the data the instance persists, so raw access to the underlying disks or snapshots does not reveal cached contents.
-        - **Backups inherit protection:** Encryption applied at the instance level extends to the data captured in backups and exports.
-        - **Regulatory expectation:** Many compliance regimes require that stored sensitive data is encrypted at rest.
+        Raw access to the underlying disks or to a snapshot of them reveals the cached contents directly, with no connection to the instance and no password needed. For a datastore whose typical contents are session tokens, credentials, and personal records held for fast lookup, that is a complete compromise of everything currently cached.
 
-        **Risk mitigation**
+        Backups carry the same property. Encryption applied at the instance level extends to the data captured in backups and exports, so an unencrypted instance keeps producing unencrypted artifacts that circulate with much less control than the instance itself.
 
-        - **Reduces breach impact:** Encrypted data files are unreadable to an attacker who obtains raw storage without the keys.
-        - **Transparent coverage:** TDE encrypts persisted data without any change to how applications read or write keys.
+        Encryption at rest is also what most compliance regimes expect of any store holding sensitive data, and the transparency of TDE means the applications reading and writing keys are unaffected by turning it on.
+
+        TDE addresses the storage layer only. A client that authenticates successfully sees plaintext values, so it does not substitute for requiring a password on the instance or for encrypting the connection, both of which companion checks in this policy cover.
       audit: |
         ### Audit via Console
 
@@ -3522,18 +3552,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every ApsaraDB for MongoDB instance has transparent data encryption (TDE) enabled so that database data is encrypted at rest. Without TDE, the instance's data files and backups are persisted to the underlying storage in plaintext.
+        This check verifies that an ApsaraDB for MongoDB instance encrypts its stored documents using transparent data encryption (TDE).
+
+        TDE applies at the storage layer, so the collections, indexes, and oplog the instance persists are written as ciphertext while queries continue to behave exactly as before. You enable it in the ApsaraDB for MongoDB console on the Data Security page under TDE, selecting the Key Management Service key to use, or with the `ModifyDBInstanceTDE` API action passing `--TDEStatus enabled`. Note the lowercase value: the MongoDB service and the Terraform `tde_status` argument both use `enabled`, unlike the capitalized form other Alibaba Cloud database services expect.
 
         **Why this matters**
 
-        - **Protects data at rest:** TDE encrypts the data the database persists, so raw access to the underlying disks or snapshots does not reveal document contents.
-        - **Backups inherit protection:** Encryption applied at the instance level extends to the data captured in backups.
-        - **Regulatory expectation:** Many compliance regimes require that stored sensitive data, especially personal data, is encrypted at rest.
+        Without TDE, anyone reaching the storage beneath the database reads the documents as stored. Because document databases keep entire records in a single structure, a raw file gives up complete objects with their nested fields rather than fragments that must be reassembled, and it does so without an authenticated session or an entry in any access log.
 
-        **Risk mitigation**
+        Backups inherit the encryption state of the instance that produced them. Unencrypted backups of a document store are especially attractive because they are self-describing and portable, and they are handled with far less care than the live instance.
 
-        - **Reduces breach impact:** Encrypted data files are unreadable to an attacker who obtains raw storage without the keys.
-        - **Transparent coverage:** TDE encrypts persisted data without changing how applications query the database.
+        Encryption at rest is a standing requirement in most compliance regimes for stored personal data, and the storage-layer placement of TDE meets it without changes to how applications query the database.
+
+        An attacker who authenticates as a valid user still sees plaintext, so TDE is the wrong control for that risk. Pair it with a scoped whitelist, enforced TLS, and audit logging, which companion checks in this policy cover.
       audit: |
         ### Audit via Console
 
@@ -3635,18 +3666,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every ApsaraDB for MongoDB instance encrypts client connections with TLS and has the audit log feature enabled. Traffic to a MongoDB instance without TLS travels in plaintext, and without audit logging there is no record of the operations executed against the database to support detection and investigation.
+        This check verifies that an ApsaraDB for MongoDB instance both encrypts client sessions with TLS and keeps a record of the operations run against it.
+
+        The two controls live side by side in the ApsaraDB for MongoDB console on the Data Security page, one under SSL and the other under Audit Log. From the command line they are two separate calls: `ModifyDBInstanceSSL` with `--SSLAction Open` turns on TLS, and `ModifyAuditPolicy` with `--AuditStatus enable` turns on auditing. In Terraform the TLS half is the `ssl_action` argument set to `Open`, while auditing is declared through a separate `alicloud_mongodb_audit_policy` resource.
 
         **Why this matters**
 
-        - **Plaintext traffic is interceptable:** Without TLS, credentials and query results can be read or tampered with by anything able to observe the connection path.
-        - **No audit trail blinds detection:** Audit logs record the queries and administrative actions run against the database; without them, malicious access and data exfiltration leave no trace.
-        - **Accountability:** Audit logging attributes database operations to a source, which is essential for incident response and compliance evidence.
+        Without TLS, the authentication exchange and every returned document travel the network in plaintext. An observer on the path recovers the credentials first and the data second, and the same position permits tampering with results in flight rather than only reading them.
 
-        **Risk mitigation**
+        Without audit logging there is no record of which queries and administrative commands ran. An attacker who obtains valid credentials then operates invisibly: a bulk read of a collection looks identical to normal traffic, and after the fact there is nothing to distinguish an exfiltration from a routine workload.
 
-        - **Protects data on the wire:** TLS prevents eavesdropping and manipulation of MongoDB traffic in transit.
-        - **Enables detection and forensics:** An audit trail lets defenders identify abnormal access and reconstruct what an attacker did.
+        Auditing also supplies attribution. Tying an operation to a source and an account is what makes an investigation possible at all, and it is the evidence compliance regimes expect when they require accountability for access to stored data.
+
+        The two controls answer different questions, which is why the check requires both: TLS decides whether an outsider on the network learns anything, and the audit trail decides whether you can tell what an insider or a credential thief did. The Terraform-declared form asserts only `ssl_action`, because the audit policy is a resource of its own rather than an argument on the instance.
       audit: |
         ### Audit via Console
 
@@ -3753,18 +3785,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no ApsaraDB for MongoDB instance IP whitelist contains the open CIDR block `0.0.0.0/0`. A whitelist entry of `0.0.0.0/0` permits connection attempts from any source address, exposing the database to the entire internet and reducing security to the database password alone.
+        This check verifies that an ApsaraDB for MongoDB instance accepts connections only from source addresses you explicitly permitted.
+
+        Each instance carries whitelist groups naming the addresses and CIDR blocks allowed to reach the database port. You edit them in the ApsaraDB for MongoDB console on the Data Security page under Whitelist Settings, or with the `ModifySecurityIps` API action, and in Terraform through the `security_ip_list` argument on the instance. The check fails an instance whose whitelist contains the open block `0.0.0.0/0`, and when reading a live instance it also rejects a bare `0.0.0.0` entry and any other range with a `/0` prefix length.
 
         **Why this matters**
 
-        - **Internet-wide reachability invites attack:** An open whitelist lets any host on the internet reach the database port, exposing it to credential-stuffing, brute-force, and exploitation of any service vulnerability.
-        - **Password becomes the only barrier:** With the network control removed, a single weak or leaked credential is enough for full database access.
-        - **Data stores are high-value targets:** MongoDB instances hold application data that is directly valuable to attackers, so broad exposure carries outsized risk.
+        An open whitelist lets any host on the internet reach the database port. That invites credential stuffing, brute-force attempts against the accounts you have defined, and attempts to exploit any vulnerability in the exposed service, all answered directly by the database.
 
-        **Risk mitigation**
+        With the network control removed, one weak or previously leaked credential is enough for full access to every collection. Document stores are a favored target precisely because a successful login yields complete application records, so the value an attacker extracts from a single compromised password is unusually high.
 
-        - **Limits the reachable surface:** A tightly scoped whitelist restricts connections to known application networks.
-        - **Adds a network barrier:** Requiring both a permitted source address and valid credentials forces an attacker to overcome two independent controls.
+        Scoping the whitelist to the application networks forces an attacker to satisfy two independent conditions rather than one: they must originate from an address you permitted and hold valid credentials, which normally means compromising something inside your environment first.
+
+        The check passes an instance that reports no whitelist entries at all, since a group that permits no sources grants no access. Replacing the open block with the specific application CIDRs is the remediation; pairing it with enforced TLS and audit logging, which companion checks in this policy cover, ensures that permitted connections are also protected and recorded.
       audit: |
         ### Audit via Console
 
@@ -3867,18 +3900,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that symmetric, KMS-managed customer master keys (CMKs) have automatic key rotation enabled. Without rotation, the same key material protects data indefinitely, so a single key compromise exposes the entire history of data encrypted under that key.
+        This check verifies that automatic key rotation is turned on for symmetric, KMS-generated customer master keys (CMKs).
+
+        Without rotation the same key material protects data indefinitely, so a single key compromise exposes the entire history of data encrypted under that key. Rotation is enabled per key in the KMS console by opening the customer master key and turning on Key Rotation with a rotation period, or with `aliyun kms UpdateRotationPolicy --EnableAutomaticRotation true`. In Terraform the equivalent is setting `automatic_rotation` to `Enabled` on the key.
 
         **Why this matters**
 
-        - **Limits key exposure window:** Rotating key material regularly bounds how much data is protected by any single version of a key.
-        - **Contains compromise:** If a key version is exposed, rotation ensures newer data is protected by material the attacker does not hold.
-        - **Meets cryptographic hygiene expectations:** Regular rotation is a baseline expectation of most key-management standards.
+        Rotating key material regularly bounds how much data, and how much elapsed time, any single version of a key protects. Without it, the exposure window for a key version is the lifetime of the key itself.
 
-        **Risk mitigation**
+        If a key version is exposed, rotation ensures that everything encrypted afterwards is protected by material the attacker does not hold, so the compromise of one version does not automatically extend to data encrypted under later ones.
 
-        - **Reduces blast radius:** Compromise of one key version does not compromise data encrypted under later versions.
-        - **Automates a manual control:** Automatic rotation removes reliance on operators remembering to rotate keys on schedule.
+        Regular rotation is also a baseline expectation of most key management standards, and doing it automatically removes the reliance on an operator remembering to rotate keys on schedule. A rotation policy that exists in a runbook rather than in the key configuration is a policy that lapses quietly.
+
+        This check asserts only that rotation is turned on; a companion check in this policy bounds how long the configured rotation interval may be, so a key can satisfy this check and still rotate far too slowly. Keys are assessed only when they are enabled, generated by KMS rather than imported, and used for encryption and decryption. Material imported into KMS cannot be rotated by the service, and keys with another usage are covered by their own lifecycle, so both are out of scope here.
       audit: |
         ### Audit via Console
 
@@ -3975,18 +4009,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that KMS customer master keys with automatic rotation enabled carry a configured rotation interval of 365 days (`31536000s`) or less. A rotation interval longer than a year leaves key material in service well beyond common cryptographic-hygiene guidance.
+        This check verifies that the configured rotation period on a KMS customer master key is no longer than 365 days.
+
+        Alibaba Cloud KMS expresses the rotation period as a duration string, so a compliant key carries an interval of `31536000s` or less. Turning rotation on says nothing about how often it happens, and an interval set several years out leaves key material in service well beyond common cryptographic hygiene guidance while still reading as rotating. The period is set in the KMS console on the key's Rotation Period field, or with `aliyun kms UpdateRotationPolicy --KeyId <key-id> --EnableAutomaticRotation true --RotationInterval 31536000s`. In Terraform it is the `rotation_interval` argument on the key.
 
         **Why this matters**
 
-        - **Bounds material lifetime:** A shorter rotation interval reduces the amount of data and time any single key version protects.
-        - **Aligns with policy baselines:** Annual rotation is a widely referenced maximum for symmetric key material.
-        - **Reduces standing risk:** Long-lived key versions accumulate exposure from backups, logs, and prior access.
+        A shorter rotation interval reduces the amount of data, and the span of time, that any single key version protects. That is the entire value of rotation, and a long interval gives most of it back.
 
-        **Risk mitigation**
+        Annual rotation is a widely referenced maximum for symmetric key material, so an interval beyond a year puts the account outside the baseline that most audit programs assume.
 
-        - **Shrinks compromise value:** Frequent rotation limits the payoff of capturing a single key version.
-        - **Enforces a ceiling:** A defined maximum interval prevents rotation from being set so far out that it never meaningfully occurs.
+        Long-lived key versions accumulate exposure from backups, log copies, and every principal who held access at any point during the version's life. Frequent rotation limits the payoff of capturing a single version, and a defined ceiling on the interval prevents rotation from being scheduled so far out that it never meaningfully occurs.
+
+        This check evaluates only keys that already have automatic rotation enabled; whether rotation is turned on at all is the subject of a companion check in this policy. The two are meant to be read together, since a key can pass this one by having rotation enabled with a tight interval, or pass it vacuously by not being in scope.
       audit: |
         ### Audit via Console
 
@@ -4067,19 +4102,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that the Alibaba Cloud account has at least one ActionTrail trail that is enabled, actively delivering logs, and configured to capture both read and write events (`EventRW` of `All`). ActionTrail records management events across the account, so a disabled trail, an account with no trail at all, or a trail scoped to only one event direction leaves administrative and API activity unrecorded.
+        This check verifies that the account has at least one ActionTrail trail that is enabled, actively delivering logs, and capturing both read and write events with an `EventRW` value of `All`.
+
+        ActionTrail records management events across services, so an account with no trail, a trail that has been stopped, or a trail scoped to a single event direction leaves administrative and API activity unrecorded. Trails are created in the ActionTrail console under Trails, or with `aliyun actiontrail CreateTrail --EventRW All` followed by `aliyun actiontrail StartLogging`. Delivery targets an Object Storage Service bucket, a Simple Log Service project, or both.
 
         **Why this matters**
 
-        - **Audit logging is the record of who did what:** ActionTrail captures console and API operations across services; without it there is no authoritative trail of resource changes, sign-ins, or configuration edits.
-        - **Read events matter too:** A write-only trail records the change but not the reconnaissance that preceded it, so data-access and enumeration activity goes unrecorded.
-        - **Detection depends on logs:** Threat detection, alerting, and post-incident forensics all rely on a continuous event record; a stopped or missing trail creates a blind spot an attacker can operate within undetected.
-        - **Compliance requires retained audit records:** Regulatory regimes expect account activity to be logged and retained, and an unenabled trail fails that expectation outright.
+        Audit logging is the record of who did what. ActionTrail captures console and API operations across services, and without it there is no authoritative account of resource changes, sign-ins, or configuration edits, so no action can be attributed to an identity after the fact.
 
-        **Risk mitigation**
+        Read events matter as much as write events. A trail limited to writes records the change but not the reconnaissance that preceded it, so enumeration and data-access activity, which is where an intrusion usually starts, goes entirely unrecorded.
 
-        - **Preserves accountability:** An enabled, logging trail attributes every recorded action to an identity, deterring misuse and supporting investigations.
-        - **Enables timely response:** Continuous delivery of events to OSS or Simple Log Service feeds monitoring and alerting so suspicious activity can be caught early.
+        Detection depends on the log existing. Threat detection, alerting, and post-incident forensics all rely on a continuous event record, and a stopped or missing trail creates a blind spot an attacker can operate inside without ever being observed. Continuous delivery to Object Storage Service or Simple Log Service is what feeds the monitoring that catches suspicious activity while it is still in progress.
+
+        Regulatory regimes expect account activity to be logged and retained, and an unenabled trail fails that expectation outright. This check confirms that a qualifying trail exists and is running; it does not evaluate the retention, access controls, or integrity protections applied to the destination bucket or project, which need their own review.
       audit: |
         ### Audit via Console
 
@@ -4184,19 +4219,21 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that the account has at least one VPC flow log that is in the active state and captures all traffic (`TrafficType` of `All`). Flow logs capture information about the traffic flowing through elastic network interfaces, VSwitches, and VPCs, providing the network-level visibility needed to detect anomalous connections and investigate incidents. A flow log scoped to only `Allow` or only `Drop` records half the picture.
+        This check verifies that the account captures network traffic records through at least one VPC flow log that is in the `Active` state with a `TrafficType` value of `All`.
+
+        Flow logs record information about the traffic crossing elastic network interfaces, VSwitches, and VPCs, giving the network-level visibility needed to detect anomalous connections and reconstruct incidents. A flow log scoped to only `Allow` or only `Drop` traffic records half the picture. Flow logs are created in the VPC console under Flow Log, or with `aliyun vpc CreateFlowLog --TrafficType All`, and are delivered to a Simple Log Service project and Logstore.
 
         **Why this matters**
 
-        - **Network activity is otherwise invisible:** Without flow logs there is no record of accepted or rejected connections, making it impossible to reconstruct lateral movement, data exfiltration, or reconnaissance after the fact.
-        - **Partial capture hides half the evidence:** Recording only accepted traffic loses the scanning and probing that rejected rules blocked; recording only rejected traffic loses the connections that succeeded.
-        - **Detection and forensics need traffic records:** Flow logs feed monitoring and threat-detection pipelines; an inactive or absent flow log removes a primary signal for identifying malicious network behavior.
-        - **Misconfigured exposure goes unnoticed:** Overly permissive security groups or unexpected egress are far easier to spot when the traffic that traverses them is being logged.
+        Network activity is otherwise invisible. Without flow logs there is no record of which connections were accepted and which were rejected, which makes it impossible to reconstruct lateral movement, data exfiltration, or reconnaissance once an incident is discovered.
 
-        **Risk mitigation**
+        Partial capture hides half the evidence. Recording only accepted traffic loses the scanning and probing that security group rules blocked, which is the earliest signal of an attacker mapping the environment. Recording only rejected traffic loses the connections that actually succeeded, which is where the damage happened.
 
-        - **Improves incident response:** Active flow logs let responders trace which addresses communicated with which resources and when.
-        - **Supports continuous monitoring:** Delivering traffic records to Simple Log Service enables alerting on suspicious flows before they escalate.
+        Detection pipelines need the traffic record as an input. Flow logs feed monitoring and threat detection, and an inactive or absent flow log removes a primary signal for identifying malicious network behavior. Delivering the records to Simple Log Service is what enables alerting on suspicious flows before they escalate rather than after.
+
+        Overly permissive security groups and unexpected egress are also far easier to spot when the traffic traversing them is being logged, so flow logs surface misconfiguration and not only intrusion.
+
+        This check is satisfied by a single qualifying flow log covering the network; it does not assert that every interface or VSwitch is individually covered, so confirm that the flow log's scope actually spans the resources you care about.
       audit: |
         ### Audit via Console
 
@@ -4303,18 +4340,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that Container Service for Kubernetes (ACK) clusters do not expose their Kubernetes API server on a public internet endpoint. When a cluster is created with an internet-facing API server load balancer, the control plane is reachable from any network, so the only barrier to the cluster is the strength of its authentication and authorization.
+        This check verifies that Container Service for Kubernetes (ACK) clusters keep their Kubernetes API server off the public internet.
+
+        When a cluster is created with an internet-facing API server load balancer, the control plane is reachable from any network, so the only barrier left in front of the cluster is the strength of its authentication and authorization. A private cluster exposes only the intranet endpoint, visible in the Container Service console under Cluster Information and Basic Information. In Terraform the control is the `slb_internet_enabled` argument, and the cluster creation request carries the equivalent `endpoint_public_access` field.
 
         **Why this matters**
 
-        - **The API server is the control plane:** Anyone who can reach and authenticate to the Kubernetes API server can schedule workloads, read secrets, and manage every resource in the cluster.
-        - **Public exposure invites attack:** An internet-reachable API server is continuously discoverable and probed for weak credentials, token leaks, and unpatched vulnerabilities.
-        - **Defense in depth:** Keeping the API server on a private endpoint means an attacker must first gain a foothold inside the VPC before they can even attempt to authenticate.
+        The API server is the control plane. Anyone who can reach it and authenticate can schedule workloads, read every secret in the cluster, and manage every resource it holds, so network reachability of that one endpoint effectively defines the perimeter of the whole cluster.
 
-        **Risk mitigation**
+        Public exposure invites continuous attack. An internet-reachable API server is discoverable by mass scanning and is probed constantly for weak credentials, leaked service account tokens, and unpatched control-plane vulnerabilities. Removing it from the public internet takes the cluster out of that traffic entirely.
 
-        - **Shrinks the attack surface:** A private-only API server removes the cluster control plane from internet-wide scanning and brute-force attempts.
-        - **Forces network proximity:** Administrators reach the cluster over the VPC, a bastion, or a VPN, adding a network boundary in front of authentication.
+        Keeping the API server private adds a network boundary in front of authentication. An attacker must first establish a foothold inside the VPC before they can even attempt to authenticate, and administrators reach the cluster over the VPC, a bastion, or a VPN, which are paths that can themselves be logged and controlled.
+
+        The public API server endpoint is chosen when the cluster is created and cannot be removed from an existing cluster through the console. Short of rebuilding, restrict the API server security group and use the intranet endpoint for administration; for a permanently private control plane, create a replacement cluster with the internet API server load balancer disabled and migrate the workloads across.
       audit: |
         ### Audit via Console
 
@@ -4412,18 +4450,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that Container Service for Kubernetes (ACK) clusters ship Kubernetes API server audit logs from the control plane to Log Service. Audit logging records who called the API server, what they requested, and the outcome. Without it, there is no authoritative record of control-plane activity to investigate.
+        This check verifies that Container Service for Kubernetes (ACK) clusters ship Kubernetes API server audit logs from the control plane to Log Service.
+
+        Audit logging records who called the API server, what they requested, and what the outcome was. Collection is turned on in the Container Service console under Operations, then Log Center and Control Plane Logs, by enabling control-plane log collection with the `audit` component selected and a Log Service project chosen. The same configuration is applied by posting the control-plane log request with `aliyun cs` and including `audit` in the component list.
 
         **Why this matters**
 
-        - **No audit log, no forensics:** If the audit component is disabled, malicious or accidental API server actions leave no trail, so an intrusion cannot be reconstructed after the fact.
-        - **Detection depends on logs:** Alerting on suspicious API activity, such as unexpected secret reads or privilege escalations, requires the audit stream to exist.
-        - **Compliance expectation:** Most security frameworks require that access to sensitive systems is logged and retained.
+        Without the audit component, malicious or accidental API server actions leave no trail at all. An intrusion cannot be reconstructed, the scope of a compromise cannot be bounded, and there is no way to distinguish an attacker's activity from routine operations after the fact.
 
-        **Risk mitigation**
+        Detection depends on the audit stream existing before anything goes wrong. Alerting on suspicious API activity such as unexpected secret reads, service account token requests, or privilege escalations requires the events to have been captured in the first place, and no amount of later investigation can recover events that were never recorded.
 
-        - **Enables investigation:** A complete audit trail lets responders determine the scope and impact of an incident.
-        - **Supports detection:** Streaming audit events to Log Service allows anomaly detection and alerting on control-plane misuse.
+        Most security frameworks require that access to sensitive systems is logged and retained, and a Kubernetes control plane holding the account's workloads and secrets is squarely such a system. Streaming those events to Log Service also puts them somewhere a compromised cluster cannot quietly erase them.
+
+        This check confirms that the cluster collects the audit component. It does not evaluate the retention period on the Log Service project, who can read the resulting Logstore, or whether anything alerts on its contents, so pair it with a review of the destination project's configuration.
       audit: |
         ### Audit via Console
 
@@ -4487,18 +4526,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that Container Service for Kubernetes (ACK) clusters enable RAM Roles for Service Accounts (RRSA). RRSA issues OIDC tokens so that individual Kubernetes service accounts assume narrowly scoped RAM roles, instead of every pod inheriting the shared worker node RAM role. Without RRSA, any workload on a node can use the node's role and reach whatever that role is permitted to do.
+        This check verifies that Container Service for Kubernetes (ACK) clusters enable RAM Roles for Service Accounts, known as RRSA.
+
+        RRSA issues OpenID Connect tokens so that individual Kubernetes service accounts assume narrowly scoped RAM roles, instead of every pod inheriting the shared worker node RAM role. Without it, any workload on a node can use the node's role and reach whatever that role is permitted to do. RRSA is turned on in the Container Service console under Cluster Information and Basic Information, with `aliyun cs` against the cluster's RRSA enable path, or by setting `enable_rrsa` to `true` in Terraform. Enabling it is only the first half of the work; service accounts must then be bound to the scoped RAM roles their workloads require.
 
         **Why this matters**
 
-        - **Shared node role is over-broad:** When pods rely on the worker node RAM role, a single compromised container inherits the same cloud permissions as every other workload on the node.
-        - **No per-workload boundary:** Without RRSA there is no way to grant one application access to a specific bucket or key without granting it to all co-located workloads.
-        - **Least privilege for workloads:** RRSA lets each service account carry only the permissions its application needs, containing the blast radius of a compromise.
+        A shared node role is over-broad by construction. When pods rely on the worker node RAM role, a single compromised container inherits exactly the same cloud permissions as every other workload scheduled on that node, including workloads owned by other teams.
 
-        **Risk mitigation**
+        There is no per-workload boundary without RRSA. One application cannot be granted access to a specific bucket or key without simultaneously granting it to every co-located pod, so the node role drifts toward the union of everything anything on the cluster has ever needed.
 
-        - **Scopes credentials to workloads:** Per-service-account roles ensure a compromised pod can only reach the resources that workload was granted.
-        - **Removes reliance on the node role:** Workloads stop borrowing the broad node identity, closing a common lateral-movement path.
+        RRSA restores least privilege at the workload level. Each service account carries only the permissions its application needs, so a compromised pod reaches only the resources that workload was granted, and workloads stop borrowing the broad node identity that makes lateral movement easy.
+
+        Once RRSA is enabled on a cluster it cannot be turned off, so treat it as a one-way change and confirm that the OpenID Connect issuer and role trust policies are in place before workloads begin depending on them.
       audit: |
         ### Audit via Console
 
@@ -4598,18 +4638,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that no Apsara File Storage NAS access rule grants read-write (`RDWR`) access to the entire internet. A NAS access group controls which clients may mount a file system; an access rule that combines a world-open source (`0.0.0.0/0` or the IPv6 `::/0`) with read-write permission lets any reachable host both read and modify stored files.
+        This check verifies that mount access to Apsara File Storage NAS is scoped to named VPC and on-premises ranges instead of granting the `RDWR` permission to the entire internet.
+
+        A NAS access group is the list of rules deciding which clients may mount a file system, and each rule pairs a source address range with a read/write permission. A rule that sets its `source_cidr_ip` to `0.0.0.0/0`, or its IPv6 source to `::/0`, while holding the `RDWR` permission lets any host able to reach the mount target both read and modify stored files. The rules live under **Permission Groups** in the NAS console, and `aliyun nas ModifyAccessRule` changes them from the command line.
 
         **Why this matters**
 
-        - **World-writable exports are a data-integrity risk:** A read-write rule open to `0.0.0.0/0` allows any client that can reach the mount target to alter or destroy files, not just read them.
-        - **Exfiltration and tampering:** Sensitive data in a file system exposed to the whole internet can be copied out, encrypted for ransom, or silently corrupted.
-        - **Blast radius:** A single overly broad rule can undo tighter controls elsewhere, because NAS evaluates access rules by priority across the whole access group.
+        A world-writable export is a data-integrity problem before it is a confidentiality one. Any client that can reach the mount target can alter or destroy files, not only read them, so an unauthenticated stranger holds the same power over the file system as the application that owns it.
 
-        **Risk mitigation**
+        The confidentiality loss follows anyway. Sensitive data on a file system exposed to the whole internet can be copied out wholesale, encrypted for ransom, or corrupted quietly enough that the damage surfaces only when a restore is attempted.
 
-        - **Scope to known networks:** Restricting `source_cidr_ip` to specific VPC or on-premises ranges removes anonymous internet clients from the mount surface.
-        - **Prefer read-only where possible:** Granting `RDONLY` for broad ranges limits an exposed export to disclosure rather than modification.
+        The blast radius is wider than a single rule suggests. NAS evaluates access rules by priority across the whole access group, so one overly broad entry can undo tighter rules written alongside it, and the group may be attached to more than one file system.
+
+        Where a broad range genuinely has to be served, granting `RDONLY` rather than `RDWR` reduces the exposure from modification to disclosure. This check looks only at the read-write case, so a permissive read-only rule still deserves its own review.
       audit: |
         ### Audit via Console
 
@@ -4716,18 +4757,19 @@ queries:
     impact: 75
     docs:
       desc: |
-        This check ensures that Alibaba Cloud Firewall is provisioned and switched on for the account. Cloud Firewall is the managed boundary firewall that inspects and filters north-south and east-west traffic; when it is not enabled, no centrally managed control policies are applied to internet-facing and inter-VPC traffic.
+        This check verifies that the account has a managed boundary firewall in force, meaning Alibaba Cloud Firewall is provisioned and its protection is switched on.
+
+        Cloud Firewall inspects and filters north-south traffic at the internet edge and east-west traffic between VPCs, applying the account's control policies at both. It is activated by purchasing an edition and switching protection on in the Cloud Firewall console, and `aliyun cloudfw DescribeUserBuyVersion` reports the account's current status.
 
         **Why this matters**
 
-        - **A boundary firewall is a baseline control:** Without Cloud Firewall enabled, the account has no managed choke point to enforce allow/deny policy on traffic crossing its perimeter.
-        - **Visibility gap:** Cloud Firewall provides traffic analysis and intrusion prevention; leaving it off removes a primary source of network telemetry and blocking.
-        - **Consistent policy enforcement:** A central firewall applies uniform control policies rather than relying on per-resource security groups that can drift.
+        Without it the account has no managed choke point at all. Every allow and deny decision falls to per-resource security groups and network ACLs, which are edited by whoever owns the workload and drift apart over time, so there is no single place where the intended perimeter policy is written down, let alone enforced.
 
-        **Risk mitigation**
+        The loss is as much visibility as enforcement. Cloud Firewall supplies traffic analysis and intrusion prevention over the flows crossing the perimeter, and with it off the account has no view of what is reaching in or heading out, which is the telemetry an investigation would otherwise start from.
 
-        - **Managed perimeter enforcement:** Enabling Cloud Firewall establishes a single place to define and enforce boundary allow/deny rules.
-        - **Reduced exposure:** An active firewall can block malicious inbound and outbound flows before they reach or leave workloads.
+        An active firewall also blocks malicious inbound and outbound flows before they touch a workload, so a compromised instance attempting to call out meets a boundary control rather than an open path.
+
+        Provisioning alone is not the finish line. Once the firewall is on, its control policies still have to say something meaningful, and a companion check in this policy fails an inbound policy that accepts every protocol from every source.
       audit: |
         ### Audit via Console
 
@@ -4793,18 +4835,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every provisioned Alibaba Anti-DDoS instance is enabled so that its DDoS mitigation is actively protecting the associated endpoints. An Anti-DDoS instance that exists but is not enabled leaves the workloads it is meant to shield without volumetric-attack protection. If the account has no Anti-DDoS instances the check passes, so it never forces a purchase.
+        This check verifies that DDoS mitigation already purchased for the account is actually in force, requiring every provisioned Anti-DDoS instance to be enabled.
+
+        An Anti-DDoS instance absorbs and scrubs volumetric floods on behalf of the endpoints associated with it, but only once it is enabled and a protected object is attached. An instance that exists in the account without being enabled shields nothing. Instances are reviewed under **Assets** > **Instances** in the Anti-DDoS console, and `aliyun ddoscoo DescribeInstances` reports their state.
 
         **Why this matters**
 
-        - **Availability under attack:** Anti-DDoS absorbs and scrubs volumetric floods; a disabled instance cannot protect the endpoints it was bought for.
-        - **Silent lapse:** A protection instance can be present in the account yet not actively enabled, giving a false sense of coverage.
-        - **Continuity dependency:** Public-facing services often depend on DDoS mitigation to stay reachable during an attack.
+        Availability is the entire point of the purchase. A volumetric flood saturates the link or the frontend before any application-layer control is reached, and mitigation only helps if it is scrubbing traffic when the flood arrives. A disabled instance cannot protect the endpoints it was bought for.
 
-        **Risk mitigation**
+        The lapse is a quiet one. The instance appears in the console, on the invoice, and in any inventory of security controls, so a reviewer counting protections records coverage that does not exist. Nothing about the account looks wrong until an attack tests it.
 
-        - **Active mitigation:** An enabled instance scrubs attack traffic before it overwhelms the protected service.
-        - **Verified coverage:** Confirming the enabled state ensures the purchased protection is actually in force.
+        Public-facing services frequently depend on this mitigation to stay reachable at all during an attack, so the gap is discovered at the worst possible moment, under load, with no time left to attach a protected object and switch the instance on.
+
+        An account with no Anti-DDoS instances passes. This check confirms that protection already paid for is switched on; it never argues that an account ought to buy Anti-DDoS in the first place.
       audit: |
         ### Audit via Console
 
@@ -4871,18 +4914,19 @@ queries:
     impact: 75
     docs:
       desc: |
-        This check ensures that internet-facing Server Load Balancer (SLB) instances do not expose plaintext `HTTP` listeners. An internet-facing load balancer that serves an `HTTP` listener terminates or forwards unencrypted web traffic over the public internet, where it can be read or modified in transit. Web traffic reaching a public load balancer should use `HTTPS` so it is protected by TLS.
+        This check verifies that public web traffic reaching a Server Load Balancer (SLB) instance is protected by TLS, requiring internet-facing load balancers to serve no plaintext `HTTP` listener.
+
+        An internet-facing SLB accepts client connections from the public internet. A listener declared with the `HTTP` protocol terminates or forwards that traffic unencrypted across untrusted networks, while an `HTTPS` listener presents a server certificate and protects the same traffic with TLS. Listeners are managed on the **Listeners** tab of each load balancer in the SLB console, and `aliyun slb CreateLoadBalancerHTTPSListener` adds an encrypted one from the command line.
 
         **Why this matters**
 
-        - **Traffic is exposed in transit:** A public `HTTP` listener carries credentials, session tokens, and payloads in cleartext across untrusted networks.
-        - **Interception and tampering:** On-path attackers can read or alter unencrypted web traffic between clients and the load balancer.
-        - **Downgrade surface:** Offering `HTTP` at all invites clients onto an unencrypted path even when an `HTTPS` listener also exists.
+        Cleartext on a public path exposes exactly what is worth stealing. Credentials submitted to a login form, session tokens replayed on every subsequent request, and the request and response bodies themselves all cross the internet readable by anything on the path.
 
-        **Risk mitigation**
+        Reading is not the limit. An on-path attacker can rewrite an unencrypted response as easily as observe it, injecting content or altering a request before it reaches the backend, and neither the client nor the load balancer has any way to detect the change.
 
-        - **Encrypt web traffic end to public edge:** Serving only `HTTPS` on internet-facing load balancers protects client traffic with TLS.
-        - **Remove the cleartext option:** Eliminating public `HTTP` listeners closes the unencrypted path entirely.
+        Offering `HTTP` at all creates a downgrade path even when `HTTPS` is available beside it. Clients follow the first URL they are handed, bookmarks and hardcoded links keep pointing at the plaintext port, and traffic settles on the unencrypted listener without anyone choosing it.
+
+        Internal load balancers pass this check, since the exposure it describes depends on the public address. The assertion is that no `HTTP` listener exists on a public instance, so a listener kept only to redirect clients onward to `HTTPS` still fails it.
       audit: |
         ### Audit via Console
 
@@ -4950,18 +4994,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that Web Application Firewall (WAF) protected domains that serve HTTPS do not negotiate down to a legacy TLS version. Domains configured with a minimum TLS version of `tlsv1` or `tlsv1.1` allow clients to connect over protocol versions with known cryptographic weaknesses. HTTPS-enabled WAF domains should require TLS 1.2 or higher. Domains that do not serve HTTPS, and accounts with no WAF domains, pass because there is no negotiated TLS floor to weaken.
+        This check verifies that domains fronted by Web Application Firewall (WAF) enforce a modern TLS floor, refusing sessions below TLS 1.2.
+
+        WAF terminates HTTPS on behalf of the domains it protects, and each HTTPS-enabled domain carries a minimum TLS version. A domain set to `tlsv1` or `tlsv1.1` invites clients onto protocol versions with known cryptographic weaknesses, because that floor is the oldest version the endpoint will still accept. The setting sits in the HTTPS settings of each domain under **Website Configuration** in the WAF console.
 
         **Why this matters**
 
-        - **Legacy TLS is broken:** TLS 1.0 and 1.1 are deprecated and carry known weaknesses that undermine the confidentiality and integrity of the connection.
-        - **Downgrade exposure:** Permitting an old minimum version lets clients negotiate a weak session even when stronger versions are available.
-        - **Compliance expectation:** Modern standards require disabling early TLS for public web endpoints.
+        TLS 1.0 and 1.1 are deprecated rather than merely dated. They rest on constructions that have not held up, and the resulting weaknesses undermine the confidentiality and integrity of the session itself, not just the strength of a preference.
 
-        **Risk mitigation**
+        A low floor is a live downgrade path, not a dormant one. Stronger versions being available changes nothing while the endpoint still answers on an older one, and an attacker able to influence the negotiation will steer sessions toward the weakest version offered rather than the best both sides support.
 
-        - **Raise the floor:** Setting the minimum to TLS 1.2 or higher forces every session onto a modern, supported protocol version.
-        - **Remove weak negotiation:** Disallowing `tlsv1` and `tlsv1.1` eliminates downgrade to deprecated cryptography.
+        Public web endpoints also sit squarely inside the scope of modern compliance regimes, which require early TLS to be disabled outright and treat a permissive floor as a finding in its own right rather than a risk to be argued about.
+
+        Domains that do not serve HTTPS pass, as do accounts with no WAF domains at all, because neither case has a negotiated TLS floor to weaken. Raising the floor can cut off very old clients, so confirm the traffic profile before changing a domain that serves a long tail of legacy user agents.
       audit: |
         ### Audit via Console
 
@@ -5011,18 +5056,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that every Cloud SSO directory demands a second factor on every sign-in. The setting has three states: `Enabled` requires a second factor from everyone, `Byp` requires one only for sign-ins the service judges risky, and `Disabled` never requires one. Only `Enabled` protects every session.
+        This check verifies that every Cloud SSO directory demands a second factor on every sign-in rather than on a subset the service selects for itself.
+
+        The setting has three states. `Enabled` requires a second factor from everyone, `Byp` requires one only for sign-ins the service judges risky, and `Disabled` never requires one. Only `Enabled` protects every session, so it is the sole passing value. Set it in the Cloud SSO console under **Settings** on the **User Setting** tab, where **MFA Requirement for Logon** in the **Username-password Login** section controls the directory, or with `aliyun cloudsso SetMFAAuthenticationStatus --MFAAuthenticationStatus Enabled`. In Terraform the value is `mfa_authentication_status` on the directory resource.
 
         **Why this matters**
 
-        - **Cloud SSO fronts every member account:** A directory user signs in once and assumes roles across the resource directory, so one compromised sign-in reaches far beyond a single account.
-        - **Risk-based prompting has gaps:** `Byp` leaves the service to decide which sign-ins look risky, and an attacker operating from a familiar network or device is exactly the case it does not flag.
-        - **Passwords alone are routinely defeated:** Phishing, credential stuffing, and reuse remain the most common initial-access techniques.
+        Cloud SSO fronts every member account in the resource directory. A directory user signs in once and then assumes roles across those accounts, so a single compromised sign-in reaches far beyond the blast radius of one account's credentials.
 
-        **Risk mitigation**
+        Risk-based prompting leaves the gap that matters most. `Byp` delegates to the service the judgment of which sign-ins look suspicious, and an attacker operating from a familiar network, a known device, or a stolen session context is precisely the case that heuristic does not flag. The sign-ins it does challenge are the clumsy ones.
 
-        - **Blocks credential-only takeover:** A stolen password on its own no longer produces a session.
-        - **Covers every user uniformly:** Enforcing at the directory level removes per-user gaps that opt-in enrollment leaves behind.
+        Passwords on their own are defeated routinely. Phishing, credential stuffing, and reuse across unrelated services remain the most common initial-access techniques, and none of them are addressed by password policy alone.
+
+        An account with no Cloud SSO directory has nothing to evaluate and passes. Where Cloud SSO is in use it typically coexists with RAM users who sign in directly, and a companion check in this policy covers the second factor on those identities.
       audit: |
         ### Audit via Console
 
@@ -5119,20 +5165,19 @@ queries:
     impact: 60
     docs:
       desc: |
-        This check ensures that every Cloud SSO directory requires passwords of at least 14 characters and forbids a password that contains the user's own name. Cloud SSO keeps its own password policy, separate from the Resource Access Management policy, so a hardened RAM account says nothing about the directory its workforce actually signs in to.
+        This check verifies that the workforce directory enforces its own credential floor, requiring every Cloud SSO directory to demand passwords of at least 14 characters and to forbid a password that contains the user's own name.
 
-        The character-class requirements the directory reports are not asserted. `GetPasswordPolicy` returns them, but `SetPasswordPolicy` accepts no parameter for any of them, so they are service-fixed and an operator has no way to act on a finding about them.
+        Cloud SSO keeps a password policy entirely separate from the Resource Access Management policy, so a hardened RAM account says nothing about the directory the workforce actually signs in to. Set both values in the Cloud SSO console under **Settings** on the **User Setting** tab through **Edit** in the **Password Policy** section, or run `aliyun cloudsso SetPasswordPolicy --MinPasswordLength 14 --PasswordNotContainUsername true`. The Terraform equivalent is `min_password_length` and `password_not_contain_username` inside the `password_policy` block on the directory resource.
 
         **Why this matters**
 
-        - **Length defeats offline cracking:** Each additional character multiplies the work an attacker must do against a captured hash, and length buys more than composition rules do.
-        - **Username-derived passwords are guessed first:** A password containing the account name is the first thing credential-stuffing and targeted guessing attempts try.
-        - **The directory policy is easy to miss:** Teams that harden RAM often leave the Cloud SSO directory at its defaults, where the workforce identities actually live.
+        Length is what defeats offline cracking. Each additional character multiplies the work an attacker must do against a captured hash, and the return on length exceeds the return on composition rules by a wide margin at any realistic password size.
 
-        **Risk mitigation**
+        A password containing the account name is among the first candidates any targeted guessing attempt tries, because the username is public to anyone who has seen a directory listing, an email address, or a support ticket. Forbidding it removes the cheapest guess in the attacker's list.
 
-        - **Raises the cost of guessing:** Brute-force and credential-stuffing campaigns become impractical against the whole directory at once.
-        - **Applies uniformly:** A directory-level policy removes the per-user variation that guidance alone leaves behind.
+        The directory policy is easy to overlook precisely because RAM gets the attention. Teams harden the account they audit and leave the directory at its defaults, even though that directory is where the human identities live and where a workforce compromise would begin.
+
+        The character-class requirements the directory reports are deliberately not asserted. `GetPasswordPolicy` returns them, but `SetPasswordPolicy` accepts no parameter for any of them, so they are fixed by the service and a finding about them would give an operator nothing to act on.
       audit: |
         ### Audit via Console
 
@@ -5252,18 +5297,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that no Cloud SSO directory lets a signed-in user retrieve long-lived access credentials for themselves. When the setting is on, a user who has completed a sign-in can mint credentials that keep working after the session that produced them has ended, which converts a short-lived interactive session into standing programmatic access.
+        This check verifies that access through Cloud SSO stays bound to a live session, ensuring that no directory lets a signed-in user retrieve long-lived access credentials for themselves.
+
+        When the setting is on, any user who completes a sign-in can mint credentials that keep working after the session that produced them has ended, converting short-lived interactive access into standing programmatic access that no longer answers to the sign-in flow. Turn it off in the Cloud SSO console under **Settings** on the **User Setting** tab through **Edit** in the **Login Preference** section, or run `aliyun cloudsso SetLoginPreference --AllowUserToGetCredentials false`. In Terraform the value is `allow_user_to_get_credentials` inside the `login_preference` block on the directory resource.
 
         **Why this matters**
 
-        - **It defeats session lifetime:** Cloud SSO bounds how long a session lasts; a self-issued credential outlives that bound and keeps working after sign-out.
-        - **It widens the value of one compromise:** An attacker who lands a single session can leave with credentials that survive password resets and MFA re-enrollment.
-        - **The credentials are invisible to sign-in monitoring:** Later use looks like ordinary API traffic rather than a new sign-in, so alerting on unusual logins never fires.
+        Self-issued credentials defeat session lifetime. Cloud SSO bounds how long a session lasts, and that bound is a deliberate control; a credential minted during the session outlives it and keeps working long after sign-out.
 
-        **Risk mitigation**
+        The setting also multiplies the value of a single compromise. An attacker who lands one session can walk away with credentials that survive a password reset, an MFA re-enrollment, and the revocation of the session itself, so incident response that ends the session does not end the access.
 
-        - **Keeps access tied to the session:** Every request traces back to a live, re-authenticated sign-in.
-        - **Shrinks the compromise window:** Ending the session ends the access, with no separate credential to find and revoke.
+        Later use of those credentials is invisible to sign-in monitoring. The traffic looks like ordinary API activity rather than a new logon, so alerting built around unusual sign-ins never fires and the only trace is in the API audit trail, if anyone is reading it.
+
+        The check evaluates the directory setting, not the credentials that have already been issued under it. After turning the option off, inventory and revoke any credentials users minted while it was on, since existing ones keep working on their own terms.
       audit: |
         ### Audit via Console
 
@@ -5371,18 +5417,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that no Container Registry repository can be pulled without credentials. A repository is anonymously pullable when its visibility is `PUBLIC` and the registry instance answers on an internet endpoint, at which point anyone who learns or guesses the repository path can download every image in it.
+        This check verifies that every Container Registry repository requires credentials before an image can be pulled.
+
+        A repository's type governs whether it is anonymously pullable. A repository whose visibility is `PUBLIC` can be downloaded by anyone who learns or guesses its path once the registry instance answers on an internet endpoint. Repository type is set in the Container Registry console under **Repository** > **Repositories** by editing the repository and choosing **Private**, with the `aliyun cr UpdateRepository` call passing `--RepoType PRIVATE`, or in Terraform through `repo_type`. This check requires every repository in the instance to be private.
 
         **Why this matters**
 
-        - **Images carry more than application code:** Layers routinely include configuration files, private dependencies, and credentials baked in at build time, none of which are recoverable once downloaded.
-        - **Repository paths are guessable:** Registry namespaces follow organizational naming, so a public repository is discoverable without any prior access.
-        - **Pulls leave no attribution:** An anonymous pull identifies no principal, so exfiltration through a public repository is invisible in access logs.
+        Images carry far more than application code. Layers routinely include configuration files, private dependencies, and credentials baked in at build time, and none of that is recoverable once someone has downloaded the image.
 
-        **Risk mitigation**
+        Repository paths are guessable. Registry namespaces follow organizational naming, so a public repository is discoverable without any prior access to the account.
 
-        - **Forces authenticated pulls:** Every download presents credentials that can be authorized, logged, and revoked.
-        - **Contains build-time leakage:** A secret accidentally baked into a layer stays inside the trust boundary instead of reaching the internet.
+        Anonymous pulls leave no attribution. A pull that presents no credentials identifies no principal, so exfiltration through a public repository is invisible in access logs. Requiring authentication means every download presents credentials that can be authorized, logged, and revoked, and a secret accidentally baked into a layer stays inside the trust boundary instead of reaching the internet.
+
+        The check reads the repository type alone, so it flags a public repository whether or not the instance currently exposes an internet endpoint, since that endpoint can be enabled later without any change to the repository. An instance that holds no repositories has nothing to evaluate and passes.
       audit: |
         ### Audit via Console
 
@@ -5480,18 +5527,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every Container Registry repository forbids overwriting an existing tag. Without tag immutability a tag is a movable pointer, so `app:1.4.2` can be repointed at different content after it was reviewed, signed off, and deployed, and every later pull of that tag silently gets the new image.
+        This check verifies that every Container Registry repository refuses to overwrite an existing tag.
+
+        Tag immutability binds a tag to the content it first pointed at. Without it a tag is a movable pointer, so `app:1.4.2` can be repointed at different content after it was reviewed, signed off, and deployed, and every later pull of that tag silently gets the new image. Immutability is turned on in the Container Registry console under **Repository** > **Repositories** by editing the repository and selecting **Immutable**, through `aliyun cr UpdateRepository` with `--TagImmutability true`, or in Terraform through `tag_immutability`. This check requires it on every repository.
 
         **Why this matters**
 
-        - **The reviewed artifact stops being the deployed artifact:** Scanning, signing, and approval all attach to content that a later push can replace under the same name.
-        - **Rollback becomes unreliable:** Redeploying a known-good tag no longer reproduces the known-good image, so incident recovery can reintroduce the problem.
-        - **It is a quiet supply-chain foothold:** Anyone with push access can change what production runs without touching any deployment manifest.
+        The reviewed artifact stops being the deployed artifact. Scanning, signing, and approval all attach to content that a later push can replace under the same name, so the assurance gathered before release describes an image that is no longer the one being pulled.
 
-        **Risk mitigation**
+        Rollback becomes unreliable. Redeploying a known-good tag no longer reproduces the known-good image, so incident recovery can reintroduce the very problem it was meant to undo.
 
-        - **Binds a name to fixed content:** A tag that cannot be moved means what was approved is what runs.
-        - **Makes changes explicit:** Shipping different content requires a new tag, which shows up in the deployment diff.
+        A movable tag is a quiet supply-chain foothold. Anyone with push access can change what production runs without touching any deployment manifest. With immutability in place, shipping different content requires a new tag, which shows up in the deployment diff and in change review.
+
+        The `aliyun cr UpdateRepository` call rewrites the repository type and summary alongside the immutability flag, so pass the current values for both or an unrelated setting will be reset as a side effect. An instance that holds no repositories passes.
       audit: |
         ### Audit via Console
 
@@ -5594,18 +5642,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every Container Registry instance has at least one image scan rule. A scan rule is what makes vulnerability scanning happen on its own: it names the repositories and tag patterns to scan and the trigger that starts a scan. With no rule the registry still offers scanning, but only if somebody remembers to start one by hand, which means images are pushed and deployed unexamined.
+        This check verifies that every Container Registry instance has at least one image scan rule configured.
+
+        A scan rule is what makes vulnerability scanning happen on its own. It names the repositories and tag patterns to scan and the trigger that starts a scan. With no rule the registry still offers scanning, but only if somebody remembers to start one by hand, which means images are pushed and deployed unexamined. Scan rules live in the Container Registry console under **Security and Trust** > **Image Scanning**, and `aliyun cr CreateScanRule` creates one with `--TriggerType AUTO` so it runs on every push. This check requires the instance to have a non-empty set of scan rules.
 
         **Why this matters**
 
-        - **Container images accumulate known vulnerabilities:** Base images and system packages age between rebuilds, so an image that was clean at build time is not clean months later.
-        - **Manual scanning does not scale:** A registry with dozens of repositories and continuous pushes has no realistic manual path to full coverage.
-        - **Scanning on push catches problems before deployment:** Finding a vulnerable layer at push time is far cheaper than finding it running in production.
+        Container images accumulate known vulnerabilities. Base images and system packages age between rebuilds, so an image that was clean at build time is not clean months later. An image is never patched in place; it is rebuilt and redeployed, and a scan is what tells you when that is due.
 
-        **Risk mitigation**
+        Manual scanning does not scale. A registry with dozens of repositories and continuous pushes has no realistic manual path to full coverage, and the repositories that go unscanned are the ones nobody is thinking about.
 
-        - **Gives continuous coverage:** Every push matching the rule is examined without human involvement.
-        - **Produces an inventory of exposure:** Scan results turn "we might have vulnerable images" into a concrete, prioritizable list.
+        Scanning on push catches problems before deployment. Finding a vulnerable layer at push time is far cheaper than finding it running in production, and accumulated results turn a vague sense that vulnerable images might exist into a concrete, prioritizable inventory.
+
+        The check confirms only that a rule exists. It does not evaluate the scope or trigger of that rule, so a rule covering one namespace on a manual trigger still passes. Set the scope to the repositories you actually want covered and choose the on-push trigger.
       audit: |
         ### Audit via Console
 
@@ -5674,18 +5723,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every Elasticsearch cluster stores its indexed data on encrypted data node disks. Disk encryption is chosen when the cluster is created and cannot be turned on afterwards, so a cluster built without it stays unencrypted for its whole life.
+        This check verifies that every Elasticsearch cluster stores its indexed data on encrypted data node disks.
+
+        Disk encryption protects the storage that backs the cluster's indexes and the snapshots taken from that storage. It is chosen when the cluster is created and cannot be turned on afterwards, so a cluster built without it stays unencrypted for its whole life. The Elasticsearch console shows the setting under **Basic Information** for the data nodes, cluster creation carries it in the `diskEncryption` field of `nodeSpec`, and Terraform declares it through `data_node_disk_encrypted`. This check requires encryption to be enabled.
 
         **Why this matters**
 
-        - **Search clusters concentrate sensitive data:** Indexes are built from logs, documents, and application records, often holding personal data drawn from many systems at once.
-        - **Encryption at rest covers the storage layer:** It protects data on the underlying disks and in the snapshots taken from them, where access controls of the search API no longer apply.
-        - **The decision is permanent:** Because the setting cannot be changed later, an unencrypted cluster requires a rebuild and reindex to fix.
+        Search clusters concentrate sensitive data. Indexes are built from logs, documents, and application records, often holding personal data drawn from many systems at once, so a single cluster can be the densest copy of that data anywhere in the account.
 
-        **Risk mitigation**
+        Encryption at rest covers a layer the search API does not. It protects data on the underlying disks and in the snapshots taken from them, where the access controls of the search API no longer apply. Media, backups, and detached volumes then yield ciphertext instead of readable index data, and encryption at rest is an explicit expectation of most regulatory regimes covering personal data.
 
-        - **Removes plaintext at rest:** Media, backups, and detached volumes yield ciphertext instead of readable index data.
-        - **Supports data-protection obligations:** Encryption at rest is an explicit expectation of most regulatory regimes covering personal data.
+        The decision is permanent. Because the setting cannot be changed later, an unencrypted cluster is fixed only by creating a replacement with encryption enabled, reindexing or restoring a snapshot into it, cutting clients over, and releasing the original.
+
+        Treat a failing result as a migration to plan rather than a setting to toggle, and enable disk encryption on every new cluster at creation time so the question does not arise again.
       audit: |
         ### Audit via Console
 
@@ -5791,18 +5841,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no Elasticsearch cluster exposes a public network endpoint. With the public endpoint switched off a cluster is reachable only from inside its VPC; with it on, the cluster answers on an internet address and the public IP allowlist becomes the only thing between the index and the internet.
+        This check verifies that Elasticsearch clusters are reachable only from inside their VPC.
+
+        Public network access decides whether a cluster answers on an internet address in addition to its VPC endpoint. Switched off, traffic must originate inside the VPC or arrive through a controlled network connection. Switched on, the cluster answers on an internet address and the public IP allowlist becomes the only thing between the index and the internet. The setting is **Public Network Access** in the Elasticsearch console under **Configuration and Management** > **Security**, `aliyun elasticsearch UpdatePublicNetwork` turns it off with `enablePublic` set to `false`, and Terraform declares it through `enable_public`.
 
         **Why this matters**
 
-        - **Search endpoints are directly queryable:** The Elasticsearch API returns documents, so reaching the endpoint with valid credentials is equivalent to reading the data.
-        - **Allowlists drift:** A public endpoint gated only by an address list degrades quietly as ranges are widened for convenience or troubleshooting.
-        - **Internet-facing search clusters are actively hunted:** Exposed Elasticsearch endpoints are a long-standing source of large-scale data disclosure.
+        Search endpoints are directly queryable. The Elasticsearch API returns documents, so reaching the endpoint with valid credentials is equivalent to reading the data, with no application layer in between deciding what a caller is allowed to see.
 
-        **Risk mitigation**
+        Allowlists drift. A public endpoint gated only by an address list degrades quietly as ranges are widened for convenience or during troubleshooting, and nobody narrows them again once the work is done.
 
-        - **Removes the internet path entirely:** Traffic must originate inside the VPC or arrive through a controlled network connection.
-        - **Makes the network boundary the primary control:** Access no longer depends on an allowlist staying correct over time.
+        Internet-facing search clusters are actively hunted. Exposed Elasticsearch endpoints are a long-standing source of large-scale data disclosure. Turning the public endpoint off removes that path entirely and makes the network boundary the primary control, so access stops depending on an allowlist staying correct over time.
+
+        Where a public endpoint is genuinely required, this check fails by design and the exception belongs in your risk register. A companion check in this policy covers that case by requiring the public allowlist to name specific ranges rather than admitting every source address.
       audit: |
         ### Audit via Console
 
@@ -5906,18 +5957,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no Elasticsearch cluster with a public endpoint allows every source address. When the public network is switched on, the public IP allowlist is the whole of the access control at the network layer, and an entry of `0.0.0.0/0` removes it, leaving the cluster credentials as the only barrier between the index and the internet.
+        This check verifies that an Elasticsearch cluster reachable from the internet restricts which source addresses may connect to it.
+
+        When public network access is switched on, the public IP allowlist is the whole of the access control at the network layer. An entry of `0.0.0.0/0` removes that control, leaving the cluster credentials as the only barrier between the index and the internet. The allowlist is edited in the Elasticsearch console under **Configuration and Management** > **Security** next to **Public IP Address Whitelist**, replaced wholesale by `aliyun elasticsearch UpdatePublicWhiteIps`, or declared in Terraform through `public_whitelist`.
 
         **Why this matters**
 
-        - **A wide-open allowlist is the same as no allowlist:** Every host on the internet can open a connection and begin authenticating.
-        - **Credential attacks become continuous:** With the endpoint reachable from anywhere, brute-force and credential-stuffing traffic never stops.
-        - **It is often a leftover:** `0.0.0.0/0` is added during a migration or a debugging session and rarely removed once the work is finished.
+        A wide-open allowlist is the same as no allowlist. Every host on the internet can open a connection and begin authenticating, so the network layer contributes nothing and one weak or leaked credential is enough.
 
-        **Risk mitigation**
+        Credential attacks become continuous. With the endpoint reachable from anywhere, brute-force and credential-stuffing traffic never stops, and the noise it generates buries the authentication failures that actually matter.
 
-        - **Restores a network barrier:** Only named ranges can reach the endpoint at all, so authentication is a second layer rather than the only one.
-        - **Shrinks the reachable surface:** Scanning and exploitation traffic from unrelated networks never arrives.
+        An entry of `0.0.0.0/0` is often a leftover. It gets added during a migration or a debugging session and is rarely removed once the work is finished, so the exposure long outlives the reason for it. Listing only named ranges such as `203.0.113.0/24` restores a real network barrier: only those ranges reach the endpoint at all, authentication becomes a second layer rather than the only one, and scanning traffic from unrelated networks never arrives.
+
+        A cluster whose public network access is switched off passes regardless of what its allowlist holds, because no internet path exists for the list to govern. Terraform code that declares no allowlist at all also passes, since there is no wide-open entry to find.
       audit: |
         ### Audit via Console
 
@@ -6032,18 +6084,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that no Function Compute function is allowed to reach the public internet for outbound requests. Internet access is on by default, so a function that only ever talks to services inside its VPC still carries an open egress path it never uses.
+        This check verifies that outbound internet egress is turned off for every Function Compute function.
+
+        Function Compute gives each function a default elastic network interface that can reach the public internet, and that access is on by default. A function that only ever talks to services inside its VPC still carries an open egress path it never uses. The setting is administered in the Function Compute console on the function's Configuration tab, under Advanced Settings, where the network option named "Allow Default ENI to Access the Internet" must be disabled. The same change is available through `aliyun fc UpdateFunction` with `internetAccess` set to `false`, or by declaring `internet_access` as `false` in Terraform.
 
         **Why this matters**
 
-        - **Egress is the exfiltration path:** Code that can reach the internet can send whatever it can read to an arbitrary destination, which is what a compromised dependency does first.
-        - **Function code changes faster than review:** A function is redeployed on every release, so an egress path granted once persists through every later change to the code.
-        - **Least functionality applies to network reach:** A function that talks only to a database and a queue has no business initiating arbitrary outbound connections.
+        Egress is the exfiltration path. Code that can reach the internet can send whatever it can read to an arbitrary destination, and reaching out to an attacker-controlled host is the first thing a compromised dependency does. Everything the function's role, environment, and mounted data expose becomes reachable from outside the account the moment the code is subverted.
 
-        **Risk mitigation**
+        Function code changes faster than review does. A function is redeployed on every release, so an egress path granted once quietly persists through every later change to the code, long after the person who enabled it has stopped thinking about it.
 
-        - **Removes the unattended outbound path:** Data cannot leave through the function even if the code is subverted.
-        - **Forces deliberate connectivity:** Reaching an external service requires a NAT gateway or endpoint that is declared, reviewed, and visible.
+        Least functionality applies to network reach, not only to permissions. A function that talks to a database and a queue has no business initiating arbitrary outbound connections, and removing that reach means data cannot leave through the function even if the code is subverted.
+
+        A function that genuinely needs to call an external service should reach it through a NAT gateway or a VPC endpoint, so the connectivity is declared, reviewed, and visible rather than granted implicitly by a default.
       audit: |
         ### Audit via Console
 
@@ -6146,18 +6199,19 @@ queries:
     impact: 90
     docs:
       desc: |
-        This check ensures that no Function Compute function carries a credential in its environment variables. Environment variables are stored and returned as configured, so anything placed there is readable by every principal who can describe the function and is copied into deployment logs, templates, and backups along the way.
+        This check verifies that no Function Compute function carries a credential in its environment variables.
+
+        Environment variables are stored and returned exactly as configured, so anything placed there is readable by every principal who can describe the function, and is copied into deployment logs, templates, and backups along the way. The check inspects both variable names and values, flagging names such as `access_key_id`, `access_key_secret`, `db_password`, `client_secret`, and `connection_string`, and values that look like an Alibaba Cloud AccessKey ID beginning with `LTAI`, a PEM private key block, or a JSON Web Token. Function environment variables are edited in the Function Compute console on the Configuration tab under Advanced Settings, or through `aliyun fc UpdateFunction`.
 
         **Why this matters**
 
-        - **Describe permission becomes credential access:** Reading a function's configuration is a low-privilege, rarely-audited action, so a secret there is far more reachable than one in a vault.
-        - **Secrets spread with the configuration:** Values appear in CI output, Terraform state, and change history, multiplying the places a leak can happen.
-        - **They outlive their purpose:** A credential pasted into an environment variable during development is rarely rotated or removed once the function ships.
+        Describe permission becomes credential access. Reading a function's configuration is a low-privilege, rarely audited action, so a secret sitting in an environment variable is far more reachable than the same secret held in a vault, and a principal who can inspect function configuration gains standing credentials by doing nothing more than looking.
 
-        **Risk mitigation**
+        Secrets spread with the configuration. The value turns up in CI output, Terraform state, and change history, multiplying the number of places a leak can originate and the number of systems that must be scrubbed once one happens.
 
-        - **Keeps secrets in a system built for them:** KMS Secrets Manager provides access control, rotation, and an audit trail that environment variables do not.
-        - **Shrinks the blast radius of read access:** A principal who can inspect function configuration no longer gains standing credentials by doing so.
+        Credentials placed in environment variables also outlive their purpose. A value pasted in during development is rarely rotated or removed once the function ships, so it keeps working indefinitely.
+
+        Store the value in KMS Secrets Manager instead, grant the function's RAM role permission to read it, and pass only the secret name in the environment so the function fetches the value at startup. Secrets Manager supplies the access control, rotation, and audit trail that environment variables cannot. After moving a credential, rotate the exposed value, because it has already been readable for as long as it was configured.
       audit: |
         ### Audit via Console
 
@@ -6307,18 +6361,19 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that no IPsec VPN connection negotiates DES or 3DES, for either the IKE key exchange or the IPsec payload. Both are obsolete: single DES has a 56-bit effective key, and 3DES is limited by its 64-bit block size, which makes it vulnerable to birthday attacks on long-lived connections. A site-to-site tunnel is exactly the long-lived, high-volume case where that matters.
+        This check verifies that IPsec VPN tunnels negotiate a modern block cipher, in both the IKE key exchange and the IPsec payload transform.
+
+        Single DES has a 56-bit effective key and is brute-forceable outright. 3DES escapes the key-length problem but is limited by its 64-bit block size, which exposes it to birthday attacks once enough data passes under one key, and a site-to-site tunnel is exactly the long-lived, high-volume case that reaches such a threshold. The algorithms are set per connection under **Interconnections** > **VPN** > **IPsec Connections** in the VPC console, or with `aliyun vpc ModifyVpnConnectionAttribute`; this check requires that neither `des` nor `3des` appears on either side.
 
         **Why this matters**
 
-        - **The tunnel carries everything between two networks:** A VPN connection typically fronts an entire site or data center, so weak cipher selection exposes all of that traffic at once.
-        - **Weak ciphers are chosen by default or by habit:** DES and 3DES survive in configurations copied from older peers and templates long after they stopped being appropriate.
-        - **Recorded traffic can be attacked later:** Ciphertext captured today remains attackable, so an obsolete cipher is a retroactive exposure, not just a present one.
+        A VPN connection usually fronts an entire site or data center rather than one service, so cipher selection here is not the property of a single application. Everything crossing between the two networks inherits it at once.
 
-        **Risk mitigation**
+        Weak ciphers persist by habit rather than by decision. `des` and `3des` are carried forward in configurations copied from older peers and vendor templates, and because the tunnel comes up and passes traffic, nothing ever prompts a review.
 
-        - **Puts the tunnel on modern cryptography:** AES with a 128-bit or larger key removes the practical attacks against DES and 3DES.
-        - **Protects both negotiation and payload:** Hardening the IKE exchange as well as the IPsec transform closes the weaker of the two halves.
+        Recorded ciphertext stays attackable. Traffic captured today can be decrypted whenever the effort becomes worthwhile, so an obsolete cipher is a retroactive exposure rather than only a present one. Moving both halves to AES with a 128-bit or larger key removes the practical attacks against DES and 3DES.
+
+        Changing the algorithm requires the matching change on the customer gateway at the far end, so plan the two together; a mismatch leaves the tunnel down rather than insecure. A companion check in this policy covers the Diffie-Hellman group that seeds these keys.
       audit: |
         ### Audit via Console
 
@@ -6453,18 +6508,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every IPsec VPN connection negotiates its keys with Diffie-Hellman group 14 or higher, and does not disable perfect forward secrecy. Groups 1, 2, and 5 use 768-, 1024-, and 1536-bit MODP primes; 1024-bit MODP is within reach of a well-resourced attacker who precomputes against the small number of primes in common use, which is exactly the situation a fixed standard group creates.
+        This check verifies that IPsec VPN connections agree their keys with a Diffie-Hellman group of 14 or higher and do not turn perfect forward secrecy off.
+
+        Groups 1, 2, and 5 use 768-, 1024-, and 1536-bit MODP primes. The 1024-bit prime is within reach of a well-resourced attacker who precomputes against the small set of primes in common use, which is precisely the situation a fixed standard group creates. The group is set for both the IKE and the IPsec phase under **Interconnections** > **VPN** > **IPsec Connections** in the VPC console, or with `aliyun vpc ModifyVpnConnectionAttribute`; this check rejects `group1`, `group2`, `group5`, and `disabled` on either side.
 
         **Why this matters**
 
-        - **A weak group undoes a strong cipher:** AES-256 protects nothing if the key that seeds it was derived from an exchange an attacker can break.
-        - **Standard groups are shared targets:** Precomputation against a widely reused prime is amortized across every connection that uses it.
-        - **Disabling forward secrecy makes it retroactive:** Without PFS, recovering one long-term key exposes traffic from every earlier session.
+        A weak group undoes a strong cipher. AES-256 protects nothing if the key seeding it came out of an exchange the attacker can solve, and the tunnel gives no outward sign that the weaker of its two halves is the one that decides the outcome.
 
-        **Risk mitigation**
+        Standard groups are shared targets rather than per-connection ones. The expensive work of precomputing against a widely reused prime is paid once and amortized across every connection in the world that negotiated it, so choosing a common small group hands an attacker a discount that your specific traffic did nothing to earn. Group 14 and above keep the discrete-logarithm problem infeasible at realistic attacker budgets.
 
-        - **Puts key agreement out of practical reach:** Group 14 and above keep the discrete-logarithm problem infeasible at realistic attacker budgets.
-        - **Contains any single key compromise:** Rekeying with fresh material means a recovered key does not decrypt past traffic.
+        Disabling forward secrecy makes any key compromise retroactive. Without it, recovering a single long-term key exposes traffic from every earlier session that key protected, while rekeying with fresh material confines a compromise to one session.
+
+        Alibaba Cloud's documented default for both the IKE and the IPsec group is `group2`, which this check rejects, so a connection leaving its configuration blocks out fails rather than passing quietly. Raising the group also requires the matching change on the customer gateway at the far end.
       audit: |
         ### Audit via Console
 
@@ -6640,18 +6696,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no network ACL has an ingress rule accepting traffic from `0.0.0.0/0` on every protocol, on every port, or on SSH (22) or RDP (3389). A network ACL is the subnet-level filter that sits in front of every security group in the vSwitches it is bound to, so a permissive entry here quietly re-opens what the security groups were written to close.
+        This check verifies that the subnet-level filter in front of a VPC does not accept administrative traffic from the whole internet.
+
+        A network ACL is bound to vSwitches and evaluated ahead of the security groups attached to the instances inside them, so whatever it accepts reaches everything in those subnets. The check fails an inbound entry whose policy is `accept` and whose source is `0.0.0.0/0` when it covers every protocol, every port through `-1/-1`, or a TCP range containing SSH on port 22 or RDP on port 3389. Entries live under **Access Control** > **Network ACL** in the VPC console and are replaced with `aliyun vpc UpdateNetworkAclEntries`.
 
         **Why this matters**
 
-        - **It applies to a whole subnet at once:** One accepting entry covers every instance in every vSwitch the ACL is bound to, present and future.
-        - **It is reviewed less often than security groups:** Teams audit security groups routinely and network ACLs rarely, so a permissive entry survives longer.
-        - **A rule spanning a port opens it:** An entry written as `1/1024` opens SSH just as surely as one written `22/22`, which makes literal-port review unreliable.
+        One accepting entry covers a whole subnet at once, every instance in every vSwitch the ACL is bound to, including instances created long after the entry was written. A permissive ACL quietly re-opens exactly what the security groups underneath it were written to close.
 
-        **Risk mitigation**
+        Network ACLs are also reviewed far less often than security groups. Teams audit security groups as routine hygiene and rarely open the ACL list at all, so a permissive entry added during a migration survives long after everyone who understood it has moved on.
 
-        - **Restores the subnet boundary:** Only named source ranges reach management ports, whatever the security groups say.
-        - **Gives defense in depth:** A security group loosened by mistake is still backed by the ACL in front of it.
+        A rule spanning a port opens it as surely as a rule naming it. An entry written `1/1024` publishes SSH just as `22/22` does, which is why review by eye for literal port numbers is unreliable and why this check tests range containment rather than exact matches.
+
+        Scoped entries restore the subnet boundary and give real defense in depth, since a security group loosened by mistake is still backed by the ACL in front of it. An entry publishing a port the service is genuinely meant to serve, such as `443` from `0.0.0.0/0`, is expected and passes.
       audit: |
         ### Audit via Console
 
@@ -6802,18 +6859,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every secret held in KMS Secrets Manager rotates automatically. A secret with rotation set to `Disabled` or `Suspended` keeps the same value indefinitely, so the window in which a copy taken from a log, a backup, or a developer's machine still works never closes on its own.
+        This check verifies that every secret held in KMS Secrets Manager rotates automatically.
+
+        A secret whose rotation state is `Disabled` or `Suspended` keeps the same value indefinitely, so the window in which a copy taken from a log, a backup, or a developer's machine still works never closes on its own. Rotation is configured in the KMS console under Resource and then Secrets, by opening the secret, choosing Configure Rotation, and setting an automatic rotation interval. The same policy is set with `aliyun kms UpdateSecretRotationPolicy --EnableAutomaticRotation true`, or in Terraform with `enable_automatic_rotation` and a `rotation_interval`.
 
         **Why this matters**
 
-        - **Secrets leak through copies, not the vault:** The value reaches application logs, CI output, and local environments; rotation is what makes those copies stop working.
-        - **A static secret has an unbounded compromise window:** Without rotation, an attacker who obtains the value keeps access until somebody notices, which may be never.
-        - **Suspended rotation looks configured:** A suspended schedule reads as "rotation is set up" in a console review while nothing actually rotates.
+        Secrets leak through copies, not through the vault. The value reaches application logs, CI output, and local development environments, and rotation is the mechanism that makes those scattered copies stop working. Without it, a stolen value keeps working until somebody notices, which may be never.
 
-        **Risk mitigation**
+        A static secret therefore has an unbounded compromise window. An attacker who obtains the value once retains the access it grants for as long as the secret exists, and nothing in the account marks the moment that access should have ended.
 
-        - **Puts an expiry on every leaked copy:** A stolen value stops working at the next rotation whether or not the theft was detected.
-        - **Exercises the rotation path:** Regular automatic rotation proves consumers handle a changing value, so an emergency rotation during an incident is not the first attempt.
+        A suspended rotation schedule is the worst of both states, because it looks configured. It reads as "rotation is set up" during a console review while nothing is actually rotating, so the gap survives exactly the kind of inspection meant to catch it.
+
+        Regular automatic rotation also exercises the rotation path itself. Consumers are proven to handle a changing value under normal conditions, so an emergency rotation during an incident is not the first attempt. Choose an interval that matches the sensitivity of the value, and confirm that every consumer reads the secret at use rather than caching it at deployment.
       audit: |
         ### Audit via Console
 
@@ -6913,18 +6971,19 @@ queries:
     impact: 70
     docs:
       desc: |
-        This check ensures that every secret in KMS Secrets Manager is encrypted under a customer master key rather than the service default. A customer master key gives the account its own key policy, rotation schedule, and audit trail for the material that protects the secret value.
+        This check verifies that secrets in KMS Secrets Manager are encrypted under a customer master key rather than the service default.
+
+        A customer master key gives the account its own key policy, rotation schedule, and audit trail for the material that protects the secret value, none of which the account controls when the service default is used. The key is chosen when the secret is created, in the KMS console under Resource and then Secrets, with `aliyun kms CreateSecret --EncryptionKeyId <cmk-id>`, or through the `encryption_key_id` argument in Terraform.
 
         **Why this matters**
 
-        - **Key policy becomes a second gate:** With a customer master key, reading a secret needs both Secrets Manager permission and permission on the key, so a single over-broad grant is no longer sufficient.
-        - **Key use is logged separately:** Decrypt operations against the key appear in the key's own audit trail, giving a record of access that Secrets Manager permissions alone do not produce.
-        - **Revocation becomes possible:** Disabling the key makes every secret it protects unreadable at once, which is the fastest containment step during an incident.
+        The key policy becomes a second gate. With a customer master key, reading a secret requires both Secrets Manager permission and permission on the key itself, so a single over-broad grant on Secrets Manager is no longer sufficient to read the value. Secret administration and key administration can also be held by different principals, which turns a single compromised identity into an incomplete one.
 
-        **Risk mitigation**
+        Key use is logged separately. Decrypt operations against a customer master key appear in the key's own audit trail, producing a record of access that Secrets Manager permissions alone do not generate, and giving investigators a second, independent view of who read what.
 
-        - **Puts key control in the account:** Rotation and disablement are decisions the account owner makes rather than the service.
-        - **Separates duties:** Secret administration and key administration can be held by different principals.
+        Revocation becomes possible. Disabling the key makes every secret it protects unreadable at once, which is often the fastest containment step available during an incident. Rotation and disablement become decisions the account owner makes rather than decisions delegated to the service.
+
+        The encryption key of a secret cannot be changed after creation, so remediating an existing secret means creating a replacement under the intended key, repointing consumers at it, deleting the original, and rotating the value. Treat the rotation as mandatory rather than optional, since the old value was protected by material the account never controlled.
       audit: |
         ### Audit via Console
 
@@ -7024,18 +7083,17 @@ queries:
     impact: 80
     docs:
       desc: |
-        This check ensures that every Apsara File Storage NAS file system is encrypted at rest. Encryption is chosen when the file system is created and cannot be turned on afterwards, so an unencrypted file system stays that way until its contents are copied to a new one.
+        This check verifies that encryption at rest is in force on every Apsara File Storage NAS file system.
+
+        NAS encrypts data on the underlying media and in snapshots when the file system is created, and that choice is fixed at that moment. There is no console switch to turn it on later, so an unencrypted file system stays unencrypted until its contents are copied to a new one. New file systems select it in the **File System List** area of the NAS console, or through `EncryptType` on `aliyun nas CreateFileSystem`.
 
         **Why this matters**
 
-        - **Shared file systems accumulate everything:** A NAS mount is written to by many hosts over a long life, so its contents are broader and older than any single application's data.
-        - **Encryption at rest covers the storage layer:** It protects the data on the underlying media and in snapshots, where POSIX permissions and mount targets no longer apply.
-        - **The decision is permanent:** Because it cannot be changed later, an unencrypted file system requires a full copy to remediate.
+        A shared file system accumulates everything. It is written to by many hosts over a long life, so its contents end up broader and older than any single application's data, and whoever eventually reads that media has no way to know which generation of the business it belongs to.
 
-        **Risk mitigation**
+        Encryption at rest covers the layer where the other controls stop. POSIX permissions and mount targets govern live access through the NFS path; they say nothing about the physical storage or about a snapshot restored somewhere else. Encryption is what keeps those artifacts as ciphertext rather than readable files, and it is an explicit expectation of most regimes covering personal or regulated data.
 
-        - **Removes plaintext at rest:** Media and snapshots yield ciphertext rather than readable files.
-        - **Supports data-protection obligations:** Encryption at rest is an explicit expectation of most regimes covering personal or regulated data.
+        The permanence is what makes this worth catching early. Remediating an existing file system means creating an encrypted replacement, copying the contents across, repointing every mount target, and deleting the original, which is a maintenance window rather than a setting change. Catching it at declaration time, before any data lands, costs nothing.
       audit: |
         ### Audit via Console
 
@@ -7138,18 +7196,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no custom ECS image owned by the account is published to every Alibaba Cloud user. A public custom image can be launched by anyone in any account, and its disk contents are readable by whoever launches it.
+        This check verifies that custom images owned by the account are shared deliberately rather than published to every Alibaba Cloud user.
+
+        A custom image is a full copy of a disk, and publishing it as a community image makes it launchable by anyone in any account. Whoever launches it can then read everything the image contains. Publication status is reviewed in the ECS console under **Instances & Images** > **Images** on the **Custom Images** tab, and it is reversed with `aliyun ecs ModifyImageSharePermission --IsPublic false`. Only images the account itself owns are evaluated; marketplace and vendor images are out of scope.
 
         **Why this matters**
 
-        - **Images capture whatever was on the disk:** Golden images routinely carry configuration files, deployment keys, agent credentials, and application source that were never meant to leave the account.
-        - **Publishing is a one-way door in practice:** Once an image has been public, copies may already exist in other accounts, and un-publishing does not recall them.
-        - **It is easy to do by accident:** Sharing is a separate call from image creation, so an image made public during a migration or a partner hand-off is rarely reviewed again.
+        Golden images capture whatever happened to be on the disk when they were taken. In practice that routinely includes configuration files, deployment keys, agent credentials, and application source that were never intended to leave the account, none of which is obvious from the image name.
 
-        **Risk mitigation**
+        Publishing is a one-way door in practice. Once an image has been public, copies may already exist in other accounts, and un-publishing does not recall them; anything sensitive the image carried has to be treated as exposed and rotated.
 
-        - **Keeps disk contents inside the account:** Only principals in the account, or accounts explicitly named, can launch from the image.
-        - **Preserves attribution:** Sharing with named accounts leaves a record of who was granted access and when.
+        It is also easy to do without noticing. Sharing is a separate call from image creation, so an image made public during a migration or a partner hand-off is rarely revisited, and nothing about day-to-day use of the image signals that it is world-readable.
+
+        Where an image genuinely needs to reach another team or partner, share it with named account IDs instead. That keeps the disk contents inside a known boundary and leaves a record of who was granted access and when, which blanket publication does not.
       audit: |
         ### Audit via Console
 
@@ -7217,18 +7276,19 @@ queries:
     impact: 85
     docs:
       desc: |
-        This check ensures that no enabled Cloud Firewall inbound policy accepts every protocol from every source to every destination. Cloud Firewall is the account's internet-edge filter; a single accept-any rule there means the edge enforces nothing and every downstream security group and network ACL is on its own.
+        This check verifies that the account's internet-edge filter actually filters, failing any enabled inbound Cloud Firewall policy that accepts every protocol from every source to every destination.
+
+        Cloud Firewall control policies are the allow and deny list applied to traffic crossing the account boundary. A policy whose direction is inbound, whose action is `accept`, whose protocol is `ANY`, and whose source and destination are both `0.0.0.0/0` permits everything the edge sees. Inbound policies live under **Prevention Configuration** > **Access Control** > **Policy Configuration** > **Internet Border** in the Cloud Firewall console, and `aliyun cloudfw ModifyControlPolicy` narrows one from the command line.
 
         **Why this matters**
 
-        - **It negates the control it belongs to:** Buying and enabling Cloud Firewall and then accepting everything leaves the account with the cost and none of the protection.
-        - **It is invisible in downstream reviews:** An auditor checking security groups sees a well-scoped configuration and no sign that the edge in front of them is wide open.
-        - **Accept-any rules are added as temporary fixes:** They are the fastest way to unblock a broken deployment and among the least likely to be removed afterwards.
+        Such a rule negates the control it belongs to. The account pays for a boundary firewall, enables it, then instructs it to permit everything, which leaves the cost in place and the protection absent, and every downstream security group and network ACL on its own.
 
-        **Risk mitigation**
+        It is also close to invisible in downstream reviews. An auditor examining security groups finds a carefully scoped configuration and sees nothing to suggest the edge in front of them was told to wave traffic through, so the finding never surfaces where people are actually looking.
 
-        - **Restores the edge as a real boundary:** Traffic must match a specific protocol, port, and source to reach the account at all.
-        - **Makes exceptions explicit:** Every permitted flow is a named rule that can be reviewed and expired.
+        Accept-any rules arrive as temporary fixes. They are the fastest way to unblock a deployment that will not come up, they are typically added under time pressure by someone chasing a connectivity problem, and they are among the least likely changes to be undone once the immediate problem goes away.
+
+        A scoped policy naming a protocol, destination port, and source range restores the edge as a real boundary and makes every permitted flow a named rule that can be reviewed and expired. A policy must name either a single application or an application list, so `ApplicationName` is mandatory when narrowing a rule through the API.
       audit: |
         ### Audit via Console
 


### PR DESCRIPTION
Rewrites all 66 check descriptions in `content/mondoo-alibaba-security.mql.yaml` to the description shape in `content/CLAUDE.md`. Prose only.

## What changed structurally

| Before | After |
|---|---|
| Opener often restated the title | Opener begins with the literal `This check` and names a **security capability**, not the resource |
| Setting rarely located | A paragraph naming the Alibaba Cloud console path, the `aliyun` CLI command, or the API action, plus the value the check requires |
| `**Why this matters**` was a bulleted list with bold lead-in labels | Two to four **prose paragraphs**, keeping the substance of every bullet |
| `**Risk mitigation**` heading with a second bulleted list | Heading **removed**; its substance folded into the Why prose or the closing paragraph |
| No statement of scope | Closing paragraph on when the control does not apply, what to pair it with, or what the check deliberately does not assert |
| Nothing | House style enforced: no em/en dashes, no ` -- `, no parenthetical asides beyond acronym expansion on first use, US spelling, no MQL accessor paths, no check UIDs in prose |

Word counts: min 248, max 310, average 284.

## Specifics were preserved, not replaced

This policy's descriptions were already good, so the pass was a structural conversion plus sharpening rather than a replacement. Example, `mondoo-alibaba-security-fc-function-no-credentials-in-env`:

**Before**

> This check ensures that no Function Compute function carries a credential in its environment variables. Environment variables are stored and returned as configured, so anything placed there is readable by every principal who can describe the function and is copied into deployment logs, templates, and backups along the way.
>
> **Why this matters**
>
> - **Describe permission becomes credential access:** Reading a function's configuration is a low-privilege, rarely-audited action, so a secret there is far more reachable than one in a vault.
> - **Secrets spread with the configuration:** Values appear in CI output, Terraform state, and change history, multiplying the places a leak can happen.
> - **They outlive their purpose:** A credential pasted into an environment variable during development is rarely rotated or removed once the function ships.
>
> **Risk mitigation**
>
> - **Keeps secrets in a system built for them:** KMS Secrets Manager provides access control, rotation, and an audit trail that environment variables do not.
> - **Shrinks the blast radius of read access:** A principal who can inspect function configuration no longer gains standing credentials by doing so.

**After**

> This check verifies that no Function Compute function carries a credential in its environment variables.
>
> Environment variables are stored and returned exactly as configured, so anything placed there is readable by every principal who can describe the function, and is copied into deployment logs, templates, and backups along the way. The check inspects both variable names and values, flagging names such as `access_key_id`, `access_key_secret`, `db_password`, `client_secret`, and `connection_string`, and values that look like an Alibaba Cloud AccessKey ID beginning with `LTAI`, a PEM private key block, or a JSON Web Token. Function environment variables are edited in the Function Compute console on the Configuration tab under Advanced Settings, or through `aliyun fc UpdateFunction`.
>
> **Why this matters**
>
> Describe permission becomes credential access. Reading a function's configuration is a low-privilege, rarely audited action, so a secret sitting in an environment variable is far more reachable than the same secret held in a vault, and a principal who can inspect function configuration gains standing credentials by doing nothing more than looking.
>
> Secrets spread with the configuration. The value turns up in CI output, Terraform state, and change history, multiplying the number of places a leak can originate and the number of systems that must be scrubbed once one happens.
>
> Credentials placed in environment variables also outlive their purpose. A value pasted in during development is rarely rotated or removed once the function ships, so it keeps working indefinitely.
>
> Store the value in KMS Secrets Manager instead, grant the function's RAM role permission to read it, and pass only the secret name in the environment so the function fetches the value at startup. Secrets Manager supplies the access control, rotation, and audit trail that environment variables cannot. After moving a credential, rotate the exposed value, because it has already been readable for as long as it was configured.

Every bullet survives as prose, the `**Risk mitigation**` content became the closing paragraph, and the new text adds the concrete detection patterns and the console location that the old text left out.

The same discipline applied throughout. Retained verbatim: the Cloud SSO `Enabled`/`Byp`/`Disabled` tri-state, the `acs:*:*:*:*` wildcard with its `NotAction`/`NotResource` carve-out, the `EventRW` and `TrafficType` values of `All`, the `31536000s` rotation interval, the `Disabled`/`Suspended` secret rotation states, the 56-bit DES key and the 3DES 64-bit block size, the 768/1024/1536-bit MODP primes of Diffie-Hellman groups 1, 2 and 5, the `1/1024` port-range example for network ACLs, the `tlsv1`/`tlsv1.1` WAF floor, the `RDWR`/`RDONLY` NAS permissions, the `0.0.0.0/0` and `::/0` literals, and the 90-day and 14-character thresholds.

Near-identical siblings were made distinct rather than duplicated. The four security-group checks now argue from their own protocol and threat, the four TDE checks describe what each engine actually persists, and the three database allowlist checks name their own allowlist mechanism and console path.

## Nothing but `docs.desc` changed

No `mql`, `filters`, `tags`, `impact`, `props`, `title`, `audit`, or `remediation` was modified. Proven mechanically: parse the bundle at `origin/main` and at this branch tip, replace every `docs.desc` and the `policies[].version` with a placeholder, and assert the trees are equal.

```
STRUCTURAL DIFF: trees identical apart from docs.desc and policy version
```

The policy `version` moves `1.2.0` to `1.2.1`, one PATCH level.

## Validation

| Gate | Result |
|---|---|
| `cnspec policy lint content/mondoo-alibaba-security.mql.yaml` | valid policy bundle(s) |
| `typos` | no output |
| `go test ./internal/bundle/...` | ok |
| Openers not starting `This check` | 0 of 66 |
| Missing `**Why this matters**` | 0 of 66 |
| `—`, `–`, or ` -- ` | 0 |
| `**Risk mitigation**` remaining | 0 |
| MQL accessor paths in prose | 0 |
| Bullet lines in descriptions | 0 |
| Byte-identical sibling descriptions | 0 |
| Parentheticals that are not acronym expansions | 0 |
| Substance audit: specifics in the old text absent from the new | 0 real losses |

The substance audit flags five acronym tokens (`SSRF`, `OSS`, `OIDC`, `PFS`) and the shorthand `*/*`. In each case the expanded form is present instead: "server-side request forgery", "Object Storage Service", "OpenID Connect", "perfect forward secrecy", and for the wildcard policy the precise `Action` `*` with `Resource` `*` or `acs:*:*:*:*`. No fact was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
