### PR TITLE
📝 oci: rewrite check descriptions as prose

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.6.0
+    version: 4.6.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -213,20 +213,19 @@ queries:
       oci.identity.user.mfaActivated == true
     docs:
       desc: |
-        This check ensures that every active IAM user in the OCI tenancy is enrolled in multi-factor authentication. By default OCI does not enforce MFA enrollment, leaving accounts protected only by passwords until an administrator or the user explicitly activates a second factor.
+        This check verifies that multi-factor authentication is activated for every user in the active lifecycle state.
+
+        Multi-factor authentication in OCI binds a Console sign-in to a registered TOTP authenticator app in addition to the account password. Enrollment is never automatic. OCI creates users with password authentication alone, and the account stays single-factor until the user or an administrator registers a device under Identity & Security > Domains > Users, so a tenancy that has never run an enrollment campaign is a tenancy where every account is one stolen password away from being used.
 
         **Why this matters**
 
-        - **Credential theft protection:** Passwords alone are vulnerable to phishing, brute-force, and credential-stuffing attacks, all of which MFA defeats at the authentication step.
-        - **Blast-radius reduction:** A compromised password cannot be used to access the OCI Console or APIs without the enrolled second factor, limiting the impact of a stolen credential.
-        - **Privileged account security:** Administrative users who can modify IAM, networking, or compute configurations represent the highest-value targets, and MFA raises the cost of attacking those accounts significantly.
-        - **Audit trail integrity:** MFA-protected logins produce stronger assurance that activity records in audit logs correspond to the legitimate account owner.
+        A password is a replayable secret. A phishing page, a credential-stuffing run against a password reused from a breached site, and offline brute force against a leaked hash all end the same way, with an attacker holding a string that signs in. A registered second factor defeats all three at the authentication step, because the stolen string no longer completes a login on its own.
 
-        **Risk mitigation**
+        The accounts worth enrolling first are the ones that can rewrite the environment. A member of the `Administrators` group, or of any group holding `allow group <group> to manage all-resources in tenancy`, can attach policies, mint API signing keys for other identities, open security lists, and read storage in every compartment. One compromised administrator password is a full tenancy takeover, so this is where a second factor buys the most.
 
-        - **Enforce enrollment for all active users:** Require every active user to register a TOTP-based authenticator before granting access to protected resources.
-        - **Prioritize privileged identities:** Begin enforcement with administrator and operator accounts, where the impact of compromise is greatest.
-        - **Monitor MFA status continuously:** Audit MFA enrollment across all active users regularly and alert on any account where enrollment lapses.
+        MFA also gives the audit trail meaning. Without it, a log entry asserts only that someone knew a password. With it, the sign-in carries far stronger assurance that the recorded principal really was the account owner, which is exactly the assurance an incident investigation runs on.
+
+        Enroll administrators and operators first, extend to the remaining active users, and audit enrollment continuously so an account whose device registration lapses is caught rather than quietly falling back to a password alone.
       audit: |
         ### Audit via Console
 
@@ -302,19 +301,19 @@ queries:
       oci.identity.user.emailVerified == true
     docs:
       desc: |
-        This check ensures that every active IAM user with an email address on file has completed the email verification step. OCI records an email for a user when it is set, but the address remains unverified until the user confirms ownership through a verification link.
+        This check verifies that every active user carrying an email address has proven ownership of that address.
+
+        OCI stores a user's email as soon as an administrator or the user sets it, and tracks separately whether the address has been verified. Verification completes only when the recipient follows the confirmation link OCI mails out, so until then the attribute is present but unproven. Administrators review the state and resend the confirmation from Identity & Security > Domains > Users. The check looks at users in the active state that actually have an address on file and requires the verified flag to be set.
 
         **Why this matters**
 
-        - **Account recovery reliability:** Password-reset and account-recovery notifications are delivered by email; an unverified address means those messages may never reach the intended recipient.
-        - **Security alert delivery:** OCI sends alerts about suspicious sign-in activity and policy changes to the user's registered email; unverified addresses silently drop these notifications.
-        - **Orphaned identity indicator:** An active account with an unverified email often signals that the user never completed setup, which may mean the account was created for a person who no longer works with the organization.
+        Email is the account recovery channel. Password reset links and one-time codes are delivered to the recorded address, so an unverified address means a locked-out user may be unable to self-recover, and it leaves open the worse possibility that recovery mail is arriving at an address the organization does not control and cannot audit.
 
-        **Risk mitigation**
+        It is also the security notification channel. OCI mails users about suspicious sign-in activity and about identity changes affecting their account. An unverified address drops those messages silently. Nothing bounces, nobody escalates, and the first visible sign of a compromised account becomes whatever the attacker chooses to do with it.
 
-        - **Require verification at account creation:** Make email verification a mandatory step in your user onboarding workflow so no account enters active status with an unverified address.
-        - **Audit periodically:** Review active users for unverified addresses on a regular schedule and contact affected users to complete verification.
-        - **Disable unresolved accounts:** Deactivate accounts whose email addresses remain unverified after a defined grace period to reduce the dormant-identity attack surface.
+        An unverified address on an active account is a useful signal in its own right. It usually means the person never finished setup, which frequently means the account was provisioned for someone who never started or who left before completing onboarding. What remains is an active identity holding whatever group memberships it was given, with no owner reading anything OCI sends about it.
+
+        Make verification a required step of onboarding so no account reaches active status unproven, review active users for unverified addresses on a schedule, and deactivate accounts that remain unverified past a defined grace period rather than letting them accumulate.
       audit: |
         ### Audit via Console
 
@@ -392,20 +391,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no IAM policy contains a statement granting `manage all-resources in tenancy`, which conveys unrestricted administrative control over every resource across the entire OCI tenancy. OCI ships without this statement by default; it must be explicitly written, and any policy that includes it gives the assigned group full read-write-delete access to every service and every compartment.
+        This check verifies that no IAM policy grants unrestricted administrative control across the entire tenancy.
+
+        OCI policies are written as statements in a sentence-like language rather than as JSON documents. A statement reads `allow group <group> to <verb> <resource-type> in <scope>`, where the verb is `inspect`, `read`, `use`, or `manage` in increasing order of power. The statement rejected here is `allow group <group> to manage all-resources in tenancy`, combining the strongest verb, the widest resource type, and the root scope in one line. A new tenancy carries no such grant outside the built-in policy for `Administrators`, so it must be written deliberately, under Identity & Security > Policies, through `oci iam policy update`, or from Terraform, which this check also inspects as configuration, plan, and state.
 
         **Why this matters**
 
-        - **Unlimited blast radius:** A user or service principal bound to this policy can create, modify, or delete any resource in any compartment, including IAM configurations, network infrastructure, and stored data.
-        - **Least-privilege violation:** Granting more permission than a role requires makes it impossible to contain the damage from a compromised account or a misconfigured automation credential.
-        - **Audit complexity:** Broad policies obscure who can do what, making it difficult to produce accurate access reports for audits or incident investigations.
-        - **Lateral and vertical movement:** An attacker who gains access to a group holding this policy has immediate tenancy-wide privilege escalation with no further steps required.
+        Scope in OCI inherits downward. `in tenancy` is not simply a larger compartment than `in compartment X`; it is the root, so the grant reaches every compartment beneath it, including compartments created later. A group holding it can create, modify, and delete any resource of any type anywhere: users and policies, VCNs and security lists, block volumes, Object Storage buckets, and databases.
 
-        **Risk mitigation**
+        That makes such a policy an escalation terminus. An attacker who phishes one member of the group, or who finds an API signing key belonging to one, is already a tenancy administrator with no further pivot to perform and no compartment boundary left to cross. An automation credential attached to the group by convenience carries the same reach.
 
-        - **Replace with compartment-scoped policies:** Define policies that grant access to specific resource families inside named compartments rather than across the entire tenancy.
-        - **Use resource-type specificity:** Prefer statements like `manage instance-family` or `manage virtual-network-family` over `manage all-resources` to align permissions with each group's actual responsibilities.
-        - **Review periodically:** Audit IAM policies at the tenancy level on a regular cadence and remove or narrow any statement that grants broader access than the current workload requires.
+        Broad grants also destroy the readability of access. When a single policy answers yes to everything, an access review cannot state which team reaches which data, and an investigation cannot narrow who was capable of a given change.
+
+        Grant the resource families a group actually operates, inside the compartments it owns, using statements such as `manage instance-family` or `manage virtual-network-family` in a named compartment. Review tenancy-level policies regularly and narrow anything broader than the current workload requires.
       audit: |
         ### Audit via Console
 
@@ -542,19 +540,19 @@ queries:
       oci.identity.user.apiKeys.none(state == "ACTIVE")
     docs:
       desc: |
-        This check ensures that IAM users in an inactive lifecycle state have no API keys in the active state. OCI marks a user as inactive when an administrator changes the account state, but it does not automatically revoke or deactivate credentials associated with that account, leaving API keys fully functional even after the user is deactivated.
+        This check verifies that programmatic credentials are revoked when a user account is deactivated, by requiring that users outside the active lifecycle state hold no API signing key in the active state.
+
+        An OCI API signing key is an RSA key pair. The public half is uploaded against the user and identified by fingerprint, and the private half signs every REST API and SDK request that user makes. Deactivating the user changes the account lifecycle state and blocks Console sign-in, but it does nothing to the keys. They stay listed against the account and stay usable. Removing them is a separate action, taken under Identity & Security > Domains > Users on the user's API keys, or with `oci iam user api-key delete` against the key fingerprint.
 
         **Why this matters**
 
-        - **Orphaned programmatic access:** Active API keys on an inactive account provide a working credential path to OCI APIs even though the human identity behind that account no longer has authorized access.
-        - **Undetected compromise window:** Attackers who obtain a leaked API key from a deactivated user may use it for extended periods before anyone notices, because inactive accounts rarely appear in routine access reviews.
-        - **Credential hygiene:** Industry security frameworks require that access credentials be revoked immediately when an identity is deprovisioned; active keys on inactive accounts represent a direct gap in that requirement.
+        An active key on a deactivated account is a working credential for an identity that is supposed to have no access. Every policy that once applied to that user still applies to requests signed by the key, so the API path stays fully open while the Console path looks closed. Whoever last held the private key, a departed employee, a decommissioned build agent, or an attacker who copied it earlier, keeps that access.
 
-        **Risk mitigation**
+        The exposure is also unusually long-lived. Deactivated accounts drop out of the reviews that focus on active users, so nobody is looking. A leaked key belonging to a deactivated identity can be exercised for months before anyone connects the API activity to an account everyone believed was shut down.
 
-        - **Revoke credentials at deactivation:** Incorporate API key deletion into the user deactivation workflow so credentials are removed at the same time the account state changes.
-        - **Automate offboarding checks:** Use automated scanning to detect and alert on any active credential associated with a non-active user account.
-        - **Review regularly:** Audit API key state across all users, not just active ones, to catch credentials that were missed during offboarding.
+        Frameworks that govern identity lifecycle require credentials to be revoked at deprovisioning, not merely disabled at the sign-in surface. An active key on an inactive account is a direct, demonstrable gap against that requirement.
+
+        Fold key deletion into the deactivation runbook so both happen together, and enumerate credentials across all users rather than only active ones, which is the only way to find the keys earlier offboardings missed.
       audit: |
         ### Audit via Console
 
@@ -626,19 +624,19 @@ queries:
       oci.identity.user.authTokens.none(state == "ACTIVE")
     docs:
       desc: |
-        This check ensures that IAM users in an inactive lifecycle state have no authentication tokens in the active state. Like API keys, auth tokens remain functional after an account is deactivated unless they are explicitly deleted, because OCI does not automatically revoke credentials when user state changes.
+        This check verifies that token credentials are revoked at deprovisioning, by requiring that users outside the active lifecycle state hold no auth token in the active state.
+
+        An OCI auth token is an Oracle-generated password string used where request signing is not an option, notably for `docker login` against Container Registry, for the Swift API in front of Object Storage, and for service integrations such as Autonomous Database. The token value is displayed once at creation and never again, and each user may hold at most two. Deactivating the account leaves those tokens in place and usable. Deleting them is a separate step, taken on the user under Identity & Security > Domains > Users or with `oci iam auth-token delete`.
 
         **Why this matters**
 
-        - **Persistent API access path:** Authentication tokens provide programmatic access to OCI services including Object Storage; an active token on an inactive account is a fully functional credential that bypasses the account deactivation.
-        - **Silent exposure:** Auth tokens are not visible in routine user-facing dashboards, making them easier to overlook during offboarding than other credential types.
-        - **Offboarding gap:** Failing to remove tokens when deactivating a user leaves a residual access path that contradicts the intent of the deactivation and creates compliance exposure.
+        An active token on an inactive account is a fully functional bearer credential that walks straight past the deactivation. Anything the token was minted for still works: pushing and pulling images from a registry, listing and downloading buckets over Swift. Unlike a signing key, a token needs no private file to be useful, so a copy pasted into a pipeline variable or a wiki page is immediately usable by whoever reads it.
 
-        **Risk mitigation**
+        Tokens are also the credential type most often missed. They do not appear in the user-facing dashboards people check during offboarding, and because the secret was shown only once, it typically lives inside a CI system or a container build rather than anywhere identity administrators look. The account is closed, the reviewer sees nothing, and the token keeps authenticating.
 
-        - **Delete tokens at deactivation:** Add auth token deletion to your standard user offboarding checklist so tokens are removed at the same time the account is deactivated.
-        - **Automate credential cleanup:** Implement scripts or lifecycle automation that enumerate and remove active tokens from any account transitioning to an inactive state.
-        - **Audit inactive accounts regularly:** Periodically list all credentials associated with inactive users and remove any that remain active.
+        Leaving them behind directly contradicts the intent of the deactivation and creates compliance exposure, since the identity is recorded as deprovisioned while a working credential for it remains.
+
+        Add token deletion to the offboarding checklist alongside key revocation, automate enumeration and removal for any account transitioning out of the active state, and periodically list credentials on inactive accounts to catch what earlier passes left behind.
       audit: |
         ### Audit via Console
 
@@ -723,20 +721,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets are configured with a `NoPublicAccess` access type, preventing anonymous read or listing of bucket contents from the internet. The OCI default when creating a bucket is `NoPublicAccess`, but the setting can be changed to `ObjectRead` or `ObjectReadWithoutList`, which expose object data publicly.
+        This check verifies that anonymous, unauthenticated access to an Object Storage bucket is disabled by requiring the public access type `NoPublicAccess`.
+
+        Every bucket carries a public access type that decides whether a caller must prove who it is. `NoPublicAccess` forces each request to present a signed identity that IAM then authorizes. `ObjectRead` lets anyone on the internet both list the bucket and download its objects, and `ObjectReadWithoutList` still serves object data to anonymous callers while withholding only the listing. New buckets are created as `NoPublicAccess`, so a public bucket is always a deliberate change. Restore it under Storage > Buckets on the bucket detail page, or run `oci os bucket update --namespace <namespace> --name <bucket> --public-access-type NoPublicAccess`.
 
         **Why this matters**
 
-        - **Data exposure prevention:** A publicly accessible bucket allows any internet user to retrieve stored objects without authentication, which can expose sensitive files, credentials, backups, or application data.
-        - **Automated discovery risk:** Scanning tools continuously enumerate cloud storage endpoints for publicly accessible buckets, meaning misconfigured buckets are found quickly by adversaries.
-        - **Accidental misconfiguration:** Visibility settings are easy to change inadvertently during bucket management, and without continuous enforcement, a single change can expose an entire bucket's contents.
-        - **Regulatory compliance:** Regulations including GDPR, HIPAA, and PCI DSS require that access to personal and payment data be restricted to authorized parties; a public bucket directly violates those controls.
+        A publicly accessible bucket hands any internet user the stored objects without authentication. In practice that means sensitive files, credentials, backups, and application data leave the tenancy with no record of who took them and no way to revoke what was already copied.
 
-        **Risk mitigation**
+        Object Storage endpoints are predictable. Bucket names are unique within a tenancy namespace and region, so once an attacker learns your namespace they can grind candidate names against a fixed URL pattern. Scanning tools do exactly this continuously, which is why a bucket that turns public is found in hours rather than months.
 
-        - **Default to private:** Set all new buckets to `NoPublicAccess` and treat any deviation as a change that requires documented business justification.
-        - **Use pre-authenticated requests for sharing:** Grant time-limited, scoped access to individual objects via pre-authenticated request URLs rather than making entire buckets public.
-        - **Audit access types continuously:** Regularly enumerate all buckets and alert on any bucket whose access type deviates from `NoPublicAccess`.
+        Visibility is also easy to flip by accident during routine bucket management, and one such change exposes an entire bucket's contents at once. GDPR, HIPAA, and PCI DSS all require access to personal and payment data to be restricted to authorized parties, and a public bucket violates that outright.
+
+        When something genuinely must be shared outside the tenancy, issue a pre-authenticated request instead. It grants revocable, time-limited access scoped to a single object or a name prefix rather than opening the whole bucket. Treat any bucket whose access type deviates from `NoPublicAccess` as a change that needs documented business justification, and enumerate access types continuously so a deviation raises an alert rather than waiting for an audit.
       audit: |
         ### Audit via Console
 
@@ -846,19 +843,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets are configured with versioning enabled, so that every version of every object is preserved when objects are overwritten or deleted. OCI does not enable versioning by default; a bucket must be explicitly configured to retain object versions.
+        This check verifies that object versioning is enabled on Object Storage buckets, so that overwriting or deleting an object preserves the copy that was there before.
+
+        With versioning set to `Enabled`, each write creates a new version and a delete only writes a delete marker, leaving the previous version retrievable by its version ID. Buckets are created with versioning off, so version retention has to be turned on deliberately, either in the Console under Storage > Buckets on the bucket detail page or with `oci os bucket update --namespace <namespace> --name <bucket> --versioning Enabled`. Once enabled, versioning can be suspended but never returned to the disabled state, so versions already captured stay available.
 
         **Why this matters**
 
-        - **Accidental deletion recovery:** Without versioning, a deleted object is permanently gone; with versioning enabled, the previous version can be restored without data loss.
-        - **Ransomware resilience:** Versioning limits the damage from destructive operations, such as ransomware that overwrites files, because earlier clean versions remain available for recovery.
-        - **Change auditability:** Versioning creates an implicit audit trail of object modifications, supporting forensic investigations and compliance reviews that require demonstrating data integrity over time.
+        Without versioning, a deleted object is permanently gone the moment the delete call returns. There is no undo, no grace period, and no way to tell after the fact what the object contained. With versioning on, the previous version is restored in place with no data loss and no dependency on a separate backup system.
 
-        **Risk mitigation**
+        Versioning also limits the blast radius of destructive operations. Ransomware that encrypts files by overwriting them in place produces new versions rather than destroying the originals, so an earlier clean version of every affected object remains available for recovery.
 
-        - **Enable versioning on all important buckets:** Apply versioning to every bucket that holds data that cannot be easily regenerated, including backups, logs, and application state.
-        - **Pair with lifecycle policies:** Configure object lifecycle rules to expire old versions after a defined retention period, balancing recovery capability with storage cost.
-        - **Test restoration procedures:** Periodically verify that previous object versions can be successfully retrieved to confirm that recovery procedures work before they are needed.
+        Retained versions form an implicit audit trail of how an object changed and when, which is what forensic investigations and compliance reviews need in order to demonstrate data integrity over time.
+
+        Apply versioning to every bucket holding data that cannot be easily regenerated, including backups, logs, and application state. Pair it with object lifecycle rules that expire noncurrent versions after a defined retention period, otherwise storage cost grows with every write and never comes back down. Finally, periodically retrieve a previous version for real, because a recovery procedure that has never been exercised is an assumption rather than a capability.
       audit: |
         ### Audit via Console
 
@@ -969,19 +966,17 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets are configured to emit object-level events, recording when objects are created, updated, or deleted. Object event emission is disabled by default on new buckets and must be explicitly enabled.
+        This check verifies that object-level event emission is enabled on Object Storage buckets, so that changes to stored data produce records another service can act on.
+
+        When object events are on, the bucket publishes a message to the OCI Events service every time an object is created, updated, or deleted, using the event types `com.oraclecloud.objectstorage.createobject`, `com.oraclecloud.objectstorage.updateobject`, and `com.oraclecloud.objectstorage.deleteobject`. New buckets have emission turned off, so nothing is published until it is switched on with the Emit Object Events setting on the bucket detail page or with `oci os bucket update --namespace <namespace> --name <bucket> --object-events-enabled true`.
 
         **Why this matters**
 
-        - **Unauthorized access detection:** Without object events, there is no bucket-level signal when objects are read, modified, or removed by an unexpected actor, leaving data access blind spots.
-        - **Incident response support:** Object events feed OCI Events and Notifications, enabling automated alerting and response workflows when suspicious activity occurs on stored data.
-        - **Compliance audit trails:** Many regulatory frameworks require demonstrating that access to sensitive data is logged; object-level events provide the per-operation records that satisfy those requirements.
+        Without object events the data plane is silent. The Audit service records the control-plane call that created or reconfigured the bucket, but not the objects written into it, so an attacker holding valid credentials can stage, modify, and remove objects without generating a single reviewable record. That is a blind spot precisely where the data lives.
 
-        **Risk mitigation**
+        Events are also the input to automated response rather than just a log to read later. An Events rule can route matches to Notifications, Functions, or Streaming, and Service Connector Hub can forward them onward to a SIEM, so a burst of deletes against a backup bucket raises an alert while the incident is still in progress instead of surfacing in the next quarterly review. Many regulatory frameworks require demonstrating that access to sensitive data is logged, and these per-operation records are what satisfies that requirement.
 
-        - **Enable object events on all buckets:** Turn on event emission for every bucket, especially those holding sensitive or regulated data.
-        - **Route events to a SIEM or notification endpoint:** Connect OCI Events to an alerting rule so that anomalous object operations trigger an automated response rather than going unreviewed.
-        - **Retain event records:** Archive event data for a period consistent with your regulatory retention requirements to support forensic investigations.
+        Object events cover writes, not reads. If you also need to know who downloaded an object, enable Object Storage read access logs through the Logging service alongside this setting. Retain both for a period consistent with your regulatory retention requirements so an investigation has history to work with, and turn emission on for every bucket that holds sensitive or regulated data rather than only the ones currently in an audit's scope.
       audit: |
         ### Audit via Console
 
@@ -1092,19 +1087,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets are encrypted using a customer-managed key stored in OCI Vault rather than the default Oracle-managed encryption key. OCI encrypts all Object Storage data at rest automatically using Oracle-managed keys, so the risk here is not the absence of encryption but the absence of customer control over the key lifecycle.
+        This check verifies that Object Storage buckets encrypt data with a customer-managed key held in OCI Vault rather than the default Oracle-managed key.
+
+        All Object Storage data is encrypted at rest regardless of this setting, so the exposure here is not missing encryption but missing control over the key lifecycle. Assigning a Vault master encryption key to a bucket puts key creation, rotation, disabling, and deletion in your hands. Assign one in the Console through the bucket's Encryption Key setting or with `oci os bucket update --namespace <namespace> --name <bucket> --kms-key-id <key_ocid>`, and grant the service access to it first with a policy statement of the form `allow service objectstorage-<region> to use keys in compartment <compartment>`.
 
         **Why this matters**
 
-        - **Key revocation capability:** With a customer-managed key, you can immediately revoke access to all encrypted data by disabling or deleting the key in OCI Vault, which is not possible with Oracle-managed keys.
-        - **Separation of duties:** Storing encryption keys in a customer-controlled vault separates key management from data management, enabling independent access controls and audit trails for each.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA, PCI DSS, and FedRAMP require that organizations demonstrate control over the keys used to protect regulated data; Oracle-managed keys do not satisfy that requirement.
+        A customer-managed key gives you a revocation switch. Disabling or scheduling deletion of the key in Vault renders every object encrypted under it unreadable immediately, which is the only fast containment move available when a bucket's contents must be denied to an attacker. An Oracle-managed key offers no such control.
 
-        **Risk mitigation**
+        Holding the key in a vault you control separates key management from data management. The people who administer buckets and the people who administer keys can be different groups with different policies and separate audit trails, so compromising one role does not automatically yield plaintext.
 
-        - **Provision keys in OCI Vault before bucket creation:** Create a dedicated vault and master encryption key and assign it to each bucket that holds sensitive data.
-        - **Configure automatic key rotation:** Set a rotation policy on each customer-managed key to limit the exposure window if a key is ever compromised.
-        - **Monitor key usage:** Review OCI Audit logs for key operations to detect unauthorized access or unexpected key management activity.
+        HIPAA, PCI DSS, and FedRAMP all expect an organization to demonstrate control over the keys protecting regulated data, and an Oracle-managed key cannot satisfy that evidence requirement because you cannot show who used it or withdraw it.
+
+        Provision the vault and master encryption key before the bucket is created, since assigning a key later applies to newly written objects while existing objects stay encrypted under the previous key until they are rewritten. Set a rotation policy on each key to bound the exposure window if one is ever compromised, and review Audit logs for key operations so unexpected use or an unauthorized key management change is noticed.
       audit: |
         ### Audit via Console
 
@@ -1234,20 +1229,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI VCN security list contains an ingress rule that permits all protocols from the source CIDR `0.0.0.0/0`. A rule combining `protocol: all` with `source: 0.0.0.0/0` allows every IP and every network protocol into the subnet with no restriction, effectively disabling network-layer access control for inbound traffic.
+        This check verifies that no VCN security list admits every network protocol from the public internet.
+
+        A security list is the subnet-level firewall of an OCI Virtual Cloud Network, and every VNIC placed in the subnet inherits its rules. An ingress rule that pairs `protocol: all` with `source: 0.0.0.0/0` and a `sourceType` of `CIDR_BLOCK` matches TCP, UDP, ICMP and every other IP protocol in a single line, so the subnet boundary stops filtering anything inbound. The check requires that no rule combines those two values. Rules live under Networking > Virtual Cloud Networks > Security Lists in the Console and are edited with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Full internet exposure:** All ports and protocols on every instance in the affected subnet become reachable from any host on the internet, removing the subnet boundary as a defensive layer.
-        - **Service discovery by attackers:** Automated scanning tools continuously probe cloud IP ranges; an all-protocols rule guarantees that every service running on instances in the subnet will be enumerated and targeted.
-        - **Lateral movement amplification:** Once one instance in the subnet is compromised, the same overly permissive rule may enable the attacker to reach other instances directly over non-standard protocols.
-        - **No defense-in-depth:** Security controls at higher layers such as host firewalls or application authentication become the only remaining barriers, eliminating the network layer from the defense stack.
+        All ports and all protocols on every instance in the affected subnet become reachable from any host on the internet, which removes the network layer from the defense stack entirely. Host firewalls and application authentication are then the only barriers left, and they are the layers most likely to be incomplete on a freshly provisioned image.
 
-        **Risk mitigation**
+        Automated scanners sweep published cloud address ranges continuously. An all-protocols rule guarantees that every service listening on any instance in the subnet is enumerated, catalogued and targeted, including services the team had forgotten were running.
 
-        - **Replace all-protocol rules with specific rules:** Define ingress rules that name the protocol and port range required by each workload rather than allowing all traffic.
-        - **Restrict source CIDR blocks:** Limit inbound access to known trusted IP ranges or specific CIDR blocks rather than accepting traffic from the entire internet.
-        - **Use Network Security Groups for instance-level control:** Apply NSGs alongside security lists to enforce fine-grained access at the instance level as an additional layer of protection.
+        The damage does not stop at the perimeter. Once one instance in the subnet is compromised, the same rule lets the attacker reach its neighbors directly over non-standard protocols such as GRE or ESP that no port-based control would have anticipated.
+
+        Replace the rule with ingress rules that name the protocol number and the destination port range each workload actually needs, and narrow the source to the CIDR blocks that legitimately originate that traffic. Where instances in one subnet need different exposure, attach network security groups to their VNICs so access is decided per instance rather than for the whole subnet at once. An NSG is the instance-level companion to a security list and applies alongside it, adding a second layer rather than replacing the first.
       audit: |
         ### Audit via Console
 
@@ -1384,19 +1378,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI VCN security list contains a TCP ingress rule from `0.0.0.0/0` that omits destination port restrictions. A TCP ingress rule with protocol `6` (TCP), source `0.0.0.0/0`, and no `tcpOptions` block allows every TCP port on the affected instances to be reached from the internet.
+        This check verifies that every TCP ingress rule accepting traffic from the public internet is scoped to a destination port range.
+
+        An OCI security list rule names its protocol by IANA number, so TCP is `6`, and the destination port range lives in an optional `tcpOptions` block, written `tcp_options` in Terraform. Omitting that block is not a neutral default. A rule with protocol `6`, source `0.0.0.0/0` and no `tcpOptions` opens all 65535 TCP ports on every instance in the subnet. The port range is set in the rule editor on the security list details page in the Console, or in the ingress rules payload passed to `oci network security-list update`.
 
         **Why this matters**
 
-        - **All TCP services exposed:** Without port restrictions, SSH, RDP, database ports, and any other TCP service on instances in the subnet are reachable by any host on the internet.
-        - **Brute-force and exploitation surface:** Management ports such as SSH (22) and RDP (3389) become targets for credential brute-force and known-vulnerability scanning as soon as they are internet-accessible.
-        - **Data exfiltration paths:** Open database or application ports allow an attacker who gains access to a host to exfiltrate data over standard TCP channels without needing to circumvent additional network controls.
+        Portless rules are usually written by accident. An operator opens a web tier, leaves the port fields blank in the Console form, and ships a rule that also exposes SSH on 22, RDP on 3389, and whatever database listener the application happens to run alongside it.
 
-        **Risk mitigation**
+        Management ports are found first. Credential brute force and known-vulnerability scanning begin against 22 and 3389 within minutes of the instance answering on a public address, and neither the security list nor the subnet applies any rate limiting to the attempts.
 
-        - **Always specify port ranges in TCP ingress rules:** Every TCP ingress rule from a public CIDR must include explicit `tcp_options` with minimum and maximum port values that cover only the required service ports.
-        - **Restrict source CIDR blocks for management ports:** Limit SSH and RDP access to specific administrative IP ranges rather than `0.0.0.0/0`, regardless of whether port restrictions are also applied.
-        - **Audit security lists for portless TCP rules:** Regularly scan all security lists for TCP ingress rules that omit port options and remediate any that are found.
+        An open database or application port also gives an attacker who already holds a foothold a clean route back out. Data leaves over an ordinary TCP session to a port the rule permits, with no further network control to circumvent and nothing anomalous about the connection itself.
+
+        Give every internet-facing TCP ingress rule explicit minimum and maximum port values covering only the service ports required, and keep management ports restricted to administrative CIDR blocks whether or not the range is scoped. Sweeping existing security lists for TCP rules that carry no port options is the fastest way to find the ones already deployed.
       audit: |
         ### Audit via Console
 
@@ -1546,19 +1540,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI VCN security list contains an egress rule that allows all protocols to the destination `0.0.0.0/0`. A rule combining `protocol: all` with `destination: 0.0.0.0/0` places no restriction on outbound traffic, allowing any compromised instance to communicate freely with any external host over any protocol.
+        This check verifies that no VCN security list permits outbound traffic on every protocol to every destination on the internet.
+
+        Egress rules govern traffic leaving the subnet and carry a `destination` plus a `destinationType`, which is either `CIDR_BLOCK` for an arbitrary range or `SERVICE_CIDR_BLOCK` for an Oracle services label reached through a service gateway. A rule combining `protocol: all` with `destination: 0.0.0.0/0` places no constraint at all on what an instance may talk to. The check requires that no egress rule holds both values. Egress rules are managed on the security list details page in the Console or through `oci network security-list update`.
 
         **Why this matters**
 
-        - **Data exfiltration channel:** An unrestricted egress rule gives a compromised instance a direct, unconstrained path to send data to any external server, including attacker-controlled infrastructure.
-        - **Command-and-control communication:** Malware running on an instance with unrestricted egress can establish outbound connections to command-and-control servers on any port, making it difficult to detect and disrupt using DNS or IP-based blocking alone.
-        - **Lateral network abuse:** A compromised instance can be used to probe or attack external targets, creating legal and reputational exposure for the tenancy owner.
+        Unrestricted egress is what turns a single compromised instance into a data breach. The attacker already has code running; the rule supplies an unconstrained path for moving whatever that code can read to infrastructure they control.
 
-        **Risk mitigation**
+        It also keeps the intrusion alive. An implant can reach a command-and-control endpoint on any protocol and any port, so address and DNS blocklists become the only detection surface, and beaconing hidden inside an unusual protocol never touches them.
 
-        - **Define specific egress rules:** Replace all-protocol egress rules with rules that name the destination CIDR, protocol, and port range required by the workload.
-        - **Route internet-bound traffic through a controlled egress point:** Use a NAT gateway combined with a firewall or proxy to inspect and log outbound traffic before it leaves the VCN.
-        - **Monitor outbound traffic patterns:** Alert on large or unusual outbound data transfers and connections to unexpected external destinations.
+        The tenancy carries the third-party consequences. An instance with open egress can be used to scan, brute force or flood external targets, and the abuse reports, the bandwidth charges and the reputational damage land on the tenancy owner rather than on the attacker.
+
+        Replace the rule with egress rules naming the destination CIDR, protocol and port range each workload needs, and use a `SERVICE_CIDR_BLOCK` destination for traffic to Oracle services so it never traverses the internet at all. Route what genuinely must leave through a NAT gateway fronted by a firewall or proxy that can inspect and log it, and alert on large or unusual outbound transfers.
       audit: |
         ### Audit via Console
 
@@ -1682,20 +1676,19 @@ queries:
       oci.identity.user.lastLogin > time.now - 90 * time.day
     docs:
       desc: |
-        This check ensures that every active IAM user account has a recorded sign-in within the past 90 days. OCI does not automatically deactivate accounts based on inactivity, so accounts belonging to users who have left the organization or changed roles can remain active indefinitely without any login activity.
+        This check verifies that access is only retained where it is actually being used, by requiring every active user with a recorded sign-in to have logged in within the last 90 days.
+
+        OCI records the timestamp of a user's most recent successful sign-in and never acts on it. There is no inactivity expiry, no automatic deactivation, and no warning, so an account keeps its group memberships and its credentials indefinitely whether it is used daily or was last touched two years ago. Administrators see the last sign-in on the user under Identity & Security > Domains > Users and deactivate an account from the same page. Accounts that have never signed in at all are outside this check and need their own review.
 
         **Why this matters**
 
-        - **Orphaned identity risk:** Accounts that were not deactivated during offboarding retain whatever permissions they held at the time the user last worked, which may include access to sensitive resources.
-        - **Undetected compromise window:** A dormant account that is compromised may see attacker activity go unnoticed for a long time because there is no baseline of expected legitimate logins to compare against.
-        - **Attack surface accumulation:** Each stale active account adds credentials to the environment that serve no operational purpose but represent a potential entry point for unauthorized access.
-        - **Access review accuracy:** Compliance access reviews require accurate data about who has access and whether that access is actively used; stale accounts undermine the reliability of those reviews.
+        A stale account is usually an account whose owner is gone. Offboarding that removed a person from mail and chat but never reached OCI leaves an identity holding whatever it held on their last working day, including any compartment access and any policy grants attached to its groups. Nothing shrank when the person left.
 
-        **Risk mitigation**
+        Dormancy also removes the detection signal that catches misuse. An account used every morning has a rhythm, so activity at three in the morning from an unfamiliar region stands out. An account with no activity has no baseline to break, which is why attackers favor them and why intrusions through them run long before anyone notices.
 
-        - **Disable accounts unused for 90 days:** Establish an automated process that flags and deactivates accounts with no login activity within the defined window.
-        - **Integrate with HR offboarding:** Connect IAM lifecycle management with HR systems so that accounts are deactivated promptly when employment ends.
-        - **Review regularly:** Run periodic access reviews that include last-login data, and require documented justification for any active account that has not been used recently.
+        Every unused account is also pure attack surface, one phished password or leaked key away from becoming an entry point. Access reviews depend on this data being honest: a review that certifies access without last sign-in evidence certifies a list of names, not a set of people who need what they hold.
+
+        Flag and deactivate accounts idle beyond the window automatically, connect identity lifecycle to the HR offboarding trigger so departures reach the tenancy, and require documented justification to keep an unused account active.
       audit: |
         ### Audit via Console
 
@@ -1781,20 +1774,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that no IAM policy contains a statement granting `manage all-resources in compartment`, which conveys unrestricted administrative control over every resource within the target compartment. While compartment-scoped policies are less dangerous than tenancy-wide permissions, granting full management of all resources within a compartment still violates least privilege and can enable significant damage if an account is compromised.
+        This check verifies that IAM grants inside a compartment are scoped to specific resource types rather than conveying full control of everything in it.
+
+        The statement rejected here is `allow group <group> to manage all-resources in compartment <name>`. It is narrower than the tenancy-wide form because the compartment boundary still holds, but within that boundary it is absolute: the strongest verb applied to every resource type OCI offers. Compartments exist to bound what a team can reach, and this statement spends that boundary on the outer edge while scoping nothing inside it. Statements are managed under Identity & Security > Policies or with `oci iam policy update`, and this check inspects live policies as well as Terraform configuration, plans, and state.
 
         **Why this matters**
 
-        - **Compartment-wide blast radius:** A user or automation credential bound to this permission can create, modify, or delete any resource inside the compartment, including IAM sub-configurations, storage, compute, and networking.
-        - **Least-privilege violation:** Granting access to `all-resources` makes it impossible to scope blast radius to the subset of resource types a role actually needs, which is the fundamental goal of compartment-based isolation.
-        - **Audit and attribution difficulty:** Broad policies obscure which groups have access to which resource types, complicating access reviews and incident investigations.
-        - **Lateral movement within the compartment:** An attacker with this permission can exploit any resource in the compartment to escalate privileges or move to other resources without any additional IAM steps.
+        A compartment is rarely small. Production compartments commonly hold the compute instances, the VCN and its security lists, the block volumes, the Object Storage buckets, and the databases for a whole application. A group with this grant can create, reconfigure, and delete all of it, so a credential issued for one narrow job, such as a pipeline that only replaces instances, can also open a security list or empty a bucket.
 
-        **Risk mitigation**
+        That breadth turns a single compromise into a compartment-wide incident. An attacker landing on any principal in the group needs no further IAM step: every resource is already in reach, and each is a candidate for staging further access.
 
-        - **Replace with resource-type-specific statements:** Rewrite broad policies to use named resource families such as `manage instance-family` or `manage virtual-network-family` that match each group's actual operational scope.
-        - **Apply the minimum-permission principle:** Grant only the resource types a group needs to perform its function, and add resource types only when a documented business need arises.
-        - **Audit compartment policies regularly:** Review policies in each compartment on a scheduled basis and narrow any statement that grants access broader than the workload requires.
+        It also blurs the picture the compartment model was built to make clear. When several groups each hold everything within a compartment, an access review cannot say which team owns which resource type.
+
+        Rewrite these into named resource families matching what each group operates, such as `manage instance-family` or `manage virtual-network-family`, and add resource types only when a documented need appears. Remember also that a policy attached at the tenancy root reaches this compartment too, so narrowing the compartment policy is only half the work.
       audit: |
         ### Audit via Console
 
@@ -1935,20 +1927,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets are configured with cross-region replication enabled. By default, OCI buckets store objects in a single region with no automatic copying to a secondary location, meaning a regional failure or disaster can result in data unavailability or permanent loss.
+        This check verifies that Object Storage buckets replicate their objects to a second region, so that no single region holds the only copy of the data.
+
+        A replication policy names a destination bucket in another region and continuously copies new and updated objects to it. Buckets have no replication by default. Create a policy in the Console under the bucket's Replication panel or with `oci os replication create-replication-policy`, and first allow the service to write at the destination with a statement of the form `allow service objectstorage-<region> to manage object-family in compartment <compartment>`. While a policy is active the destination bucket accepts writes only from replication, so the replica cannot quietly diverge. The Terraform versions of this check expect a replication policy resource for every bucket the configuration declares.
 
         **Why this matters**
 
-        - **Regional resilience:** Replication automatically copies objects to a destination bucket in another region, so a single-region outage does not destroy the only copy of your data.
-        - **Reduced recovery time:** Recovering from a single-region failure without replication requires slow, manual restoration from backups, extending service downtime.
-        - **Data availability:** Cross-region replication keeps a synchronized replica ready to serve reads or take over writes immediately when the primary region is unavailable.
-        - **Compliance readiness:** Many data protection and business-continuity frameworks require geographically separated copies of critical data.
+        A regional outage or a regional disaster takes the only copy of the data with it when replication is off. The bucket is not corrupted, it is simply unreachable, and every service that depends on it stops until the region returns.
 
-        **Risk mitigation**
+        Recovering without a replica means restoring from backup media by hand, object by object or archive by archive, which stretches an outage from minutes into hours or days. A synchronized replica in another region is ready to serve reads or absorb writes as soon as traffic is redirected.
 
-        - **Enable replication on critical buckets:** Prioritize buckets that hold regulated, business-critical, or irreplaceable data.
-        - **Select an appropriate destination region:** Choose a destination that satisfies your compliance, latency, and jurisdictional requirements.
-        - **Monitor replication status:** Regularly verify that objects are replicating successfully and alert on replication lag or failure.
+        Many data protection and business continuity frameworks require geographically separated copies of critical data, and a single-region bucket cannot demonstrate that separation.
+
+        Prioritize buckets holding regulated, business-critical, or irreplaceable data, and pick a destination region that satisfies your jurisdictional, latency, and compliance constraints. Where data residency rules forbid copying outside a jurisdiction, that is a legitimate reason to leave replication off and rely on in-region durability. Replication is asynchronous and it propagates deletes, so it is an availability control rather than a backup. Pair it with versioning or retention rules to survive destructive writes, and monitor policy status so replication lag or a stalled policy is alerted on rather than discovered during a failover.
       audit: |
         ### Audit via Console
 
@@ -2085,20 +2076,21 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Object Storage buckets using the Archive storage tier are configured with versioning enabled. Archive-tier buckets are typically used for long-term retention of backups, compliance records, and historical logs; without versioning, any object that is deleted or overwritten is permanently gone.
+        This check verifies that Object Storage buckets on the `Archive` tier keep prior object versions, so long-term records survive an overwrite or a delete.
+
+        A bucket's storage tier is fixed at creation and cannot be changed afterward, and `Archive` is chosen for data meant to sit untouched for years: backups, compliance records, and historical logs. Versioning is a separate setting and is off unless requested, so an archive bucket can silently be a single-copy store. Turn it on from the bucket detail page or with `oci os bucket update --namespace <namespace> --name <bucket> --versioning Enabled`.
 
         **Why this matters**
 
-        - **Accidental deletion protection:** Versioning retains previous object versions so that a mistaken delete or overwrite can be reversed without restoring from a separate backup.
-        - **Ransomware and insider-threat resilience:** An attacker who gains write access cannot permanently destroy archived data when older versions are preserved and can be recovered.
-        - **Compliance and legal hold support:** Regulations and audit requirements frequently mandate that archived records remain recoverable and unaltered for defined retention periods.
-        - **Lower recovery cost:** Retrieving a versioned object is far faster and cheaper than restoring from a secondary backup copy stored in a different medium.
+        The data in an archive bucket is usually the copy of last resort. When versioning is off, a mistaken delete or an overwrite of the wrong object name destroys the record with nothing behind it, and the mistake is typically discovered months later when someone finally goes looking. Versioning makes that reversible without involving a separate backup system.
 
-        **Risk mitigation**
+        It also removes permanent destruction from an attacker's reach. Write access alone is no longer enough to erase archived data, because older versions remain and can be recovered, which matters for both ransomware and a departing insider with retained credentials.
 
-        - **Enable versioning on all archive-tier buckets:** Apply the setting at bucket creation time so it is never overlooked for new buckets.
-        - **Use lifecycle policies to manage costs:** Configure version-expiry rules to expire older versions after your required retention window to avoid unbounded storage growth.
-        - **Consider Object Lock for immutability:** For compliance-critical archives, combine versioning with Object Lock to prevent deletions even by privileged users.
+        Regulations and audit obligations frequently require archived records to stay recoverable and unaltered for a defined retention period, and only retained versions can prove the record was never quietly replaced.
+
+        Recovery from a version is also cheaper and far faster than rebuilding from a secondary backup copy on different media, even accounting for the restore step that `Archive` objects require before they can be downloaded, which can take up to an hour.
+
+        Enable versioning when the bucket is created so it is never overlooked, and configure lifecycle rules that expire noncurrent versions once your retention window closes, since `Archive` bills a 90-day minimum retention per object and unbounded version growth is expensive. For compliance-critical archives, combine versioning with a locked retention rule, which is OCI's write-once-read-many control and blocks deletion even by privileged users.
       audit: |
         ### Audit via Console
 
@@ -2210,20 +2202,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI VCN security lists are configured to block SSH (TCP port 22) ingress from any source (0.0.0.0/0). SSH exposed to the entire internet is one of the most common initial-access vectors for cloud infrastructure attacks, and automated scanners discover open port 22 within minutes of a new instance receiving a public IP.
+        This check verifies that SSH administrative access is never reachable from the entire internet.
+
+        The rule shape the check rejects is TCP, protocol number `6`, with source `0.0.0.0/0` and a destination port range that covers 22, including a rule that names no port range at all and therefore covers 22 by omission. A security list applies to every VNIC in its subnet, so one such rule exposes port 22 on every instance there, including instances whose owners never intended to accept remote logins. Tighten the source on the security list details page in the Console or with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Brute-force exposure:** An internet-accessible SSH port receives continuous credential-stuffing and password-spray attempts from botnets scanning the entire IPv4 address space.
-        - **Vulnerability exploitation:** Unpatched SSH daemons are periodically affected by remote-code-execution CVEs; unrestricted access allows exploitation without any prior credential.
-        - **Lateral movement:** A compromised instance reachable via public SSH becomes a pivot point for moving deeper into the VCN and reaching internal resources.
-        - **Data exfiltration path:** Attackers who gain SSH access have an encrypted, interactive channel to exfiltrate data that is difficult to distinguish from legitimate management traffic.
+        Port 22 on a fresh public address is found in minutes. Botnets sweep the whole IPv4 space continuously and feed the hits into credential stuffing runs that replay username and password pairs harvested from unrelated breaches, then into password spraying against `root`, `opc` and other predictable account names that Oracle Linux images ship with.
 
-        **Risk mitigation**
+        Credentials are not the only route in. Unpatched SSH daemons are periodically affected by remote code execution CVEs, and an unrestricted rule means a bug of that kind is exploitable by anyone before any authentication step is reached.
 
-        - **Restrict SSH to trusted source CIDRs:** Replace the 0.0.0.0/0 source with specific CIDR ranges for your corporate VPN, bastion subnet, or jump-box IP.
-        - **Use OCI Bastion service:** Route administrative SSH through the OCI Bastion service so that port 22 never needs to be exposed directly on production instances.
-        - **Enforce key-based authentication:** Disable password authentication in the SSH daemon configuration to eliminate brute-force credential attacks even if the port is temporarily accessible.
+        What follows an SSH compromise is worse than the login. The attacker holds an interactive shell inside the VCN and uses it as a pivot toward internal resources that were never meant to be reachable from outside, and the encrypted channel doubles as an exfiltration path that looks exactly like legitimate administration in flow logs.
+
+        Restrict the source to the CIDR blocks of your corporate VPN, bastion subnet or jump host, or remove the rule entirely and reach instances through the OCI Bastion service, which brokers sessions without port 22 ever being open. Disabling password authentication in the SSH daemon closes the brute force path even during a window when the port is briefly reachable.
       audit: |
         ### Audit via Console
 
@@ -2381,20 +2372,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI VCN security lists are configured to block RDP (TCP port 3389) ingress from any source (0.0.0.0/0). Remote Desktop Protocol exposed to the public internet is the top initial-access vector used by ransomware operators and is actively scanned and exploited within minutes of a new Windows instance receiving a public IP.
+        This check verifies that Windows remote desktop access is not exposed to the whole internet.
+
+        The check rejects TCP ingress, protocol number `6`, from source `0.0.0.0/0` whose destination port range covers 3389, and equally a rule that specifies no port range, since that covers 3389 as well. Because a security list governs the entire subnet, the rule reaches every Windows instance placed in it. Rules are edited on the security list details page under Networking > Virtual Cloud Networks, or with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Ransomware delivery:** Internet-exposed RDP is the leading entry point for ransomware gangs, who purchase or brute-force valid credentials and then move laterally to deploy encryption payloads.
-        - **Credential attack surface:** Windows accounts targeted over public RDP are subject to continuous brute-force and credential-stuffing campaigns with no rate limiting at the network level.
-        - **Known RDP vulnerabilities:** Critical RCE-class vulnerabilities in the RDP stack (BlueKeep, DejaBlue) have been actively exploited in the wild against internet-exposed endpoints.
-        - **Lateral movement risk:** A single compromised Windows instance reachable via public RDP gives an attacker an authenticated foothold to pivot to other systems within the VCN.
+        Internet-facing RDP is the single most common entry point in ransomware intrusions. An access broker buys or brute forces a valid Windows account, sells the foothold, and the buyer moves laterally through the domain before deploying an encryption payload, so the port exposure and the ransom note can be weeks apart.
 
-        **Risk mitigation**
+        The preauthentication surface is the other half of the problem. BlueKeep and DejaBlue were remote code execution flaws in the RDP stack itself that required no credentials at all, and both were exploited in the wild against internet-exposed endpoints. A rule opening 3389 to `0.0.0.0/0` makes every future bug of that class immediately reachable.
 
-        - **Restrict RDP to trusted source CIDRs:** Replace the 0.0.0.0/0 source with specific CIDR ranges for your corporate VPN or management subnet.
-        - **Use OCI Bastion for remote desktop access:** Route RDP sessions through the OCI Bastion service so that port 3389 never needs to be exposed on the public internet.
-        - **Enforce Network Level Authentication:** Require NLA on all Windows instances so that unauthenticated connection attempts are rejected before a full RDP session is established.
+        Windows accounts on a public 3389 also absorb continuous brute force with no rate limiting anywhere in the network path. Account lockout policies that protect an on-premises domain then work against you, handing an attacker a denial of service against your own administrators.
+
+        Limit the source to the CIDR blocks of a corporate VPN or management subnet, or run sessions through the OCI Bastion service so 3389 never faces the internet. Require Network Level Authentication, or NLA, on every Windows instance so unauthenticated connection attempts are rejected before a session is established, and keep it in place after the rule is tightened.
       audit: |
         ### Audit via Console
 
@@ -2552,20 +2542,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI VCN security lists are configured to block unrestricted UDP ingress from any source (0.0.0.0/0) by requiring all UDP ingress rules to specify a destination port range. An ingress rule for UDP from 0.0.0.0/0 with no port restriction makes every UDP service running on the instance reachable from the internet.
+        This check verifies that every UDP ingress rule accepting internet traffic names the destination ports it opens.
+
+        UDP is protocol `17` in an OCI security list rule, and its port range lives in an optional `udpOptions` block. A rule with source `0.0.0.0/0`, protocol `17` and no `udpOptions` exposes every UDP port on every instance in the subnet, so the check requires the port range to be present. Set it in the rule editor on the security list details page in the Console, or in the ingress rules payload of `oci network security-list update`.
 
         **Why this matters**
 
-        - **DDoS amplification risk:** Internet-accessible UDP services such as DNS (53), NTP (123), and SNMP (161) are routinely abused as amplification reflectors in distributed denial-of-service attacks, directing large volumes of traffic at third-party victims while billing the OCI tenant for outbound bandwidth.
-        - **Information disclosure:** Unrestricted SNMP access from the internet can leak detailed infrastructure topology, interface configurations, and system information to any external requester.
-        - **Large attack surface:** Without port restrictions, every UDP application on the instance is potentially reachable, including services never intended for external access.
-        - **Evasion of monitoring:** Connectionless UDP traffic is harder to attribute and correlate in flow logs than TCP, making abuse of unrestricted UDP ports more difficult to detect.
+        The danger with UDP is not only what reaches you but what you are made to send. DNS on 53, NTP on 123 and SNMP on 161 all answer with far more bytes than they receive, so an exposed instance is drafted as a reflector in a distributed denial-of-service amplification attack. The attacker spoofs a victim's address, your instance replies to the victim, and the tenancy is billed for the outbound bandwidth of an attack it is unwittingly carrying out.
 
-        **Risk mitigation**
+        SNMP leaks on the way in as well. An unauthenticated read from the internet returns interface tables, routing information, running processes and system descriptions, which amounts to a topology map handed to whoever asked for it.
 
-        - **Always specify destination port ranges in UDP rules:** Explicitly name the ports your workload requires rather than omitting the port restriction.
-        - **Restrict source CIDRs:** Limit UDP ingress from 0.0.0.0/0 only where truly necessary, and prefer known trusted IP ranges even then.
-        - **Use the minimum required UDP ports:** Audit each workload to determine which UDP services must be internet-accessible and remove all others.
+        Detection is weaker here than on TCP. Connectionless traffic has no handshake to correlate, so flow records show packets without sessions, and abuse of an open UDP port is far harder to separate from ordinary noise than the equivalent TCP activity would be.
+
+        Name the exact port range each UDP workload requires rather than leaving the options block off, and keep the source restricted to known ranges even when a range is present. Where a UDP service must answer the public internet, place it behind rate limiting and confirm it is not configured to respond to spoofed or recursive queries.
       audit: |
         ### Audit via Console
 
@@ -2703,20 +2692,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI VCN security lists are configured so that no ingress rule sourced from 0.0.0.0/0 is marked as stateless. Stateless rules do not track connection state, so return traffic is not automatically permitted and every packet is evaluated independently, making internet-facing stateless rules both harder to reason about and more likely to be accidentally over-permissive.
+        This check verifies that internet-facing ingress relies on stateful connection tracking rather than stateless packet matching.
+
+        Security list rules in OCI are stateful by default: traffic allowed inbound has its return traffic permitted automatically, and the reverse holds for egress. Marking a rule stateless turns that off, and each packet is then matched on its own against the rule set with no memory of the connection it belongs to. The check requires that no ingress rule whose source is `0.0.0.0/0` carries `isStateless: true`. The flag is a checkbox in the Console rule editor and a field in the payload of `oci network security-list update`.
 
         **Why this matters**
 
-        - **No connection tracking:** A stateless ingress rule from 0.0.0.0/0 permits inbound packets without any awareness of whether they belong to an established session, removing the fundamental protection that stateful inspection provides.
-        - **Incomplete return-traffic control:** Because stateless rules require explicit matching egress rules for return traffic, operators often compensate by adding broad outbound allowances, further widening the effective security boundary.
-        - **Harder to audit:** The stateless/stateful distinction is easy to overlook in the console and CLI; auditors reviewing security-list rules may not spot that an otherwise routine-looking internet rule bypasses connection tracking.
-        - **Increased misconfiguration risk:** Stateless rules that omit port restrictions or use wide CIDRs produce a compounded risk because there is no connection-state guard to catch packets that would otherwise be blocked.
+        A stateless internet-facing rule admits packets with no notion of whether they belong to a session anyone established. Crafted packets that claim to be mid-connection are matched on their headers alone, and the connection-tracking layer that would have discarded them is not there to do it.
 
-        **Risk mitigation**
+        The knock-on effect is usually the larger one. Return traffic for a stateless rule needs its own matching egress rule, and when the return path breaks the fastest fix is a wide outbound allowance. The stateless ingress rule that looked narrow ends up paired with an egress rule that is not.
 
-        - **Use stateful rules for all internet-facing ingress:** Reserve stateless rules for high-throughput internal paths where connection-tracking overhead is a documented concern, never for rules sourced from 0.0.0.0/0.
-        - **Audit existing rules regularly:** Scan security lists for the `isStateless: true` flag on any rule whose source is 0.0.0.0/0 and convert them to stateful equivalents.
-        - **Enforce stateful-by-default in IaC:** In Terraform, always set `stateless = false` on ingress blocks to make stateful behavior explicit and reviewable in code.
+        These rules also hide well. The stateless setting is one checkbox in the Console and one field in a CLI response, so a reviewer scanning security lists sees a rule with a specific protocol and port and no reason to look further, while that rule is bypassing connection tracking entirely.
+
+        Reserve stateless rules for high-throughput internal paths where per-instance connection-tracking limits are a documented and measured constraint, never for anything sourced from the internet. In Terraform the same flag is spelled `stateless`, and writing `stateless = false` explicitly on ingress blocks makes the choice visible in code review instead of leaving it to a default.
       audit: |
         ### Audit via Console
 
@@ -2853,20 +2841,19 @@ queries:
           mondoo.com/icon: terraform
     docs:
       desc: |
-        This check ensures that OCI VCN security lists are configured to block unrestricted TCP egress to any destination (0.0.0.0/0) by requiring all TCP egress rules to specify a destination port range. An egress rule for TCP to 0.0.0.0/0 with no port restriction allows a compromised instance to communicate with any TCP service on the internet.
+        This check verifies that outbound TCP to the internet is limited to the destination ports a workload actually needs.
+
+        An egress rule with protocol `6`, destination `0.0.0.0/0`, a `destinationType` of `CIDR_BLOCK` and no `tcpOptions` block lets an instance open a TCP connection to any port on any host on the internet. Most workloads need `443` and very little else, so the check requires a destination port range on any TCP egress rule aimed at the whole internet. Egress rules are edited on the security list details page in the Console or with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Data exfiltration channel:** Unrestricted outbound TCP gives an attacker who has compromised an instance a wide-open path to send any data to any internet destination on any port.
-        - **Command-and-control connectivity:** Malware can establish command-and-control channels over non-standard TCP ports to evade detection; broad egress rules make these channels indistinguishable from legitimate traffic.
-        - **Malware staging:** Attackers use unrestricted egress to download additional tools, backdoors, and payloads from internet-hosted staging servers after initial access.
-        - **Compliance violations:** Regulatory frameworks typically require that cloud workloads implement egress filtering to prevent unauthorized data flows out of the environment.
+        Post-exploitation tooling depends on outbound TCP. The initial foothold is usually small, and the operator's next move is to pull down the real toolkit, a backdoor or a ransomware payload from a staging host. A port-scoped egress rule breaks that step; an unscoped one funds it.
 
-        **Risk mitigation**
+        Command and control follows the same path in reverse. Implants prefer high-numbered or unusual ports precisely because inspection tends to be weakest there, and a rule that allows every port makes an outbound session on 8443 or 4444 indistinguishable at the network layer from a legitimate API call.
 
-        - **Specify destination port ranges on all TCP egress rules:** Explicitly allow only the ports your workload requires (for example, 443 for HTTPS) and deny everything else.
-        - **Restrict destination CIDRs where possible:** Where the set of external endpoints a workload communicates with is known, restrict egress to those specific CIDR blocks or use a managed NAT gateway with an egress security policy.
-        - **Monitor outbound traffic for anomalies:** Enable VCN flow logs and alert on unexpected outbound connections even after tightening egress rules.
+        Exfiltration then needs no cleverness at all. A compromised instance with unrestricted outbound TCP writes data straight to a listener the attacker controls, with no egress control between the process and the internet to record or interrupt it. Regulatory frameworks that require egress filtering exist for exactly this case, and an unscoped rule will not satisfy them.
+
+        Give each TCP egress rule the ports its workload needs, typically `443` for HTTPS, and restrict the destination CIDR wherever the set of external endpoints is known. Route the remainder through a NAT gateway with an egress policy, and enable VCN flow logs so unexpected outbound connections stay visible after the rules are tightened.
       audit: |
         ### Audit via Console
 
@@ -3004,20 +2991,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that all running OCI compute instances are configured with at least one freeform tag. By default, OCI instances launch without any freeform tags, leaving resources unattributed for cost allocation, access control, and operational management.
+        This check verifies that every running compute instance carries resource attribution metadata in the form of at least one freeform tag.
+
+        Freeform tags are unstructured key and value labels that any user with write access to the instance can apply, unlike defined tags, which are drawn from a tag namespace and can be pushed onto new resources through compartment tag defaults. Instances launch with an empty freeform tag map unless the launch request supplies one. You add them under Compute > Instances > Add tags in the Console, with `oci compute instance update --instance-id <id> --freeform-tags`, or through the `freeform_tags` argument in Terraform. The check requires the map to be non-empty on every instance in the running state.
 
         **Why this matters**
 
-        - **Resource attribution:** Without tags, instances cannot be tied to a team, project, cost center, or environment, making it impossible to accurately allocate cloud spending or assign ownership.
-        - **Access control enforcement:** Tag-based IAM policies that restrict what actions specific groups can perform on resources cannot function when instances carry no tags.
-        - **Incident response speed:** During a security incident, identifying the owner and purpose of an untagged instance adds meaningful delay to investigation and containment.
-        - **Orphan detection:** Untagged instances that have been abandoned by their original owners are indistinguishable from intentionally running workloads, allowing cost and risk to accumulate silently.
+        Without tags, an instance cannot be tied to a team, project, cost center, or environment, so cloud spending cannot be allocated accurately and no one can be named as the owner when the instance misbehaves.
 
-        **Risk mitigation**
+        Tag-based access control stops working entirely. OCI supports conditional statements such as `allow group Developers to manage instance-family in compartment Dev where target.resource.tag.Environment = 'dev'`, and an instance with no tags does not match any tag condition, so the intended restriction silently fails to apply to it.
 
-        - **Define and enforce a mandatory tagging policy:** Establish required tags such as `Owner`, `Environment`, `Project`, and `CostCenter` and apply them consistently at instance launch time.
-        - **Embed tags in IaC templates:** Set `freeform_tags` in Terraform or instance launch templates so that no instance can be created without meeting the organization's minimum tag requirements.
-        - **Audit regularly for untagged resources:** Schedule periodic scans of the compartment to catch instances that were created outside of approved IaC workflows.
+        During a security incident, identifying the owner and purpose of an untagged instance adds real delay to investigation and containment, at exactly the moment when delay is most expensive. The same gap makes orphan detection impossible: an instance abandoned by its original owner looks identical to a deliberately running workload, so cost and unpatched risk accumulate unnoticed.
+
+        Define a mandatory tag set such as `Owner`, `Environment`, `Project`, and `CostCenter`, and set `freeform_tags` in the Terraform modules and launch templates that create instances so nothing can be built without meeting the minimum. Pair that with compartment-level tag defaults, and audit compartments periodically to catch instances created outside the approved pipeline.
       audit: |
         ### Audit via Console
 
@@ -3131,20 +3117,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every active OCI IAM auth token was created within the last 90 days. Auth tokens authenticate to OCI APIs and services such as Container Registry and Autonomous Database, and they never expire on their own, so a token that is not rotated behaves as a long-lived static credential.
+        This check verifies that auth tokens are rotated on a fixed cadence, by requiring every active token to have been created within the last 90 days.
+
+        An auth token is an Oracle-generated password used by services that accept a shared secret instead of a signed request, including Container Registry, the Swift interface to Object Storage, and Autonomous Database integrations. Tokens have no expiry of any kind: once created, a token stays valid until somebody deletes it, which makes an unrotated token a permanent static credential in everything but name. Tokens are listed and deleted on the user under Identity & Security > Domains > Users, or with `oci iam auth-token list` and `oci iam auth-token delete`.
 
         **Why this matters**
 
-        - **Extended exposure window:** Auth tokens persist indefinitely until an administrator deletes them, meaning a token leaked into a source repository, CI log, or third-party service remains valid for years.
-        - **Offboarding risk:** When employees leave an organization, their tokens stay active unless explicitly deleted; a 90-day rotation cadence limits the maximum residual access period.
-        - **Blast radius over time:** The longer a token exists, the more places a copy of it may reside, such as in code archives, container image layers, or incident logs, multiplying the effective blast radius of a single leaked credential.
-        - **Forced rotation cadence:** A 90-day rotation window enforces a predictable schedule that keeps credentials fresh and encourages automation of token management.
+        Because nothing expires, the exposure window on a leaked token is the remaining life of the tenancy. A token committed to a repository, echoed into a CI log, or pasted into a third-party service is still good years later, and no built-in event will ever invalidate it. A 90-day ceiling turns an unbounded window into a bounded one.
 
-        **Risk mitigation**
+        Copies also multiply with age. The longer a token exists, the more archives, container image layers, backup snapshots, and incident tickets contain it, so the number of places a single credential can leak from grows steadily even when nothing about the token changes. Rotation resets that count.
 
-        - **Rotate tokens on a fixed schedule:** Record each token's creation date and replace the token before it is 90 days old.
-        - **Revoke and reissue long-lived tokens:** Identify active tokens that exceed the 90-day window, delete them, and distribute replacements to the owning systems.
-        - **Automate token rotation:** Build rotation workflows that generate a replacement token, distribute it, verify it works, and then delete the old token before the rotation deadline.
+        Rotation further caps residual access after people leave. A departed engineer's token stays live until it is explicitly deleted, and a fixed cadence bounds that gap even when the offboarding step is skipped.
+
+        Each user may hold only two auth tokens at once, which shapes how rotation must run: create the replacement into the free slot, deploy and verify it in the consuming system, then delete the superseded one. Automating that sequence is the practical way to hold the cadence, since it removes the temptation to leave a working token in place because replacing it by hand is disruptive.
       audit: |
         ### Audit via Console
 
@@ -3228,21 +3213,21 @@ queries:
       ).all(members.length <= 5)
     docs:
       desc: |
-        This check ensures that no OCI IAM group holding tenancy-wide administrative privilege contains more than five members. A group counts as administrative when a policy grants it `manage all-resources in tenancy`, and also when its name follows the usual administrative naming. OCI's built-in `Administrators` group and any custom group modeled after it can attach policies, manage keys, and access every resource in the tenancy, making excessive membership a high-impact risk.
+        This check verifies that tenancy-wide administrative privilege is held by a small, deliberate set of accounts, by requiring any group with that privilege to have no more than five members.
+
+        A group counts as administrative here on the strength of what it can do, not what it is named. Any group named as the subject of a statement granting `manage all-resources in tenancy` qualifies, and so do groups whose names follow the conventional administrative patterns such as `Administrators`, `tenancy-admins`, or `superusers`, which catches groups reaching the same power by another route. Membership is managed under Identity & Security > Domains > Groups and listed with `oci iam group list-users`.
 
         **Why this matters**
 
-        - **Credential compromise blast radius:** Every member of a tenancy-admin group can perform any action in the tenancy; compromising any one account through phishing, credential theft, or session hijacking results in full tenancy takeover.
-        - **Privilege creep:** Admin access granted temporarily for a project or emergency is rarely revoked, so group membership grows over time with no corresponding increase in business justification.
-        - **Offboarding gaps:** Large admin groups accumulate former-employee memberships that persist long after the individuals have left the organization.
-        - **Attribution difficulty:** When many accounts share the highest privilege level, audit logs become harder to interpret because any of the oversized group's members could have made a given change.
-        - **Naming does not track privilege:** A group called after a team can hold the same tenancy-wide grant as one called `Administrators`, so reviewing by name alone leaves the largest privileges unexamined.
+        Every member of such a group can do everything the tenancy permits: attach and rewrite policies, create credentials for other identities, and read, alter, or destroy resources in every compartment. Compromising any single member through phishing, a stolen signing key, or a hijacked session yields the entire tenancy, so the group's size is simply the number of independent paths to total control.
 
-        **Risk mitigation**
+        These groups grow quietly. Admin access granted for a migration weekend or an incident is almost never revoked afterward, and departures that miss the group leave former employees holding the highest privilege in the environment long after their last day.
 
-        - **Limit membership to five or fewer active accounts:** Review the admin group against a documented list of personnel who genuinely require tenancy-wide access and remove anyone who does not.
-        - **Use break-glass accounts for emergency access:** For users who only occasionally need admin access, provision a separate break-glass account that is activated on demand rather than keeping them in the persistent admin group.
-        - **Review group membership regularly:** Schedule periodic access reviews to catch accumulation of stale memberships before they become a risk.
+        Size also degrades attribution. When a dozen accounts share the top privilege level, an audit log narrows a destructive change to any of a dozen people, which is not an answer an investigation can act on.
+
+        Naming is the trap worth watching. A group named after a team can carry exactly the same tenancy-wide grant as `Administrators`, so a review that reads group names rather than the statements pointing at them walks straight past the largest privileges in the tenancy.
+
+        Hold the group to a documented list of people who genuinely need tenancy-wide access, give occasional users a break-glass account activated on demand instead of standing membership, and review the roster on a schedule.
       audit: |
         ### Audit via Console
 
@@ -3325,20 +3310,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Network Security Groups (NSGs) are configured to block SSH (TCP port 22) and RDP (TCP port 3389) ingress from any IPv4 source (0.0.0.0/0) or IPv6 source (::/0). NSGs apply at the VNIC level and are the modern, more granular replacement for subnet security lists; a permissive NSG rule can expose a single instance to internet admin-port attacks even when the subnet's security lists are correctly locked down.
+        This check verifies that no network security group admits SSH or RDP ingress from the entire internet.
+
+        A network security group is a set of stateful ingress and egress rules that Oracle Cloud Infrastructure applies at the VNIC level, the more granular successor to subnet security lists. Each ingress rule names a source CIDR, an IP protocol, and for TCP, which OCI records as protocol `6`, a destination port range. The check fails any rule whose source is `0.0.0.0/0` or `::/0` and whose TCP port range covers 22 for SSH or 3389 for RDP, and it counts a rule declaring no destination port range as covering both, because such a rule opens every TCP port. Rules live under Networking > Virtual cloud networks > Network security groups, and `oci network nsg rules update` edits them.
 
         **Why this matters**
 
-        - **VNIC-level bypass:** An NSG rule permitting SSH or RDP from 0.0.0.0/0 on a single VNIC negates otherwise-strict subnet controls, creating a gap that is invisible to checks focused only on security lists.
-        - **Rapid discovery:** Automated internet scanners identify open SSH and RDP ports on public IPs within minutes of a new instance launching, giving attackers an immediate window for credential attacks.
-        - **Brute-force and exploitation:** Internet-exposed admin ports attract continuous password-spray, credential-stuffing, and known-vulnerability exploitation attempts with no rate limiting at the network layer.
-        - **Dual-stack exposure:** Without checking both IPv4 and IPv6 sources, a security rule that blocks 0.0.0.0/0 but permits ::/0 leaves instances reachable over IPv6 from the entire internet.
+        Because groups attach per VNIC, one permissive rule negates otherwise strict subnet controls. The gap is invisible to any review that looks only at security lists: the subnet can be locked down correctly while a single instance answers the internet on port 22.
 
-        **Risk mitigation**
+        Automated scanners identify open SSH and RDP ports on a new public IP address within minutes of instance launch. What follows is continuous password spraying, credential stuffing, and exploitation of known vulnerabilities in the listening service, none of it rate limited at the network layer.
 
-        - **Restrict admin-port sources to trusted CIDRs:** Replace 0.0.0.0/0 and ::/0 sources in NSG ingress rules for ports 22 and 3389 with specific CIDR ranges for bastion hosts, VPN gateways, or management subnets.
-        - **Route administrative access through OCI Bastion:** Use the OCI Bastion service to provide time-limited, audited SSH and RDP sessions without exposing admin ports to the internet at all.
-        - **Align NSG rules with subnet security-list posture:** Treat NSG hardening as a complement to, not a replacement for, subnet-level controls so that both layers enforce the same admin-port policy.
+        Blocking only IPv4 is not enough: a rule set that denies `0.0.0.0/0` while permitting `::/0` leaves the same two ports reachable over IPv6 from the whole internet, which is why both sources are tested.
+
+        Where administrative access must reach an instance, replace the open source with the ranges operators connect from: bastion hosts, VPN gateways, or a management subnet. Better still, route that access through the OCI Bastion service, which brokers time limited and audited SSH and RDP sessions without either port being published. Treat group hardening as a complement to subnet security lists, not a replacement, so both layers enforce the same admin port policy.
       audit: |
         ### Audit via Console
 
@@ -3535,20 +3519,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI compute instance with a public IP address sits behind a network security group that admits traffic from any address. OCI treats an absent NSG the same way it treats a wide-open one: with no group attached, the VNIC has no VNIC-level ingress filter at all and relies entirely on the subnet's security lists, which are often shared across many instances and may carry permissive default rules.
+        This check verifies that every compute instance holding a public IP address is filtered by a network security group that does not admit traffic from any address.
+
+        Network security groups are the per-workload segmentation mechanism in Oracle Cloud Infrastructure, evaluated at the VNIC rather than at the subnet. OCI treats an absent group exactly the way it treats a wide open one: with no group attached, the VNIC has no VNIC-level ingress filter at all and falls back entirely on the subnet's security lists. The check therefore fails both the instance with a permissive group and the instance with none. Attach groups under Compute > Instances > Attached VNICs > Edit VNIC, with `oci network vnic update --nsg-ids`, or through `nsg_ids` inside the VNIC details of a Terraform instance.
 
         **Why this matters**
 
-        - **No per-host ingress filter:** Without an NSG, every inbound port allowed by the subnet security list is reachable from the internet for that specific VNIC, with no host-level override possible.
-        - **Shared-subnet exposure:** Subnets used for multiple workloads commonly have relaxed security-list rules to accommodate the broadest workload; attaching no NSG means inheriting all of that permissiveness rather than scoping rules to the host's actual services.
-        - **Silent misconfiguration:** An operator who forgets to attach an NSG produces an internet-exposed instance that passes checks focused only on security lists, leaving the gap invisible until a scan explicitly targets VNIC-level controls.
-        - **Granularity loss:** NSGs are the intended mechanism for per-workload network segmentation in OCI; skipping them forces all access control into coarser subnet-level constructs that do not scale with instance diversity.
+        Without a group, every inbound port the subnet security list allows is reachable from the internet on that specific VNIC, and there is no host-level override available to narrow it.
 
-        **Risk mitigation**
+        Subnets shared by several workloads accumulate relaxed security-list rules, because the list has to accommodate the broadest workload on it. Attaching no group means inheriting all of that permissiveness instead of scoping ingress to the services this host actually offers.
 
-        - **Require at least one NSG on every public VNIC:** Define NSG attachment as a mandatory requirement in your instance launch process, enforced by IaC templates and access policies.
-        - **Scope NSG rules to the workload:** Create an NSG per workload type (web servers, databases, management hosts) with ingress rules that permit only the ports that workload must expose, then attach that NSG to all VNICs serving that workload.
-        - **Prefer private subnets for non-public workloads:** Where an instance does not need a public IP, place it in a private subnet to eliminate the VNIC-level internet exposure entirely.
+        The failure is quiet. An operator who forgets the attachment produces an internet-exposed instance that passes any review focused on security lists alone, so the gap stays hidden until something explicitly examines VNIC-level controls.
+
+        Make group attachment a mandatory step in the instance launch path, enforced in infrastructure-as-code templates and by the access policies that govern who may launch. Define one group per workload type, such as web servers, databases, and management hosts, with ingress rules that permit only the ports that workload must expose, then attach it to every VNIC serving that workload. Where an instance has no reason to hold a public IP address at all, move it to a private subnet and remove the VNIC-level internet exposure entirely.
       audit: |
         ### Audit via Console
 
@@ -3689,20 +3672,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI compute instance is configured with the legacy Instance Metadata Service v1 (IMDSv1) endpoints disabled in its `instanceOptions`. IMDSv1 does not require the requesting process to authenticate, so any server-side request forgery vulnerability in an application running on the instance can be used to read instance principal tokens and all other metadata without any credentials.
+        This check verifies that compute instances accept only authenticated instance metadata requests, by requiring `instanceOptions.areLegacyImdsEndpointsDisabled` to be true.
+
+        The Instance Metadata Service answers requests at the link-local address 169.254.169.254 and hands out instance configuration, cloud-init `user_data`, and, crucially, short-lived instance principal tokens. Version 1 of that service answers any plain HTTP GET with no authentication at all. Version 2 requires the caller to first obtain a session token through a PUT request and then present it on every read. Disabling the legacy endpoints is set under Compute > Instances > Edit > Instance metadata service in the Console, with `oci compute instance update --instance-id <id> --instance-options`, or through `are_legacy_imds_endpoints_disabled = true` in the `instance_options` block of an `oci_core_instance` Terraform resource.
 
         **Why this matters**
 
-        - **SSRF to credential theft:** IMDSv1 responds to any HTTP GET to 169.254.169.254, including requests triggered by an SSRF vulnerability in a web application; IMDSv2 requires a PUT-based session token that SSRF payloads typically cannot produce.
-        - **Broad process exposure:** Every process running on the instance, including application containers and third-party services, can query IMDSv1 endpoints without restriction, multiplying the attack surface.
-        - **Privilege escalation:** Instance principal tokens retrieved from IMDSv1 grant the IAM permissions attached to the instance's dynamic group, potentially allowing an attacker to access other OCI resources in the tenancy.
-        - **No legitimate SDKs require IMDSv1:** The OCI SDK and CLI use IMDSv2 by default, so disabling legacy endpoints does not break any correctly-written workload.
+        A server-side request forgery flaw in any application on the instance is enough to read IMDSv1. The attacker only needs to coerce the application into fetching a URL, and a GET to 169.254.169.254 returns metadata with no credential of any kind. The PUT-plus-header handshake that IMDSv2 demands is something most SSRF primitives cannot produce, because they control a URL and not an HTTP method or header.
 
-        **Risk mitigation**
+        What comes back is not just configuration. Instance principals are the mechanism by which compute gets OCI credentials without an API key: a dynamic group matches the instance by rule, and IAM policies grant that dynamic group permissions. A token pulled from IMDSv1 carries exactly those permissions, so the blast radius is whatever the dynamic group was granted across the tenancy.
 
-        - **Disable legacy IMDS endpoints at instance launch:** Set `are_legacy_imds_endpoints_disabled = true` in the `instance_options` block of every `oci_core_instance` Terraform resource so the protection is applied from the start.
-        - **Migrate applications to IMDSv2 before enforcing:** Audit any automation or bootstrap scripts that call 169.254.169.254 directly and update them to include the required IMDSv2 session-token header before disabling v1.
-        - **Enforce the setting via IAM or launch templates:** Use compartment-level policies or Terraform module defaults to ensure that newly created instances always launch with IMDSv1 disabled.
+        Every process on the host can reach the legacy endpoints, including application containers and third-party agents, so the exposure is not limited to one privileged service.
+
+        The OCI SDK and CLI speak IMDSv2 by default, so correctly written workloads are unaffected. Before enforcing, audit bootstrap scripts and automation that call the metadata address directly and update them to request a session token first, then set the flag in your Terraform module defaults so new instances launch with it off.
       audit: |
         ### Audit via Console
 
@@ -3837,20 +3819,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI compute instance metadata does not contain credentials, including suspicious key names (such as `password`, `secret`, `api_token`, `aws_access_key_id`, and similar), AWS access key ID patterns in values, PEM private key blocks, or JWT tokens. Instance metadata is readable by anyone with `compute-instance:read` IAM permission and by every process on the instance via the IMDS endpoints, making it a high-visibility credential-leak channel.
+        This check verifies that no credential material has been placed in compute instance metadata, where it would be readable without any secret-management control.
+
+        Instance metadata is a free-form key and value map supplied at launch and used for legitimate purposes such as SSH authorized keys and the cloud-init `user_data` payload. This check inspects it for two things: keys named like credentials, including `password`, `passwd`, `secret`, `api_token`, `bearer_token`, `db_password`, `private_key`, `access_key`, `client_secret`, `connection_string`, `oci_api_key`, `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token`; and values shaped like credentials, meaning AWS access key identifiers, PEM blocks that open with `-----BEGIN` and carry a `PRIVATE KEY-----` header, and JSON Web Tokens. Any hit fails.
 
         **Why this matters**
 
-        - **Persistent exposure:** Credentials placed in instance metadata persist for the entire life of the instance and cannot be scoped to a specific process or container; they are available to all code running on the host.
-        - **Broad IAM read access:** Any user or service with read access to the compartment can retrieve instance metadata with a single API call, so the audience for a leaked credential is not limited to the instance owner.
-        - **IMDS accessibility:** Every process on the instance, including any compromised application, can read metadata values via the IMDS endpoint at 169.254.169.254 without requiring any IAM permissions.
-        - **Rotation is destructive:** Unlike secrets stored in OCI Vault, rotating a credential embedded in instance metadata requires recreating the instance; the old value remains exposed until the instance is replaced.
+        Metadata is readable by anyone holding the `compute-instance:read` IAM permission on the compartment, so a single API call retrieves the value and the audience is far wider than the instance owner. It is simultaneously readable by every process on the host through the metadata endpoint at 169.254.169.254, with no IAM permission required at all, which means any compromised application or sidecar container reads it too.
 
-        **Risk mitigation**
+        A credential parked there is scoped to nothing. It cannot be restricted to one process, one container, or one time window, and it persists for the entire life of the instance.
 
-        - **Rotate exposed credentials immediately:** Treat any credential found in instance metadata as compromised and revoke and reissue it before making any other change.
-        - **Use OCI Vault for secrets:** Store application credentials in OCI Vault and retrieve them at runtime via the resource principal authentication flow, which never requires placing secret values in metadata.
-        - **Audit IaC templates and launch scripts:** Review all Terraform modules, cloud-init scripts, and launch configurations to ensure that no credential values are passed through the `metadata` map.
+        Rotation is destructive rather than routine. A secret in OCI Vault is replaced with a new version in place, but a value baked into instance metadata generally requires recreating the instance to change, and the old value stays exposed until that happens.
+
+        Treat anything found here as already compromised: revoke and reissue it before making any other change. Store application credentials in OCI Vault and fetch them at runtime through instance or resource principal authentication, and review Terraform modules, cloud-init files, and launch configurations so no value is passed through the `metadata` map in the first place.
       audit: |
         ### Audit via Console
 
@@ -4017,20 +3998,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every HTTPS and HTTP/2 listener on OCI load balancers is configured to accept only TLS 1.2 or TLS 1.3 connections. Oracle's default SSL configuration permits older protocol versions, but TLS 1.0 and TLS 1.1 have been formally deprecated and are vulnerable to well-known downgrade and padding-oracle attacks.
+        This check verifies that every HTTPS and HTTP/2 listener on an OCI load balancer negotiates only TLS 1.2 or TLS 1.3, with TLS 1.0, TLS 1.1, and SSL 3.0 removed from the offered protocol set.
+
+        A listener that terminates TLS carries an SSL configuration whose protocol list names the versions it will accept. Oracle's default configuration permits older protocol versions, so a listener created without an explicit list can still answer a client that asks for a deprecated one. The check requires that the list contain none of `TLSv1`, `TLSv1.1`, or `SSLv3`, leaving `TLSv1.2` and `TLSv1.3` as the only possible outcomes. Edit the list under Networking > Load balancers > Listeners in the Console, or with `oci lb listener update`.
 
         **Why this matters**
 
-        - **Downgrade exposure:** Accepting TLS 1.0 or 1.1 provides a negotiated downgrade path that bypasses the security guarantees of newer TLS sessions.
-        - **Known protocol weaknesses:** TLS 1.0 and 1.1 are susceptible to BEAST, POODLE, CRIME, and LUCKY13 attacks that allow partial or full plaintext recovery from intercepted sessions.
-        - **Weak cipher dependency:** Legacy TLS versions force support for CBC-mode cipher suites with known structural weaknesses that authenticated-encryption modes eliminate.
-        - **Broad regulatory alignment:** Many security and payment frameworks prohibit TLS versions older than 1.2 for systems handling sensitive data.
+        Keeping a deprecated version in the offered set creates a negotiated downgrade path. An attacker who can influence the handshake steers the client onto TLS 1.0 or TLS 1.1, and the session then runs under the guarantees of the weaker version rather than the stronger one the client was capable of.
 
-        **Risk mitigation**
+        Both versions are formally deprecated and carry published attacks. BEAST, POODLE, CRIME, and LUCKY13 allow partial or full plaintext recovery from an intercepted session, and each targets structure that TLS 1.2 and TLS 1.3 removed. Legacy versions also force support for CBC-mode cipher suites, whose lack of authenticated encryption is what makes padding-oracle recovery workable in the first place.
 
-        - **Eliminates downgrade paths:** Clients are forced to negotiate TLS 1.2 or TLS 1.3, removing the weakest negotiation outcome.
-        - **Enforces modern cipher use:** TLS 1.2 and 1.3 listeners exclusively negotiate AEAD cipher suites with forward-secret key exchange.
-        - **Reduces interception risk:** Prevents attackers on transit networks from exploiting padding-oracle or block-cipher attacks against captured traffic.
+        Many security and payment frameworks prohibit protocol versions older than TLS 1.2 for any system handling sensitive data, so a listener that still offers them is an audit finding as well as an exposure.
+
+        Clients that genuinely require TLS 1.0 are running software long past end of support. If one must be accommodated, isolate it behind a dedicated listener with a documented retirement date rather than widening the protocol list on the listener that serves everyone else.
       audit: |
         ### Audit via Console
 
@@ -4191,20 +4171,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every HTTPS and HTTP/2 listener on OCI load balancers is configured to use a modern Oracle-managed cipher suite rather than the compatible or legacy suites that include RC4, 3DES, and non-AEAD CBC-mode algorithms. Oracle ships the `oci-compatible-ssl-cipher-suite-v1` suite primarily for interoperability with old clients, but its inclusion of known-weak ciphers makes it unsuitable for production use.
+        This check verifies that every HTTPS and HTTP/2 listener on an OCI load balancer is bound to a modern Oracle-managed cipher suite rather than one that still offers RC4, 3DES, or non-AEAD CBC-mode algorithms.
+
+        A listener's SSL configuration names exactly one cipher suite. The check accepts `oci-modern-ssl-cipher-suite-v1`, `oci-default-ssl-cipher-suite-v1`, and the version-specific `oci-tls-1-2-*` and `oci-tls-1-3-*` suites. It rejects `oci-compatible-ssl-cipher-suite-v1`, which Oracle ships mainly for interoperability with old clients and which includes known-weak ciphers that make it unsuitable for production, along with any custom suite outside the approved names. Select the suite in the listener's SSL configuration under Networking > Load balancers > Listeners in the Console, or with `oci lb listener update`.
 
         **Why this matters**
 
-        - **Cryptographic weaknesses:** RC4 has well-documented statistical biases that allow plaintext recovery; 3DES is vulnerable to the Sweet32 birthday attack at practical traffic volumes.
-        - **Padding-oracle susceptibility:** Non-AEAD CBC ciphers lack the authentication required to prevent padding-oracle attacks that recover session data.
-        - **No practical client need:** By 2026, any client that requires these ciphers is running software past its end-of-life and should be rebuilt rather than accommodated at the load balancer edge.
-        - **Forward secrecy gaps:** Weak cipher suites often use static RSA key exchange, which exposes past sessions if the server's private key is ever disclosed.
+        RC4 has well-documented statistical biases that let an attacker recover plaintext from enough captured sessions, and 3DES falls to the Sweet32 birthday attack at traffic volumes a busy listener reaches in hours. Neither is theoretical at the scale a public load balancer operates.
 
-        **Risk mitigation**
+        CBC-mode suites without authenticated encryption leave ciphertext malleable, which is the condition padding-oracle attacks need to peel a session apart. Modern suites restrict negotiation to GCM and ChaCha20 authenticated encryption, where that condition does not exist.
 
-        - **Eliminates weak ciphers from negotiation:** Modern suites restrict available algorithms to ECDHE key exchange and GCM or ChaCha20 authenticated encryption.
-        - **Enforces forward secrecy:** ECDHE key exchange ensures that captured traffic cannot be decrypted even with future access to the server's private key.
-        - **Narrows the attack surface:** Removing legacy cipher fallback eliminates an entire class of negotiated-downgrade attacks.
+        Weak suites also tend to permit static RSA key exchange. A session negotiated that way is decryptable by anyone who later obtains the server's private key, whether from a backup, a misfiled export, or a future compromise. The ECDHE key exchange that the modern suites require makes captured traffic worthless afterward, because the secret that would decrypt it no longer exists anywhere.
+
+        There is no practical client left that needs these algorithms. By 2026, anything demanding them is past its end of life and should be rebuilt rather than accommodated at the load balancer edge, and removing the legacy fallback closes an entire class of negotiated-downgrade attack at the same time.
       audit: |
         ### Audit via Console
 
@@ -4343,20 +4322,19 @@ queries:
       oci.loadBalancer.loadBalancer.listeners.any(protocol.in(["HTTPS", "HTTP2"]))
     docs:
       desc: |
-        This check ensures that every OCI load balancer exposing an HTTP listener also exposes at least one HTTPS or HTTP/2 listener. A load balancer that serves HTTP with no accompanying TLS listener provides no encrypted path for the service, meaning that traffic including credentials, session cookies, and form submissions travels in cleartext across any network between the client and the load balancer.
+        This check verifies that any OCI load balancer publishing an HTTP listener also publishes at least one HTTPS or HTTP/2 listener, so the service has an encrypted path clients can be moved onto.
+
+        A load balancer answering only on plain HTTP gives the application no transport security to offer. Credentials, session cookies, and form submissions cross every network between the client and the load balancer in cleartext. Add a TLS listener under Networking > Load balancers > Listeners in the Console with protocol `HTTPS` or `HTTP2` and an SSL configuration that references a certificate, or run `oci lb listener create` with the same values. The check is satisfied once one such listener exists. It does not require the HTTP listener to be removed, since serving a redirect is a legitimate reason to keep it.
 
         **Why this matters**
 
-        - **Credential exposure:** Authenticated sessions sent over HTTP are recoverable by any observer on the network path, including shared Wi-Fi, ISP infrastructure, and transit networks.
-        - **No redirect capability:** Redirecting HTTP clients to HTTPS requires the load balancer to have an HTTPS listener to redirect them to; without one, the application cannot enforce transport security.
-        - **Content injection risk:** Cleartext HTTP responses can be modified in transit, allowing injection of malicious scripts, tracking pixels, or redirects.
-        - **Browser and search engine penalties:** Modern browsers and crawlers increasingly flag HTTP-only endpoints, reducing user trust and discoverability.
+        Anything an authenticated session carries over HTTP is recoverable by any observer on the path, and the path is longer than it looks: shared Wi-Fi, the customer's ISP, and every transit network in between. A stolen session cookie needs no password to replay.
 
-        **Risk mitigation**
+        Redirecting HTTP clients to HTTPS requires somewhere to redirect them to. With no HTTPS listener the application cannot enforce transport security at all, and the headers that would carry that enforcement are inert. HSTS, CSP, and the `Secure` cookie attribute mean something only when the response carrying them arrived over TLS.
 
-        - **Enables TLS enforcement:** Providing an HTTPS listener is the prerequisite for any HTTP-to-HTTPS redirect or HSTS header enforcement.
-        - **Closes passive sniffing:** Authenticated sessions routed over HTTPS are encrypted in transit and no longer recoverable from captured packets.
-        - **Supports modern security headers:** HSTS, CSP, and secure cookie attributes only provide meaningful protection when delivered over HTTPS.
+        Cleartext responses are modifiable in flight, not merely readable. An attacker on the path can inject a script, a tracking pixel, or a redirect into a page the user believes came from you, which turns passive eavesdropping into active compromise of the browser session.
+
+        Browsers and search crawlers increasingly flag HTTP-only endpoints as insecure, so an unencrypted listener costs user trust and discoverability on top of the exposure. Once the HTTPS listener exists, follow it by redirecting the HTTP listener to it rather than leaving both serving content.
       audit: |
         ### Audit via Console
 
@@ -4444,20 +4422,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every Oracle Kubernetes Engine cluster is configured with a private Kubernetes API endpoint so the control plane is not reachable from the public internet. Oracle defaults to a public endpoint when `is_public_ip_enabled` is not explicitly set to false, which means clusters provisioned without explicit network hardening are internet-exposed by default.
+        This check verifies that the Kubernetes API server of every Oracle Kubernetes Engine (OKE) cluster is reachable only from inside the virtual cloud network, with no public IP address on its endpoint.
+
+        A cluster's endpoint configuration decides whether the control plane receives a public address alongside its private one. Oracle assigns a public endpoint when `is_public_ip_enabled` is not explicitly set to false, so a cluster provisioned without deliberate network hardening is internet-exposed from its first minute. The check requires that configuration to exist and to disable the public IP; the Terraform versions insist on the `endpoint_config` block being declared at all, because a manifest that omits it silently inherits Oracle's public default. The setting is chosen at creation time under Developer Services > Kubernetes Clusters (OKE) in the cluster's network configuration.
 
         **Why this matters**
 
-        - **High-value attack surface:** The Kubernetes API server is the single most privileged endpoint in any cluster; a valid credential or exploitable bug grants full control of every namespace and workload.
-        - **Ongoing CVE exposure:** Kubernetes regularly ships auth-bypass, SSRF, and privilege-escalation CVEs; a public endpoint turns each disclosure into an immediate internet-wide attack window.
-        - **Credential brute-force risk:** Public API endpoints are continuously scanned and subjected to credential-stuffing attacks against exposed kubeconfig credentials.
-        - **Alert noise and capacity drain:** Internet-reachable API servers generate constant scan traffic that fills audit logs and consumes control-plane request capacity.
+        The API server is the single most privileged endpoint in any cluster. Whoever reaches `kube-apiserver` with a valid credential, or with an exploitable bug, controls every namespace and workload: reading every secret, scheduling a privileged pod that mounts the host filesystem, and executing commands inside running containers.
 
-        **Risk mitigation**
+        Kubernetes ships auth-bypass, SSRF, and privilege-escalation fixes on a regular cadence. A public endpoint converts each disclosure into an immediate internet-wide attack window in which the only defense is how quickly Oracle patches the control plane. Between CVEs the endpoint is still continuously scanned, and kubeconfig credentials leaked from a laptop or a CI log get replayed against it by automated credential-stuffing tools.
 
-        - **Eliminates public control-plane exposure:** Removing the public IP from the API endpoint takes the cluster off the internet-wide attack surface entirely.
-        - **Enforces controlled access paths:** Administrative access must go through OCI Bastion, VPN, or VCN peering, all of which are auditable and can be gated by identity.
-        - **Limits blast radius of future CVEs:** A private endpoint means that exploiting any future Kubernetes API vulnerability requires network adjacency, not just internet access.
+        Even the traffic that fails costs something, filling audit logs with noise that hides real authentication events and consuming control-plane request capacity that legitimate controllers need.
+
+        With the public IP removed, administrators reach the cluster through an OCI Bastion session, an IPSec VPN or FastConnect circuit, or a peered VCN, every one of which is identity-gated and auditable. The practical effect on the next Kubernetes CVE is that exploiting it requires network adjacency rather than an internet route.
       audit: |
         ### Audit via Console
 
@@ -4579,20 +4556,19 @@ queries:
       oci.oke.cluster.availableKubernetesUpgrades.length < 3
     docs:
       desc: |
-        This check ensures that OCI Kubernetes Engine clusters are running a Kubernetes version that is not significantly behind Oracle's current supported releases. The check flags clusters with three or more available upgrades pending, which is a strong indicator that the cluster is running a version near or past its end-of-support window and is no longer receiving security patches from Oracle.
+        This check verifies that OKE clusters run a Kubernetes version still inside Oracle's supported release window rather than one that has drifted toward or past its end-of-support date.
+
+        Oracle Kubernetes Engine (OKE) publishes the upgrade targets available to each cluster, and the length of that list measures how far behind the control plane has fallen. The check fails a cluster with three or more upgrades pending, which places it at least three releases behind current and near or past the point where Oracle stops shipping security backports for it. The Console shows the same state as an Upgrade Available banner on the cluster's detail page. Control plane and node pools move separately: `oci ce cluster update --kubernetes-version` advances the control plane, and each node pool then needs its own upgrade or a recreate of its nodes.
 
         **Why this matters**
 
-        - **Unpatched CVE accumulation:** Oracle backports security fixes only to supported minor versions; an EOL cluster accumulates every CVE disclosed after its drop date with no remediation path short of a major version upgrade.
-        - **High-severity vulnerability class:** Many Kubernetes CVEs fall into auth-bypass or privilege-escalation categories, making an unpatched cluster a tenant-to-tenant pivot risk in shared infrastructure.
-        - **Version skew instability:** Major gaps between the control plane version and node pool versions cause feature incompatibilities and can result in workload failures or degraded scheduling.
-        - **Support window obligations:** Regulatory and contractual obligations often require running supported, patched software versions; an EOL Kubernetes cluster can create a compliance gap.
+        Oracle backports security fixes only to supported minor versions. Once a cluster falls out of that window it accumulates every CVE disclosed after its drop date with no remediation path short of a major version upgrade, exactly the sort of disruptive change teams keep deferring, so the gap widens rather than closes.
 
-        **Risk mitigation**
+        The vulnerability classes involved are not cosmetic. Many Kubernetes CVEs are auth-bypass or privilege-escalation flaws, which makes an unpatched cluster a tenant-to-tenant pivot in shared infrastructure: a workload that should only ever see its own namespace becomes a route into the rest of the estate.
 
-        - **Ensures ongoing patch coverage:** Staying within the supported version window guarantees the cluster receives Oracle's security backports as CVEs are disclosed.
-        - **Reduces upgrade shock:** Incremental upgrades through supported releases are less disruptive than emergency major-version migrations forced by an EOL event.
-        - **Maintains Oracle supportability:** Clusters running supported versions are eligible for Oracle support assistance and incident response.
+        Falling behind destabilizes the cluster on its own terms too. Large gaps between the control plane version and the version running on node pools produce feature incompatibilities that surface as failing workloads or degraded scheduling long before anyone connects the symptom to version skew. Regulatory and contractual obligations also routinely require running supported, patched software, so an end-of-life cluster is a compliance finding as well as a security one.
+
+        Staying inside the window, ideally within two releases of the newest version OKE offers, keeps security backports flowing, keeps the cluster eligible for Oracle support and incident response, and replaces emergency major-version migrations with routine incremental upgrades.
       audit: |
         ### Audit via Console
 
@@ -4671,20 +4647,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Kubernetes Engine cluster has image signature verification enabled, requiring that container images pass a cryptographic signature check before they are admitted to run. Without this policy, the cluster will pull and run any image referenced in a pod spec with no authenticity verification, making it vulnerable to supply-chain attacks where a malicious or tampered image is substituted.
+        This check verifies that container image signature verification is enforced on every OKE cluster, so that only images signed by a key the cluster trusts are admitted to run.
+
+        An Oracle Kubernetes Engine (OKE) image verification policy binds a cluster to one or more master encryption keys held in OCI Vault. With the policy enabled, the cluster resolves each image's signature in OCI Container Registry and refuses to create the container when the signature is absent or was produced by a key outside that list. The check requires the image policy configuration to exist and to be enabled, since a cluster that never declares one accepts whatever a pod spec names. Enable it under Developer Services > Kubernetes Clusters (OKE) > Image Verification Policies, or with `oci ce cluster update --image-policy-config`, and add at least one Key Management master encryption key as the signing authority.
 
         **Why this matters**
 
-        - **Supply-chain substitution risk:** A compromised registry, typo-squatted image name, or man-in-the-middle during image pull can silently replace a trusted image with a malicious one.
-        - **Manifest tampering:** An attacker with write access to a Helm chart, Kustomize overlay, or CI pipeline can swap image references without touching the running cluster.
-        - **Public image compromise:** Widely-used public base images have historically been trojanized through maintainer account takeover, injecting malicious code into images pulled by thousands of clusters.
-        - **Cryptographic gate:** Image policy verification adds a signature requirement that every supply-chain attack path must defeat, requiring the attacker to compromise the signing key rather than just the image or manifest.
+        Without a signature gate, the cluster pulls and runs any image reference with no authenticity verification at all. A compromised registry, a typo-squatted image name, or a man-in-the-middle during the pull silently substitutes a malicious image for a trusted one, and nothing in the deployment path notices.
 
-        **Risk mitigation**
+        The manifest is as soft a target as the registry. An attacker with write access to a Helm chart, a Kustomize overlay, or a CI pipeline can swap an image reference without ever touching the running cluster, and the change reads as an ordinary version bump in review. Widely used public base images have themselves been trojanized through maintainer account takeover, injecting malicious code into images that thousands of clusters pull on the next deploy.
 
-        - **Blocks unsigned images at admission:** Any image that is not signed by a trusted KMS key is rejected before a container is created, preventing unsigned workloads from ever running.
-        - **Raises the bar for supply-chain attacks:** Substituting a malicious image requires forging or stealing a signing key, not just pushing to a registry or rewriting a manifest.
-        - **Aligns with SLSA and supply-chain guidance:** Cryptographic image verification is a core control in supply-chain security frameworks, demonstrating a verifiable chain of custody from build to deploy.
+        Signature verification puts a cryptographic requirement in front of all of those paths. Substituting an image no longer means pushing to a registry or rewriting a manifest; it means forging or stealing a signing key held in Vault, a far narrower and far better guarded target. That verifiable chain of custody from build to deploy is also what supply-chain frameworks such as SLSA ask for.
+
+        Restrict use of the signing key so only the build pipeline can sign, and pair the policy with a rule requiring images come from the tenancy's own registry, since verification covers only what the named keys actually signed.
       audit: |
         ### Audit via Console
 
@@ -4807,20 +4782,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every OCI Kubernetes Engine node pool places its worker nodes in subnets configured with `prohibitPublicIpOnVnic = true`, so that worker VNICs cannot be assigned a public IP address. A node pool subnet without this flag allows worker nodes to receive public IPs, making the kubelet, container runtime, and any host-networked pod directly reachable from the internet.
+        This check verifies that OKE worker nodes cannot be given a public IP address, by requiring every subnet a node pool uses to prohibit public IPs on its VNICs.
+
+        Oracle Kubernetes Engine (OKE) worker nodes inherit their internet reachability from the subnet they sit in. A subnet created with `prohibitPublicIpOnVnic = true`, returned by the API as `prohibitPublicIpOnVnic: true`, refuses to assign a public IP to any VNIC placed in it, which is the structural form of a private subnet; a subnet without the flag lets a worker node come up with a public address. The check requires the flag on every subnet backing every node pool. It is fixed when the subnet is created under Networking > Virtual Cloud Networks, so a public worker subnet is corrected by building a private subnet and moving the node pool, not by editing the existing one.
 
         **Why this matters**
 
-        - **Direct kubelet exposure:** A worker node with a public IP exposes the kubelet on port 10250, the container runtime socket, and any pod using `hostPort` or `hostNetwork` directly to internet scanning and exploitation.
-        - **High-value compromise target:** Gaining a foothold on a single worker node typically yields in-memory service-account tokens, cached secrets, and a lateral movement path into the rest of the cluster.
-        - **Subnet-level structural guarantee:** Setting `prohibitPublicIpOnVnic: true` at the subnet level prevents accidental public IP assignment even if a node pool is reconfigured or a new pool is added to the same subnet.
-        - **Egress bypass:** Worker nodes with public IPs can route outbound traffic directly to the internet, bypassing the NAT gateway and service gateway paths that provide egress logging and filtering.
+        A worker node with a public IP puts the kubelet on port 10250, the container runtime socket, and any pod using `hostPort` or `hostNetwork` directly in front of internet scanning and exploitation. These are not endpoints designed to survive hostile exposure; the kubelet's read and exec surfaces exist for the control plane to use over a trusted network.
 
-        **Risk mitigation**
+        A single worker is a rich prize. A foothold there typically yields in-memory service-account tokens, secrets cached by running pods, and a lateral path into the rest of the cluster, so the node's exposure is really the cluster's exposure.
 
-        - **Removes internet reachability of worker nodes:** Placing workers in private subnets means the kubelet, container runtime, and workloads are unreachable from outside the VCN without an explicit path through a bastion or load balancer.
-        - **Channels node egress through inspectable paths:** Private subnet workers must route internet-bound traffic through a NAT gateway, where it can be logged, filtered, and alarmed.
-        - **Prevents configuration drift:** The subnet-level prohibition is a structural control that holds even when node pools are replaced, scaled, or recreated.
+        Public-addressed workers also route outbound traffic straight to the internet, bypassing the NAT gateway and service gateway paths where egress is logged, filtered, and alarmed. That removes the one place where command-and-control or exfiltration traffic from a compromised pod would have been visible.
+
+        Because the prohibition lives on the subnet rather than the node pool, it holds even when pools are replaced, scaled, or added, a failure mode no node-pool-level setting covers. Administrators reach private workers through a bastion host or an OCI Bastion session, and inbound application traffic arrives through a load balancer in a separate public subnet, so nothing legitimate requires a worker node to hold a public IP.
       audit: |
         ### Audit via Console
 
@@ -4938,20 +4912,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Kubernetes Engine node pool has at least one Network Security Group attached to its worker node VNICs. Without NSGs, the node pool's network access is governed solely by the subnet's security lists, which apply uniformly to every VNIC in the subnet regardless of workload type, making it difficult to express least-privilege rules that are scoped specifically to the node pool.
+        This check verifies that every OKE node pool has at least one Network Security Group attached to its worker node VNICs, so that node traffic has a firewall boundary of its own rather than only the subnet's security lists.
+
+        A Network Security Group (NSG) is a per-VNIC rule set that follows the resources placed in it, while a security list applies to every VNIC in the subnet regardless of what runs there. The check requires the node pool's network configuration to name at least one NSG, and the Terraform versions require the node configuration block to exist with a non-empty `nsg_ids` list, since a node pool that omits the block gets no NSG at all. Attach one in the node pool's network settings under Developer Services > Kubernetes Clusters (OKE), or through the node configuration details passed to `oci ce node-pool update`.
 
         **Why this matters**
 
-        - **Coarse subnet-level controls:** Security lists apply to every resource in the subnet, including non-OKE workloads, so tightening rules for worker nodes can break other services sharing the same subnet.
-        - **Inability to reference other NSGs:** Security list rules are IP-range-based; NSG rules can reference other NSGs by identity, keeping node pool rules stable as service IP ranges change.
-        - **Silent exposure risk:** A single overly permissive rule in the subnet security list widens the node pool's exposure without any indication at the node pool level.
-        - **Defense-in-depth layering:** NSGs provide a per-resource firewall layer that supplements subnet-level rules, ensuring nodes have a dedicated access control boundary.
+        With only a security list in play, the rules governing worker nodes are the rules governing everything else in the subnet, including non-OKE workloads. Tightening them to what the kubelet and CNI actually need risks breaking a neighboring service, so in practice the rules stay looser than the node pool warrants and nobody can safely narrow them.
 
-        **Risk mitigation**
+        The two rule types also differ in what they can express. Security list rules are IP-range based, whereas NSG rules can name another NSG as their source or destination. Rules written against the load balancer NSG or the cluster API NSG stay correct as addresses change, while IP-range rules drift out of sync with the infrastructure they were meant to describe and are then widened to compensate.
 
-        - **Per-node-pool firewall boundary:** An attached NSG scopes ingress and egress rules specifically to the node pool's VNICs, independent of other resources in the same subnet.
-        - **Stable NSG-to-NSG references:** Rules that reference the load balancer NSG or cluster API NSG remain valid as IP ranges change, reducing the chance of rules drifting out of sync.
-        - **Eliminates the subnet-only failure mode:** Attaching an NSG ensures that the node pool has at least one access control layer that cannot be inadvertently widened by changes to unrelated resources in the subnet.
+        The failure is quiet, too. One overly permissive rule added to a shared subnet's security list widens the node pool's exposure with no signal at the node pool level, because nothing in the pool's own configuration records the change.
+
+        Attaching an NSG does not by itself narrow anything: OCI permits traffic that either the subnet's security lists or an attached NSG allows. Treat this as the prerequisite step, then pare the shared security list back to the minimum so the NSG becomes the layer that actually decides what reaches the nodes.
       audit: |
         ### Audit via Console
 
@@ -5094,18 +5067,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Kubernetes Engine (OKE) clusters encrypt Kubernetes secrets in etcd using a customer-managed key stored in OCI Vault rather than relying on the default Oracle-managed encryption. By default OKE encrypts etcd with an Oracle-managed key, so the risk here is not the absence of encryption but the absence of customer control over the key that protects application secrets, service-account tokens, and other sensitive objects.
+        This check verifies that OKE encrypts Kubernetes secrets at rest in etcd with a customer-managed key held in OCI Vault instead of the Oracle-managed key applied by default.
+
+        Oracle Kubernetes Engine (OKE) already encrypts etcd, so the gap this closes is not missing encryption but missing customer control over the key that protects application secrets, service-account tokens, and every other sensitive object the control plane stores. The check requires a master encryption key to be assigned to the cluster. Choose it under Advanced options when creating the cluster with Encrypt Kubernetes secrets using a KMS key, or pass `--kms-key-id` to `oci ce cluster create`, and grant the service access with a statement such as `allow service oke to use keys in compartment <compartment-name>`.
 
         **Why this matters**
 
-        - **Key revocation capability:** A customer-managed key lets you revoke access to every Kubernetes secret in the cluster by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Holding the key in a customer-controlled vault separates key management from cluster administration, enabling independent access controls and audit trails.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data, including secrets held in a Kubernetes control plane.
+        A customer-managed key gives you a kill switch. Disabling or deleting the key in OCI Vault renders every Kubernetes secret in the cluster unreadable, which is the fastest containment action available when a cluster is suspected of being compromised. With the Oracle-managed default there is no equivalent lever to pull.
 
-        **Risk mitigation**
+        Holding the key in a vault you control also separates key management from cluster administration. The people who can operate the cluster and the people who can authorize use of the key become distinct sets of principals with distinct IAM policies, and key operations land in an audit trail that a cluster administrator cannot quietly edit.
 
-        - **Assign a Vault key at cluster creation:** Reference a master encryption key when creating the cluster; the secrets-encryption key cannot be changed after the cluster exists.
-        - **Rotate and monitor keys:** Configure rotation on the key and review OCI Audit logs for key operations that touch cluster secrets.
+        Frameworks such as HIPAA and PCI DSS ask for demonstrable control over the keys protecting regulated data, and secrets sitting in a Kubernetes control plane are squarely inside that scope. An Oracle-managed key is encryption you can attest to but not key custody you can evidence.
+
+        The key must be assigned when the cluster is created, because the secrets-encryption key cannot be added or changed afterward; retrofitting means building a new cluster and migrating workloads to it. Once assigned, configure rotation on the key and review OCI Audit for key operations touching the cluster. Note that this protects control-plane storage, so pair it with a runtime flow where pods fetch credentials from Vault rather than relying on long-lived Kubernetes secrets.
       audit: |
         ### Audit via Console
 
@@ -5218,20 +5192,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Autonomous Database either requires mutual TLS authentication or restricts network access through a private endpoint, IP allowlist, or attached Network Security Groups. By default, a newly provisioned Autonomous Database that is not placed in a private subnet and has no access control list accepts any wallet-authenticated connection from the public internet, which is the weakest access posture the service permits.
+        This check verifies that every Autonomous Database gates connections behind either mutual TLS or a network restriction, so that stolen credentials alone cannot open a session.
+
+        Autonomous Database admits clients in one of two handshake modes. With mutual TLS required, the client must present the certificate packaged in the database's connection wallet, and the handshake fails before any credential is evaluated if that certificate is missing or has been rotated out. With mutual TLS optional, no wallet participates and the session is admitted on credentials alone. This check passes a database that requires mutual TLS, and also one that constrains who can reach it at all: a private endpoint address, a non-empty access control list of permitted sources, or attached network security groups. All of these live under Oracle Database > Autonomous Database > Network in the Console, or in `oci db autonomous-database update`.
 
         **Why this matters**
 
-        - **Credential-only attack path:** Without mTLS, a leaked database username and password is sufficient for any internet-connected attacker to connect; mTLS requires both credentials and the client-side wallet certificate.
-        - **Wallet leak amplification:** ADB connection wallets are frequently committed to code repositories or shared over support channels; mTLS turns such a leak from a direct compromise into an additional layer that also requires credentials.
-        - **Open listener risk:** A public ADB with no ACL or NSG accepts connection attempts from any IP address, exposing the SQL Net listener to continuous brute-force and vulnerability scanning.
-        - **Defense-in-depth baseline:** IP ACLs and NSGs provide a network-layer gate that remains effective even if both credentials and wallet material leak.
+        A public Autonomous Database with mutual TLS optional and an empty access control list is the weakest posture the service permits. An empty list is not a closed door but the absence of one: with no entries there is nothing to filter against, so any address on the internet may attempt a connection. A leaked application password is then the whole attack, and the SQL*Net listener absorbs continuous brute-force and vulnerability scanning.
 
-        **Risk mitigation**
+        Wallets leak during ordinary operations. They are committed to code repositories, pasted into ticketing systems, and forwarded over support channels. Requiring mutual TLS does not make that harmless, but it splits the compromise in two, since the attacker now needs wallet material as well as credentials.
 
-        - **Closes the credentials-only connection path:** Requiring mTLS means that credential theft alone is insufficient for an attacker to open a database session.
-        - **Scopes reachability to known sources:** An ACL or NSG limits which IP addresses or VCN resources can even attempt a connection, blocking opportunistic scanning at the network layer.
-        - **Aligns with Oracle's recommended production posture:** Oracle's documentation identifies mTLS-required or private-endpoint access as the expected baseline for production Autonomous Databases.
+        An access control list or a network security group is a different kind of gate, one that still holds when both credentials and wallet leak, because it filters before the listener is reached. Oracle treats required mutual TLS or private endpoint access as the expected posture for production.
+
+        Where a platform genuinely cannot distribute wallets, making mutual TLS optional is defensible only alongside a private endpoint or a tightly scoped allowlist.
       audit: |
         ### Audit via Console
 
@@ -5374,20 +5347,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI Autonomous Database serves its management web URLs on a public endpoint. When an Autonomous Database is not placed in a private subnet, Oracle publishes a set of management interfaces including APEX, SQL Developer Web, ORDS, GraphStudio, and Machine Learning Notebooks that are reachable from any IP address, even when an IP allowlist or NSG is in place.
+        This check verifies that an Autonomous Database's browser-based management interfaces are served only inside the virtual cloud network and never on a public endpoint.
+
+        Every Autonomous Database publishes a set of management URLs alongside the SQL listener: the service console, Database Actions with its SQL Developer Web worksheet, Oracle REST Data Services or ORDS, Oracle APEX, GraphStudio, and Machine Learning Notebooks. A database provisioned into a subnet resolves those URLs only through its private endpoint. A database provisioned without one gets a public copy of each interface, and the existence of that copy does not depend on whether an IP access control list or a network security group is attached. Choose private endpoint access in the Network section when creating the database under Oracle Database > Autonomous Database, or supply a subnet to `oci db autonomous-database create`.
 
         **Why this matters**
 
-        - **Broad management web surface:** APEX, ORDS, and SQL Developer Web present web-based authentication surfaces that are credential-stuffing targets and have historically shipped pre-authentication CVEs exploitable by unauthenticated internet users.
-        - **Allowlist drift:** IP access control lists are operationally fragile; networks change, VPN exit IPs rotate to other tenants, and permissive CIDRs accumulate as temporary debugging steps that are never cleaned up.
-        - **Pre-authentication vulnerability exposure:** Pre-authentication CVEs in ORDS or APEX allow an unauthenticated attacker to enumerate or exploit the database without any credentials; private-endpoint mode eliminates this entire surface.
-        - **Stricter than mTLS or ACL:** Requiring a private endpoint is a stronger control than mTLS or an ACL because it removes the management web surface entirely rather than just protecting the SQL listener.
+        The management surface is much wider than the listener. Database Actions runs arbitrary SQL as the connected schema, loads data files, and publishes REST endpoints. An unauthenticated request that reaches these URLs already gets a login form that accepts database usernames for credential stuffing and a precise fingerprint of the ORDS and APEX versions behind it, which is what an attacker needs to select an exploit.
 
-        **Risk mitigation**
+        ORDS and APEX have both shipped pre-authentication vulnerabilities, the class that requires no credentials at all. When the management URLs answer only inside the virtual cloud network, that entire class becomes unreachable from the internet regardless of what the database's authentication settings say.
 
-        - **Eliminates the public management surface:** A private-endpoint ADB has no public URLs at all; APEX, ORDS, and associated tools are only reachable from within the VCN.
-        - **Removes pre-authentication CVE exposure:** Without public management URLs, vulnerabilities in the ADB web stack are not reachable by internet-based attackers regardless of authentication state.
-        - **Eliminates allowlist rot as a failure mode:** A private-endpoint database cannot be accidentally made internet-reachable through misconfigured or accumulated ACL entries.
+        Access control lists rot. Networks are renumbered, VPN exit addresses are recycled to other tenants, and permissive ranges added for one debugging session are never removed. A private endpoint database cannot be made internet-reachable by that drift, which is why this is a stronger control than mutual TLS or an allowlist.
+
+        Teams that need APEX or Database Actions from outside the virtual cloud network should reach them through a bastion or reverse proxy inside it, not by reopening the public endpoint.
       audit: |
         ### Audit via Console
 
@@ -5506,20 +5478,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every OCI DB System is deployed in a subnet configured with `prohibitPublicIpOnVnic = true`, so that the database VNIC cannot receive a public IP address. A DB system whose VNIC carries a public IP is directly reachable from the internet, exposing the Oracle database listener to internet scanning, brute-force attempts, and direct exploitation of any unpatched Oracle Database CVE.
+        This check verifies that DB systems sit in subnets that structurally forbid a public IP address on any attached VNIC.
+
+        An OCI subnet carries a `prohibitPublicIpOnVnic` setting. Created with `prohibitPublicIpOnVnic = true` and reported by the API as `prohibitPublicIpOnVnic: true`, the subnet refuses a public address to every VNIC in it, and the restriction is enforced by the subnet rather than by the resource placed in it. When the flag is `false`, a DB system's VNIC can take a public IP, and the Oracle listener answers directly from the internet. The setting is fixed when the subnet is created, chosen as a private subnet under Networking > Virtual Cloud Networks > Subnets, and readable with `oci network subnet get`.
 
         **Why this matters**
 
-        - **Continuous internet scanning:** Public-IP database listeners are probed constantly for Oracle-specific CVEs, default credentials, and TNS-layer vulnerabilities from across the internet.
-        - **Lack of protective controls:** DB systems do not benefit from the WAF, DDoS mitigation, and rate-limiting protections that typically front internet-facing applications, leaving the listener directly exposed.
-        - **Direct exfiltration path:** A public IP on the DB system also provides an outbound internet path for data exfiltration if the host is compromised.
-        - **Structural protection:** Setting `prohibitPublicIpOnVnic: true` at the subnet level prevents a public IP from being assigned even if the DB system is reconfigured or replaced.
+        An Oracle listener on a public address is found within hours. Internet-wide scanners fingerprint the TNS layer, replay default credentials for accounts such as `SYSTEM` and `DBSNMP`, and test unpatched Oracle Database CVEs against whatever version the handshake discloses. There is no human in that loop and no ramp-up period.
 
-        **Risk mitigation**
+        Databases also get none of the protections that normally sit in front of internet-facing services. A web application has a WAF, DDoS mitigation, and rate limiting between it and the internet. A DB system VNIC has only its security lists and network security groups, so every request that those permit lands directly on the listener with no inspection and no throttling.
 
-        - **Removes the database from internet-reachable address space:** Without a public IP, the Oracle listener is not addressable from outside the VCN, eliminating all internet-originating attacks.
-        - **Forces application traffic through VCN paths:** Application-to-database connectivity flows through subnet routing and VCN peering, keeping traffic within controlled network boundaries.
-        - **Prevents accidental re-exposure:** Subnet-level VNIC prohibition holds across DB system replacements and configuration changes, providing a durable structural control.
+        The public address is a path outward as well as inward. A host compromised through an application tier or a stolen operating system credential can stream table contents straight to an attacker-controlled address, because the interface used to reach the database is also a route off it.
+
+        Because the prohibition lives on the subnet, it survives DB system replacement, scaling, and reconfiguration. An operator who later launches a node with a public IP request in that subnet gets a failure instead of an exposure, which is what makes this a durable control rather than a setting to reaudit after every change.
       audit: |
         ### Audit via Console
 
@@ -5617,20 +5588,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that the subnet hosting each OCI DB System has no route rule that sends the default route (`0.0.0.0/0`) to an internet gateway. Even when the DB system itself has no public IP, an internet-gateway route in the subnet means that any process running on the database host can initiate outbound connections to arbitrary internet addresses, creating a data exfiltration path that bypasses all egress controls.
+        This check verifies that the subnet hosting a DB system has no default route to an internet gateway, so that a compromised database host has no direct path off the network.
+
+        A route table entry that sends `0.0.0.0/0` to an internet gateway makes every resource in the subnet capable of originating outbound connections to any internet address, and of receiving return traffic on those connections. This is independent of whether the DB system has a public IP: an instance with only a private address still egresses through the gateway if the route exists. Inspect and edit the association under Networking > Virtual Cloud Networks > Route Tables, or with `oci network route-table update`.
 
         **Why this matters**
 
-        - **Exfiltration enablement:** An attacker who gains remote code execution on a DB host can stream database contents to any internet address without restriction if an IGW route is present in the subnet.
-        - **Ransomware double-extortion:** Ransomware actors exfiltrate data before encrypting it; an open egress path turns a ransomware incident into a confirmed data breach.
-        - **IGW route persistence:** Internet-gateway routes outlive individual DB systems; a route added for a previous resource remains in place and applies to every future resource placed in the subnet.
-        - **NAT gateway alternative:** Patch downloads and OCI service calls that require outbound connectivity can be routed through a NAT gateway with logging enabled, providing the same functionality without unrestricted internet access.
+        Unrestricted egress is what turns database access into data loss. An attacker with code execution on the host, whether through an unpatched database CVE or stolen operating system credentials, can open a session to any address and stream tablespace contents out at line rate. No inspection point sees the transfer, because there is none between the host and the gateway.
 
-        **Risk mitigation**
+        Ransomware operators depend on that path. Current practice is to exfiltrate before encrypting, so that refusing to pay still costs the victim a disclosure. An open egress route is what converts an availability incident into a confirmed breach with regulatory notification obligations attached.
 
-        - **Eliminates the direct data exfiltration path:** Without an IGW route, compromised DB host processes cannot reach arbitrary internet addresses regardless of what other controls are in place.
-        - **Channels egress through auditable paths:** Replacing the IGW route with a NAT gateway or service gateway route means all outbound traffic is logged and can be alarmed on unusual destinations.
-        - **Prevents lateral movement to internet infrastructure:** Removing IGW routes closes the outbound channel that attackers use to call out to command-and-control infrastructure from a compromised host.
+        Routes outlive the resources that motivated them. An internet gateway route added years ago for a jump host remains in the table after that host is deleted and silently applies to every DB system placed in the subnet afterward, which is why a subnet inherited from another team is worth checking before it is used for a database.
+
+        Hosts do legitimately need outbound access for patch downloads and OCI service calls. Route that traffic through a NAT gateway with flow logs enabled, or through a service gateway for OCI endpoints, so the same functionality exists but every destination is recorded and unusual ones can be alarmed on.
       audit: |
         ### Audit via Console
 
@@ -5731,20 +5701,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every active OCI Vault secret older than 365 days has scheduled rotation enabled. Vault secrets without scheduled rotation behave like static long-lived credentials: any exposure of the plaintext, whether historical, current, or future, remains effective indefinitely until an operator manually rotates the value.
+        This check verifies that scheduled rotation is enabled on Vault secrets that have already exceeded a one year lifetime, so that no credential remains valid indefinitely.
+
+        OCI Vault can replace a secret's contents on its own cadence rather than waiting for an operator. A rotation configuration names the target system holding the credential, either an Autonomous Database or an OCI Function that performs the change, along with a rotation interval expressed as an ISO 8601 duration. Vault then creates a new secret version, updates the target system, and promotes that version to current. You configure it under Identity & Security > Vault > Secrets in the Console or with `oci vault secret update`, and in Terraform it is a `rotation_config` block with `is_scheduled_rotation_enabled` set to true. The check evaluates active secrets created more than 365 days ago. Because Terraform cannot know how old a secret will be, the Terraform version of this check requires the rotation configuration on every managed secret.
 
         **Why this matters**
 
-        - **Unbounded exposure window:** A secret that has never rotated is only as secure as its least-secure moment across its entire lifetime; any past disclosure remains a valid attack vector.
-        - **Offboarded-user persistence:** Employees, contractors, or third-party tools that once had access to a plaintext secret retain implicit access until the secret is rotated, regardless of IAM changes.
-        - **CI and tool compromise residue:** A secret read by a compromised CI pipeline or development machine remains fully effective until it is rotated, even after the compromised system is remediated.
-        - **Compliance cadence requirements:** Many security frameworks require credentials to be rotated on a defined schedule; a secret with no rotation schedule cannot satisfy a mandatory rotation interval.
+        A secret that has never rotated is only as strong as its weakest moment across its entire history. Any disclosure at any point in those 365 days or more remains a live attack path today, because nothing has invalidated the value.
 
-        **Risk mitigation**
+        That history includes people and systems that are no longer trusted. Employees, contractors, and third-party tools that once read the plaintext keep working access regardless of later IAM changes, and a secret pulled by a compromised CI pipeline or developer laptop stays fully effective even after the compromised host itself is rebuilt.
 
-        - **Caps the useful lifetime of any leaked secret:** With scheduled rotation, any leaked value is valid only until the next rotation window, converting an indefinite exposure into a time-bounded one.
-        - **Surfaces historical exposure impact:** Rotation invalidates any copy of the old value, including those held by systems that accessed the secret before a compromise was detected.
-        - **Forces applications to stay wired to Vault:** Scheduled rotation requires consuming applications to fetch current values from Vault dynamically, preventing plaintext caching that defeats rotation.
+        Enabling rotation converts an open-ended exposure into a bounded one: a leaked value is useful only until the next rotation window, and every stale copy dies with it. It also forces consuming applications to read the current value from Vault at runtime rather than caching plaintext, which is the habit that quietly defeats rotation.
+
+        Many frameworks additionally mandate a defined rotation interval, and a secret with no schedule cannot demonstrate one.
       audit: |
         ### Audit via Console
 
@@ -5878,20 +5847,21 @@ queries:
       oci.vault.secret.timeOfCurrentVersionExpiry > time.now
     docs:
       desc: |
-        This check ensures that every active OCI Vault secret has a current version whose expiry timestamp is either unset or in the future. A secret whose current version has an expiry in the past indicates either that the rotation schedule failed to execute or that a consuming application is still using a version the operator intended to be invalidated, which is both an operational failure and a security signal.
+        This check verifies that the credential lifetime declared on a Vault secret is being honored, by requiring the current version's expiry timestamp to be unset or still in the future.
+
+        An expiry time is attached to a secret version when that version is created, either in the Console under Identity & Security > Vault > Secrets when you add a version, or through `oci vault secret update` supplying new secret content with an expiry. The timestamp is a statement of intent: after this moment, the version should no longer be the one in use. The check passes an active secret whose current version has no expiry set and fails one whose current version expired in the past.
 
         **Why this matters**
 
-        - **Broken rotation pipeline indicator:** An expired version that is still active means the automated rotation function did not complete successfully, leaving dependents on out-of-policy credential material.
-        - **Silent credential staleness:** Applications that cache Vault secret values continue authenticating with the expired credential without any error, masking the failure until the credential is forcibly invalidated by the downstream system.
-        - **Compliance schedule violation:** Expiry timestamps are typically set to enforce a rotation cadence required by policy; a past-expiry version means the intended rotation interval was not honored.
-        - **Dependency mapping gaps:** An expired version still in active use often reveals that not all consumers of the secret were identified when the rotation was configured.
+        An expired version that is still current is direct evidence that the rotation pipeline did not finish. The scheduled rotation function either never ran or failed partway, and every dependent is now authenticating with credential material the organization has already declared out of policy.
 
-        **Risk mitigation**
+        The failure is silent by default. Applications that cached the value keep authenticating successfully and log nothing unusual, so the first visible symptom often arrives only when the downstream system finally rejects the credential and the workload breaks in production.
 
-        - **Surfaces failed rotation pipelines early:** Alerting on past-expiry secrets catches rotation failures before the downstream system invalidates the credential and causes an outage.
-        - **Enforces the intended secret lifecycle:** Flagging expired-but-active secrets creates a forcing function to identify why rotation did not complete and fix the rotation target configuration.
-        - **Aligns operational reality with Vault policy:** Resolving expired versions ensures the credential lifetime reflected in Vault matches what consuming applications actually use.
+        Where the expiry was chosen to satisfy a mandated rotation cadence, a past-due version means that interval was not met, and the gap is auditable.
+
+        A version that is expired yet still in active use also tends to expose an incomplete dependency map. It usually means at least one consumer of the secret was never identified when rotation was configured, so the rotation target list is wrong and will fail the same way next cycle.
+
+        Alert on past-expiry secrets rather than waiting for the outage, then fix the rotation target configuration instead of simply extending the expiry, so that what Vault records as the credential lifetime matches what applications actually use.
       audit: |
         ### Audit via Console
 
@@ -5969,19 +5939,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Functions applications are configured to store no credentials in their environment variable configuration map. By default, OCI Functions allows any key-value pair in application config, but config values are readable by any principal with `functions-application:read` permission and are inherited by every function in the application, making them an exposed and broad-scope credential store.
+        This check verifies that OCI Functions applications hold no credentials in their configuration map, neither under a credential-shaped key name nor as a credential-shaped value.
+
+        An application's config map is a set of key-value pairs that OCI Functions injects as environment variables into every function in the application. The check rejects key names such as `password`, `db_password`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `oci_api_key`, `api_token`, `bearer_token`, `private_key`, `client_secret`, and `connection_string`, and it separately inspects the values for AWS access key IDs, PEM private key blocks that open with `-----BEGIN` and close with `PRIVATE KEY-----`, and JSON Web Tokens. Review the map under Developer Services > Functions on the application's configuration page, or with `oci fn application update --config`.
 
         **Why this matters**
 
-        - **Wide exposure surface:** The application config map is returned by the `GetApplication` API call and is visible to all IAM principals with compartment read access.
-        - **Cross-function leakage:** Credentials placed in application config are inherited by every function in the application, including functions that do not need them.
-        - **No rotation or audit trail:** Credentials stored in config lack the rotation lifecycle and access logging that a proper secrets manager provides.
-        - **Snapshot persistence:** Environment variable values are captured in observability backends and logging pipelines, extending the lifetime of any exposed secret far beyond its intended scope.
+        The config map is not a secret store. `GetApplication` returns the whole map to any principal holding `functions-application:read`, which a statement as ordinary as `allow group Developers to read fn-app in compartment Apps` confers. The audience for anything written there is everyone with read access to the compartment, not just the people who maintain the function.
 
-        **Risk mitigation**
+        The scope is wrong in the other direction too. Application config is inherited by every function in the application, so a credential added for one function is handed to all of them, including functions that have no business holding it and functions added later by someone who never saw it go in.
 
-        - **Secrets manager integration:** Functions should retrieve credentials at runtime from OCI Vault using the function's resource principal, which provides audited, rotatable access without config-map exposure.
-        - **Immediate rotation on finding:** Any credential detected in application config must be treated as compromised and rotated before removal, since the value has already been visible to all principals with read access.
+        Values placed there also escape the config map. Environment variables are captured by observability backends, logging pipelines, and Terraform state, which extends a secret's lifetime and reach well past the moment it is deleted from the application. And unlike a managed secret, a config value has no rotation lifecycle and no access log recording who read it.
+
+        OCI Vault exists for exactly this: a function should fetch its credentials at runtime using its resource principal, which is audited, rotatable, and scoped to the one function that needs it. Anything this check finds should be treated as already compromised and rotated before it is removed, since it has been readable all along. Non-secret settings such as endpoints, timeouts, and feature flags are what the config map is for and are not what the check objects to.
       audit: |
         ### Audit via Console
 
@@ -6153,19 +6123,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Container Instances are configured to pull container images exclusively from the tenancy's OCIR registry. By default, OCI Container Instances accept any image URL, including references to public registries such as Docker Hub or GitHub Container Registry, which the tenancy does not control and cannot audit.
+        This check verifies that every container running on an OCI Container Instance is pulled from the tenancy's own registry rather than from an arbitrary external one.
+
+        Each container in an instance carries an image URL, and the check requires it to begin with a regional OCI Container Registry (OCIR) hostname matching the `*.ocir.io` pattern, meaning a region key followed by `.ocir.io`, such as `iad.ocir.io` or `phx.ocir.io`. By default Container Instances accept any image URL at all, including references to public registries such as Docker Hub or GitHub Container Registry that the tenancy neither controls nor can audit. Image URLs are set per container when the instance is created under Developer Services > Container Instances, and the Terraform versions additionally require at least one container to be declared, so an instance with no containers block cannot pass by default.
 
         **Why this matters**
 
-        - **Supply chain trust boundary:** Images from external registries bypass the tenancy's vulnerability scanning, signing, and tag-immutability controls that OCIR provides.
-        - **Malicious image risk:** Public registries have been repeatedly targeted by typosquatting and compromised CI pipelines that push crypto-mining payloads or backdoored base images.
-        - **Production availability dependency:** Pulling from external registries couples container instance availability to a third-party registry's uptime and policy decisions.
-        - **Chain of custody:** OCIR creates an auditable record of every image version running in production; external registries do not.
+        An image pulled from outside the tenancy skips every control the tenancy has built. Vulnerability scanning, signature verification, and tag immutability are enforced on OCIR content; none of them apply to a tag someone pulled straight from a public registry, so an instance can be running code that no scanner in the estate has ever examined.
 
-        **Risk mitigation**
+        Public registries are an actively worked attack surface. Typosquatted names sit one character away from popular images, and compromised CI pipelines have repeatedly pushed crypto-mining payloads and backdoored base images under legitimate-looking tags. A mutable public tag can also change under a running deployment, so the image validated last month is not necessarily the image that starts tonight.
 
-        - **Approved registry enforcement:** Requiring all image URLs to match the `*.ocir.io` pattern ensures every running image passed through the tenancy's onboarding pipeline.
-        - **Vulnerability scanning gate:** Images mirrored into OCIR can be scanned before workloads are launched, reducing the risk of deploying images with known vulnerabilities.
+        The dependency is operational as well as adversarial. Pulling from a third-party registry ties instance startup to that registry's uptime, rate limits, and policy decisions, any of which can stop a scale-out or a restart at the worst possible moment.
+
+        Requiring OCIR keeps an auditable record of every image version that has run in production, which external registries simply do not provide. The practical workflow is to mirror approved third-party images into OCIR, scan them on push, and reference the mirrored copy from the instance. The check accepts any region's OCIR endpoint, so this does not pin workloads to a single region.
       audit: |
         ### Audit via Console
 
@@ -6340,19 +6310,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Object Storage bucket retention rules are configured with a locked status, meaning the lock time has been set and has taken effect. By default, retention rules can be created in an unlocked state, which allows any bucket administrator to modify or delete them, making the retention commitment revocable under the same compromise scenario the rule is meant to survive.
+        This check verifies that every retention rule on an Object Storage bucket is locked and that its lock has already taken effect.
+
+        A retention rule blocks deletion and modification of covered objects for its duration, but a rule created without a lock time can be shortened or removed at will by anyone who can administer the bucket. Locking makes the commitment binding: once the lock time passes, no principal in the tenancy can delete the rule or reduce its duration, including the `Administrators` group, and the duration can only be extended. Set the lock time on the bucket's Retention Rules panel or with `oci os retention-rule create --namespace <namespace> --bucket-name <bucket> --time-rule-locked <timestamp>`. It must be at least 14 days in the future, a deliberate delay that leaves you a window to cancel a mistake before the rule becomes permanent.
 
         **Why this matters**
 
-        - **WORM semantics require locking:** An unlocked retention rule is functionally identical to having no retention rule at all, since a privileged attacker can remove it before destroying data.
-        - **Ransomware target:** Ransomware operators specifically target backup stores and typically begin by removing retention controls to shorten recovery windows before encrypting or deleting objects.
-        - **Compliance requirements:** Regulatory frameworks that require immutable audit logs or data retention rely on the lock being non-revocable for the duration of the retention period.
-        - **Single-admin defeat:** Without locking, a single compromised admin account can erase the retention guarantee before data destruction, eliminating the recovery path.
+        An unlocked retention rule is functionally identical to no retention rule. It stops accidents, but the attacker scenario retention exists for is one where the adversary already holds administrative credentials, and that adversary deletes the rule first and the objects second.
 
-        **Risk mitigation**
+        Ransomware operators work this way by design. They locate the backup and archive stores, strip the controls that would shorten their leverage, and only then encrypt or delete, precisely so the victim has no clean recovery point. A locked rule survives that sequence, because the attacker's own privileges cannot revoke it, and objects covered by an in-effect rule cannot be deleted or overwritten at all.
 
-        - **Survivable retention commitment:** A locked retention rule cannot be deleted by any principal in the tenancy during the lock period, making it resistant to admin-level compromise.
-        - **Ransomware recovery headroom:** Locked rules preserve object versions even when the account itself is under attacker control, enabling recovery after destructive incidents.
+        Compliance frameworks requiring immutable audit logs or fixed data retention depend on the guarantee being non-revocable for the whole period. A rule a single compromised account can erase does not meet that bar, even though a configuration audit shows it as though it does.
+
+        Because the 14-day delay is also the window in which an attacker could cancel a newly created lock, alert on retention rule creation and deletion. The Terraform version of this check requires only that a lock time is declared, since configuration cannot show whether the delay has already elapsed.
       audit: |
         ### Audit via Console
 
@@ -6496,19 +6466,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that Object Storage bucket retention rules are configured with a duration of at least 30 days, or at least one year for year-denominated rules. By default, OCI permits retention rules with any positive duration, including durations shorter than the typical ransomware dwell time, which defeats the purpose of maintaining a recovery-capable backup store.
+        This check verifies that Object Storage retention rules hold objects long enough to be useful, requiring at least 30 days or at least 1 year for rules expressed in years.
+
+        A retention rule's duration is an amount plus a unit of `DAYS` or `YEARS`, and OCI accepts any positive value, including a one-day rule that satisfies a configuration audit while protecting essentially nothing. This check accepts a duration of 30 days or more, or 1 year or more when the unit is years. Adjust the value on the bucket's Retention Rules panel or with `oci os retention-rule update`, keeping in mind that a locked rule's duration can be extended but never shortened.
 
         **Why this matters**
 
-        - **Ransomware dwell time:** Most ransomware operators maintain persistence for more than 14 days before executing; a retention window shorter than that provides no meaningful recovery capability.
-        - **False sense of protection:** A sub-30-day retention rule appears as a security control in configuration audits but does not actually protect against the threat models retention is designed to address.
-        - **Accidental deletion recovery:** Legitimate data loss scenarios, including storage corruption and accidental deletes discovered late, often require more than a week of backup history to resolve.
-        - **Regulatory alignment:** Common frameworks specify retention in months or years, not days; short retention durations fail to meet these expectations.
+        Retention length is calibrated against how long an intruder stays before acting. Ransomware operators commonly hold persistence for more than 14 days before triggering encryption, mapping the environment and identifying backups first. A retention window shorter than the dwell time means every retained copy was already written under the attacker's control by the time recovery starts, so there is no clean point to restore from.
 
-        **Risk mitigation**
+        A short rule is worse than an absent one in one specific way: it reports as a control in place. Configuration reviews, compliance evidence, and dashboards all show retention enabled, and nobody discovers the window was too small to matter until the recovery attempt fails.
 
-        - **Dwell-time-resistant windows:** A 30-day minimum ensures retention outlasts typical ransomware dwell times, preserving at least one clean recovery point.
-        - **Regulatory baseline:** Aligning to a 30-day minimum positions the organization within the lower bound of common compliance retention requirements.
+        Ordinary data loss needs a similar margin. Storage corruption and accidental deletions are frequently noticed long after the fact, and resolving them usually requires more than a week of history, not a couple of days.
+
+        Common regulatory frameworks state retention in months or years rather than days, so a sub-30-day window falls below the lower bound of what an auditor will accept. Treating 30 days as the floor keeps at least one recovery point outside typical dwell time and puts the organization inside that lower bound, while regulated records generally need a much longer window derived from the specific obligation rather than from this minimum.
       audit: |
         ### Audit via Console
 
@@ -6663,19 +6633,21 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI IAM policies are configured to grant permissions only to specific groups, dynamic groups, or named services, never to the `any-user` principal. By default, OCI IAM allows `Allow any-user` statements, which grant the specified permission to every identity in the tenancy and bypass group-based access control entirely.
+        This check verifies that every IAM grant names a specific principal, by rejecting statements written against the `any-user` subject.
+
+        OCI statements normally name their subject: `allow group <group> to ...`, `allow dynamic-group <group> to ...`, or `allow service <service> to ...`. The language also accepts `allow any-user to ...`, which matches every identity in the tenancy at once. Nothing prevents it, and OCI applies it exactly as written. Statements are edited under Identity & Security > Policies or with `oci iam policy update`, and this check inspects live statements alongside Terraform configuration, plans, and state.
 
         **Why this matters**
 
-        - **Principal attribution loss:** Statements granting `any-user` cannot be attributed to specific identities in audit logs, eliminating accountability for actions taken under the grant.
-        - **Group membership bypass:** The IAM group model is the primary access-scoping mechanism; `any-user` renders it irrelevant for the covered permissions.
-        - **Broad blast radius:** Combined with a wide resource scope such as `read all-resources in tenancy`, an `any-user` grant turns the entire tenancy into an open read target for any caller that reaches the API.
-        - **Persistence risk:** `any-user` grants accumulate over time through runbooks and automation scripts and are rarely reviewed, creating long-lived overpermissive access.
+        The grant is only as narrow as the rest of the statement, and the rest is often not narrow. Paired with a wide scope, as in `allow any-user to read all-resources in tenancy`, it makes every resource in the tenancy readable by every principal that can reach the API, including service accounts created for one small job and any identity an attacker manages to obtain.
 
-        **Risk mitigation**
+        It also erases the mechanism the rest of the model depends on. Groups and dynamic groups exist so access can be reasoned about by membership: you look at who is in the group and you know who holds the permission. An `any-user` statement makes that reasoning meaningless for the permissions it covers, because no membership decision changes who is allowed.
 
-        - **Least-privilege scoping:** Replacing `any-user` with a named group or dynamic group limits the grant to only the identities that genuinely require access.
-        - **Audit trail restoration:** Group-scoped grants allow audit logs to attribute every action to the specific group member who made the request.
+        Attribution suffers the same way. A permission granted to everyone traces back to no group, so audit records show an action any identity in the tenancy was entitled to take, which an investigator cannot narrow.
+
+        These statements are unusually persistent. They tend to enter through a runbook or automation script that needed something working quickly, and are rarely revisited, so a temporary convenience becomes a standing overpermissive grant.
+
+        Replace the subject with the named group, dynamic group, or service that genuinely needs the access, which limits the grant to the identities requiring it and restores an audit trail able to name the member who acted.
       audit: |
         ### Audit via Console
 
@@ -6814,19 +6786,21 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI IAM policies contain no `Endorse` or `Admit` statements that establish cross-tenancy trust relationships without explicit ongoing business justification. By default, OCI permits these statements, which extend the tenancy's trust boundary to external parties and are a common source of undiscovered data-sharing with vendor or partner tenancies.
+        This check verifies that the tenancy's trust boundary is not extended to outside parties, by rejecting the `Endorse` and `Admit` statements that establish cross-tenancy access.
+
+        Cross-tenancy access in OCI takes two statements working as a pair. `Endorse` is written in the source tenancy and exports a permission outward, declaring that its groups may act in another tenancy. `Admit` is written in the destination tenancy and accepts inbound principals, declaring which foreign subjects may operate on its resources. Neither is blocked by default, and both are ordinary statements managed under Identity & Security > Policies or through `oci iam policy update`. The check inspects live statements and Terraform configuration, plans, and state, since these grants often arrive as infrastructure code from a vendor.
 
         **Why this matters**
 
-        - **Extended trust boundary:** An `Admit` statement allows principals from a remote tenancy to operate inside your tenancy, sometimes with broad permissions that were appropriate at onboarding but have since expanded or expired.
-        - **Partner compromise equivalence:** An attacker who compromises a partner tenancy immediately inherits every `Admit` grant that points at it, gaining access to your resources without compromising your own tenancy.
-        - **Audit path gap:** Cross-tenancy policy changes often arrive through vendor onboarding runbooks without security-team review, creating grants that are unknown to the team responsible for access governance.
-        - **Endorsement risk:** `Endorse` statements export permissions from your tenancy to a partner; a partner's account compromise becomes your data-loss event.
+        An `Admit` statement lets principals you do not manage operate inside your compartments. You cannot see the other tenancy's group memberships, enforce MFA on its users, or revoke its credentials. Grants written broadly at onboarding tend to stay as written long after the integration they were for has narrowed or ended.
 
-        **Risk mitigation**
+        That makes a partner's security posture part of yours. An attacker who compromises the remote tenancy inherits every `Admit` grant pointing at it and reaches your resources without ever touching your identities, passwords, or keys.
 
-        - **Periodic grant review:** Inventorying and reviewing every `Endorse` and `Admit` statement on a regular cadence ensures that lapsed partnerships do not leave permanent access grants behind.
-        - **Narrow scoping:** When cross-tenancy grants are genuinely required, limiting them to the narrowest possible resource type and action set reduces the impact of a partner compromise.
+        `Endorse` carries the mirror-image risk. It sends your groups' permissions outward, so if the partner tenancy is breached your data moves through a path you authorized and cannot watch.
+
+        The governance gap is what makes both dangerous in practice. Cross-tenancy statements typically arrive through a vendor onboarding runbook, applied by whoever ran the integration, and never reach the team accountable for access, so the grant exists with no owner and no review date.
+
+        Inventory every `Endorse` and `Admit` statement on a regular cadence so lapsed partnerships leave no permanent access behind, and when a cross-tenancy grant is genuinely required, scope it to the narrowest resource type, verb, and compartment that makes the integration work.
       audit: |
         ### Audit via Console
 
@@ -6967,19 +6941,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that VCN security lists are configured to block TCP ingress from the public internet (`0.0.0.0/0`) to common database listener ports, including Oracle (1521, 1522), SQL Server (1433), MySQL (3306), PostgreSQL (5432), Redis (6379), Elasticsearch (9200), and MongoDB (27017). By default, OCI security lists permit any traffic until explicitly restricted, and database ports opened to the internet are a high-value, frequently exploited target.
+        This check verifies that database listener ports are unreachable from the public internet.
+
+        The check rejects TCP ingress from `0.0.0.0/0` whose destination port range covers any common listener: Oracle on 1521 and 1522, SQL Server on 1433, MySQL on 3306, PostgreSQL on 5432, Redis on 6379, Elasticsearch on 9200, or MongoDB on 27017. A rule that names no port range at all covers every one of them. Security list rules are allow-only and there is no deny rule to override them, so a single broad rule anywhere in the list is enough to expose the listener. Remove or narrow it with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Mass exploitation campaigns:** Public MongoDB, Elasticsearch, and Redis instances have been the target of repeated mass-ransom campaigns since 2017; scanners identify and exploit these within hours of exposure.
-        - **Brute-force credential attacks:** Open MySQL, PostgreSQL, MSSQL, and Oracle listeners allow credential brute-force against whatever accounts the database instance has, with poor or no logging of failed attempts.
-        - **Schema and data leakage:** Even read-only exposure leaks schema structure, column names, and data samples that enable follow-up social engineering and more targeted attacks.
-        - **Forensic blind spot:** Most database engines log failed authentication poorly, meaning attacks on an exposed listener leave minimal evidence for incident response.
+        Redis, Elasticsearch and MongoDB have drawn repeated mass-ransom campaigns since 2017, in which scanners find an open 6379, 9200 or 27017, wipe the contents and leave a ransom note. All three historically shipped without authentication enabled, and the interval between exposure and discovery is measured in hours.
 
-        **Risk mitigation**
+        The authenticated engines fare only slightly better. An open 1521, 1522, 1433, 3306 or 5432 listener accepts unlimited credential attempts against whatever accounts exist, and most database engines log failed authentication poorly or not at all, so a sustained brute force leaves an investigation almost nothing to reconstruct.
 
-        - **Private network access only:** Database traffic should flow through a VPN, bastion, private subnet, or OCI Service Gateway, never through a public ingress rule in a security list.
-        - **Incident signal treatment:** Any new security-list rule matching this pattern should be treated as an incident signal, not a routine policy violation, and investigated immediately.
+        Even access that never succeeds leaks value. Listener banners and error responses disclose product versions, instance and service names, and schema details that make the next attempt more targeted and give a social engineer usable material.
+
+        Database traffic belongs on a private subnet reached through a VPN, a bastion host or a service gateway, never through a public ingress rule in a security list. A new security list rule matching this pattern should be handled as an incident signal and investigated immediately, not queued as a routine policy finding.
       audit: |
         ### Audit via Console
 
@@ -7169,19 +7143,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that VCN security lists are configured to block TCP ingress from the public internet (`0.0.0.0/0`) to legacy administrative and file-sharing ports, specifically FTP (21), Telnet (23), NetBIOS (135, 137-139), and SMB (445). These protocols were designed before modern authentication and encryption requirements and present serious risks when exposed to untrusted networks.
+        This check verifies that obsolete administrative and file-sharing protocols are not exposed to the internet.
+
+        The rejected shape is TCP ingress from `0.0.0.0/0` covering FTP on 21, Telnet on 23, the NetBIOS ports 135, 137, 138 and 139, or SMB on 445, including a rule with no port range, which covers all of them. These protocols predate the assumption that a network path might be hostile, and each fails in its own way once it is. Rules are removed on the security list details page under Networking > Virtual Cloud Networks or with `oci network security-list update`.
 
         **Why this matters**
 
-        - **Active exploitation history:** SMB port 445 exposure enabled the WannaCry and NotPetya outbreaks and continues to be actively exploited via the EternalBlue family of vulnerabilities.
-        - **Plaintext credential exposure:** Telnet and FTP transmit credentials in cleartext, making them trivially interceptable on any network path between the client and the server.
-        - **Reconnaissance amplification:** NetBIOS exposure leaks Windows hostnames, SIDs, and share enumeration data that directly enables follow-up attacks and privilege escalation.
-        - **No legitimate public use case:** No production workload in a cloud environment has a valid requirement to expose FTP, Telnet, NetBIOS, or SMB directly to the internet.
+        Port 445 is the one with a body count. SMB exposure carried WannaCry and NotPetya across the internet in 2017, and the EternalBlue family of exploits behind them is still folded into commodity tooling, so an open 445 remains directly exploitable rather than merely inadvisable.
 
-        **Risk mitigation**
+        Telnet on 23 and FTP on 21 carry credentials in cleartext. Anyone positioned on the path between client and server, which across the public internet means any of the networks the packets traverse, reads the username and password verbatim, and FTP's separate data channel makes the transferred content just as readable.
 
-        - **Protocol replacement:** FTP should be replaced with SFTP or HTTPS file-transfer endpoints; Telnet should be replaced with SSH.
-        - **VPN-gated file sharing:** SMB access across sites should be tunneled through a VPN or zero-trust network access solution rather than exposed through a public security-list rule.
+        NetBIOS on 135, 137, 138 and 139 is a reconnaissance gift. A remote query returns Windows hostnames, domain and workgroup membership, logged-on users, the security identifiers known as SIDs, and a list of available shares, which is precisely the input an attacker needs to choose a target account and plan privilege escalation before touching anything else.
+
+        No production cloud workload has a legitimate reason to answer these ports from the internet. Replace FTP with SFTP or an HTTPS transfer endpoint, replace Telnet with SSH, and carry SMB between sites over a VPN or a zero trust network access broker. Where a legacy system genuinely cannot be changed, move it to a private subnet and reach it through a bastion.
       audit: |
         ### Audit via Console
 
@@ -7358,19 +7332,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that VCN security lists are configured to restrict ICMP ingress from the public internet (`0.0.0.0/0`) to specific type/code values rather than permitting all ICMP types without an `icmpOptions` filter. By default, OCI allows ICMP rules to be created without type and code restrictions, which enables attackers to perform host discovery and OS fingerprinting across the entire VCN.
+        This check verifies that ICMP reachable from the internet is scoped to specific message types rather than opened wholesale.
+
+        An OCI ingress rule selects ICMP with protocol `1` for IPv4 or `58` for ICMPv6, and an optional `icmpOptions` block narrows it to a type and a code. A rule from `0.0.0.0/0` that names either ICMP protocol, or names all protocols, without an `icmpOptions` block admits every ICMP message the stack will answer, and that is the shape the check flags. Type and code are set in the rule editor in the Console or in the payload of `oci network security-list update`.
 
         **Why this matters**
 
-        - **Reconnaissance acceleration:** Unrestricted ICMP echo-reply, timestamp, and netmask probes reveal which IP addresses are live and identify the OS family running on each host, shortening the time between network exposure and exploitation.
-        - **Automated enumeration feeding:** Fingerprinting data from unrestricted ICMP feeds automated tooling that escalates from enumeration to exploit attempts within minutes of discovering a live host.
-        - **Cloud asset indexing:** Large-scale internet scanners rely on ICMP to build cloud asset inventories; open ICMP ingress ensures the VCN appears in these indexes.
-        - **PMTU compatibility:** Specific ICMP types such as type 3 code 4 (Destination Unreachable: Fragmentation Needed) are required for Path MTU discovery and should remain permitted, which is why this check only flags rules with no `icmpOptions` filter at all.
+        ICMP is how a scanner draws the map before it starts knocking. Echo requests establish which addresses are live, and timestamp and address mask requests, which many stacks still answer, narrow the operating system family by the way each one replies. That turns an unknown address range into a list of hosts with probable platforms, which is the input every later stage depends on.
 
-        **Risk mitigation**
+        Internet-wide scanning services publish those results. An open ICMP rule reliably places the VCN's public addresses in commercial and free asset indexes, where anyone can search for them by cloud region or organization long after the scan itself is forgotten.
 
-        - **Type/code scoping:** Restricting ICMP ingress to only the types workloads actually need, typically type 3 code 4 for PMTU discovery, eliminates host discovery and fingerprinting without breaking legitimate network behavior.
-        - **Source CIDR tightening:** Where broader ICMP access is needed for monitoring or troubleshooting, limiting the source CIDR to trusted NOC subnets prevents public enumeration.
+        ICMP also carries data. Echo request and reply payloads are arbitrary bytes, so a tunnel built over ping is a well-worn way to move a command channel or staged data past controls that only examine TCP and UDP, and the packets read as ordinary reachability testing in flow records.
+
+        Some ICMP must survive. Type 3 code 4, Destination Unreachable with Fragmentation Needed, is what makes Path MTU discovery work, and blocking it produces connections that establish and then stall. Scope internet-facing ICMP rules to that type and code, and where an operations team needs broader ICMP for monitoring, restrict the source CIDR to the NOC ranges instead of the whole internet.
       audit: |
         ### Audit via Console
 
@@ -7518,19 +7492,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that VCN security lists are configured to restrict IPv6 ingress from the public internet (`::/0`) with the same controls applied to IPv4 ingress, blocking all-protocol rules, unscoped TCP rules that cover SSH (22) or RDP (3389), and unscoped UDP rules. By default, organizations frequently apply IPv4 hardening while leaving IPv6 rules unreviewed, creating a parallel attack surface that bypasses IPv4-focused controls.
+        This check verifies that IPv6 ingress is held to the same restrictions as IPv4 ingress.
+
+        `::/0` is the IPv6 counterpart of `0.0.0.0/0`, and OCI carries it as a separate rule with its own source value, so hardening one address family does nothing for the other. The check rejects a rule from `::/0` that allows all protocols, a TCP rule with no destination port range, a TCP range covering SSH on 22 or RDP on 3389, and a UDP rule with no port range. Review both families side by side on the security list details page or in the output of `oci network security-list get`.
 
         **Why this matters**
 
-        - **IPv4-only monitoring blind spot:** Many network defenses, log pipelines, and IDS signatures are built around IPv4; IPv6 traffic can bypass controls that appear complete on paper but only inspect one address family.
-        - **Deliberate bypass technique:** Attackers specifically probe `::/0` rules as a bypass around tightly monitored IPv4 ACLs, knowing that security teams pay less attention to IPv6 traffic.
-        - **Retrofit oversight:** OCI VCNs that enable IPv6 after initial deployment inherit the same exposure patterns as IPv4 unless security lists are explicitly updated, a step that is routinely missed.
-        - **Growing scanner coverage:** Cloud vulnerability scanners now routinely enumerate the IPv6 address space and find fewer controls than on IPv4, making IPv6 a higher-yield target.
+        The failure is procedural rather than technical. A team tightens `0.0.0.0/0` rules during a hardening pass, ships the change, and never touches the `::/0` rules sitting beside them, because the review that prompted the work listed only IPv4 findings. The subnet ends up hardened on one address family and open on the other, and nothing in the rule listing makes the asymmetry obvious.
 
-        **Risk mitigation**
+        Detection is thinner on the IPv6 side too. Log pipelines, dashboards and intrusion detection signatures written years ago frequently key on IPv4 address formats, so traffic arriving over IPv6 passes through a monitoring stack that looks complete on paper and records nothing useful.
 
-        - **Symmetric rule management:** Every time an ingress rule permits `0.0.0.0/0`, the corresponding `::/0` rule should be audited for the same restrictions.
-        - **IPv6 elimination option:** Disabling IPv6 on VCNs that have no workload requiring it removes the parallel exposure surface entirely.
+        Attackers know the gap is systemic. Probing `::/0` reachability is a routine step precisely because IPv4 access control lists are tightly monitored and the IPv6 path often is not, and scanning services now enumerate published cloud IPv6 allocations rather than trying to brute force the address space, which removes the size advantage IPv6 was once assumed to provide.
+
+        Treat the two families as one change, so every time an ingress rule for `0.0.0.0/0` is written or narrowed the `::/0` rule is reviewed alongside it. Where no workload in the VCN requires IPv6 at all, leaving the VCN without an IPv6 CIDR block removes the parallel surface rather than requiring it to be maintained.
       audit: |
         ### Audit via Console
 
@@ -7712,19 +7686,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI database backups, both VM/BM DB system backups and Autonomous Database backups, are encrypted with customer-managed KMS keys rather than Oracle-managed default keys. By default, OCI uses Oracle-managed encryption for database backups, which means the decryption capability lives entirely within Oracle's infrastructure without tenant-controlled revocation.
+        This check verifies that database backups are encrypted under a key the tenancy controls, covering both VM and bare metal DB system backups and Autonomous Database backups.
+
+        Backups are encrypted either with an Oracle-managed key or with a master encryption key held in an OCI Vault that belongs to the tenancy. The default is Oracle-managed, which means the decryption capability lives entirely inside Oracle's infrastructure and there is no tenant-side operation that withdraws it. A customer-managed key is assigned by giving the database a vault key at provisioning under Identity & Security > Vault, backed by a statement such as `allow service database to use keys in compartment Security`. Backups then inherit the key of the database they came from.
 
         **Why this matters**
 
-        - **Extended blast radius:** Backups carry the same data sensitivity as the live database but have longer retention and wider distribution paths, including Object Storage destinations that may be shared or cross-region.
-        - **Oracle-side compromise path:** A backup encrypted only with Oracle-managed keys can be decrypted by any compromise that reaches Oracle's key management infrastructure, without the tenant being able to revoke access.
-        - **Key revocation capability:** A customer-managed key provides the option to permanently revoke access to all historical backups by disabling or deleting the key, a capability that Oracle-managed keys do not offer.
-        - **Long-term retention risk:** Backups outlive the original database; without CMK, encryption posture cannot be independently verified or strengthened after the backup is created.
+        A backup is a portable copy of the database with none of its network posture. The live database may sit behind a private endpoint in a locked-down subnet, but a principal holding `manage db-backups` can restore that data into a new DB system in a different compartment, a different subnet, or a different region, and the restored copy answers to whatever controls exist there. With a customer-managed key the restore also requires `use keys` on the vault key, so the vault policy becomes a second gate that the network controls alone never provided.
 
-        **Risk mitigation**
+        Retention widens the exposure further. Backups persist after the source database is terminated, are written to Object Storage destinations that may be replicated across regions, and are frequently the oldest surviving copy of data that has since been deleted for compliance reasons.
 
-        - **Tenant-controlled decryption:** Customer-managed KMS keys ensure that only principals with access to the customer's vault can decrypt backup data, independent of Oracle's internal key management.
-        - **Revocation path:** Disabling or deleting the CMK immediately invalidates every backup encrypted with it, providing a hard stop for data access in breach scenarios.
+        Key control is the only way to end that. Disabling or scheduling deletion of the vault key renders every backup encrypted under it permanently unreadable, which is the one action that reliably retires historical copies whose locations are no longer fully known.
+
+        Before revoking a key, confirm which backups depend on it, because the effect is immediate and applies to restores you may still need.
       audit: |
         ### Audit via Console
 
@@ -7922,19 +7896,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI API Gateway deployments are configured with anonymous access disabled (`isAnonymousAccessAllowed` set to false or absent). By default, a deployment can be created with `is_anonymous_access_allowed = true`, which allows requests without credentials to pass through even when an authentication policy is attached, turning the auth policy into an optional rather than enforced control.
+        This check verifies that anonymous access is disabled on every API Gateway deployment, so no request reaches an upstream backend without a credential.
+
+        A deployment carries a specification whose `request_policies` section holds the `authentication` policy applied to every route it serves. Inside that policy, `isAnonymousAccessAllowed` decides whether callers presenting no credential are admitted anyway. A deployment can be created with `is_anonymous_access_allowed = true`, and when it is, unauthenticated requests pass through even though an authentication policy is attached, turning that policy into an optional rather than an enforced control. This check requires the setting to be false or absent. Administer it in the Console under Developer Services > API Management > Gateways on the deployment's request policies, or with `oci api-gateway deployment update`.
 
         **Why this matters**
 
-        - **Optional authentication anti-pattern:** When anonymous access is enabled alongside an authentication policy, the policy is bypassed for unauthenticated clients, eliminating the protection it was intended to provide.
-        - **Development debt:** Anonymous access is typically enabled for a single public route during development and left in place when the deployment is promoted, silently removing authentication requirements from all routes.
-        - **Downstream assumption breakage:** WAF rules, rate-limiting policies, and authorization middleware downstream all assume an authenticated principal; anonymous traffic invalidates every assumption these layers were designed around.
-        - **Audit attribution loss:** Anonymous requests produce audit log entries with no principal identity, making it impossible to attribute actions or detect abuse patterns.
+        An authentication policy combined with allowed anonymous access is the optional-authentication anti-pattern. The policy is bypassed for unauthenticated clients, so it delivers none of the protection it was written to provide, and every route in the specification inherits that bypass rather than only the one route the operator had in mind.
 
-        **Risk mitigation**
+        Anonymous access is typically enabled for a single public route during development and left in place when the deployment is promoted. Nothing in the promotion path surfaces it, so the authentication requirement silently disappears from all routes.
 
-        - **Enforced authentication:** Disabling anonymous access forces every request through the configured authentication policy, ensuring that only authenticated callers reach upstream backends.
-        - **Attribution restoration:** With anonymous access disabled, every request carries an authenticated identity, restoring the audit trail and rate-limiting key that downstream controls depend on.
+        Everything downstream assumes an authenticated principal. WAF rules, rate-limiting policies, and authorization middleware are keyed on a caller identity, and anonymous traffic invalidates every assumption those layers were designed around. Audit log entries for anonymous requests carry no principal identity at all, so actions cannot be attributed and abuse patterns cannot be detected after the fact.
+
+        Disabling the setting forces every request through the configured authentication policy, ensuring only authenticated callers reach upstream backends, restoring the audit trail, and giving rate limiting a stable key to count against. If one route genuinely must be public, publish it as its own deployment rather than opening anonymous access across the whole specification.
       audit: |
         ### Audit via Console
 
@@ -8115,19 +8089,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI API Gateway deployments are configured with an explicit authentication policy of type `JWT_AUTHENTICATION`, `TOKEN_AUTHENTICATION`, or `CUSTOM_AUTHENTICATION`, never with a missing or `NONE` authentication type. By default, OCI API Gateway deployments can be created without any authentication policy, which makes every route in the deployment publicly callable without credentials.
+        This check verifies that every API Gateway deployment declares an explicit authentication type and never leaves it missing or set to `NONE`.
+
+        The authentication policy inside a deployment's `request_policies` block names the identity model the gateway enforces before a request is routed. `JWT_AUTHENTICATION` validates a signed token against the issuers, audiences, and public keys configured on the policy. `TOKEN_AUTHENTICATION` and `CUSTOM_AUTHENTICATION` hand the credential to an authorizer function running on OCI Functions, which returns an allow or deny decision plus context the gateway can pass to the backend. This check requires one of those types to be present and non-empty. Set it in the Console under Developer Services > API Management > Gateways on the deployment's request policies, or with `oci api-gateway deployment update`.
 
         **Why this matters**
 
-        - **Publicly callable API by default:** A deployment without an authentication policy accepts every request as unauthenticated; there is no opt-out mechanism for individual routes to add auth back.
-        - **Development workflow debt:** Unauthenticated deployments commonly result from a "we'll add auth later" workflow during API development that never gets revisited before the deployment reaches production.
-        - **Downstream control invalidation:** Rate-limiting attribution, authorization policies, and audit trails all depend on a caller identity that does not exist when no authentication policy is configured.
-        - **Stronger failure than anonymous access:** Absence of any authentication policy is a more complete failure than having a policy with anonymous access allowed, because there is no auth mechanism at all to selectively bypass.
+        A deployment created without any authentication policy accepts every request as unauthenticated, and there is no per-route opt-out that adds authentication back for individual routes. The whole specification is publicly callable from the moment it is deployed.
 
-        **Risk mitigation**
+        This is the end state of a "we'll add auth later" API development workflow. The API is built and tested against an open gateway, the deployment is promoted, and nothing in the path asks whether the identity model was ever chosen.
 
-        - **Explicit auth model requirement:** Requiring an authentication type forces teams to make a deliberate choice about which identity model the API uses before it reaches any environment that accepts real traffic.
-        - **Silent-default closure:** Enforcing authentication configuration closes the path where a deployment ships with no auth simply because the default was never changed.
+        Rate-limiting attribution, authorization policies, and audit trails all depend on a caller identity that does not exist when no authentication policy is configured. That makes a missing policy a stronger failure than a policy with anonymous access allowed, because there is no authentication mechanism at all to selectively bypass or later tighten.
+
+        Requiring an explicit type forces teams to make a deliberate choice about which identity model the API uses before it reaches any environment that accepts real traffic, and closes the path where a deployment ships with no authentication simply because the default was never changed. Pair it with disabling anonymous access, since a configured type is inert when unauthenticated callers are admitted regardless.
       audit: |
         ### Audit via Console
 
@@ -8308,19 +8282,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI API Gateway deployments with a mutual TLS configuration block are set to enforce client certificate verification (`is_verified_certificate_required = true`). By default, the `mutual_tls` block can be configured with verification disabled, which means the gateway advertises mTLS support but still accepts connections from clients that present no certificate, providing no stronger authentication than standard TLS.
+        This check verifies that API Gateway deployments configured for mutual TLS actually require a verified client certificate.
+
+        The `mutual_tls` block inside a deployment's request policies tells the gateway to ask for a client certificate during the TLS handshake, and `mutualTls.isVerifiedCertificateRequired` decides whether the gateway rejects the handshake when no valid certificate arrives. The block can be configured with verification disabled, in which case the gateway advertises mutual TLS support but still accepts connections from clients that present no certificate, providing no stronger authentication than standard TLS. This check requires `is_verified_certificate_required = true` wherever a mutual TLS configuration exists. Configure it in the Console under Developer Services > API Management > Gateways on the deployment's request policies, or with `oci api-gateway deployment update`.
 
         **Why this matters**
 
-        - **Security theater risk:** Operators reading the deployment configuration see a `mutual_tls` block and assume client certificate authentication is enforced; without the verification flag, the block has no authentication effect.
-        - **Unverified connections accepted:** Clients without certificates can still complete the TLS handshake and reach upstream backends because the gateway does not reject the handshake when verification is off.
-        - **Allowed SANs list rendered inert:** The `allowed_sans` list, which is intended to act as an allowlist of trusted client identities, cannot filter certificates that are never being verified.
-        - **Compliance misrepresentation:** Compliance reviews that check for mTLS configuration will pass a deployment where verification is disabled, creating a documented but non-functional control.
+        The unenforced form is security theater. Operators reading the deployment configuration see a `mutual_tls` block and assume client certificate authentication is enforced, when without the verification flag the block has no authentication effect whatsoever.
 
-        **Risk mitigation**
+        Clients with no certificate still complete the TLS handshake and reach upstream backends, because the gateway has been told not to reject the handshake on verification failure. The `allowed_sans` list, which is meant to act as an allowlist of trusted client identities, cannot filter certificates that are never verified in the first place, so it degrades into advisory metadata.
 
-        - **Certificate chain enforcement:** Enabling `is_verified_certificate_required = true` forces clients to present a certificate that chains to the configured CA bundle, making mTLS a real authentication layer rather than a configuration artifact.
-        - **SAN allowlist activation:** Certificate verification activates the `allowed_sans` filter, turning it from advisory metadata into an actual authorization boundary that restricts which client identities can reach the API.
+        Compliance reviews that look only for the presence of a mutual TLS configuration will pass a deployment where verification is off, producing a documented but non-functional control that survives audit after audit.
+
+        Turning verification on forces every client to present a certificate that chains to the configured certificate authority bundle, which makes mutual TLS a real authentication layer rather than a configuration artifact and activates `allowed_sans` as an actual authorization boundary over which client identities may reach the API. Deployments with no mutual TLS configuration are out of scope here; they should still enforce an authentication policy of their own.
       audit: |
         ### Audit via Console
 
@@ -8497,20 +8471,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that API Gateway deployments are configured to restrict CORS allowed origins to an explicit allowlist rather than the wildcard value `"*"`. By default, OCI API Gateway CORS policies have no wildcard restriction enforced, and wildcard origins are commonly introduced for local development then shipped to production unchanged.
+        This check verifies that API Gateway deployments restrict cross-origin resource sharing to a named allowlist of origins rather than the wildcard value `"*"`.
+
+        The CORS policy inside a deployment's request policies publishes which browser origins may read responses from the API. Its `allowedOrigins` list is the allowlist, and the wildcard entry `*` tells every browser that any page on the internet may share the response. OCI enforces no wildcard restriction of its own, and wildcard origins are commonly introduced for local development and then shipped to production unchanged. This check requires that `allowed_origins` either be absent or contain no wildcard entry. Edit it in the Console under Developer Services > API Management > Gateways on the deployment's request policies, or with `oci api-gateway deployment update`.
 
         **Why this matters**
 
-        - **Cross-site data exfiltration:** Any malicious page in a user's browser can issue authenticated requests to the API and read responses when the gateway advertises that all origins are safe to share.
-        - **Credential leakage:** The CORS specification prohibits combining wildcard origins with `Access-Control-Allow-Credentials: true`, but some servers honor the combination, exposing session tokens and cookies to arbitrary origins.
-        - **Attack surface expansion:** Wildcard CORS removes the same-origin protection that browsers rely on to keep session data scoped to the owning application.
-        - **Audit trail gap:** An explicit allowlist of frontend origins is a useful artifact for access-control audits; a wildcard provides no meaningful record of which origins are legitimate.
+        With a wildcard in place, any malicious page loaded in a user's browser can issue requests to the API and read the responses. Wildcard CORS removes the same-origin protection browsers rely on to keep session data scoped to the application that owns it, which turns a logged-in user's browser into an access path for whoever controls the page they happen to visit.
 
-        **Risk mitigation**
+        The dangerous pair is the wildcard together with credentials. The CORS specification forbids combining a wildcard origin with `Access-Control-Allow-Credentials: true`, precisely because it would let arbitrary origins make authenticated cross-origin calls, but some servers honor the combination anyway and expose session tokens and cookies to any origin that asks.
 
-        - **Restore same-origin protection:** Replacing `"*"` with a named allowlist re-enables browser enforcement of the same-origin policy for authenticated APIs.
-        - **Eliminate spec violations:** Removing the wildcard closes the credentials-plus-wildcard combination that some gateway implementations honor against specification.
-        - **Enforce explicit access control:** Requiring named origins means every new consumer must be reviewed and added, creating an ongoing access-control checkpoint.
+        An explicit list of frontend origins is also a useful artifact for access-control audits. A wildcard leaves no record of which origins were ever intended to be legitimate, so there is nothing to review against.
+
+        Replacing the wildcard with named origins re-enables browser enforcement for authenticated APIs, closes the credentials-plus-wildcard combination, and makes every new consumer a reviewed addition to the list. A genuinely public, unauthenticated, read-only endpoint is the one place a wildcard is defensible, and it belongs in its own deployment.
       audit: |
         ### Audit via Console
 
@@ -8674,20 +8647,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every active certificate managed by OCI Certificates Management has at least 30 days of validity remaining before expiry. OCI does not enforce automatic renewal by default on all certificate types, so certificates that lack a renewal rule can silently reach expiry and begin failing TLS handshakes across every service that depends on them.
+        This check verifies that every active certificate held in the OCI Certificates service carries more than 30 days of remaining validity.
+
+        The service both issues certificates from a managed certificate authority and stores certificates imported from an external one. Renewal is not automatic for every certificate type, so a certificate with no renewal rule attached simply runs down its validity period and expires. The check reads the expiry date of each certificate in the `ACTIVE` state and requires more than 30 days of headroom, which is enough for a renewal pipeline to run on its own schedule. Certificates and their renewal rules live under Identity & Security > Certificates in the Console and are edited with `oci certs-mgmt certificate update`.
 
         **Why this matters**
 
-        - **Service availability:** An expired certificate causes immediate TLS handshake failures for all consumers, triggering outages that cannot be resolved without a new certificate version.
-        - **Security regression under pressure:** Operators responding to a live outage caused by an expired certificate routinely disable certificate verification as a temporary workaround, leaving deployments running with verification permanently off.
-        - **Rushed replacement risk:** Short-notice renewals bypass the approval, pinning, and monitoring steps that govern planned certificate issuance, increasing the chance of errors or unauthorized substitution.
-        - **Broken trust assumptions:** Automated systems, load balancers, and monitoring pipelines all assume that an in-policy certificate has meaningful expiry; an expired certificate silently invalidates every assumption built on top of it.
+        Expiry is an availability event before it is a security one. The moment a certificate passes its expiry date, every consumer's TLS handshake fails at once, and nothing short of issuing and deploying a new certificate version restores service. Load balancers, internal service calls, and monitoring pipelines break together, because they all trusted the same object.
 
-        **Risk mitigation**
+        What happens next is the security problem. Operators working a live outage reach for the fastest fix available, which is usually disabling certificate verification in the client. That switch is rarely turned back on, and the deployment keeps running with verification off long after a valid certificate is in place.
 
-        - **Early detection:** Flagging certificates within 30 days of expiry surfaces renewal failures before downstream consumers begin to fail.
-        - **Scheduled remediation:** Advance notice allows renewal pipelines to run on a planned schedule rather than reactively during an incident.
-        - **Audit evidence:** Continuous validation that certificates are within policy provides evidence that the certificate inventory is actively maintained.
+        A short-notice renewal also skips the steps that govern planned issuance. Approval, pinning updates, and monitoring registration are what make a new certificate trustworthy, and a replacement rushed out mid-incident bypasses all of them, which is precisely when an unauthorized substitution would go unnoticed.
+
+        Flagging certificates 30 days out converts all of that into scheduled work and surfaces renewal failures before any downstream consumer notices. The continuous result doubles as audit evidence that the certificate inventory is actively maintained rather than rediscovered during outages.
       audit: |
         ### Audit via Console
 
@@ -8780,20 +8752,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every active certificate in OCI Certificates Management uses a key algorithm from the approved set: `RSA2048`, `RSA4096`, `ECDSA_P256`, or `ECDSA_P384`. OCI Certificates does not block the import of certificates carrying weaker legacy key algorithms such as 1024-bit RSA, so imported certificates can enter the inventory appearing identical to freshly issued ones while carrying keys that are cryptographically inadequate.
+        This check verifies that every active certificate in the OCI Certificates service is backed by a key algorithm from the approved set: `RSA2048`, `RSA4096`, `ECDSA_P256`, or `ECDSA_P384`.
+
+        The service handles two kinds of certificate. Ones it issues from a managed certificate authority take the key algorithm chosen at creation time. Imported ones carry whatever key the external issuer generated, and OCI applies no algorithm-strength gate at import, so a certificate holding a 1024-bit RSA key enters the inventory looking identical to a freshly issued one. Set the algorithm on the certificate configuration under Identity & Security > Certificates in the Console or with `oci certs-mgmt certificate create`, and reissue imported certificates that fall short.
 
         **Why this matters**
 
-        - **Factoring risk:** 1024-bit RSA keys are considered factorable by well-resourced attackers and are explicitly prohibited by NIST SP 800-131A; any session protected by such a certificate inherits that weakness.
-        - **Interoperability breakage:** Non-NIST curves and short elliptic-curve keys break strict clients and can be rejected by modern TLS stacks, causing silent availability failures alongside the security risk.
-        - **Long certificate lifetimes:** Certificates issued today are typically valid for one to several years, so a weak key accepted now becomes a multi-year liability that grows more dangerous as attack tooling improves.
-        - **Legacy import blind spot:** Imported certificates carry whatever key the external issuer used; the OCI Certificates service applies no algorithm-strength gate at import time.
+        A 1024-bit RSA key is considered factorable by a well-resourced attacker and is explicitly prohibited by NIST SP 800-131A. Every session protected by such a certificate inherits that weakness, and so does every signature the certificate has already produced, because recovering the private key unlocks all of it retroactively.
 
-        **Risk mitigation**
+        Certificate lifetimes make the exposure durable. A certificate issued today is typically valid for one to several years, so a weak key accepted now is a liability for that whole term, across which the tooling and hardware available to an attacker only improve.
 
-        - **Enforce a modern-crypto baseline:** Requiring only approved algorithms ensures every certificate in the inventory meets a documented minimum strength standard.
-        - **Surface legacy imports:** Scanning the key algorithm catches imported certificates that pre-date current standards before they are bound to production traffic.
-        - **Reduce long-term cryptographic exposure:** Keeping all certificates on strong algorithms limits the window during which a certificate could be compromised through advances in cryptanalysis.
+        Strength is not the only reason the approved list is narrow. Short elliptic-curve keys and curves outside the NIST set are rejected outright by strict TLS stacks, so an unusual choice produces intermittent connection failures that look like a network problem and get chased as one. Holding to the four approved algorithms avoids that availability failure alongside the cryptographic one.
+
+        Imported certificates are where this check earns its keep. They are the population nobody deliberately chose a key for, and the only route by which a pre-standard algorithm reaches production traffic without anyone making a decision about it.
       audit: |
         ### Audit via Console
 
@@ -8949,20 +8920,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every active certificate in OCI Certificates Management is signed with a SHA-2 family algorithm: `SHA256_WITH_RSA`, `SHA384_WITH_RSA`, `SHA512_WITH_RSA`, `SHA256_WITH_ECDSA`, `SHA384_WITH_ECDSA`, or `SHA512_WITH_ECDSA`. OCI Certificates does not block the import of certificates carrying deprecated SHA-1 or MD5 signatures, which means such certificates can enter the inventory and be trusted by internal automation even after public CAs and browsers have stopped honoring them.
+        This check verifies that every active certificate in the OCI Certificates service is signed with a SHA-2 family algorithm: `SHA256_WITH_RSA`, `SHA384_WITH_RSA`, `SHA512_WITH_RSA`, `SHA256_WITH_ECDSA`, `SHA384_WITH_ECDSA`, or `SHA512_WITH_ECDSA`.
+
+        The signature algorithm is what binds a certificate's contents to the authority that issued it. For certificates OCI issues, the algorithm is part of the certificate configuration you supply. For imported certificates it is whatever the external authority used, and the service enforces no signature-algorithm gate at import, so a deprecated SHA-1 or MD5 signature can enter the inventory without warning. Set or review the algorithm under Identity & Security > Certificates in the Console or with `oci certs-mgmt certificate update`.
 
         **Why this matters**
 
-        - **Demonstrated collision attacks:** SHA-1 collisions have been publicly demonstrated since 2017; an attacker with sufficient resources can forge a certificate that chains to a legitimate CA, defeating the identity assurance the certificate is meant to provide.
-        - **Trusted by automation:** Internally-issued SHA-1 certificates are often still honored by automation and legacy services long after browsers stopped accepting them, creating trusted but exploitable paths that are invisible in routine monitoring.
-        - **MD5 retirement:** MD5 was retired even earlier than SHA-1; any certificate still signed with MD5 is effectively a forgery primitive for any attacker with moderate resources.
-        - **Import blind spot:** The OCI Certificates service does not enforce a signature-algorithm gate at import time, so weak-signature certificates can enter the inventory without warning.
+        SHA-1 collisions have been publicly demonstrated since 2017 and have only grown cheaper. The consequence is concrete: an attacker with sufficient resources can obtain a signature over benign content and transplant it onto a certificate naming a service they do not own, producing something that chains to a legitimate authority and defeats the identity assurance the certificate exists to provide.
 
-        **Risk mitigation**
+        MD5 was retired even earlier and is worse. Collisions against it are computable on ordinary hardware, so a certificate still signed with MD5 is best treated as a forgery primitive rather than a credential.
 
-        - **Eliminate forgeable certificates:** Requiring SHA-2 signatures removes certificates for which known, practical collision techniques exist.
-        - **Close silent trust paths:** Identifying and replacing weak-signature certificates removes trust paths that modern clients have already rejected but internal systems may still honor.
-        - **Align with current standards:** Using only SHA-2 family algorithms keeps the certificate inventory consistent with NIST SP 800-131A guidance on retired hash functions.
+        Weak signatures survive because browsers are not the only relying party. Public clients stopped accepting SHA-1 years ago, but internally issued certificates are frequently still honored by scripts, agents, and legacy services that never had a policy engine to update. Those trust paths are exploitable and invisible in routine monitoring, precisely because nothing complains about them.
+
+        Reissuing under a SHA-2 algorithm keeps the inventory aligned with NIST SP 800-131A guidance on retired hash functions, and it is usually a configuration change rather than a migration, because the subject key itself does not have to change.
       audit: |
         ### Audit via Console
 
@@ -9139,20 +9109,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every active internally-issued certificate in OCI Certificates Management has auto-renewal configured through a `CERTIFICATE_RENEWAL_RULE`. Imported certificates cannot auto-renew through the service and are excluded. By default, OCI Certificates does not attach a renewal rule when a certificate is created; without one, renewal depends entirely on a manual process that can fail under personnel changes, holiday schedules, or oncall handoff gaps.
+        This check verifies that every active certificate issued by an internal certificate authority in the OCI Certificates service renews itself automatically through an attached renewal rule.
+
+        A certificate can carry a rule of type `CERTIFICATE_RENEWAL_RULE`, which tells the service to issue a new version on a defined interval and an advance window before the current version expires. No such rule is attached when a certificate is created, so automatic renewal is something you turn on rather than something you inherit. Imported certificates cannot renew through the service, since the issuing authority sits outside OCI, and the check excludes them. Attach the rule under Identity & Security > Certificates in the Console or with `oci certs-mgmt certificate update`.
 
         **Why this matters**
 
-        - **Calendar-dependent renewal failure:** Manual renewal cadence is driven by reminders and ticket due dates that break when personnel change, creating silent expiry windows that trigger simultaneous TLS failures across every dependent service.
-        - **Incident-time workarounds:** Operators responding to an expiry-caused outage routinely disable certificate verification to restore service, leaving deployments running without verification long after the replacement is issued.
-        - **Unauthorized substitution window:** A manual renewal cutover creates a brief window where an attacker with influence over the renewal process could substitute a malicious certificate without detection.
-        - **Consistent enforcement:** Auto-renewal ensures the renewal interval matches the organization's intended certificate lifetime policy rather than drifting with oncall availability.
+        Without a rule, renewal is a calendar entry. It depends on a reminder someone set, a ticket due date, and a person still in the role when it fires. Personnel changes, holiday schedules, and oncall handoff gaps break all three, and the failure stays silent until every service depending on the certificate fails its handshake in the same instant.
 
-        **Risk mitigation**
+        The recovery is worse than the outage. Operators restoring service under pressure routinely disable certificate verification in the affected clients to get traffic flowing, and that setting outlives the incident by months.
 
-        - **Eliminate the manual-renewal failure mode:** Automated renewal issues a new certificate version inside an advance window while the current one is still valid, preventing expiry-caused outages.
-        - **Remove the attacker substitution window:** Closing the manual cutover step removes the opportunity for an attacker to insert a fraudulent certificate during renewal.
-        - **Enforce lifecycle policy:** Auto-renewal ties certificate lifetime to a declared configuration rather than operator availability, making the renewal cadence consistent and auditable.
+        Manual renewal also opens a window that automation does not. Cutting over by hand means someone places new certificate material into production out of band, and anyone with influence over that process can substitute a certificate of their own without the swap looking unusual. Automated renewal issues a new version from the same authority under the same rule while the current one is still valid, which is both harder to subvert and visible in the service's own record.
+
+        A rule finally makes the renewal interval a declared value rather than a consequence of who was available. The certificate lifetime the organization intended is the lifetime it gets, and it is auditable as configuration.
       audit: |
         ### Audit via Console
 
@@ -9296,20 +9265,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every certificate authority in OCI Certificates Management has its private key material protected by a customer-managed KMS key. By default, OCI can provision CA key material under Oracle-managed encryption, which means the organization's own key-management policies, Vault IAM rules, and HSM-backed key-shape requirements cannot be enforced on the material that controls every certificate the CA will ever issue.
+        This check verifies that every active certificate authority in the OCI Certificates service has its private key material protected by a customer-managed key in OCI Vault.
+
+        An authority can be created against a key the customer owns in Vault or left under Oracle-managed encryption. The default path means the organization's own key-management policies, its Vault IAM statements such as `allow group KeyAdmins to use keys in compartment Security`, and its HSM-backed key-shape requirements cannot be applied to the material that controls every certificate the authority will ever issue. Bind the key when creating the authority under Identity & Security > Certificate Authorities in the Console, or supply the key OCID to `oci certs-mgmt certificate-authority create`.
 
         **Why this matters**
 
-        - **Master credential exposure:** A CA's private key is the master credential of the entire PKI it anchors; whoever can use that key can mint a trusted certificate for any service name in the tenancy, partner domains, and SaaS endpoints.
-        - **No customer-controlled revocation:** Without a customer-managed key, the organization cannot revoke access to CA private material by revoking a Vault policy; containment after a suspected CA compromise requires Oracle intervention instead of an immediate key-policy change.
-        - **Inherited risk in subordinate CAs:** A subordinate CA without a CMK provides a path to issue certificates whose key material the customer cannot independently control or audit.
-        - **Audit gap:** Oracle-managed defaults provide no per-operation audit trail in the customer's Vault; every CA key operation is invisible to the customer's own audit log.
+        A certificate authority's private key is the master credential of the entire public key infrastructure it anchors. Whoever can use it can mint a trusted certificate for any service name in the tenancy, for partner domains, and for the SaaS endpoints your clients resolve. No per-certificate control limits that, because the ability to issue is the control.
 
-        **Risk mitigation**
+        Containment is what customers discover too late. With an Oracle-managed key there is no Vault policy to revoke, so a suspected compromise cannot be stopped by any change the customer makes and requires Oracle to intervene. With a customer-managed key, disabling or rotating it cuts off access to the private material immediately and without rebuilding the authority.
 
-        - **Restrict decryption access:** Binding the CA private key to a customer-managed KMS key means only identities that the customer has explicitly authorized can access or use the key material.
-        - **Enable rapid containment:** If a CA compromise is suspected, revoking or rotating the KMS key immediately cuts off access to the CA private material without requiring a CA rebuild.
-        - **Provide an auditable key-use trail:** Every CA operation involving the private key appears in Vault audit logs, giving the customer visibility into signing activity independent of OCI's CA service logs.
+        The same gap applies to evidence. Key operations under Oracle management leave no entry in the customer's Vault audit log, so signing activity is visible only through the authority's own service records. A customer-managed key puts every use of the private material into a log the customer controls, independent of the service performing the operation.
+
+        Subordinate authorities inherit the problem rather than escaping it. A subordinate created without a customer-managed key is still a fully capable issuer whose key material the customer can neither control nor independently audit.
       audit: |
         ### Audit via Console
 
@@ -9449,20 +9417,19 @@ queries:
       oci.redis.cluster.subnet.prohibitPublicIpOnVnic == true
     docs:
       desc: |
-        This check ensures that every OCI Cache cluster is deployed in a subnet configured to prohibit public IP addresses on VNICs. By default, OCI subnets allow public IP assignment, and a cache cluster placed in such a subnet can be assigned a public IP that exposes the in-memory store to internet scanning with no application-layer authentication between the attacker and the data.
+        This check verifies that every OCI Cache cluster sits behind a private endpoint, in a subnet configured to prohibit public IP addresses on VNICs.
+
+        OCI Cache runs a managed in-memory data store reachable over a private endpoint inside a VCN subnet. OCI subnets allow public IP assignment by default, and a cache cluster placed in such a subnet can be given a public IP that exposes the in-memory store to internet scanning with no application layer between the attacker and the data. This check requires the cluster's subnet to prohibit public IPs on its VNICs. Create the subnet that way in the Console under Networking > Virtual Cloud Networks, or with `oci network subnet create --prohibit-public-ip-on-vnic true`, then place the cluster there from Databases > OCI Cache.
 
         **Why this matters**
 
-        - **No default authentication:** Cache engines historically default to no authentication; even with auth enabled, direct internet reachability means any authentication weakness or future CVE is immediately exploitable from anywhere on the internet.
-        - **Sensitive data exposure:** OCI Cache clusters typically hold session identifiers, OAuth refresh tokens, cached query results containing personal information, and feature-flag configurations that control application behavior.
-        - **Configuration manipulation:** An attacker with direct cache access can modify feature-flag and rate-limit data to bypass application logic and throttling, amplifying the impact beyond simple data theft.
-        - **Persistent reachability risk:** A public IP assigned to a subnet VNIC can persist across cluster restarts and updates unless the subnet itself prohibits it; subnet-level enforcement provides a structural guarantee.
+        Cache engines historically default to no authentication, and even with authentication enabled, direct internet reachability means any authentication weakness or future CVE becomes immediately exploitable from anywhere on the internet rather than only from inside the VCN.
 
-        **Risk mitigation**
+        The data these clusters hold is exactly what an attacker wants: session identifiers, OAuth refresh tokens, cached query results containing personal information, and feature-flag configurations that drive application behavior. Read access alone is a session hijacking primitive.
 
-        - **Remove internet reachability:** Deploying in a subnet that prohibits public IPs ensures the cache endpoint is never assigned an internet-routable address at any point in the cluster's lifecycle.
-        - **Force traffic through controlled paths:** All cache traffic must traverse VCN routes, NSGs, and service gateways where it can be logged and filtered.
-        - **Provide lifecycle protection:** Subnet-level enforcement is a structural control that cannot be bypassed by later configuration changes to the cluster itself.
+        Write access is worse. An attacker who can reach the cache directly can modify feature-flag and rate-limit entries to bypass application logic and throttling, which amplifies the impact well beyond data theft.
+
+        A public IP assigned to a VNIC in a permissive subnet can persist across cluster restarts and updates unless the subnet itself prohibits it. Enforcing the restriction at the subnet is structural: the endpoint is never assigned an internet-routable address at any point in the cluster's lifecycle, and the restriction cannot be undone by a later change to the cluster alone. All cache traffic is then forced through VCN routes, network security groups, and service gateways, where it can be logged and filtered.
       audit: |
         ### Audit via Console
 
@@ -9579,20 +9546,21 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Cache cluster has at least one Network Security Group attached. Subnet security lists are the only network control applied by default; NSGs provide per-cluster east-west rules and are the layer Oracle's connection guide recommends for restricting which workloads can reach an OCI Cache endpoint.
+        This check verifies that access to every OCI Cache cluster is scoped by at least one Network Security Group rather than by subnet membership alone.
+
+        Subnet security lists are the only network control OCI applies to a cache cluster by default, and they treat every VNIC in the subnet identically. A Network Security Group is attached to the cluster itself and carries rules that can name other NSGs as sources, which is the layer Oracle's connection guide recommends for restricting which workloads may reach an OCI Cache endpoint. This check requires at least one NSG on the cluster. Attach one in the Console under Databases > OCI Cache on the cluster's network configuration, or by setting `nsg_ids` with `oci redis redis-cluster update`.
 
         **Why this matters**
 
-        - **Coarse subnet rules:** Subnet security lists apply to every VNIC in the subnet; adding any new workload to the subnet silently inherits bidirectional cache access, expanding the attack surface without any explicit grant.
-        - **Lateral movement risk:** A compromised workload in the same subnet can reach the cache under a subnet-only model even if its own NSG would otherwise isolate it, because the subnet rules provide no per-source-resource scoping.
-        - **No per-cluster traffic visibility:** NSGs are the unit Oracle's flow-log integration uses to capture per-cluster network telemetry; without an NSG, traffic to and from the cache cannot be isolated in logs for security monitoring.
-        - **Missed access control changes:** Without NSG scoping, granting access to a new application tier requires modifying shared subnet rules, which affects all resources in the subnet rather than just the intended consumer.
+        Subnet security lists are coarse. They apply to every VNIC in the subnet, so adding any new workload to that subnet silently inherits bidirectional cache access, expanding the attack surface with no explicit grant and no review step.
 
-        **Risk mitigation**
+        That coarseness is a lateral movement path. Under a subnet-only model, a compromised workload sharing the subnet can reach the cache even when its own NSG would otherwise isolate it, because subnet rules offer no per-source-resource scoping.
 
-        - **Scope access to known clients:** An NSG on the cluster allows only explicitly named source NSGs to reach the cache, blocking lateral access from unrelated workloads sharing the subnet.
-        - **Decouple access control from subnet membership:** Moving cache access rules to NSGs means that adding a new workload to the subnet does not automatically grant it cache access.
-        - **Enable per-cluster traffic monitoring:** Attaching an NSG provides a logging boundary that separates cache traffic from general subnet traffic in flow logs.
+        NSGs are also the unit Oracle's flow-log integration uses to capture per-cluster network telemetry. With no NSG on the cluster, traffic to and from the cache cannot be separated from general subnet traffic in logs, so there is nothing for security monitoring to isolate.
+
+        Access changes suffer the same problem. Granting a new application tier access without NSG scoping means editing shared subnet rules, which affects every resource in the subnet rather than the intended consumer alone.
+
+        An NSG on the cluster admits only explicitly named source NSGs, blocks lateral access from unrelated workloads, decouples cache access from subnet membership, and gives flow logs a clean boundary. Pair it with a subnet that prohibits public IPs so the network controls stack rather than substitute for each other.
       audit: |
         ### Audit via Console
 
@@ -9718,20 +9686,21 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Cache cluster runs a software version in the currently supported set. Oracle's OCI Cache service has transitioned from Redis to Valkey; legacy `REDIS_*` version tracks no longer receive upstream security updates from the Valkey project, and older Valkey minor versions are dropped from Oracle's patch matrix once a successor reaches general availability.
+        This check verifies that every OCI Cache cluster runs an engine version that still receives security patches.
+
+        Oracle's OCI Cache service has transitioned from Redis to Valkey, the community fork that now carries upstream development. Legacy `REDIS_*` version tracks no longer receive upstream security updates from the Valkey project, and older Valkey minor versions drop out of Oracle's patch matrix once a successor reaches general availability. This check requires the cluster's software version to be `VALKEY_7_2` or `VALKEY_8_1`. Review and change it in the Console under Databases > OCI Cache on the cluster's details page, or with `oci redis redis-cluster update`.
 
         **Why this matters**
 
-        - **No security backports:** Unsupported engine versions do not receive CVE fixes; exploitable vulnerabilities discovered after a version reaches end-of-life remain permanently unpatched in any cluster still running it.
-        - **Elevated impact from in-memory RCE:** Cache engines typically run with elevated privileges inside the VCN; a remote-code-execution vulnerability in an unsupported engine version is a direct path to in-memory data exfiltration and lateral movement.
-        - **Reactive upgrade pressure:** Discovering an unsupported version during an incident response or audit forces a disruptive upgrade under time pressure instead of a planned migration.
-        - **Upstream abandonment:** The shift from Redis to Valkey means `REDIS_*` tracks have no upstream project providing fixes, regardless of whether Oracle continues providing its own patches.
+        Unsupported engine versions do not receive CVE fixes. A vulnerability discovered after a version reaches end of life remains permanently unpatched in any cluster still running it, and no amount of network hardening changes that.
 
-        **Risk mitigation**
+        The impact of such a vulnerability is high because of where the engine sits. Cache engines typically run with elevated privileges inside the VCN, so a remote-code-execution flaw in an unsupported version is a direct path to in-memory data exfiltration and to lateral movement toward whatever else the subnet can reach.
 
-        - **Maintain patch coverage:** Running a supported version ensures the cluster receives security patches on Oracle's published cadence.
-        - **Align with upstream support:** Restricting to `VALKEY_7_2` and `VALKEY_8_1` keeps clusters on branches that the Valkey project actively maintains.
-        - **Enforce proactive upgrades:** Flagging unsupported versions before an incident ensures migrations happen on a planned schedule rather than as emergency remediation.
+        Discovering an unsupported version during incident response or an audit forces a disruptive upgrade under time pressure. The same migration, planned in advance, is a maintenance window.
+
+        The Redis to Valkey shift makes this sharper than a normal end-of-life question. A cluster on a `REDIS_*` track has no upstream project producing fixes at all, regardless of whether Oracle continues to publish patches of its own.
+
+        Holding clusters on `VALKEY_7_2` or `VALKEY_8_1` keeps them on branches the Valkey project actively maintains and inside Oracle's published patch cadence. Keep this list current as Oracle's supported set moves, and treat a version falling off it as a scheduled migration rather than emergency remediation.
       audit: |
         ### Audit via Console
 
@@ -9841,20 +9810,19 @@ queries:
       oci.cloudGuard.securityZones.length > 0
     docs:
       desc: |
-        This check ensures that the OCI tenancy has at least one Cloud Guard security zone configured. Security Zones are OCI's preventive-control layer: operations in a zoned compartment that violate the zone's recipe policies are blocked at the API layer rather than detected after the fact. Without any zone in place, the tenancy relies entirely on detective controls, which leave a window between when a misconfiguration is created and when an operator responds to an alert.
+        This check verifies that the tenancy has preventive guardrails in place, in the form of at least one Cloud Guard security zone.
+
+        A security zone binds a compartment to a security zone recipe, a set of policies such as requiring customer-managed encryption keys, forbidding public buckets, and forbidding public network endpoints. Operations in a zoned compartment that violate the recipe are refused at the API layer at create time. Cloud Guard detectors are the other half of the service and behave differently: they observe resources after the fact and report problems for an operator to act on. This check requires at least one zone to exist. Create one in the Console under Identity & Security > Security Zones, or with `oci cloud-guard security-zone create`.
 
         **Why this matters**
 
-        - **Detective-only gap:** A bucket created with public access in an unzoned compartment is publicly readable until a detector raises an alert and an operator reacts; a zone blocks the create call before any exposure occurs.
-        - **Operator bypass risk:** An operator with sufficient permissions can override a detective finding without friction in an unzoned compartment; inside a zone, the API itself enforces the recipe regardless of operator intent.
-        - **Coverage of high-value services:** Security Zones enforce controls that detective tooling can miss, including customer-managed encryption requirements, public-endpoint restrictions, and network-exposure policies.
-        - **Structural enforcement:** Zones provide a control that survives changes to Cloud Guard detector rules and monitoring configurations; detective controls that are reconfigured or silenced do not affect zone enforcement.
+        Without any zone, the tenancy relies entirely on detective controls, which leave a window between the moment a misconfiguration is created and the moment an operator responds. A bucket created with public access in an unzoned compartment is publicly readable for the whole of that window; in a zoned compartment the create call is refused and no exposure ever occurs.
 
-        **Risk mitigation**
+        Detective findings can also be argued with. An operator holding sufficient permissions can dismiss or ignore a finding with no friction, whereas inside a zone the API enforces the recipe regardless of operator intent.
 
-        - **Shift from detect-and-react to prevent-at-create:** A configured zone converts the security posture for covered services from reactive alerting to proactive blocking at the API layer.
-        - **Reduce misconfiguration dwell time:** Zone enforcement reduces the exposure window of a misconfiguration from hours or days to zero for operations covered by the recipe.
-        - **Preserve guardrails through pipeline changes:** Zone policies survive automated pipeline activity that might inadvertently reconfigure or disable detective tooling.
+        Zones cover ground detection frequently misses, including customer-managed encryption requirements, public-endpoint restrictions, and network-exposure policies that a detector recipe may never have been configured to look for.
+
+        Enforcement is also more durable. Zone policies survive changes to detector rules and monitoring configuration, so detective tooling that is retuned, silenced, or broken by an automated pipeline does not weaken the guardrail. The result is a posture that prevents at create time instead of alerting afterward, reducing the exposure window for covered operations from hours or days to zero.
       audit: |
         ### Audit via Console
 
@@ -9945,20 +9913,21 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every Cloud Guard security zone has `is_inheritance_after_delete_enabled` set to `true`. Without this setting, deleting a parent zone strips child compartments of any inherited zone protection, silently removing the API-enforcement layer from those compartments without any indication in the audit log that they are no longer protected.
+        This check verifies that protection survives the deletion of a security zone, by requiring inheritance after delete on every Cloud Guard security zone.
+
+        A security zone applies its recipe policies to the compartment it is attached to and, through nesting, to compartments beneath it. `is_inheritance_after_delete_enabled` controls what happens to those descendants when the zone itself is removed: with it set to `true`, child compartments keep the enforcement they inherited; with it off, they lose it the moment the parent zone is deleted. This check requires the setting to be `true` on every zone. Set it in the Console under Identity & Security > Security Zones when creating or editing a zone, or with `oci cloud-guard security-zone update`.
 
         **Why this matters**
 
-        - **Silent protection gap on deletion:** Deleting a parent zone without inheritance enabled immediately removes zone enforcement from all child compartments; nothing in the audit log indicates that these compartments are no longer screened by zone policies.
-        - **Triggered by routine operations:** The deletion can result from a recipe rebuild, a tenancy reorganization, or a misconfigured IaC pipeline, none of which appear as security events to monitoring tools.
-        - **Nested compartment exposure:** Zone nesting means a single parent-zone deletion can expose multiple child compartments simultaneously, creating a broad and invisible protection gap.
-        - **No automatic reprotection:** Once the protection gap opens, it persists until an operator manually recreates the zone or explicitly applies a replacement; there is no automatic healing mechanism.
+        Deleting a parent zone without inheritance enabled strips zone enforcement from every child compartment immediately, and nothing in the audit log records that those compartments are no longer screened by zone policies. The API-enforcement layer is simply gone.
 
-        **Risk mitigation**
+        The deletion that triggers this is rarely a security event in its own right. A recipe rebuild, a tenancy reorganization, or a misconfigured infrastructure-as-code pipeline all produce it, and none of them look like anything a monitoring tool would raise.
 
-        - **Preserve child compartment protection:** With inheritance enabled, child compartments retain parent-zone enforcement through delete-and-recreate cycles, eliminating the silent protection gap.
-        - **Reduce blast radius of accidental deletion:** Inheritance limits the impact of an unintended zone deletion to the parent zone itself rather than cascading to all child compartments.
-        - **Align with Oracle's recommended configuration:** Oracle recommends enabling inheritance after deletion as the default posture for production security zones.
+        Nesting multiplies the blast radius. A single parent-zone deletion can expose several child compartments at once, so one routine operation opens a broad and invisible gap.
+
+        Nothing closes that gap on its own. It persists until an operator notices and manually recreates the zone or applies a replacement, and there is no automatic healing mechanism to fall back on.
+
+        With inheritance enabled, child compartments retain parent-zone enforcement through delete-and-recreate cycles, and an unintended deletion is limited to the parent zone rather than cascading downward. Oracle recommends enabling inheritance after deletion as the default posture for production security zones, and it costs nothing to carry.
       audit: |
         ### Audit via Console
 
@@ -10075,18 +10044,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that the OCI password policy requires passwords to be at least 14 characters long, to mix uppercase, lowercase, numeric, and special characters, and to disallow passwords that contain the username. Both policies are checked: the legacy tenancy-wide authentication policy, and the separate password policy each identity domain keeps for the users who actually sign in to it. The OCI default enforces only a 12-character minimum with a single character from three of four character classes, which permits weaker passwords than most security frameworks require.
+        This check verifies that password complexity is enforced strongly enough to resist guessing, requiring a minimum length of 14 characters, at least one uppercase letter, one lowercase letter, one numeral, and one special character, and passwords that do not contain the username.
+
+        OCI keeps password rules in two places, and both are checked. The legacy tenancy-wide authentication policy applies to local IAM users and is edited with `oci iam authentication-policy update` against the tenancy. A tenancy using identity domains keeps a separate password policy per domain under Identity & Security > Domains, and that is the policy the domain's users actually authenticate against, so a hardened tenancy policy sitting alongside a default domain policy still leaves real accounts weakly protected. A tenancy with no identity domains is judged on the tenancy-wide policy alone. The OCI default enforces only a 12-character minimum with a single character drawn from three of the four character classes.
 
         **Why this matters**
 
-        - **Brute-force resistance:** Longer passwords with mixed character classes dramatically increase the search space an attacker must cover to guess or crack a credential offline.
-        - **Credential-stuffing resistance:** Disallowing username containment prevents trivially guessable passwords derived from the account name.
-        - **Framework alignment:** Frameworks such as PCI DSS and CIS prescribe minimum length and complexity requirements that exceed the OCI defaults.
+        Length is what defeats offline cracking. Every additional character multiplies the search space an attacker has to cover, and requiring all four character classes rather than three of four removes the shortcut of a wordlist run over lowercase and digits alone. Two extra characters over the default is a large multiplier against hardware measuring its throughput in guesses per second.
 
-        **Risk mitigation**
+        Blocking username containment removes the most predictable pattern in any password corpus. A password built around the account name is the first thing a targeted guessing run tries, and it is derivable from information the attacker already has, since the username is often just an email address.
 
-        - **Set length and complexity at the tenancy level:** Configure the authentication policy once so every local IAM user inherits the stronger requirements.
-        - **Disallow username containment:** Reject passwords that embed the username to eliminate a common weak-password pattern.
+        These rules also carry compliance weight. Frameworks including PCI DSS and CIS prescribe length and complexity floors above what OCI ships with, so a tenancy left on defaults fails on configuration alone.
+
+        Set the rules in every identity domain as well as at the tenancy level, and pair them with multi-factor authentication, which is what limits the damage when a strong password is phished rather than cracked.
       audit: |
         ### Audit via Console
 
@@ -10239,18 +10209,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every active OCI IAM API signing key was created within the last 90 days, enforcing a regular rotation cadence. API signing keys authenticate to the OCI REST APIs and SDK and never expire on their own, so a key that is never rotated behaves as a permanent static credential.
+        This check verifies that API signing keys are rotated on a fixed cadence, by requiring every active key to have been created within the last 90 days.
+
+        An API signing key is an RSA key pair. The public half is uploaded against the user and identified by its fingerprint, while the private half stays on the caller and signs every request made to the OCI REST APIs, the SDKs, and the `oci` CLI. Keys carry no expiry: once uploaded, a key authenticates until an administrator deletes it, which makes an unrotated key a permanent static credential. They are managed on the user under Identity & Security > Domains > Users and with `oci iam user api-key list` and `oci iam user api-key delete`, which takes the fingerprint of the key to remove.
 
         **Why this matters**
 
-        - **Unbounded exposure window:** API signing keys remain valid until an administrator manually deletes them, so a key leaked into a repository, CI log, or laptop backup stays usable indefinitely.
-        - **Offboarding gaps:** Keys created for a person or automation that is no longer active continue to grant API access until explicitly removed.
-        - **Compromise containment:** Regular rotation limits how long a stolen private key remains useful and forces re-issuance through a controlled process.
+        Nothing about the key ages out on its own, so a private key leaked into a Git history, a build log, or an image layer stays usable for as long as the account exists. Rotation is the only mechanism that ever ends that window, and a 90-day cadence bounds it to a quarter rather than leaving it open indefinitely.
 
-        **Risk mitigation**
+        The same applies after people and systems move on. A key issued to an engineer who has left, or to an automation since retired, keeps signing valid API calls until it is explicitly removed, and the cadence caps that residual access even when the offboarding step is missed.
 
-        - **Rotate on a fixed schedule:** Replace each API signing key at least every 90 days and delete the superseded key.
-        - **Automate key replacement:** Build workflows that generate a new key pair, upload the public key, update the consuming system, and delete the old key.
+        Rotation also forces reissuance through a controlled path. Each replacement makes someone confirm which system still needs the key and where the private half is stored, which is how forgotten copies are found before an attacker finds them.
+
+        A user may hold up to three API keys at once, leaving room to rotate without an outage: generate a new pair, upload the public key, cut the consuming system over, verify it signs successfully, then delete the superseded key by fingerprint. Automating that sequence keeps the cadence from slipping.
       audit: |
         ### Audit via Console
 
@@ -10330,18 +10301,17 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Vault master encryption keys use the `HSM` protection mode rather than `SOFTWARE`. HSM-protected keys are generated and stored inside FIPS 140-2 Level 3 validated hardware security modules and the private key material never leaves the HSM, whereas software-protected keys are stored in software and can be exported.
+        This check verifies that master encryption keys are held in tamper-resistant hardware by requiring the `HSM` protection mode rather than `SOFTWARE`.
+
+        Protection mode determines where a Vault key's material lives and where cryptographic operations run. An `HSM` key is generated inside a FIPS 140-2 Level 3 validated hardware security module and its private material never leaves that module; the service can only ask the module to encrypt, decrypt, or sign. A `SOFTWARE` key is generated and stored in the service's software layer, where it is protected by a root key but can be created as exportable and retrieved through the key export API. You choose the mode under Identity & Security > Vault > Keys > Create key, or with `oci kms management key create --protection-mode HSM`, and in Terraform through the `protection_mode` argument on `oci_kms_key`. The check evaluates keys in the enabled state.
 
         **Why this matters**
 
-        - **Non-exportable key material:** HSM keys cannot be extracted, so even a compromise of the control plane cannot exfiltrate the raw key.
-        - **Tamper-resistant hardware:** Cryptographic operations execute inside certified hardware that resists physical and logical tampering.
-        - **Regulatory assurance:** Many frameworks require that keys protecting regulated data be held in validated hardware security modules.
+        Non-exportable material changes what a control plane compromise is worth. An attacker who reaches the key management API of a software key may be able to walk away with the raw bytes and then decrypt captured data offline, forever, with no further access to your tenancy. The same attacker holding an HSM key can only issue operations while the access lasts, and every one of those operations is logged in OCI Audit.
 
-        **Risk mitigation**
+        The hardware itself resists physical and logical tampering and is certified to do so, which is the assurance regulators are asking for when a framework requires that keys protecting regulated data be held in validated hardware security modules.
 
-        - **Create keys with HSM protection:** Select the HSM protection mode when provisioning master encryption keys for sensitive data.
-        - **Migrate software keys:** Where a software key already protects sensitive resources, create an HSM key and re-encrypt or re-key the affected resources.
+        Protection mode is fixed when the key is created. `oci kms management key update` can change a key's display name, tags, and rotation settings, but it cannot convert a software key to an HSM key. Remediating an existing software key therefore means creating a replacement HSM key and re-keying or re-encrypting the resources that depend on it.
       audit: |
         ### Audit via Console
 
@@ -10465,18 +10435,17 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Vault master encryption keys have automatic rotation enabled. Rotating a key generates a new key version that is used for all subsequent encryption operations while previous versions remain available to decrypt existing data. Keys that are never rotated act as long-lived static secrets, so a single compromised key version exposes every object ever encrypted with it.
+        This check verifies that master encryption keys are rotated on a schedule by the service rather than left as permanent key material.
+
+        Rotating a Vault key creates a new key version and makes it the one used for all subsequent encrypt operations, while earlier versions stay available so previously encrypted data remains readable. Nothing is re-encrypted at rotation time, so the operation is safe to automate. OCI accepts a rotation interval between 60 and 365 days. You enable it under Identity & Security > Vault > Keys > Edit in the Console, with `oci kms management key update --key-id <id> --is-auto-rotation-enabled true` supplying the rotation details, or in Terraform through `is_auto_rotation_enabled` alongside an `auto_key_rotation_details` block. The check evaluates keys in the enabled state.
 
         **Why this matters**
 
-        - **Limited exposure window:** Automatic rotation bounds how much data is protected by any single key version, reducing the impact of a compromised version.
-        - **Cryptographic hygiene:** Regular rotation is a baseline expectation for managed key material and is required by several regulatory frameworks.
-        - **Operational consistency:** Built-in rotation removes the need for manual, error-prone rotation procedures that are often skipped.
+        A key that never rotates behaves like a long-lived static secret. Every object ever encrypted under it is protected by a single version, so one compromised version exposes the entire history of that key's use rather than a slice of it. Automatic rotation bounds how much data any one version covers, which directly bounds what a single disclosure costs.
 
-        **Risk mitigation**
+        Manual rotation is the alternative, and it is the kind of scheduled maintenance that gets deferred. Each cycle requires an operator to remember, to pick a window, and to confirm dependents still work, so intervals stretch and eventually stop. Service-managed rotation removes the human step and produces an auditable record that the cadence was actually met, which is what several regulatory frameworks ask for.
 
-        - **Enable rotation on every master key:** Turn on automatic rotation for each key protecting sensitive resources.
-        - **Set an appropriate interval:** Choose a rotation interval that satisfies your compliance requirements while remaining operationally practical.
+        Choose an interval that satisfies your compliance obligations while remaining operationally practical, and confirm that the resources bound to the key handle version changes transparently before shortening it. Rotation of the master key does not by itself refresh data encryption keys already issued to storage resources, so pair it with periodic re-keying where a framework requires the protecting material to be replaced end to end.
       audit: |
         ### Audit via Console
 
@@ -10607,18 +10576,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI block volumes are encrypted using a customer-managed key stored in OCI Vault rather than the default Oracle-managed key. OCI encrypts all block storage at rest automatically, so the risk here is not the absence of encryption but the absence of customer control over the key lifecycle.
+        This check verifies that block volumes are encrypted under a key you control in OCI Vault instead of the Oracle-managed default.
+
+        Every block volume is encrypted at rest whether or not you do anything, so the gap this closes is not missing encryption but missing key custody. With the default, the Block Volume service owns the key hierarchy, and there is no key you can point at, disable, or audit separately from the storage service itself. Assigning a Vault key gives you a distinct object with its own lifecycle. You set it under Storage > Block Volumes > Assign encryption key, or with `oci bv volume update --volume-id <id> --kms-key-id <ocid>`, and in Terraform through `kms_key_id` on `oci_core_volume`. The key must live in the same region as the volume, and the Block Volume service needs permission to use it, granted with a statement such as `allow service blockstorage to use keys in compartment KeyVault`.
 
         **Why this matters**
 
-        - **Key revocation capability:** With a customer-managed key, you can immediately revoke access to all data on the volume by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Storing the key in a customer-controlled vault separates key management from storage management, enabling independent access controls and audit trails.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require organizations to demonstrate control over the keys protecting regulated data.
+        Key custody makes revocation a real, immediate control. Disabling the key in Vault stops the service from unwrapping the volume's data encryption key, so the volume can no longer be attached and reads on an already attached volume begin to fail. That is a cryptographic erase you can perform in seconds, without touching the storage itself, and it works even for data you no longer have an operational path to delete.
 
-        **Risk mitigation**
+        The same power is why deletion demands care. Scheduling a key for deletion destroys the ability to read every volume it protects, along with the backups and clones that inherited the key reference, and copying a backup to another region requires a key present in that region.
 
-        - **Assign a Vault key at volume creation:** Provision a master encryption key and reference it when creating each block volume that holds sensitive data.
-        - **Rotate and monitor keys:** Configure rotation on each key and review OCI Audit logs for key operations.
+        Custody also separates duties: the team administering storage is not the team administering keys, so the two roles have independent IAM policies and independent audit trails.
+
+        Frameworks such as HIPAA and PCI DSS expect you to demonstrate control over the keys protecting regulated data, which an Oracle-managed key does not let you show.
       audit: |
         ### Audit via Console
 
@@ -10731,18 +10701,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI boot volumes are encrypted using a customer-managed key stored in OCI Vault rather than the default Oracle-managed key. Boot volumes hold the operating system and often application binaries and configuration, so customer control over their encryption key is as important as for data volumes.
+        This check verifies that boot volumes are encrypted under a customer-managed Vault key rather than the Oracle-managed default that instances receive automatically.
+
+        A boot volume is created implicitly whenever an instance launches, and unless the launch request names a key it inherits Oracle-managed encryption without anyone deciding to accept it. That volume is not incidental storage: it holds the operating system, the application binaries, the configuration files, service account material dropped by configuration management, SSH host keys, and anything written outside the data volumes. You assign a key under Storage > Boot Volumes > Assign encryption key, with `oci bv boot-volume update --boot-volume-id <id> --kms-key-id <ocid>`, or through `kms_key_id` on `oci_core_boot_volume` in Terraform.
 
         **Why this matters**
 
-        - **Key revocation capability:** A customer-managed key lets you revoke access to the boot volume contents by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Holding the key in a customer-controlled vault separates key management from compute management.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data, including data on boot volumes.
+        Customer key custody is what lets you stop an instance from ever running again. Because the boot volume must be decrypted for the instance to start, disabling the key in Vault means the instance cannot reboot, cannot be live migrated, and cannot be recovered from its own boot volume backups. Against a host you believe is compromised, that is containment applied at the key rather than at the network.
 
-        **Risk mitigation**
+        The dependency runs the other way too, and it is the operational trap here. A key disabled or deleted by mistake takes down every instance whose boot volume it protects at the next restart, and boot volume backups and custom images created from that volume become unreadable with it.
 
-        - **Assign a Vault key to boot volumes:** Provision a master encryption key and reference it when launching instances or creating boot volumes.
-        - **Rotate and monitor keys:** Configure rotation on each key and review OCI Audit logs for key operations.
+        Image lineage deserves an explicit decision. A custom image captured from a boot volume, and any instance launched from it, is encrypted under the key named at that point rather than inheriting the source volume's, so golden images need their own key assignment.
+
+        Custody also splits key administration from compute administration, and it is what frameworks such as HIPAA and PCI DSS mean when they require demonstrable control over the keys protecting regulated data, including data resident on boot volumes. Configure rotation on each key and review OCI Audit logs for its operations.
       audit: |
         ### Audit via Console
 
@@ -10860,18 +10831,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI File Storage file systems are encrypted using a customer-managed key stored in OCI Vault rather than the default Oracle-managed key. File systems frequently hold shared application data and user files, so customer control over the encryption key is essential for sensitive workloads.
+        This check verifies that File Storage file systems are encrypted under a Vault key you administer rather than the Oracle-managed key applied by default.
+
+        File Storage differs from block storage in who touches the data. One file system is exported through mount targets and consumed concurrently by many instances, and often by many teams, so a single encryption boundary covers a shared namespace with a wide and changing set of readers. Under the Oracle-managed default, every file system in the tenancy sits behind service-owned key material with no per-file-system object you can govern. You assign a key under File Storage > File Systems > Assign encryption key, with `oci fs file-system update --file-system-id <id> --kms-key-id <ocid>`, or through `kms_key_id` on `oci_file_storage_file_system` in Terraform. The File Storage service principal must first be granted `use keys` on the compartment holding the vault, or the assignment is rejected.
 
         **Why this matters**
 
-        - **Key revocation capability:** A customer-managed key lets you revoke access to the entire file system by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Holding the key in a customer-controlled vault separates key management from file storage management.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data.
+        A customer key turns a shared export into something you can revoke centrally. Disabling it makes the file system unreadable to every mount target and every NFS client at once, without touching export options, security list rules, or client configuration. Snapshots of that file system rest on the same key, so point-in-time copies do not quietly survive the revocation.
 
-        **Risk mitigation**
+        That reach is also the failure mode to plan for. Disabling or deleting the key stops production for every workload mounting the export simultaneously, and unlike a detachable volume there is no per-consumer blast radius to fall back on.
 
-        - **Assign a Vault key to file systems:** Provision a master encryption key and reference it when creating each file system.
-        - **Rotate and monitor keys:** Configure rotation on each key and review OCI Audit logs for key operations.
+        Distinct keys per file system make tenant separation real in a shared estate. Two file systems under two different keys can be governed, rotated, and revoked independently, whereas two under one Oracle-managed default cannot be separated at all, and key administration stays with the vault owners rather than the storage team.
+
+        Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data, and rotating an assigned key plus reviewing OCI Audit for its operations is what supplies that evidence.
       audit: |
         ### Audit via Console
 
@@ -10984,18 +10956,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Database (DB system) databases use Transparent Data Encryption backed by a customer-managed key stored in OCI Vault rather than an Oracle-managed key. The database always encrypts data at rest, so the risk here is the absence of customer control over the TDE master key.
+        This check verifies that a DB system database encrypts its data files under a Transparent Data Encryption master key that the tenancy holds in an OCI Vault rather than one Oracle manages.
+
+        Transparent Data Encryption is always on for an OCI DB system database, so nothing here is about whether data at rest is encrypted. What differs is custody of the master key that unwraps the tablespace keys. By default Oracle holds it. With a customer-managed key, the master key is a versioned object in a vault in the tenancy, referenced when the database is created inside the DB home, and usable by the service only because of a statement such as `allow service database to use keys in compartment Security`. Set it in the Encryption section when creating the database under Oracle Database > Bare Metal, VM, and Exadata.
 
         **Why this matters**
 
-        - **Key revocation capability:** A customer-managed key lets you revoke access to the database contents by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Holding the TDE key in a customer-controlled vault separates key management from database administration.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data.
+        A DB system is infrastructure the tenancy operates, and that is what makes key custody meaningful here. Data files, redo, and wallet material sit on storage attached to hosts that administrators can reach. Someone who copies a datafile off the host, clones the block volume, or images the node walks away with ciphertext and nothing else, because the master key never leaves the vault and its use is authorized by a policy the DBA does not administer.
 
-        **Risk mitigation**
+        That separation is the point. Database administration and key administration become different grants, so no single compromised operator account both reads the data and controls the ability to decrypt it, and a decommissioned DB system's residual storage stops being a live copy the moment the key is disabled.
 
-        - **Assign a Vault key at provisioning:** Reference a master encryption key when creating the DB system database.
-        - **Rotate and monitor keys:** Configure rotation on each key and review OCI Audit logs for key operations.
+        Vault keys also produce evidence. Rotation is scheduled per key, and every cryptographic operation appears in OCI Audit, so control over the keys protecting regulated data can be demonstrated rather than asserted, which is what frameworks such as HIPAA and PCI DSS ask for.
+
+        Plan rotation against the database's maintenance windows, since it needs the service policy in place to succeed.
       audit: |
         ### Audit via Console
 
@@ -11127,18 +11100,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that OCI Autonomous Databases use a customer-managed key stored in OCI Vault for encryption at rest rather than the default Oracle-managed key. Autonomous Database always encrypts data at rest, so the risk here is the absence of customer control over the encryption key.
+        This check verifies that an Autonomous Database encrypts at rest under a master encryption key held in an OCI Vault in the tenancy rather than the Oracle-managed key it gets by default.
+
+        Autonomous Database always encrypts stored data, so the question is who holds the key that unwraps it. Choosing a vault key is done in the Encryption section when creating or updating the database under Oracle Database > Autonomous Database, and the service reaches the key through a statement such as `allow service database to use keys in compartment Security`.
 
         **Why this matters**
 
-        - **Key revocation capability:** A customer-managed key lets you revoke access to the database contents by disabling or deleting the key in OCI Vault.
-        - **Separation of duties:** Holding the key in a customer-controlled vault separates key management from database administration.
-        - **Regulatory key-control requirements:** Frameworks such as HIPAA and PCI DSS require demonstrable control over the keys protecting regulated data.
+        Autonomous Database gives the tenancy no host, no file system, and no wallet of its own, which makes the vault key the only lever over the ciphertext that the customer actually operates. Everything else about the database is administered through Oracle's control plane. With the default key there is no key identifier to point an auditor at, no key policy to constrain, and no operation of yours in the record; with a vault key, each use is authorized by an identity policy in the tenancy and logged in OCI Audit.
 
-        **Risk mitigation**
+        That lever is also a stop switch. Disabling the key or scheduling its deletion makes the Autonomous Database inaccessible, which is a real response to a suspected credential compromise or a legal hold on a tenant workload, and equally a real outage if it is done casually. Nothing comparable exists while Oracle holds the key.
 
-        - **Assign a Vault key at provisioning:** Reference a master encryption key when creating the Autonomous Database.
-        - **Rotate and monitor keys:** Configure rotation on each key and review OCI Audit logs for key operations.
+        The same key custody carries into the copies the service makes for you. Automatic backups, clones, and cross-region Data Guard peers derive from the database's key, so revoking it retires those copies as well instead of leaving a readable one behind.
+
+        Set the key before loading data rather than after, keep the vault in a compartment administered separately from the database, and confirm the service policy exists in that compartment or provisioning fails outright.
       audit: |
         ### Audit via Console
 
@@ -11248,18 +11222,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every OCI Virtual Cloud Network is covered by enabled flow logs, either by one log attached to the VCN itself or by a log on each of its subnets. Flow logs record accepted and rejected connections traversing the VCN's subnets, providing the network-level visibility needed for intrusion detection, incident response, and forensic analysis. OCI does not enable flow logs by default.
+        This check verifies that network traffic in every Virtual Cloud Network is being recorded.
+
+        VCN flow logs are a service log emitted through OCI Logging that captures accepted and rejected connections crossing the VCN's subnets, along with source and destination addresses, ports, protocol, byte and packet counts, and the action taken. A log enabled on the VCN itself covers every subnet beneath it; otherwise each subnet needs its own. The check accepts either arrangement, so a VCN covered subnet by subnet is not reported as a gap. Nothing is recorded until someone enables it, under Observability & Management > Logging > Logs once a log group exists, or with `oci logging log create` using a service log configuration.
 
         **Why this matters**
 
-        - **Threat detection:** Flow logs reveal port scans, lateral movement, and connections to known-malicious endpoints that are otherwise invisible.
-        - **Incident response:** During an investigation, flow logs establish which hosts communicated, when, and over which ports.
-        - **Forensic evidence:** Retained flow logs provide a durable record of network activity for after-the-fact analysis and compliance reporting.
+        Without flow logs there is no record that an attack happened. Port scans, a burst of rejected connections against an internal address, and lateral movement between subnets leave their only trace at the network layer, and nothing running on the instance is obliged to notice any of it.
 
-        **Risk mitigation**
+        During an incident the same records answer the questions that decide scope. Which hosts talked to the compromised instance, when the first connection arrived, how much data left and to where, and whether a rule that has since been fixed was ever actually used. Reconstructing that from instance logs alone is usually impossible, particularly once the instance has been terminated.
 
-        - **Enable flow logs on every VCN subnet:** Create a log group and enable flow logs for each subnet that carries sensitive traffic.
-        - **Centralize and retain logs:** Forward flow logs to a central log group with a retention period that satisfies your incident-response and compliance requirements.
+        Rejected-connection records earn their place as well. A security list doing its job drops traffic silently, and the flow log is the only place that drop becomes visible, which is the difference between a rule you believe is protecting you and a rule you can demonstrate is protecting you.
+
+        Send flow logs to a log group whose retention period matches your incident response and compliance obligations, since investigations routinely begin weeks after the activity they examine. Forward them to a central destination and alert on the patterns worth waking someone for rather than relying on anyone browsing them.
       audit: |
         ### Audit via Console
 
@@ -11367,18 +11342,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that each tunnel in an OCI site-to-site VPN IPSec connection negotiates Internet Key Exchange version 2 (IKEv2) rather than the legacy IKEv1. OCI lets you select the IKE version per tunnel, and connections created against older customer-premises equipment may still default to IKEv1, which uses a weaker key-exchange design.
+        This check verifies that every tunnel in a site-to-site VPN connection negotiates Internet Key Exchange version 2 rather than the legacy IKEv1.
+
+        An Oracle Cloud Infrastructure IPSec connection provisions two tunnels for redundancy, and the IKE version is selected per tunnel, not per connection. Connections built against older customer-premises equipment may still sit on IKEv1, whose key-exchange design is weaker than its successor. The check requires that each tunnel reports version `V2`. Set it under Networking > Customer connectivity > Site-to-Site VPN by editing the tunnel, with `oci network ip-sec-tunnel update --ipsc-id <ipsec-connection-ocid> --tunnel-id <tunnel-ocid> --ike-version V2`, or through `ike_version` in the Terraform tunnel management resource.
 
         **Why this matters**
 
-        - **Stronger key exchange:** IKEv2 uses a more robust key-agreement and rekeying design than IKEv1, reducing exposure to key-recovery and downgrade attacks against the tunnel.
-        - **Resilient session handling:** IKEv2 built-in liveness checks and MOBIKE support re-establish tunnels faster after a network interruption, shrinking the window where traffic could fail open or be rerouted.
-        - **Modern cryptographic baselines:** Security frameworks that mandate strong cryptography for data in transit expect IKEv2; IKEv1 is widely deprecated.
+        IKEv2 uses a more robust key-agreement and rekeying design than IKEv1, which narrows exposure to key-recovery attacks and to downgrade attempts against the tunnel's negotiated parameters.
 
-        **Risk mitigation**
+        Session handling is more resilient as well. The built-in liveness checks and MOBIKE support in IKEv2 re-establish a tunnel far faster after a network interruption, shrinking the window in which traffic could fail open onto an unencrypted path or be rerouted somewhere unintended.
 
-        - **Set IKEv2 on every tunnel:** Configure both tunnels of each IPSec connection to use IKEv2 and confirm the customer-premises equipment supports it.
-        - **Retire IKEv1 endpoints:** Replace or upgrade on-premises VPN devices that cannot negotiate IKEv2.
+        The version also carries compliance weight. Security frameworks that mandate strong cryptography for data in transit expect IKEv2, and IKEv1 is widely deprecated, so an IKEv1 tunnel is an audit finding as well as a technical weakness.
+
+        Change both tunnels of each connection together, and confirm first that the customer-premises equipment on the far side can negotiate IKEv2, because a one-sided change simply leaves the tunnel down. Where a device cannot negotiate it at all, the fix is to replace or upgrade that endpoint rather than to leave the connection on IKEv1 indefinitely.
       audit: |
         ### Audit via Console
 
@@ -11491,18 +11467,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that compute instance VNICs keep the source/destination check enabled, meaning the VNIC may only send and receive traffic addressed to its own IP address. Disabling the check lets an instance forward arbitrary traffic and is required only for purpose-built network appliances such as NAT instances or firewalls. Leaving it disabled on a general-purpose instance enables IP spoofing and unauthorized routing.
+        This check verifies that compute instance VNICs keep the source and destination check enabled, so a VNIC may only send and receive traffic addressed to its own IP address.
+
+        Oracle Cloud Infrastructure exposes this as a per-VNIC flag named `skipSourceDestCheck`, and the check requires it to be `false`. Setting it to `true` turns the VNIC into a forwarder: it may then emit packets carrying a source address that is not its own and accept packets destined for somewhere else, which is what a purpose-built network appliance such as a NAT instance or a firewall needs and what a general-purpose instance never does. Left disabled on an ordinary workload it enables IP spoofing and unauthorized routing. The flag lives under Compute > Instances > Attached VNICs > Edit VNIC, and `oci network vnic update --vnic-id <vnic-ocid> --skip-source-dest-check false` restores it.
 
         **Why this matters**
 
-        - **Anti-spoofing:** With the check enabled, a compromised instance cannot impersonate other hosts by sending packets with forged source addresses.
-        - **Traffic containment:** The check prevents an instance from silently routing or relaying traffic between subnets outside the intended network design.
-        - **Reduced lateral movement:** Blocking arbitrary forwarding limits an attacker's ability to pivot through a compromised host.
+        With the check enabled, a compromised instance cannot impersonate other hosts, because packets carrying a forged source address are dropped by the fabric before they reach anything.
 
-        **Risk mitigation**
+        It also contains traffic. An instance cannot silently relay or route packets between subnets that the network design never intended to connect, which is a path around security lists and network security groups that leaves no obvious trace.
 
-        - **Keep the check enabled by default:** Only disable source/destination checking on instances that are explicitly designed to route or forward traffic.
-        - **Audit appliances separately:** Where forwarding is required, document the instance as a network appliance and compensate with strict security lists and NSGs.
+        That containment is what limits lateral movement. An attacker who lands on one host cannot turn it into a router and pivot arbitrary traffic deeper into the network from there.
+
+        Disable the check only on instances explicitly designed to route or forward, and treat each one as a deliberate exception rather than a convenience. Where forwarding really is required, document the instance as a network appliance and compensate for the loss of fabric-level filtering with strict security lists and tightly scoped network security groups around it.
       audit: |
         ### Audit via Console
 
@@ -11613,19 +11590,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that no OCI compute instance is directly reachable from the public internet. An instance is internet-reachable when it has a public IP address and the network path to it admits inbound traffic from any address, either through a permissive Network Security Group or a subnet that allows internet ingress. Placing workloads behind a load balancer, bastion, or NAT gateway keeps the instances themselves off the public internet.
+        This check verifies that no compute instance is directly reachable from the public internet, taking both its addressing and its network path into account.
+
+        An instance is internet-reachable when it holds a public IP address and the path to it admits inbound traffic from any source, whether through a Network Security Group rule open to `0.0.0.0/0` or a subnet whose security list allows internet ingress. Both conditions must hold, so a public IP behind a properly scoped NSG does not fail, and a permissive NSG on a private instance does not either. You control the addressing at launch, or afterwards under Compute > Instances > Attached VNICs, and the path under Networking > Virtual cloud networks in the security lists and network security groups attached to the VNIC.
 
         **Why this matters**
 
-        - **Direct attack surface:** An internet-reachable instance exposes its operating system, SSH or RDP daemon, and any listening application ports to continuous scanning and exploitation from the entire internet.
-        - **Bypasses layered controls:** Traffic that reaches an instance directly skips the inspection, rate limiting, and TLS termination that a load balancer or WAF would otherwise apply.
-        - **Lateral movement foothold:** A compromised internet-facing instance becomes a pivot point into the private network, so removing direct reachability shrinks the blast radius of a single vulnerable host.
+        A directly reachable instance offers its operating system, its SSH or RDP daemon, and every listening application port to continuous internet-wide scanning. Exposure is measured in minutes after the address is assigned, and it does not depend on anyone knowing the host exists.
 
-        **Risk mitigation**
+        Traffic arriving that way also skips the controls you built. TLS termination, web application firewall inspection, request rate limiting, and access logging all live on the load balancer or API gateway that the direct path bypasses, so the protections are present in the architecture diagram and absent from the actual request.
 
-        - **Front workloads with managed entry points:** Route inbound traffic through a load balancer or API gateway and keep the instances in private subnets.
-        - **Use a bastion for administrative access:** Reach instances over the OCI Bastion service or a jump host instead of assigning them public IPs.
-        - **Scope ingress to known sources:** Where a public IP is unavoidable, restrict NSG ingress to specific administrative CIDRs rather than any address.
+        An internet-facing host is the natural first hop for lateral movement. Once compromised, it is already inside the VCN and can reach private subnets, database endpoints, and the instance principal credentials that its dynamic group grants. Removing direct reachability shrinks what a single vulnerable host is worth.
+
+        Front workloads with a load balancer or API gateway and keep the instances in private subnets with a NAT gateway for egress. Reach them administratively through the OCI Bastion service or a jump host rather than a public IP. Where a public IP is genuinely unavoidable, scope NSG ingress to specific administrative CIDR ranges instead of any address.
       audit: |
         ### Audit via Console
 
@@ -11698,19 +11675,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that no OCI Autonomous Database is reachable from the public internet. A database is internet-reachable when it has a public endpoint with no private endpoint and either access control is disabled or its allowlist admits any address. Even when mutual TLS is required to complete a connection, a reachable listener still exposes the database to network-level scanning and pre-authentication attacks.
+        This check verifies that no Autonomous Database is actually reachable from the public internet, judged on the combination of endpoint type and access control rather than on any single setting.
+
+        A database counts as internet-reachable when it has a public endpoint, has no private endpoint, and either has access control switched off or carries an allowlist that admits any address. That last condition is what makes this stricter than a test for whether an allowlist exists. A database whose access control list contains a single entry of `0.0.0.0/0` has a list, has entries, and is nonetheless open to everything. Review the setting under Oracle Database > Autonomous Database > Network, and prefer a private endpoint in a subnet over any allowlist on a public one.
 
         **Why this matters**
 
-        - **Exposed database listener:** A publicly reachable SQL Net listener receives connection attempts from any address, subjecting it to brute-force, enumeration, and vulnerability scanning around the clock.
-        - **Pre-authentication exposure:** Listener and management interfaces have historically shipped pre-authentication vulnerabilities that an internet-connected attacker can reach without any credentials.
-        - **Allowlist fragility:** Access control lists drift over time as networks change and permissive entries accumulate, so a private endpoint is a more durable control than an allowlist on a public endpoint.
+        A reachable listener is attacked whether or not authentication is strong. It fields connection attempts from every scanning host on the internet, which produces continuous brute-force pressure against known schema accounts, enumeration of the database version and service names from the handshake, and a steady supply of noise that buries real signals in the audit trail.
 
-        **Risk mitigation**
+        Requiring mutual TLS does not remove that exposure. The handshake happens after the packet arrives, so pre-authentication defects in the listener and the management interfaces are reached by an attacker who has no wallet and no credentials at all. Network unreachability is the control that stops the packet, and authentication is what protects the session once one is allowed.
 
-        - **Provision with a private endpoint:** Place the database in a private subnet so it has no public endpoint at all.
-        - **Restrict the public listener:** Where a public endpoint is required, enable access control and scope the allowlist to specific known networks.
-        - **Combine with mutual TLS:** Require mTLS in addition to network restrictions so credential theft alone cannot open a session.
+        Allowlists erode in a direction that is hard to notice. Ranges get widened during an incident, office networks are renumbered, and a cloud provider address permitted for one integration is later reassigned to someone else's workload. None of that changes the listener, only who can talk to it, and nobody reviews it.
+
+        Where a public endpoint is unavoidable, enable access control, scope it to named networks rather than provider-wide ranges, and require mutual TLS on top so that reachability alone does not become a session.
       audit: |
         ### Audit via Console
 
@@ -11776,19 +11753,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that the access control list applied to an Autonomous Database's Data Guard standby does not admit any address. The standby maintains its own allowlist, which can diverge from the primary's. When the standby allowlist contains an any-address entry such as `0.0.0.0/0`, the standby endpoint is reachable from networks the primary blocks, creating an exposure that a review of the primary alone would miss.
+        This check verifies that the access control list guarding an Autonomous Database's Data Guard standby contains no any-address entry, specifically `0.0.0.0/0`, a bare `0.0.0.0`, or the IPv6 equivalent `::/0`.
+
+        An Autonomous Data Guard standby keeps an access control list of its own, separate from the primary's and editable independently. The two are configured in different places in the Console, under the primary database's Network section and its Autonomous Data Guard section, so they diverge quietly. An any-address entry on the standby means its endpoint accepts connection attempts from every network on the internet, including the ones the primary's list was written to exclude.
 
         **Why this matters**
 
-        - **Divergent exposure:** A standby allowlist that admits any address exposes a fully readable copy of production data even when the primary is tightly restricted.
-        - **Disaster-recovery blind spot:** Audits often inspect only the primary endpoint, so an open standby allowlist can persist unnoticed until a role switch promotes the exposed standby.
-        - **Same data, weaker gate:** The standby holds the same records as the primary, so an any-address allowlist on it undermines the network controls placed on the primary.
+        The standby is not a partial copy or a lagging summary. It applies redo continuously and holds the same rows, the same columns, and the same regulated fields as the primary, so an attacker who reaches it reads production data. Read-only access is still full disclosure.
 
-        **Risk mitigation**
+        The exposure is invisible from the place people look. A reviewer who opens the primary database, confirms a tight allowlist, and moves on has verified nothing about the standby, and dashboards that summarize network posture per database commonly report the primary's setting. The gap persists until someone audits the disaster recovery configuration directly, or until a switchover promotes the open standby into the primary role and carries its permissive list into production traffic.
 
-        - **Mirror the primary's restrictions:** Configure the standby to reuse the primary's allowlist or apply an equally scoped set of source networks.
-        - **Remove any-address entries:** Replace `0.0.0.0/0` and equivalent entries with the specific networks that require standby access.
-        - **Review both endpoints together:** Audit primary and standby allowlists as a pair whenever Data Guard is enabled.
+        An open standby also undermines the reasoning behind every control on the primary. Restricting the primary to a handful of application subnets is only meaningful if the same data is not simultaneously answering from an unrestricted second endpoint in another availability domain or region.
+
+        Mirror the primary's source networks onto the standby, replace any-address entries with the specific ranges that genuinely need standby access such as reporting or disaster recovery test hosts, and audit both lists together whenever Autonomous Data Guard is enabled or a switchover is rehearsed.
       audit: |
         ### Audit via Console
 
@@ -11866,19 +11843,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every API gateway with a public endpoint has at least one Network Security Group attached. A public gateway with no NSG relies on the default-open posture, so its endpoint accepts inbound traffic from any address. Attaching an NSG lets the gateway restrict which sources can reach it at the network layer, in addition to the authentication policies enforced on individual deployments.
+        This check verifies that network-layer access control is applied to every API gateway that exposes a public endpoint.
+
+        An API gateway created with an endpoint type of `PUBLIC` receives an internet-routable address, and with no Network Security Group attached it inherits a default-open posture that accepts inbound traffic from any source. An NSG attached to the gateway carries ingress rules that name the source CIDRs, load balancer ranges, or peer NSGs permitted to reach it, restricting access at the network layer in addition to the authentication policies enforced on individual deployments. This check requires at least one NSG on every public gateway; private gateways are out of scope. Attach one in the Console under Developer Services > API Management > Gateways, or by setting `network_security_group_ids` with `oci api-gateway gateway update`.
 
         **Why this matters**
 
-        - **Unbounded ingress:** A public gateway with no NSG is reachable from the entire internet, exposing its endpoint to scanning and volumetric abuse before any request-level policy applies.
-        - **Defense in depth:** Network-layer restriction complements deployment authentication, so a misconfigured or newly added deployment is not immediately exposed to arbitrary sources.
-        - **Reduced abuse surface:** Limiting the reachable source ranges cuts the volume of unwanted traffic that reaches request routing and authentication.
+        A public gateway with no NSG is reachable from the entire internet. It is exposed to scanning and volumetric abuse before any request-level policy runs, so the cost of unwanted traffic is paid at the gateway regardless of whether the request would ultimately have been rejected.
 
-        **Risk mitigation**
+        Network-layer restriction is the defense-in-depth layer under deployment authentication. When a deployment is misconfigured, or when a new one is added to the gateway before its authentication policy is finalized, the NSG is what keeps it from being immediately reachable by arbitrary sources.
 
-        - **Attach an NSG to every public gateway:** Bind the gateway to an NSG whose rules admit only the source ranges that need access.
-        - **Prefer a private gateway where possible:** When consumers are internal, use a private endpoint type so the gateway has no public IP at all.
-        - **Scope NSG rules tightly:** Restrict ingress to the specific CIDRs or load balancer ranges that front the gateway.
+        Narrowing the admissible source ranges also cuts the volume of traffic that reaches request routing and authentication at all, which reduces both the noise in gateway logs and the surface an attacker can probe.
+
+        Scope the rules to the specific CIDRs or load balancer ranges that front the gateway rather than to broad ranges that only look restrictive. Where every consumer is internal, prefer a private endpoint type outright so the gateway has no public address to protect in the first place.
       audit: |
         ### Audit via Console
 
@@ -11988,19 +11965,19 @@ queries:
       oci.ai.generativeAi.endpoint.promptInjectionEnabled == true
     docs:
       desc: |
-        This check ensures that every OCI Generative AI endpoint has prompt injection detection enabled. Prompt injection detection inspects incoming prompts for adversarial instructions that attempt to override the model's guardrails, exfiltrate system prompts, or coerce the model into unintended actions. Without it, an endpoint processes crafted prompts with no defense against instruction-hijacking attacks.
+        This check verifies that adversarial prompt screening is active on every OCI Generative AI endpoint.
+
+        Prompt injection detection inspects incoming prompts for adversarial instructions that attempt to override the model's guardrails, exfiltrate the system prompt, or coerce the model into unintended actions. It is part of the content moderation guardrail configuration attached to an endpoint on a dedicated AI cluster, set under Analytics & AI > Generative AI > Endpoints when the endpoint is created or updated. The check requires `promptInjectionEnabled` to be on, and detection should be set to block rather than merely record so a flagged prompt is rejected before the model acts on it.
 
         **Why this matters**
 
-        - **Instruction hijacking:** Attackers embed hidden directives in user input to make the model ignore its constraints, leak its system prompt, or perform actions outside its intended scope.
-        - **Downstream abuse:** An endpoint wired into tools or retrieval can be steered by injected prompts into invoking actions or surfacing data the user should not reach.
-        - **Content and data integrity:** Detecting injection at the endpoint reduces the chance that manipulated model output feeds untrusted instructions into connected systems.
+        Instruction hijacking is the direct attack. An attacker embeds hidden directives in text the model will read, whether that is a chat message, an uploaded document, or a retrieved web page, and the model treats those directives as though they came from the operator. The payload asks the model to ignore its constraints, print its system prompt, or reveal the tenancy details baked into its instructions. An endpoint with no detection processes that prompt with no defense at all.
 
-        **Risk mitigation**
+        The damage compounds once the endpoint is wired into tools or retrieval. A model that can call a function, query a data store, or fetch a URL becomes an execution surface: the injected instruction steers it into invoking an action or surfacing records the requesting user has no right to see. The model is acting with the endpoint's privileges, not the caller's, so injection is a privilege escalation path rather than a content problem.
 
-        - **Enable prompt injection detection on every endpoint:** Turn on detection so adversarial prompts are identified before the model acts on them.
-        - **Set the detection mode to block where feasible:** Blocking rejects flagged prompts outright rather than only recording them.
-        - **Review flagged prompts:** Feed detection results into monitoring so recurring injection attempts are investigated.
+        Manipulated output is also an input to whatever consumes it. When a downstream system parses a completion and acts on it, an injected instruction that survives into the response becomes an untrusted instruction inside a trusted pipeline. Detecting the injection at the endpoint stops that propagation at its source.
+
+        Feed detection results into monitoring rather than treating a block as the end of the story, because a rising count of flagged prompts against one endpoint is the signal that someone is working through an attack sequence. Endpoints reachable only by trusted internal automation with fully controlled input may reasonably run with detection in recording mode, but any endpoint that sees text from a user or a third-party document should block.
       audit: |
         ### Audit via Console
 
@@ -12066,19 +12043,19 @@ queries:
       oci.ai.generativeAi.endpoint.piiDetectionEnabled == true
     docs:
       desc: |
-        This check ensures that every OCI Generative AI endpoint has personally identifiable information detection enabled. PII detection inspects prompts and responses for sensitive personal data such as names, government identifiers, and financial details. Without it, an endpoint can echo or leak sensitive data supplied in prompts or produced by the model into logs and downstream systems.
+        This check verifies that sensitive personal data is screened out of traffic through every OCI Generative AI endpoint.
+
+        Personally identifiable information detection inspects both prompts and responses for sensitive personal data such as names, government identifiers, and financial details. It is configured alongside the other guardrails on a Generative AI endpoint under Analytics & AI > Generative AI > Endpoints. The check requires `piiDetectionEnabled` to be on, and the detection mode should be set to block or redact so sensitive values are masked or rejected rather than passed through in the clear.
 
         **Why this matters**
 
-        - **Data leakage:** Without PII detection, sensitive personal data entered in prompts or generated in responses can flow unredacted into transcripts, logs, and connected applications.
-        - **Regulatory exposure:** Handling personal data without controls raises the risk of violating privacy regulations that require minimization and protection of such data.
-        - **Retention amplification:** PII captured in model interactions is often retained far longer than intended, widening the window for exposure if the store is breached.
+        Without detection, personal data entered in a prompt or generated in a response flows unredacted into everything downstream of the endpoint. Transcripts, application logs, observability pipelines, and the connected systems that consume completions all receive the raw values. A support agent pasting a customer record into a prompt has, in effect, copied that record into every log sink the application writes to, and nobody involved intended it.
 
-        **Risk mitigation**
+        The regulatory exposure follows from the same mechanic. Privacy regimes require data minimization and protection of personal data wherever it is processed, and an inference endpoint that neither detects nor masks it is processing that data without controls. The organization cannot demonstrate what personal data passed through the model, which is precisely the accounting an audit asks for.
 
-        - **Enable PII detection on every endpoint:** Turn on detection so sensitive data is identified in both prompts and responses.
-        - **Set the detection mode to block or redact where feasible:** Blocking or masking prevents sensitive data from being processed or returned in the clear.
-        - **Combine with retention controls:** Pair detection with short retention on interaction logs to limit exposure.
+        Retention amplifies the problem. Data captured in model interactions is routinely kept far longer than anyone intended, because interaction logs are stored for debugging and quality work rather than governed as a personal data store. Every extra month of retention widens the window in which a breach of that store exposes the data. Pair detection with short retention on interaction logs so that even the records that do capture personal data expire quickly.
+
+        An endpoint serving a workload that legitimately reasons over personal data, such as a claims or clinical application, still benefits from detection in redact mode on the response path even when the prompt path must pass values through.
       audit: |
         ### Audit via Console
 
@@ -12144,19 +12121,19 @@ queries:
       oci.ai.generativeAi.endpoint.contentModerationEnabled == true
     docs:
       desc: |
-        This check ensures that every OCI Generative AI endpoint has content moderation enabled. Content moderation screens prompts and responses for harmful, abusive, or policy-violating content. Without it, an endpoint can be driven to generate disallowed output or be abused to produce harmful material at scale.
+        This check verifies that harmful content screening is active on every OCI Generative AI endpoint.
+
+        Content moderation screens prompts and responses for abusive, unsafe, or policy-violating content and applies the configured action when a match is found. It is one of the guardrails set on an endpoint attached to a dedicated AI cluster, administered under Analytics & AI > Generative AI > Endpoints. The check requires `contentModerationEnabled` to be on, and the moderation mode should be set to block where the workload allows, so flagged content is rejected rather than only recorded.
 
         **Why this matters**
 
-        - **Harmful output:** Without moderation, an endpoint can produce abusive, unsafe, or policy-violating content in response to crafted prompts.
-        - **Abuse at scale:** An unmoderated endpoint exposed to users can be turned into a generator of harmful material, creating reputational and legal risk.
-        - **Guardrail completeness:** Content moderation complements prompt injection and PII detection to form a full set of endpoint guardrails.
+        An endpoint with moderation off will produce whatever a crafted prompt steers it toward. Models are trained to be helpful and will follow a request that is framed persuasively enough, so the absence of moderation is not a neutral default: it is the removal of the only input and output filter standing between a determined prompt and disallowed output.
 
-        **Risk mitigation**
+        Scale is what turns that from an incident into a liability. An unmoderated endpoint exposed to users is a machine for generating harmful material on demand, and the volume it can produce is bounded only by the cluster's throughput. The organization owns the output because it owns the endpoint, and both the reputational and the legal consequences follow the tenancy rather than the caller.
 
-        - **Enable content moderation on every endpoint:** Turn on moderation so harmful content is screened on input and output.
-        - **Set the moderation mode to block where feasible:** Blocking rejects flagged content rather than only recording it.
-        - **Monitor moderation events:** Route moderation results into monitoring to spot abuse patterns.
+        Moderation is also the third leg of the guardrail set. Prompt injection detection defends the model's instructions and personal data detection defends the data that moves through it; moderation defends the content itself. Enabling only some of the three leaves an obvious gap for anyone probing what the endpoint will accept.
+
+        Route moderation events into monitoring so that a cluster of flagged requests from one caller is visible as an abuse pattern rather than a set of isolated blocks. An endpoint whose only consumers are internal and whose output is never surfaced to a person is the one case where recording mode is a defensible choice.
       audit: |
         ### Audit via Console
 
@@ -12221,19 +12198,19 @@ queries:
       oci.ai.generativeAi.endpoint.generativeAiPrivateEndpointID != empty
     docs:
       desc: |
-        This check ensures that every OCI Generative AI endpoint is reached through a Generative AI private endpoint. A private endpoint keeps inference traffic on the customer's private network rather than traversing the public internet. Without one, prompts and responses, which frequently contain sensitive business data, travel over public paths and the endpoint is reachable from outside the private network.
+        This check verifies that inference traffic to every OCI Generative AI endpoint stays on the customer's private network.
+
+        A Generative AI private endpoint places the service behind an address inside a subnet of the customer's virtual cloud network, so callers reach the model over private paths instead of public internet routes. It is provisioned under Analytics & AI > Generative AI > Private endpoints and then associated with the inference endpoint. The check requires the endpoint to carry a private endpoint association rather than leaving `generativeAiPrivateEndpointID` empty.
 
         **Why this matters**
 
-        - **Data in transit exposure:** Prompts and responses often carry sensitive business or personal data, so keeping the traffic on a private network reduces the chance of interception.
-        - **Reduced reachability:** A private endpoint means the inference endpoint is not exposed on public network paths, shrinking its attack surface.
-        - **Network policy enforcement:** Traffic confined to the VCN can be governed by existing network security controls and monitoring.
+        Prompts and responses are among the most sensitive traffic an application generates. A prompt carries whatever context the application assembled, which routinely means customer records, source code, internal documents, or credentials pasted by a user, and the response carries the model's reasoning over all of it. Sending that over public paths puts business data on network segments the organization neither owns nor observes.
 
-        **Risk mitigation**
+        Reachability is the other half. An endpoint with no private endpoint is addressable from outside the private network, which means the attack surface includes anyone who learns the endpoint identifier and holds a credential, rather than only the workloads on the network. Confining the endpoint to a subnet removes that entire class of caller before authentication is even reached.
 
-        - **Bind every endpoint to a private endpoint:** Provision a Generative AI private endpoint in the VCN and associate each inference endpoint with it.
-        - **Keep consumers on the private network:** Route application traffic to the endpoint over the VCN rather than public addresses.
-        - **Apply network controls to the subnet:** Govern the private endpoint's subnet with NSGs and monitoring.
+        Traffic that stays inside the virtual cloud network also inherits the controls already built there. Network security groups, flow logs, route tables, and the monitoring already watching the subnet all apply to inference traffic once it runs on private addresses, whereas traffic leaving over public paths is governed by none of them.
+
+        Provision the private endpoint in the same network as the consuming application and route that application to it over private addresses, then govern the backing subnet with network security groups so the endpoint is reachable only from the workloads that should call it. An endpoint used solely for public-facing evaluation with no proprietary context is the narrow case where a public path is acceptable.
       audit: |
         ### Audit via Console
 
@@ -12300,19 +12277,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that every OCI Data Science notebook session is isolated behind a Data Science private endpoint. A notebook session runs interactive code with access to data, credentials, and network resources. A private endpoint confines the session's network access to the customer's VCN. Without one, the session's connectivity is not bounded to the private network, widening what a compromised or misused notebook can reach.
+        This check verifies that every OCI Data Science notebook session has its network reach confined to the customer's private network.
+
+        A Data Science private endpoint places a notebook session's connectivity inside a subnet of a virtual cloud network rather than allowing it to reach resources over public paths. It is created under Analytics & AI > Data Science > Private endpoints and assigned to a session when the session is created, since the binding cannot be added afterward. The check requires each session to carry a `privateEndpointID` rather than leaving it empty.
 
         **Why this matters**
 
-        - **Sensitive workload:** Notebook sessions routinely hold data sets, model artifacts, and credentials, making their network reach a meaningful part of the attack surface.
-        - **Contained connectivity:** A private endpoint keeps the session's traffic on the VCN so it can be governed by existing network controls rather than reaching resources over public paths.
-        - **Blast-radius reduction:** Confining a session to a private endpoint limits what a compromised notebook can connect to or exfiltrate data through.
+        A notebook session is an interactive shell with a data science library stack in front of it. It routinely holds the data sets an analyst is working on, model artifacts, and the credentials needed to reach object storage buckets, databases, and internal APIs. Whoever controls the session controls all of that, which makes the session's network reach a meaningful part of the tenancy's attack surface rather than a developer convenience setting.
 
-        **Risk mitigation**
+        Without a private endpoint the session's connectivity is unbounded by the network. Code running in the notebook can open outbound connections to arbitrary internet destinations, which is exactly the channel an attacker needs to exfiltrate a data set or a set of instance principal credentials. A malicious package pulled from a public index is enough to trigger it; the analyst does not have to do anything wrong.
 
-        - **Provision a Data Science private endpoint:** Create a private endpoint in the target VCN for notebook sessions to use.
-        - **Bind sessions to the private endpoint at creation:** Assign the private endpoint when creating each notebook session.
-        - **Govern the subnet:** Apply NSGs and monitoring to the subnet backing the private endpoint.
+        Binding the session to a private endpoint puts its traffic back under the controls that already exist. Route tables decide where it can go, network security groups decide what it can talk to, and flow logs record what it did, so a compromised notebook is contained by the same machinery that contains every other workload on the network.
+
+        Apply network security groups and monitoring to the subnet backing the private endpoint so the containment is real rather than nominal. Sessions used purely for offline work against public sample data are the one case where the added networking is more overhead than benefit.
       audit: |
         ### Audit via Console
 
@@ -12394,20 +12371,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every Network Firewall decryption profile blocks the TLS sessions it cannot validate. Every one of these settings defaults to permissive, so a profile created without changing them decrypts and forwards sessions whose certificate is expired, whose issuer is untrusted, or whose cipher suite or protocol version the firewall does not support.
+        This check verifies that Network Firewall decryption profiles block the TLS sessions they cannot validate rather than passing them through.
 
-        Two settings apply to every profile. The certificate settings apply to forward-proxy profiles only and read null on inbound-inspection profiles, so they are asserted only where they mean something.
+        A decryption profile tells the firewall what to do when TLS inspection encounters something it cannot handle. Every one of the relevant settings defaults to permissive, so a profile created without changing them decrypts and forwards sessions whose certificate is expired, whose issuer is untrusted, or whose cipher suite or protocol version the firewall does not support. This check requires `isUnsupportedVersionBlocked` and `isUnsupportedCipherBlocked` on every profile, and additionally requires `isExpiredCertificateBlocked`, `isUntrustedIssuerBlocked`, `isRevocationStatusTimeoutBlocked`, and `isUnknownRevocationStatusBlocked` on profiles of type `SSL_FORWARD_PROXY`. The certificate settings are forward-proxy only and read as unset on an inbound-inspection profile, so they are asserted only where they mean something. Edit profiles in the Console under Identity & Security > Network Firewall on the firewall policy, or with `oci network-firewall decryption-profile update`.
 
         **Why this matters**
 
-        - **A permissive profile forwards exactly what inspection is for:** An expired or untrusted certificate is the signal that a session is being intercepted or served by an impostor, and a profile left at its defaults passes it through anyway.
-        - **Unsupported ciphers bypass inspection entirely:** A session the firewall cannot decrypt is forwarded undecrypted unless blocking is turned on, so an attacker who negotiates an unsupported suite is invisible to every rule behind it.
-        - **The defaults read as configured:** A profile exists and is attached to a policy, so a console review shows decryption in place while nothing is actually being enforced.
+        A permissive profile forwards exactly what inspection exists to catch. An expired certificate or an untrusted issuer is the signal that a session is being intercepted or served by an impostor, and a profile left at its defaults passes that session on to the destination anyway.
 
-        **Risk mitigation**
+        Unsupported ciphers and protocol versions bypass inspection entirely. A session the firewall cannot decrypt is forwarded undecrypted unless blocking is turned on, so an attacker who negotiates an unsupported suite becomes invisible to every rule sitting behind the firewall.
 
-        - **Block on validation failure:** Turn on the expired-certificate, untrusted-issuer, and revocation-status settings on every forward-proxy profile.
-        - **Block unsupported ciphers and versions:** Turn on both settings on every profile so a session the firewall cannot read does not pass unexamined.
+        The failure mode is that the defaults read as configured. A profile exists and is attached to a policy, so a Console review shows decryption in place while nothing is actually being enforced against a session that fails validation.
+
+        Turning the settings on makes validation failure a block rather than a warning. Expect some breakage on first enforcement from internal services using self-signed or long-expired certificates, and fix those certificates rather than reverting the profile.
       audit: |
         ### Audit via Console
 
@@ -12566,18 +12542,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every Network Firewall security rule with an `ALLOW` verdict names at least one source address list. A rule's match condition is expressed by naming lists; a condition that omits the source key matches every source, so an allow rule written without one permits the named traffic from anywhere on the internet.
+        This check verifies that every Network Firewall rule granting an `ALLOW` verdict is scoped to a named source address list.
+
+        A security rule's match condition is expressed by naming lists of sources, destinations, applications, and services. A condition that omits the source key does not match a narrow set of sources; it matches every source. An allow rule written without one therefore permits the named traffic from anywhere on the internet. An empty source list behaves the same way as an absent one, so this check treats both as unscoped and requires a non-empty source address list on every allow rule. Define the lists and reference them in the Console under Identity & Security > Network Firewall on the firewall policy, or with `oci network-firewall security-rule update`.
 
         **Why this matters**
 
-        - **An omitted key is not a narrow rule, it is no rule:** The condition reads as configured, but the absent source means the firewall applies the allow verdict to traffic from any address.
-        - **It is silent in review:** A rule listing a destination and an application looks scoped; the missing source is visible only by knowing that absence means "any".
-        - **The firewall is the boundary:** Traffic this rule admits has already passed the outermost control, so a downstream security list is the only thing left.
+        An omitted key is not a narrow rule, it is no rule. The condition reads as configured and the policy applies cleanly, but the absent source means the firewall extends the allow verdict to traffic arriving from any address at all.
 
-        **Risk mitigation**
+        The defect is silent in review. A rule that lists a destination and an application looks properly scoped, and the missing source is visible only to a reviewer who already knows that absence means any.
 
-        - **Name a source address list on every allow rule:** Define the ranges the traffic is expected from and reference them in the rule's condition.
-        - **Prefer a deny-by-default policy:** Order allow rules after an explicit catch-all drop so an unscoped rule cannot become the effective policy.
+        The firewall is the boundary, which is what makes this expensive. Traffic admitted by this rule has already passed the outermost control, so whatever downstream security list or network security group happens to be in the path is the only remaining barrier, and those are usually written on the assumption that the firewall already filtered by source.
+
+        Name a source address list on every allow rule, defining the ranges the traffic is genuinely expected from. Order allow rules after an explicit catch-all drop so the policy is deny by default and a single unscoped rule cannot quietly become the effective policy.
       audit: |
         ### Audit via Console
 
@@ -12719,18 +12696,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no OCI Bastion allows session creation from `0.0.0.0/0`. The client CIDR allow list is what decides where a bastion session may be opened from, and a bastion is by design the one path into a private subnet, so an allow list of `0.0.0.0/0` publishes that path to the entire internet.
+        This check verifies that no bastion accepts session creation from every address on the internet.
+
+        The OCI Bastion service brokers access into a private subnet through three session types: a managed SSH session to an instance running the Oracle Cloud Agent Bastion plugin, an SSH port forwarding session to a specific host and port, and a dynamic port forwarding session that opens a SOCKS5 proxy. Every one of them is gated by the same list, `clientCidrBlockAllowList`, which names the source ranges a session may be created and connected from. The check fails a bastion whose list contains `0.0.0.0/0` or `::/0`. Narrow it under Identity & Security > Bastion, with `oci bastion bastion update --bastion-id <bastion-ocid> --client-cidr-list '["203.0.113.0/24"]'`, or through `client_cidr_block_allow_list` in Terraform.
 
         **Why this matters**
 
-        - **The bastion is the way in:** It exists precisely because the hosts behind it are not reachable, so its allow list is the boundary those hosts depend on.
-        - **A world-open bastion is continuously probed:** Session creation becomes reachable from anywhere, so credential attacks against it never stop.
-        - **It is usually a leftover:** `0.0.0.0/0` gets added for a remote incident or an onboarding and is rarely narrowed afterwards.
+        A bastion exists precisely because the hosts behind it are not reachable any other way, so its allow list is the boundary those hosts depend on. Widen it to the whole internet and the one designed path in becomes a public one.
 
-        **Risk mitigation**
+        Session creation then becomes reachable from anywhere, which makes the bastion a permanent target. Credential attacks against it never stop, and the audit trail fills with attempts from everywhere rather than from the handful of places your operators actually work.
 
-        - **List the ranges operators actually connect from:** Corporate egress addresses and VPN pools, not the whole internet.
-        - **Review the list on a schedule:** Ranges added for an incident should be removed when the incident closes.
+        The entry is almost always a leftover. `0.0.0.0/0` gets added to unblock a remote incident or an onboarding, the immediate problem is solved, and nobody narrows it again once the reason has passed.
+
+        List the ranges operators genuinely connect from, which is corporate egress addresses and VPN pools, and keep the list short enough that each entry is recognizable. Review it on a schedule, and treat any range added during an incident as expiring when that incident closes.
       audit: |
         ### Audit via Console
 
@@ -12848,18 +12826,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every OCI Bastion caps session lifetime at one hour or less. The maximum session time-to-live is the longest a session may stay open before it has to be recreated, and OCI permits up to three hours. A bastion session is privileged access into a private subnet, so its lifetime is the window in which a session left open on an unattended workstation, or captured from one, remains usable.
+        This check verifies that every bastion caps how long a session may stay open at one hour or less.
+
+        `maxSessionTtlInSeconds` on an OCI Bastion is the ceiling applied to every session created through it, managed SSH and port forwarding alike, after which the session ends and has to be recreated. Oracle permits values up to three hours, and the check requires 3600 seconds or fewer. A bastion that reports no limit at all fails as well, because an unbounded lifetime is not a bounded one. Because a bastion session is privileged access into a private subnet, that ceiling is the window in which a session left open on an unattended workstation, or captured from one, remains usable. Set it under Identity & Security > Bastion, with `oci bastion bastion update --bastion-id <bastion-ocid> --max-session-ttl 3600`, or through `max_session_ttl_in_seconds` in Terraform.
 
         **Why this matters**
 
-        - **A live session needs no credentials:** Whoever reaches the terminal inherits the access, so the ceiling on session length is the ceiling on that exposure.
-        - **Long sessions outlive the work:** Access granted for a twenty-minute task stays open for hours if nothing forces it closed.
-        - **Recreation is cheap:** Reopening a session is a single command, so a short ceiling costs little and bounds every session at once.
+        A live session needs no credentials. Whoever reaches the terminal inherits the access already established there, so the ceiling on session length is directly the ceiling on that exposure.
 
-        **Risk mitigation**
+        Sessions also outlive the work that justified them. Access opened for a twenty-minute task stays open for hours when nothing forces it closed, and the operator has long since moved on to something else.
 
-        - **Set the maximum TTL to one hour or less:** Long-running work can reconnect; the ceiling only affects how long a forgotten session survives.
-        - **Prefer per-session TTLs below the bastion ceiling:** Sessions can request less than the maximum, and routine access rarely needs the full hour.
+        Recreating a session costs a single command, so a short ceiling is cheap. It bounds every session on the bastion at once, without anyone having to remember to close one.
+
+        Set the maximum to one hour or less and let long-running work reconnect, since the ceiling only decides how long a forgotten session survives. Individual sessions can request less than the bastion maximum, and routine access rarely needs the full hour, so prefer per-session lifetimes well below the ceiling rather than treating the maximum as the default.
       audit: |
         ### Audit via Console
 
@@ -12983,20 +12962,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every primary DNS zone answering publicly has DNSSEC signing enabled. DNSSEC signs the zone's records so a resolver can verify that the answer it received is the one the zone published. Without it, a resolver has no way to tell a genuine answer from a forged one, and OCI creates zones with DNSSEC disabled.
+        This check verifies that answers served by public DNS zones are cryptographically verifiable, by requiring DNSSEC signing on every primary zone with global scope.
 
-        Private zones and secondary zones are not in scope: a private zone answers only inside attached VCNs, and a secondary zone serves records signed at its primary.
+        DNSSEC signs a zone's records so a validating resolver can confirm that the answer it received is the one the zone actually published. OCI creates zones with DNSSEC disabled, so a zone is unsigned unless someone turns signing on. This check applies only to zones that are both primary and publicly resolvable: a private zone answers only inside the VCNs attached to it, and a secondary zone serves records signed at its primary, so neither is a place DNSSEC is configured. Enable it in the Console under Networking > DNS Management > Zones, or with `oci dns zone update`, then publish the resulting DS record at the parent.
 
         **Why this matters**
 
-        - **An unsigned answer is unverifiable:** Cache poisoning and on-path answer substitution redirect users and services to attacker-controlled addresses with nothing to detect the swap.
-        - **DNS decides where everything goes:** A forged record redirects mail, API traffic, and certificate validation challenges, which is the step that makes fraudulent certificate issuance possible.
-        - **The failure is silent:** Traffic reaches the wrong host and works, so nothing in the application signals that resolution was tampered with.
+        An unsigned answer is unverifiable. Cache poisoning and on-path answer substitution let an attacker feed a resolver a record pointing at an address they control, and the resolver has no means of telling that answer apart from a genuine one. Every client behind that resolver then goes where the attacker chose.
 
-        **Risk mitigation**
+        DNS decides where everything goes, which is what makes the payoff so large. A forged record redirects mail, redirects API traffic, and redirects the HTTP and DNS challenges that certificate authorities use to validate domain control, and that last one is the step that turns a poisoned cache into fraudulent certificate issuance under the victim's own name.
 
-        - **Enable DNSSEC on every public primary zone:** Signing makes forged answers detectable by any validating resolver.
-        - **Publish the DS record at the parent:** Signing only takes effect once the delegation carries the matching DS record, so complete the chain of trust at the registrar.
+        The failure is silent. Traffic reaches the wrong host and the application works, so nothing in logs or user experience signals that resolution was tampered with.
+
+        Signing only takes effect once the delegation carries the matching DS record, so complete the chain of trust at the registrar or parent zone. Signing without publishing the DS record leaves the zone as unprotected as before.
       audit: |
         ### Audit via Console
 
@@ -13117,20 +13095,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no IPSec tunnel is configured with Diffie-Hellman group 2 or group 5 for either the IKE key exchange or the IPSec rekey. Group 2 is a 1024-bit MODP prime and group 5 is 1536-bit; both are fixed, standardized primes shared by everyone who selects them, which is the cheapest possible target for precomputation. Group 14 and above keep the discrete-logarithm problem out of practical reach.
+        This check verifies that no site-to-site VPN tunnel uses Diffie-Hellman group 2 or group 5, for either the phase 1 IKE key exchange or the phase 2 IPSec rekey.
 
-        Only tunnels with a custom proposal set are evaluated. A tunnel using Oracle's default proposals reports no configured group, and Oracle's defaults do not include the weak ones.
+        Group 2 is a 1024-bit MODP prime and group 5 is 1536-bit. Both are fixed, standardized primes shared by everyone who selects them, which makes them the cheapest possible target for precomputation: the expensive work is done once against the prime and then reused against every exchange that chose it. Group 14 at 2048 bits and above keep the discrete-logarithm problem out of practical reach. The check reads the configured group on tunnels carrying a custom proposal set, and the negotiated group on tunnels whose IKE or ESP association is up. A tunnel left on Oracle's default proposals reports no configured group, and those defaults do not include the weak ones. Edit proposals under Networking > Customer connectivity > Site-to-Site VPN, or through the phase one and phase two detail blocks of the Terraform tunnel management resource.
 
         **Why this matters**
 
-        - **A weak exchange undoes a strong cipher:** AES-256 protects nothing if the key that seeds it came from an exchange an attacker can break.
-        - **Shared primes amortize the attack:** Precomputation against one widely reused prime pays off against every tunnel that selected it, which is what makes group 2 a practical target rather than a theoretical one.
-        - **Recorded traffic stays attackable:** Ciphertext captured today can be decrypted whenever the exchange falls, so a weak group is a retroactive exposure.
+        A weak exchange undoes a strong cipher. AES-256 protects nothing when the key that seeds it came from a key agreement an attacker can break, and the cipher suite named in the tunnel configuration says nothing about that.
 
-        **Risk mitigation**
+        Shared primes amortize the attack. Precomputation against one widely reused prime pays off against every tunnel that selected it, which is what turns group 2 from a theoretical concern into a practical one.
 
-        - **Set group 14 or higher on both phases:** Configure the IKE and IPSec proposals together, and apply the matching change on the customer-premises equipment.
-        - **Prefer Oracle's defaults over a weak custom set:** A custom proposal is worth keeping only when it is stronger than the default, not weaker.
+        Recorded traffic stays attackable. Ciphertext captured today can be decrypted whenever the exchange finally falls, so a weak group is a retroactive exposure across everything the tunnel has already carried.
+
+        Configure group 14 or higher on both phases together, and apply the matching change on the customer-premises equipment before or alongside it. A custom proposal set is worth keeping only when it is stronger than Oracle's default, never when it is weaker.
       audit: |
         ### Audit via Console
 
@@ -13312,20 +13289,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every IPSec tunnel with an established data channel negotiates perfect forward secrecy. With forward secrecy, each rekey derives fresh key material from a new Diffie-Hellman exchange, so recovering one key does not decrypt anything that came before it. Without it, a single recovered key opens every session it ever protected.
+        This check verifies that site-to-site VPN tunnels carrying live traffic negotiate perfect forward secrecy on the IPSec phase.
 
-        Only tunnels whose ESP security association is established are evaluated. The provider reports forward secrecy as disabled on a tunnel that is down, because the negotiated crypto is simply unavailable, and a tunnel that has never come up is not evidence of a misconfiguration.
+        With forward secrecy, every phase 2 rekey derives fresh key material from a new Diffie-Hellman exchange, so recovering the key protecting one interval decrypts only that interval. Without it, key material is chained from the original exchange and a single recovered key opens every session it ever protected. Only tunnels whose ESP security association is established are evaluated, because the provider reports forward secrecy as disabled on a tunnel that is down: the negotiated crypto is simply unavailable, and a tunnel that never came up is not evidence of a misconfiguration. Turn it on under Networking > Customer connectivity > Site-to-Site VPN by editing the tunnel, or through `is_pfs_enabled` in the phase two details of the Terraform tunnel management resource.
 
         **Why this matters**
 
-        - **It bounds a key compromise in time:** With forward secrecy, a recovered key exposes one rekey interval; without it, the whole history of the tunnel.
-        - **Site-to-site tunnels are long-lived and high-volume:** They carry months of traffic between two networks, which is exactly the case where retroactive decryption is worth the most.
-        - **Captured traffic is patient:** An attacker can record now and decrypt later, so the protection has to be in place before the key is ever at risk.
+        Forward secrecy bounds a key compromise in time. With it, a recovered key exposes one rekey interval; without it, the whole history of the tunnel is exposed at once.
 
-        **Risk mitigation**
+        Site-to-site tunnels are exactly the case where that distinction is worth the most. They are long-lived and high-volume, joining two networks for months at a stretch, so the accumulated traffic behind a single key is enormous.
 
-        - **Enable perfect forward secrecy on the IPSec phase:** Configure it on the tunnel and apply the matching setting on the customer-premises equipment.
-        - **Pair it with a strong Diffie-Hellman group:** Fresh key material from a weak group is still weak key material.
+        Captured traffic is patient. An attacker records now and decrypts later, whenever the key becomes recoverable, so the protection has to already be in place before the key is ever at risk. It cannot be applied retroactively.
+
+        Enable it on the tunnel and apply the matching setting on the customer-premises equipment, since both sides have to offer it for the negotiation to land there. Pair it with a strong Diffie-Hellman group, because fresh key material derived from a weak group is still weak key material.
       audit: |
         ### Audit via Console
 
@@ -13455,20 +13431,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that no local peering gateway, remote peering connection, or dynamic routing gateway attachment peers with a network in another tenancy. Cross-tenancy peering joins two address spaces under different owners, so traffic can reach the VCN from a network the tenancy's own administrators do not control and cannot inspect.
+        This check verifies that no VCN peering path crosses a tenancy boundary.
 
-        Cross-tenancy peering is sometimes deliberate, for a partner integration or a split-billing arrangement. This check surfaces every instance so each can be confirmed as intended rather than discovered later.
+        Three constructs can carry one. A local peering gateway joins two VCNs in the same region, a remote peering connection joins dynamic routing gateways across regions, and a dynamic routing gateway attachment binds a VCN to a gateway. Each carries a flag marking the far side as belonging to another tenancy, and the check requires all three to be false. Cross-tenancy peering joins two address spaces under different owners, so traffic reaches the VCN from a network the tenancy's own administrators neither control nor can inspect. Establishing one also takes matching IAM statements in both tenancies, such as `endorse group NetworkAdmins to manage remote-peering-from in tenancy Acceptor` on the requestor side and `admit group NetworkAdmins of tenancy Requestor to manage remote-peering-to in compartment Network` on the acceptor side, which must live in the tenancy root compartment.
 
         **Why this matters**
 
-        - **It extends the trust boundary silently:** Once the peering is established and routes are published, hosts in the other tenancy are simply on the network, with no gateway, no logging point, and no authentication in between.
-        - **The other side is not yours to audit:** Its security lists, its compromised hosts, and its own peerings are outside your control while its traffic is inside your VCN.
-        - **It survives the reason for it:** A peering set up for a migration or a proof of concept stays routable long after the project ends, because nothing expires it.
+        The trust boundary extends silently. Once the peering is established and routes are published, hosts in the other tenancy are simply on the network, with no gateway, no logging point, and no authentication in between.
 
-        **Risk mitigation**
+        The other side is not yours to audit. Its security lists, its compromised hosts, and its own onward peerings are entirely outside your control while its traffic is already inside your VCN.
 
-        - **Confirm each peering against a documented agreement:** Every cross-tenancy link should trace to a named counterparty and a business reason.
-        - **Constrain what the peering can reach:** Advertise only the CIDRs the integration needs, and back the peering with security lists that scope it to specific hosts and ports.
+        It also survives the reason for it. A peering set up for a migration or a proof of concept stays routable long after the project ends, because nothing expires it and nothing reports it.
+
+        Cross-tenancy peering is sometimes deliberate, for a partner integration or a split-billing arrangement, so the check surfaces every instance to be confirmed as intended rather than discovered later. Trace each one to a named counterparty and a documented business reason, advertise only the CIDRs that integration actually needs, and back the peering with security lists that scope it to specific hosts and ports.
       audit: |
         ### Audit via Console
 
@@ -13607,18 +13582,19 @@ queries:
           mondoo.com/filter-icon: terraform
     docs:
       desc: |
-        This check ensures that every network load balancer with a public IP address has at least one network security group attached. A public network load balancer answers on the internet, and with no NSG the only ingress filter in front of it is the subnet's security list, which is usually shared across every resource in that subnet and written for the broadest of them.
+        This check verifies that every network load balancer holding a public IP address has at least one network security group attached to filter what reaches it.
+
+        A network load balancer operates at layer 4, so ingress filtering is the whole of its access control. The check passes when the load balancer is private or when at least one network security group is attached to it. Attach groups under Networking > Load balancers > Network load balancers in the Console, or with `oci nlb network-load-balancer update`.
 
         **Why this matters**
 
-        - **A load balancer forwards what reaches it:** Traffic the NLB accepts is delivered to the backend set, so the filter in front of the NLB is the filter in front of the backends.
-        - **Shared security lists are the wrong granularity:** A rule written for one workload in the subnet applies to the load balancer too, so the NLB inherits access nobody chose for it.
-        - **Layer 4 offers nothing else:** A network load balancer has no listener-level authentication or TLS policy to fall back on, unlike an application load balancer.
+        With no network security group, the only ingress filter in front of a public network load balancer is the subnet's security list. That list is shared by every resource in the subnet and is written for whichever workload needed the broadest access, so the load balancer inherits a rule set nobody chose for it. A port opened for one instance is open at the load balancer too.
 
-        **Risk mitigation**
+        Whatever reaches the load balancer reaches the backend set. A network load balancer does not inspect or authenticate traffic, it forwards it, so the filter in front of the load balancer is the filter in front of the backends, and those backends were usually built assuming something upstream was doing the filtering.
 
-        - **Attach an NSG scoped to the listener ports:** Allow only the ports the service publishes, from the ranges expected to reach it.
-        - **Make the load balancer private where it does not need to be public:** A private NLB removes the internet path entirely.
+        A layer 7 load balancer has other places to put a control, including listener-level TLS policy and cipher selection. A network load balancer has none of them. That is why leaving ingress to a shared security list is not a partial answer but the absence of one.
+
+        Scope the attached group to the ports the service actually publishes, from the address ranges expected to reach it. Where the load balancer has no reason to answer on the internet, making it private is the stronger outcome, because it removes the public path rather than filtering it.
       audit: |
         ### Audit via Console
 
@@ -13729,20 +13705,19 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-6
     docs:
       desc: |
-        This check ensures that no network load balancer is actually reachable from the internet. Reachability is not the same as having a public IP: the load balancer is reachable only when it has a public address, sits on a subnet whose route table forwards a default route to an enabled internet gateway, and has an attached network security group or subnet security list that admits traffic from any address. A load balancer that fails any one of those is not on the internet, whatever its address suggests.
+        This check verifies that no network load balancer has a working path from the internet, judging reachability as a whole rather than treating a public address as the answer.
 
-        A load balancer that is meant to serve the public will fail this check. It is intended for internal load balancers, where a public path is a mistake rather than a design.
+        Reachability requires three conditions at once. The load balancer has a public IP address, it sits on a subnet whose route table sends a default route to an enabled internet gateway, and an attached network security group or the subnet's security list admits traffic from any source address. Break any one of the three and it is not on the internet, whatever its address suggests. A load balancer meant to serve the public will fail this check, which is expected: the check is written for internal load balancers, where a public path is a mistake rather than a design.
 
         **Why this matters**
 
-        - **Address is a poor proxy for exposure:** Reviewing public IPs alone flags load balancers that nothing can reach and misses ones whose exposure comes from a permissive security list.
-        - **Exposure is assembled from three places:** The address, the route table, and the ingress rules are usually owned by different people, so no single review catches the combination.
-        - **An internal load balancer fronts internal services:** Backends behind it are typically built assuming only trusted callers arrive, so an unnoticed internet path reaches software that was never hardened for it.
+        A public address is a poor proxy for exposure in both directions. Reviewing addresses alone raises load balancers that nothing can actually reach, which trains reviewers to dismiss the finding, and it misses the one whose address looks routine but whose exposure comes from a permissive security list rule added for a debugging session and never removed.
 
-        **Risk mitigation**
+        The three conditions also sit with three different owners. The address is set when the load balancer is created, the route table belongs to whoever manages the virtual cloud network, and the ingress rules belong to whoever owns the security group, so no single review sees the combination that produces the exposure.
 
-        - **Make internal load balancers private:** A private network load balancer has no public address and no internet path at all.
-        - **Break the path where the public address is required:** Remove the default route to the internet gateway, or narrow the ingress rules so no rule admits any address.
+        An internal load balancer fronts internal services, and those services are built assuming only trusted callers arrive. Authentication is thinner, administrative endpoints stay published, and debug interfaces stay enabled, because the network was the control. An unnoticed internet path lands directly on software never hardened for it.
+
+        Where the load balancer has no reason to be public, recreate it as private and the path ceases to exist. Where a public address is genuinely required, break the path elsewhere: remove the default route to the internet gateway, or narrow the ingress rules so none admits an arbitrary source.
       audit: |
         ### Audit via Console
 


### PR DESCRIPTION
Rewrites all 99 check descriptions in `content/mondoo-oci-security.mql.yaml` to the prose
form described in `content/CLAUDE.md`.

This policy's content was already good, so this is a **structural conversion plus
sharpening**, not a replacement. Every named API action, IAM statement, permission string,
port number, algorithm name, service default and numeric threshold in the old text was
carried forward.

## What changed structurally

| Before | After |
|---|---|
| Opens `This check ensures that <resource> ...` | Opens `This check verifies that <capability> is <required state>` |
| `**Why this matters**` as a bulleted list with bold labels | `**Why this matters**` as two to four prose paragraphs |
| `**Risk mitigation**` heading with a second bullet list | Heading removed, content folded into the prose and closing paragraph |
| No pointer to where the setting is administered | Names the OCI Console path, the `oci` CLI command, or the IAM policy statement |
| Closing bullet restating the opener | Closing paragraph covers when the check should not apply, or what to pair it with |

## Example: specifics preserved

`mondoo-oci-security-iam-no-broad-compartment-policies`, before:

> This check ensures that no IAM policy grants `manage all-resources in compartment`...
>
> **Why this matters**
>
> - **Excessive compartment access:** A group with this grant can create, modify, or delete every resource in the compartment.
> - **Least-privilege violation:** ...
>
> **Risk mitigation**
>
> - **Scope to resource families:** Prefer `manage instance-family` or `manage virtual-network-family`...

After:

> This check verifies that IAM grants inside a compartment are scoped to specific resource types rather than conveying full control of everything in it.
>
> The statement rejected here is `allow group <group> to manage all-resources in compartment <name>`. It is narrower than the tenancy-wide form because the compartment boundary still holds, but within that boundary it is absolute: the strongest verb applied to every resource type OCI offers. [...] Statements are managed under Identity & Security > Policies or with `oci iam policy update` [...]
>
> **Why this matters**
>
> A compartment is rarely small. Production compartments commonly hold the compute instances, the VCN and its security lists, the block volumes, the Object Storage buckets, and the databases for a whole application. [...]
>
> Rewrite these into named resource families matching what each group operates, such as `manage instance-family` or `manage virtual-network-family` [...] Remember also that a policy attached at the tenancy root reaches this compartment too, so narrowing the compartment policy is only half the work.

Both statement forms, both resource families and the least-privilege argument survive; the
compartment-inheritance trap is new.

## Three factual corrections

1. Object Storage object events cover `createobject`, `updateobject` and `deleteobject`,
   not reads. The old event-logging text claimed reads were covered. The read blind spot is
   now paired with Logging service read access logs instead.
2. Object Lock is an AWS feature, not an OCI one. The archive bucket versioning description
   pointed at it; it now points at OCI locked retention rules.
3. Security list rules are allow-only with an implicit drop. The claim that "OCI security
   lists permit any traffic until explicitly restricted" was removed from two descriptions
   and replaced with the accurate framing.

## Nothing else changed

**No `mql`, `filters`, `tags`, `impact`, `props`, `title`, `audit` or `remediation` content
was modified.** Proven mechanically: the bundle is parsed at `origin/main` and at this tip,
every `docs.desc` and the policy `version` are replaced with placeholders, and the two
trees are asserted equal. They are.

Policy `version` bumped `4.6.0` to `4.6.1`.

## Validation

| Gate | Result |
|---|---|
| `cnspec policy lint content/mondoo-oci-security.mql.yaml` | valid policy bundle(s) |
| `typos` | clean, no allowlist touched |
| `go test ./internal/bundle/...` | ok |
| Structural diff vs `origin/main` | trees identical after placeholdering desc + version |
| Opens with `This check` | 99 / 99 |
| `**Why this matters**` present | 99 / 99 |
| `**Risk mitigation**` remaining | 0 |
| Em dash, en dash or ` -- ` | 0 |
| MQL accessor paths in prose | 0 |
| Bullet lines | 0 |
| Byte-identical siblings | 0 |
| Trailing whitespace | 0 |

Word counts run 271 to 383, median 323.

### Substance preservation

Audited two ways, both comparing against the new description **as a whole string** so a
literal that was reworded out entirely is caught rather than being treated as a formatting
change.

**Pass 1, authoritative:** every backticked literal in each old description must appear
somewhere in the corresponding new description, in any form.

**0 of 380 backticked literals dropped across 99 checks.**

An earlier revision of this PR dropped seven. All seven are now restored, in whichever
spelling fits the sentence, keeping the API and Terraform forms wherever the old text
carried both:

| Check | Restored |
|---|---|
| `vcn-no-unrestricted-ingress-all-tcp-ports` | `tcp_options` alongside `tcpOptions` |
| `vcn-no-stateless-ingress-from-internet` | `stateless = false` alongside `isStateless: true` |
| `oke-node-pool-private-subnets` | `prohibitPublicIpOnVnic = true` and `prohibitPublicIpOnVnic: true` |
| `dbsystem-private-subnet` | `prohibitPublicIpOnVnic = true` and `prohibitPublicIpOnVnic: true` |
| `container-instances-approved-registry` | `*.ocir.io` alongside `iad.ocir.io` |

`Allow any-user` in `iam-no-any-user-policies` was also queried. It differs only in the
capitalization of `Allow`; the new text carries the full statement
`allow any-user to read all-resources in tenancy`, which is strictly more specific than the
fragment the old text gave.

**Pass 2, advisory:** identifiers, numbers, acronyms and CIDRs. 20 tokens flagged across 15
checks, all acronyms deliberately written out in full, which a literal comparison cannot see
through: `mTLS` to "mutual TLS", `WORM` to "immutable, cannot be deleted", `CVE` to
"vulnerability" and "pre-authentication", `CMK` to "customer-managed key", `PKI` to
"certificate authority", `WAF` to "web application firewall", `PMTU` to "path MTU, type 3
code 4", `IDS` to "intrusion detection", `IGW` to "internet gateway", `AEAD` to
"authenticated encryption", `EOL` to "end-of-life", `MSSQL` to "SQL Server".

One deliberate removal: `HIPAA` and `PCI DSS` were dropped from
`adb-customer-managed-encryption`, where the sentence was verbatim identical to the DB
system sibling. Keeping both would have produced exactly the search-and-replace pair this
rewrite exists to eliminate. Both frameworks are retained in the DB system description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
