### PR TITLE
📝 content: rewrite AI, EDR and MCP check descriptions

### DIFF
--- a/content/mondoo-ai-security.mql.yaml
+++ b/content/mondoo-ai-security.mql.yaml
@@ -4,7 +4,7 @@
 policies:
   - uid: mondoo-ai-security
     name: Mondoo AI Security
-    version: 2.1.0
+    version: 2.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -122,14 +122,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Unapproved AI coding agents and local LLM runtimes running as live processes can transmit proprietary source code, customer data, or secrets to untrusted model providers. Only AI tools reviewed and approved by the security team should be permitted to execute on corporate endpoints. The `mondooAiSecurityApprovedProcesses` property defines the allow-list and can be customized for your environment.
+        This check verifies that no unapproved AI agent or local model runtime is currently running.
+
+        The check reads the process table for executables matching a set of known AI agent and local inference tool names, and excludes anything named in this policy's approved-process property. A process is only visible while it runs, so this catches tools in active use rather than merely installed.
 
         **Why this matters**
 
-        - **Data egress:** A running AI agent can stream open files and repository contents to a third-party API without the user explicitly authorizing each transfer.
-        - **Credential exposure:** Agents often read environment variables and configuration files that contain tokens, leaking them to the model provider.
-        - **Bypassed review:** Code generated or modified by an unsanctioned agent skips the controls that govern approved tooling.
-        - **Reduced visibility:** Security teams cannot account for data handled by tools they have not inventoried.
+        A running process is the state in which an AI tool is actually moving data. It has files open, it has a network connection to a model provider, and it is answering completions with whatever context it gathered.
+
+        That distinguishes this from the companion checks on installed packages. A tool that is installed but never launched has transferred nothing; one that is running has a live path from the endpoint's filesystem to a third party, and the traffic is HTTPS to a vendor API rather than anything a data loss control would recognize.
+
+        The approval question is what makes this actionable rather than a survey. The concern is not that developers use AI tooling, it is that a tool nobody reviewed has been granted access to source code and credentials, under terms nobody read, sending data to a provider nobody assessed.
+
+        Maintain the approved-process property as the list of tools that have been through that review. A failure names a tool that has not been, which is a conversation with the developer rather than automatically an incident.
       audit: |-
         To verify that no unapproved AI agent processes are running:
 
@@ -257,14 +262,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Unapproved AI tools installed through system package managers such as apt, dnf, rpm, or the Windows uninstall registry remain available even when not actively running. Only AI tools reviewed and approved by the security team should be present on corporate endpoints. The `mondooAiSecurityApprovedPackages` property defines the allow-list and can be customized for your environment.
+        This check verifies that no unapproved AI tool is installed through a system package manager.
+
+        The check reads the installed package inventory, which covers `apt`, `dnf`, `rpm`, and the Windows uninstall registry, matching known AI agent and local inference tool names and excluding anything named in this policy's approved-package property.
 
         **Why this matters**
 
-        - **Latent risk:** An installed but idle AI tool can be launched at any time, reintroducing data-egress exposure on demand.
-        - **Cached state:** Package installations often retain credentials and configuration from prior use that survive between sessions.
-        - **Inventory gaps:** Tools installed outside the approved set leave security teams without an accurate picture of endpoint software.
-        - **Update channels:** Unsanctioned packages pull updates from third-party repositories that are not part of the organization's supply chain.
+        An installed tool is available whether or not anyone is currently using it. It survives reboots, it is present for any user of the machine, and it can be launched at any time, so the window of exposure is the life of the installation rather than the duration of a session.
+
+        Package-manager installs matter more than they first appear because they are the ones that persist through the endpoint's normal lifecycle. They are captured in images, restored by configuration management, and reinstalled when a machine is rebuilt, so a tool that arrived once tends to keep arriving.
+
+        They are also the installs that are easiest to inventory and hardest for a user to hide, which makes this the most reliable of the three detection paths in this policy.
+
+        Maintain the approved-package property to reflect what has actually been reviewed. Where a failure names a tool a team genuinely needs, the outcome should be a review and an addition to the property rather than an exception on the endpoint.
       audit: |-
         To verify that no unapproved AI tools are installed via package managers:
 
@@ -365,14 +375,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Homebrew is a common installation path for desktop AI applications on macOS, and packages installed this way persist outside the approved software set. Only AI tools reviewed and approved by the security team should be present on corporate endpoints. The `mondooAiSecurityApprovedHomebrewPackages` property defines the allow-list and can be customized for your environment.
+        This check verifies that no unapproved AI tool is installed through Homebrew.
+
+        The check reads the Homebrew package list, matching known AI agent and local inference tool names and excluding anything named in this policy's approved-Homebrew property. It complements the system package check, which does not see Homebrew.
 
         **Why this matters**
 
-        - **Unmanaged installs:** Homebrew lets users install AI tools without administrator review or change control.
-        - **Latent risk:** A package that is installed but idle can be launched at any time, reintroducing data-egress exposure.
-        - **Inventory gaps:** Tools installed outside the approved set leave security teams without an accurate picture of endpoint software.
-        - **Third-party taps:** Homebrew casks can pull from community taps that are not part of the organization's supply chain.
+        Homebrew is where desktop AI tooling actually arrives on macOS. It installs into a user-writable prefix and needs no administrative privilege, so a developer can add a tool without a request, a ticket, or any event that management tooling observes.
+
+        That is the reason this needs its own check rather than being folded into the package inventory. An endpoint can look clean to a system package audit while carrying a full set of AI agents under Homebrew, and on a developer fleet that is the likely arrangement rather than an edge case.
+
+        Homebrew installs are also the least likely to be captured by an organization's software inventory, so they persist unnoticed and outlive the project that prompted them.
+
+        Keep the approved-Homebrew property aligned with the system approved-package property, since a tool approved through one path and not the other produces a confusing split result on a machine that has both.
       audit: |-
         To verify that no unapproved AI tools are installed via Homebrew:
 
@@ -444,14 +459,17 @@ queries:
       cursor.rules.none()
     docs:
       desc: |
-        Cursor is an AI-native code editor that sends code to cloud AI models for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
+        This check verifies that the Cursor editor is not configured on this endpoint.
+
+        Cursor is an AI-native editor built on the VS Code codebase. The check reads its configuration for three separate signals: stored skills, registered MCP servers, and rule files. Any one of them present means Cursor was configured here, not merely installed.
 
         **Why this matters**
 
-        - **Source code exposure:** Editing files in Cursor routinely uploads code context to a cloud model provider.
-        - **Credential leakage:** Repository files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through Cursor skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned editor leaves security teams without an accurate picture of how code leaves the endpoint.
+        The three signals mean different things and that is why all are read. A skill is a saved instruction set. A rule file is persistent context injected into every request, which frequently encodes internal architecture and conventions. A registered MCP server is tool access, meaning the editor can reach whatever that server exposes.
+
+        The exposure is not the editing, it is what leaves with it. These agents send file contents, surrounding code, and frequently the whole repository index to a model provider to answer a completion. That traffic looks like ordinary HTTPS to a vendor API, so it does not appear as data loss to a network monitor, and the provider's retention and training terms govern what happens to it afterward. Cursor's codebase indexing makes the volume larger than a completion tool's: it embeds the repository so that retrieval can pull relevant files into context, so the material that reaches the provider is not limited to the file on screen.
+
+        Removing the binary is not sufficient on its own. The configuration this check reads persists after an uninstall, so clear it as part of removal, and expect the check to keep failing until you do.
       audit: |-
         To verify that Cursor is not configured on the endpoint:
 
@@ -542,14 +560,17 @@ queries:
       windsurf.rules.none()
     docs:
       desc: |
-        Windsurf is an AI-native code editor from Codeium that sends code to cloud AI models for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
+        This check verifies that the Windsurf editor is not configured on this endpoint.
+
+        Windsurf is an AI-native editor from the Codeium team, built on the VS Code codebase. The check reads its configuration for stored skills, registered MCP servers, and rule files. Any one present means Windsurf was configured here.
 
         **Why this matters**
 
-        - **Source code exposure:** Editing files in Windsurf routinely uploads code context to a cloud model provider.
-        - **Credential leakage:** Repository files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through Windsurf skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned editor leaves security teams without an accurate picture of how code leaves the endpoint.
+        Reading three signals rather than one matters because they persist independently. An organization that removed the application may still have rule files and MCP registrations on disk, and those describe the internal systems the editor was pointed at even after the editor is gone.
+
+        The exposure is not the editing, it is what leaves with it. These agents send file contents, surrounding code, and frequently the whole repository index to a model provider to answer a completion. That traffic looks like ordinary HTTPS to a vendor API, so it does not appear as data loss to a network monitor, and the provider's retention and training terms govern what happens to it afterward.
+
+        Removing the binary is not sufficient on its own. The configuration this check reads persists after an uninstall, so clear it as part of removal, and expect the check to keep failing until you do.
       audit: |-
         To verify that Windsurf is not configured on the endpoint:
 
@@ -639,14 +660,17 @@ queries:
       goose.extensions.none()
     docs:
       desc: |
-        Goose is an open-source AI agent from Block that connects to multiple model providers and executes code with full system access through extensions. When it is configured on an endpoint, it can act autonomously on local files and systems. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Goose agent is not configured on this endpoint.
+
+        Goose is an open-source agent from Block that connects to a range of model providers and gains capability through extensions. The check reads its configuration for stored skills and installed extensions.
 
         **Why this matters**
 
-        - **Autonomous execution:** Goose extensions can run commands and modify files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to whichever model provider it is connected to.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Extensions are the significant half. Goose's model is that capability comes from what you attach to it, so an extension list is a description of what the agent can reach on this machine and beyond it.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own. Goose is designed to run autonomously rather than to suggest, so the gap between a prompt and an executed command is smaller than with a completion tool.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Goose is not configured on the endpoint:
 
@@ -723,14 +747,17 @@ queries:
       zed.extensions.none()
     docs:
       desc: |
-        Zed is a code editor with built-in AI assistant features that send code to cloud model providers for completion and chat. When it is configured on an endpoint, proprietary source code can be transmitted to third-party services as part of normal editing. Endpoints should carry only the editors approved by the security team.
+        This check verifies that the Zed editor is not configured on this endpoint.
+
+        Zed is a code editor with built-in AI assistant features. The check reads its installed extension list.
 
         **Why this matters**
 
-        - **Source code exposure:** Zed's AI features upload code context to a cloud model provider during editing.
-        - **Credential leakage:** Repository files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through Zed skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned editor leaves security teams without an accurate picture of how code leaves the endpoint.
+        This check reads extensions only, which is a narrower signal than the editors assessed elsewhere in this policy. It establishes that Zed was set up and extended on this endpoint; it does not by itself establish that the AI features were used.
+
+        The exposure is not the editing, it is what leaves with it. These agents send file contents, surrounding code, and frequently the whole repository index to a model provider to answer a completion. That traffic looks like ordinary HTTPS to a vendor API, so it does not appear as data loss to a network monitor, and the provider's retention and training terms govern what happens to it afterward.
+
+        Because the signal is narrower, treat a failure as a prompt to ask what the editor is configured to do rather than as evidence that code has left. Zed's assistant features are opt-in and provider-configurable, so the answer varies by installation.
       audit: |-
         To verify that Zed is not configured on the endpoint:
 
@@ -810,14 +837,17 @@ queries:
       cline.skills.none()
     docs:
       desc: |
-        Cline is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Cline agent is not configured on this endpoint.
+
+        Cline is an autonomous coding agent that runs inside a VS Code-compatible editor and can execute terminal commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Cline can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Cline is one of the agents in this policy that acts rather than suggests. It plans a change, edits files, runs commands, reads the output, and iterates, with the developer approving steps rather than writing them.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Cline is not configured on the endpoint:
 
@@ -900,14 +930,17 @@ queries:
       roo.skills.none()
     docs:
       desc: |
-        Roo Code is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Roo Code agent is not configured on this endpoint.
+
+        Roo Code is an autonomous coding agent forked from Cline, running inside a VS Code-compatible editor with the ability to execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Roo Code can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Its shared origin with Cline matters for inventory: an organization that reviewed and approved one may have the other present without noticing, because they behave similarly and are configured separately. A companion check in this policy reads its VS Code extension identifier, which is the other place it appears.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Roo Code is not configured on the endpoint:
 
@@ -987,14 +1020,17 @@ queries:
       continuedev.skills.none()
     docs:
       desc: |
-        Continue is an open-source AI coding assistant that connects to a range of cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Continue assistant is not configured on this endpoint.
+
+        Continue is an open-source coding assistant that can be pointed at a wide range of model providers, including self-hosted ones. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Continue can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to whichever model provider it is connected to.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Its provider flexibility is the reason it needs assessing rather than assuming. The same tool can be configured against a vendor API, an internal inference endpoint, or a developer's own machine, and those have entirely different data paths. The tool's presence does not tell you which one is in use.
+
+        The exposure therefore depends on configuration in a way it does not for a single-provider tool. Continue pointed at an approved internal endpoint may be entirely acceptable; the same binary pointed at a public API is an unreviewed data path. Neither is distinguishable from the presence of the tool alone.
+
+        A failure here is a prompt to read the configuration rather than to remove the tool. Establish which provider it targets, then either approve that configuration explicitly or change it.
       audit: |-
         To verify that Continue is not configured on the endpoint:
 
@@ -1074,14 +1110,17 @@ queries:
       trae.skills.none()
     docs:
       desc: |
-        Trae is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Trae agent is not configured on this endpoint.
+
+        Trae is an AI coding agent that connects to cloud model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Trae can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        This check establishes only that the agent holds stored skills on this endpoint. It does not read which model provider is configured, so the destination of any data it sends is not determined here.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Trae is not configured on the endpoint:
 
@@ -1155,14 +1194,17 @@ queries:
       opencode.skills.none()
     docs:
       desc: |
-        OpenCode is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the OpenCode agent is not configured on this endpoint.
+
+        OpenCode is a terminal-based AI coding agent. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** OpenCode can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        A terminal agent is worth separating from an editor-based one. It runs where the developer's shell environment already is, so the credentials, cloud profiles, and SSH configuration available to that shell are available to it without any further grant.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that OpenCode is not configured on the endpoint:
 
@@ -1236,14 +1278,17 @@ queries:
       kiro.skills.none()
     docs:
       desc: |
-        Kiro is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Kiro agent is not configured on this endpoint.
+
+        Kiro is an AI coding agent that connects to cloud model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Kiro can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        The stored skills this check reads are themselves worth inspecting when it fails. A skill is an instruction set someone wrote and saved, so it frequently records what the agent was being used for and against which systems.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Kiro is not configured on the endpoint:
 
@@ -1317,14 +1362,17 @@ queries:
       pi.skills.none()
     docs:
       desc: |
-        Pi is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Pi agent is not configured on this endpoint.
+
+        Pi is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Pi can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        This check reads configuration rather than activity, so it answers whether the agent was set up here and not how much it was used. Both matter, but only the first is available from the endpoint's state.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Pi is not configured on the endpoint:
 
@@ -1396,14 +1444,17 @@ queries:
       mistral.vibe.skills.none()
     docs:
       desc: |
-        Mistral Vibe is an AI coding agent from Mistral that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Mistral Vibe agent is not configured on this endpoint.
+
+        Mistral Vibe is an AI coding agent from Mistral that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Mistral Vibe can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Provider identity matters for the questions a review has to answer: where the data is processed, under which jurisdiction, and on what retention and training terms. Those differ between vendors and are the substance of an approval decision.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Mistral Vibe is not configured on the endpoint:
 
@@ -1475,14 +1526,17 @@ queries:
       antigravity.skills.none()
     docs:
       desc: |
-        Antigravity is an AI coding agent from Google that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Antigravity agent is not configured on this endpoint.
+
+        Antigravity is an AI coding agent from Google that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Antigravity can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        An organization that has approved a vendor's cloud services has not thereby approved that vendor's coding agent. The data path is different, the terms are usually different, and the material involved is source code rather than the workloads covered by an existing agreement.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Antigravity is not configured on the endpoint:
 
@@ -1556,14 +1610,17 @@ queries:
       ibm.bob.skills.none()
     docs:
       desc: |
-        IBM Bob is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the IBM Bob agent is not configured on this endpoint.
+
+        IBM Bob is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** IBM Bob can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Enterprise-vendor agents are the ones most likely to be adopted informally on the strength of an existing relationship, without the separate review the data path warrants.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that IBM Bob is not configured on the endpoint:
 
@@ -1635,14 +1692,17 @@ queries:
       openclaw.skills.none()
     docs:
       desc: |
-        OpenClaw is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the OpenClaw agent is not configured on this endpoint.
+
+        OpenClaw is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** OpenClaw can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Open-source agents are typically installed directly from a repository rather than through a package manager, which is why this policy reads agent configuration as well as package inventories. A tool installed that way is invisible to a software audit.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that OpenClaw is not configured on the endpoint:
 
@@ -1714,14 +1774,17 @@ queries:
       snowflake.cortex.skills.none()
     docs:
       desc: |
-        Snowflake Cortex Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Snowflake Cortex Code agent is not configured on this endpoint.
+
+        Snowflake Cortex Code is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Snowflake Cortex Code can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        An agent from a data platform vendor deserves particular attention on a machine that also holds credentials for that platform, since the agent's local privileges include whatever the developer's session can reach.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Snowflake Cortex Code is not configured on the endpoint:
 
@@ -1793,14 +1856,17 @@ queries:
       junie.skills.none()
     docs:
       desc: |
-        Junie is an AI coding agent from JetBrains that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Junie agent is not configured on this endpoint.
+
+        Junie is an AI coding agent from JetBrains that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Junie can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Agents distributed alongside a widely used IDE arrive with the IDE's own update mechanism, so they can appear on an endpoint without a separate installation event for anyone to review.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Junie is not configured on the endpoint:
 
@@ -1872,14 +1938,17 @@ queries:
       augment.skills.none()
     docs:
       desc: |
-        Augment is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Augment agent is not configured on this endpoint.
+
+        Augment is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Augment can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Agents that index a whole repository to answer questions transfer far more than the file being edited, so the volume reaching a provider is a property of the tool's design rather than of how carefully it is used.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Augment is not configured on the endpoint:
 
@@ -1951,14 +2020,17 @@ queries:
       warp.skills.none()
     docs:
       desc: |
-        Warp is an AI-powered terminal that sends command history and context to cloud model providers for its AI features. When it is configured on an endpoint, command output and code context can be transmitted to third-party services. Endpoints should carry only the terminals approved by the security team.
+        This check verifies that the Warp terminal is not configured on this endpoint.
+
+        Warp is a terminal emulator with built-in AI features that send command context to a model provider. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Command exposure:** Warp's AI features send command history and output to a cloud model provider.
-        - **Credential leakage:** Commands and output may contain tokens and secrets that reach a third-party API.
-        - **Autonomous suggestions:** AI-generated commands can be executed in the terminal without separate review.
-        - **Inventory gaps:** An unsanctioned terminal leaves security teams without an accurate picture of how data leaves the endpoint.
+        A terminal is a different exposure from an editor. What passes through it is not source code but commands and their output: connection strings, tokens pasted into a shell, the contents of files echoed during troubleshooting, and the names of internal hosts and services.
+
+        Command history is also unusually revealing about infrastructure. A sequence of shell commands describes the systems an engineer administers, how they authenticate, and what they were doing at the time, which is a precise operational picture rather than a code sample.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Warp is not configured on the endpoint:
 
@@ -2038,14 +2110,17 @@ queries:
       kilocode.skills.none()
     docs:
       desc: |
-        Kilo Code is an AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Kilo Code agent is not configured on this endpoint.
+
+        Kilo Code is an AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Kilo Code can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Several agents in this policy share a common ancestor and were forked from one another, so an organization that assessed one may have a close relative installed elsewhere in the fleet under a different name.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Kilo Code is not configured on the endpoint:
 
@@ -2125,14 +2200,17 @@ queries:
       openhands.skills.none()
     docs:
       desc: |
-        OpenHands is an autonomous AI coding agent that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the OpenHands agent is not configured on this endpoint.
+
+        OpenHands is an autonomous AI coding agent that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** OpenHands can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        OpenHands is built for autonomy rather than assistance: it is designed to take a task description and work through it, which means longer unattended runs and more commands executed per instruction.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own. The longer the agent runs unattended, the more of that execution nobody watched.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that OpenHands is not configured on the endpoint:
 
@@ -2204,14 +2282,17 @@ queries:
       qwen.code.skills.none()
     docs:
       desc: |
-        Qwen Code is an AI coding agent from Alibaba that connects to cloud model providers and can execute commands and modify files on the endpoint. When it is configured, proprietary source code and credentials can be transmitted to third-party services. Endpoints should carry only the AI agents approved by the security team.
+        This check verifies that the Qwen Code agent is not configured on this endpoint.
+
+        Qwen Code is an AI coding agent from Alibaba that connects to model providers and can execute commands and modify files. The check reads the agent's own configuration for stored skills. A skill is a saved instruction set the agent loads and acts on, so its presence means the agent was set up on this machine rather than merely downloaded.
 
         **Why this matters**
 
-        - **Autonomous execution:** Qwen Code can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent sends file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned agent leaves security teams without an accurate picture of how code and data leave the endpoint.
+        Where the model provider processes data is a question an approval has to answer explicitly, because it determines which jurisdiction's law applies to source code and any customer data caught in context.
+
+        The exposure is execution, not just disclosure. An agent that can run commands and edit files acts with the developer's full local privileges: their SSH keys, their cloud credentials, their access to internal services. A prompt that reaches it, whether from a user, a fetched web page, or a file in the repository, becomes an instruction it may act on, and the resulting commands are indistinguishable from the developer's own.
+
+        Where this tool is on the approved list, exempt it deliberately rather than suppressing the check, so the exemption is recorded and reviewed when the approval changes.
       audit: |-
         To verify that Qwen Code is not configured on the endpoint:
 
@@ -2292,14 +2373,17 @@ queries:
       ).none()
     docs:
       desc: |
-        Codeium AI coding extensions installed in VS Code-compatible editors transmit source code to cloud AI models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Codeium extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `codeium.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Codeium extension is installed:
 
@@ -2378,14 +2462,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Tabnine AI coding extensions installed in VS Code-compatible editors can transmit source code to cloud AI models for completion depending on configuration. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Tabnine extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `tabnine.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension can upload code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Tabnine is configurable between local and cloud models, so its data path depends on how it was set up. The presence of the extension does not establish which mode is active, which is why a failure here is a question to answer rather than a conclusion.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Tabnine extension is installed:
 
@@ -2464,14 +2553,17 @@ queries:
       ).none()
     docs:
       desc: |
-        Supermaven AI coding extensions installed in VS Code-compatible editors transmit source code to cloud AI models for completion. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Supermaven extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `supermaven.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Supermaven extension is installed:
 
@@ -2550,14 +2642,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Continue is an open-source AI coding assistant that connects to a range of LLM providers. When its extension is installed in a VS Code-compatible editor, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Continue extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches the `continue.continue` extension identifier. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to whichever model provider it is connected to.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Continue can be pointed at many providers including self-hosted ones, so the destination is a configuration question rather than a property of the extension. Read the configuration before deciding whether this finding matters.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Continue extension is installed:
 
@@ -2636,14 +2733,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Cline, formerly Claude Dev, is an autonomous AI agent that runs as a VS Code extension and can execute code and modify files. When its extension is installed in a VS Code-compatible editor, it can act on local files and send code context to a cloud model provider. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Cline extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches the `saoudrizwan.claude-dev` identifier, which is Cline's original publisher name, and identifiers beginning with `cline.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Autonomous execution:** The extension can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent uploads file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        Cline is an autonomous agent rather than a completion tool. Installed as an extension, it can execute terminal commands and modify files, acting with the developer's full local privileges.
+
+        That is a materially different exposure from an extension that suggests code. The agent's actions are indistinguishable from the developer's own, and a prompt reaching it from a fetched page or a file in the repository becomes an instruction it may act on.
+
+        The two identifiers matter because the extension was renamed. An inventory built only on the current name misses installations that predate the change.
+
+        Where Cline is approved, exempt it deliberately. Note that this policy also reads Cline's own configuration separately, so an approved installation may produce two findings that need exempting together.
       audit: |-
         To verify that no Cline extension is installed:
 
@@ -2722,14 +2824,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Sourcegraph Cody is an AI coding extension that transmits source code to cloud AI models for completion and chat. When its extension is installed in a VS Code-compatible editor, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Sourcegraph Cody extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches the `sourcegraph.cody` extension identifier. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Cody's value comes from repository-wide context, so it is designed to send more than the open file. That is the feature working as intended and it is also what makes the volume reaching the provider larger than a line-completion tool's.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Sourcegraph Cody extension is installed:
 
@@ -2808,14 +2915,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Extensions from the OpenAI publisher installed in VS Code-compatible editors, such as the Codex extension `openai.chatgpt`, transmit source code to OpenAI's cloud models for completion and chat. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no extension published by OpenAI is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `openai.`, which covers the Codex and ChatGPT extensions. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Matching on the publisher rather than a single extension name is deliberate: it catches the publisher's current and future extensions without needing the list maintained. The cost is that a failure names the publisher rather than the specific tool, so check which extension is actually installed.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no OpenAI extension is installed:
 
@@ -2894,14 +3006,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Anthropic Claude extensions installed in VS Code-compatible editors transmit source code to Anthropic's cloud models for completion and chat. Even where Claude tooling is approved elsewhere, an editor extension that has not been reviewed represents an uninventoried path for code to leave the endpoint. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Anthropic Claude extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `anthropic.claude`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        Approval of a vendor's tooling elsewhere does not extend to an editor extension. The extension is a separate data path with its own access to the workspace, so an organization that approved a vendor's API or its command-line tooling has not thereby assessed what the extension reads.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Anthropic Claude extension is installed:
 
@@ -2980,14 +3097,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Cursor-specific AI extensions installed in VS Code-compatible editors bring Cursor's AI completion and chat features into editors where they have not been reviewed. When such an extension is present, proprietary code can leave the endpoint as part of normal editing. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Cursor-specific extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches extension identifiers beginning with `cursor.` or `anysphere.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Source code exposure:** The extension uploads code context to a cloud model provider during editing.
-        - **Credential leakage:** Files opened in the editor may contain tokens and secrets that are sent alongside code context.
-        - **Bypassed review:** AI-generated edits applied through the extension skip the controls that govern approved tooling.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        An editor extension sees what the editor sees. It has access to the open file, the workspace, and in most cases the ability to read any file the editor can, and it sends the parts it needs to a model provider to answer a completion.
+
+        That access is granted at install time and is not scoped per project. An extension installed to help with one repository is equally present when the developer opens a different one, including repositories with stricter handling requirements than the one that prompted the install.
+
+        These extensions bring Cursor's completion and chat features into editors other than Cursor itself, which is the case this check exists for. An organization that decided against Cursor as an editor can still have its AI features present through an extension in the editor it does use.
+
+        Where the extension is approved, exempt it deliberately so the approval is recorded. Extensions update themselves, so an approval is a statement about a publisher rather than about a fixed version.
       audit: |-
         To verify that no Cursor-specific extension is installed:
 
@@ -3069,14 +3191,19 @@ queries:
       ).none()
     docs:
       desc: |
-        Roo Code is an autonomous AI agent forked from Cline that runs as a VS Code extension and can execute code and modify files. When its extension is installed in a VS Code-compatible editor, it can act on local files and send code context to a cloud model provider. Only AI extensions reviewed and approved by the security team should be installed.
+        This check verifies that no Roo Code extension is installed in a VS Code-compatible editor.
+
+        The check reads the installed extension list and matches the `rooveterinaryinc.roo-cline` identifier and identifiers beginning with `roocode.`. VS Code-compatible covers VS Code itself and the editors built on its extension model, so one installation of the extension is found wherever it lives.
 
         **Why this matters**
 
-        - **Autonomous execution:** The extension can run commands and edit files with the user's full privileges.
-        - **Source code exposure:** The agent uploads file and repository context to a cloud model provider.
-        - **Credential leakage:** Files and environment variables read by the agent may contain tokens that reach a third-party API.
-        - **Inventory gaps:** An unsanctioned extension leaves security teams without an accurate picture of how code leaves the endpoint.
+        Roo Code is an autonomous agent forked from Cline. Installed as an extension it can execute commands and modify files, acting with the developer's full local privileges rather than suggesting text.
+
+        The exposure is execution as well as disclosure. A prompt that reaches the agent, from a user, a fetched page, or a file in the repository, becomes an instruction it may act on, and the commands it runs are indistinguishable from the developer's own.
+
+        Both identifiers are matched because the extension was published under one name and later another, so an inventory built on the current name alone misses earlier installations.
+
+        Where Roo Code is approved, exempt it deliberately. This policy also reads its own configuration separately, so an approved installation produces two findings.
       audit: |-
         To verify that no Roo Code extension is installed:
 
@@ -3166,14 +3293,19 @@ queries:
       gemini.mcpServers.none(name != props.mondooAiSecurityApprovedMcpServers)
     docs:
       desc: |
-        Model Context Protocol servers grant AI agents tool access to internal systems such as email, source control, databases, and messaging platforms. Only MCP servers reviewed and approved by the security team should be configured across Claude Code, OpenAI Codex, Cursor, GitHub Copilot, Windsurf, and Gemini CLI. The `mondooAiSecurityApprovedMcpServers` property defines a single centralized allow-list and can be customized for your environment, for example `return /(?i)(mondoo|github|jira)/`.
+        This check verifies that no unapproved Model Context Protocol server is registered with any AI agent on the endpoint.
+
+        MCP servers give an agent tool access to systems: source control, ticketing, messaging, databases, cloud APIs. The check reads the registered server list across every agent this policy knows about, including Claude Code, OpenAI Codex, Cursor, and the others, and fails any server not named in this policy's approved-MCP property.
 
         **Why this matters**
 
-        - **Broad data access:** An MCP server can read, modify, or exfiltrate data across connected internal systems on behalf of the user.
-        - **Implicit consent:** Once a server is configured, the agent can invoke its tools without the user approving each individual action.
-        - **Highest-risk vector:** Unreviewed MCP servers combine remote system access with autonomous agent behavior, making them the most consequential AI shadow IT exposure.
-        - **Inventory gaps:** Servers configured outside the approved set leave security teams unaware of which systems an agent can reach.
+        An MCP server is a capability grant, not a data path. Where a completion tool sends code to a provider, a registered MCP server lets the agent read from and act on the system behind it, with whatever credentials that server holds.
+
+        That inverts the usual containment argument. An agent confined to a repository is a bounded problem; an agent with a registered MCP server for the ticket tracker, the internal wiki, and a cloud account is operating across the systems those servers reach, and the blast radius of a prompt injection grows accordingly.
+
+        The credentials are the part most often missed. An MCP server is configured once with a token and then used repeatedly, so the token's scope is the agent's scope, and tokens configured for convenience during setup are rarely narrowed afterward.
+
+        Reading across every agent at once is what makes this useful. Registrations are per-agent and per-user, so an organization checking only its standard agent misses servers registered with whatever else a developer installed. Maintain the approved-MCP property as the reviewed set, and treat a failure as a question about which credentials that server holds.
       audit: |-
         To verify that only approved MCP servers are configured:
 
@@ -3280,14 +3412,21 @@ queries:
       ).none()
     docs:
       desc: |
-        Local LLM inference runtimes such as Ollama, LM Studio, llama.cpp, LocalAI, GPT4All, and Jan run model inference directly on the endpoint. While they keep prompts off remote APIs, they still allow data to be processed outside approved channels and can carry licensing exposure from the model weights they load. Endpoints should run only the LLM runtimes approved by the security team.
+        This check verifies that no local LLM inference runtime is running on the endpoint.
+
+        The check reads the process table for the well-known local inference tools, including Ollama, LM Studio, llama.cpp, LocalAI, and GPT4All. It reports on running processes rather than installed software, so it reflects active use.
 
         **Why this matters**
 
-        - **Uncontrolled processing:** A local runtime lets users feed sensitive data into models outside sanctioned tooling and review.
-        - **Licensing exposure:** Downloaded model weights may carry license restrictions that create legal risk for the organization.
-        - **Resource and supply-chain risk:** Runtimes pull models from public registries that are not part of the organization's vetted supply chain.
-        - **Inventory gaps:** An unsanctioned runtime leaves security teams without an accurate picture of how data is processed on the endpoint.
+        Local inference is often adopted specifically to avoid sending data to a provider, and that reasoning is sound as far as it goes. Prompts genuinely do not leave the machine. The exposure is different rather than absent.
+
+        The model weights are the first concern. They are downloaded from public model hubs, they are large binaries whose contents cannot be meaningfully reviewed, and they run with the privileges of whatever loads them. Supply chain assurance for model artifacts is considerably weaker than for software packages, and the formats have had deserialization vulnerabilities.
+
+        The second is that local inference removes the audit trail rather than the risk. Data processed through an approved provider is at least governed by a contract and, usually, by logging. Data processed by a model a developer downloaded is governed by nothing and recorded nowhere, so an organization cannot say afterward what was processed or by which model.
+
+        The third is resource contention: inference is demanding enough to affect the endpoint's other work.
+
+        Where local inference is the deliberate choice for sensitive material, approve specific runtimes and specific model sources, and pair this with the companion check that no inference server is listening beyond the loopback interface.
       audit: |-
         To verify that no local LLM runtime is running:
 
@@ -3396,13 +3535,19 @@ queries:
       )
     docs:
       desc: |
-        Local LLM inference servers expose an HTTP API on well-known ports: 11434 for Ollama, 1234 for LM Studio, and 1337 for Jan. Listening on `127.0.0.1` or `::1` is acceptable because it limits the server to the local machine. The check fails when one of these ports is bound to `0.0.0.0`, a LAN address, or any other non-loopback interface, because that exposes the model to other hosts on the network.
+        This check verifies that no local LLM inference server is reachable from outside the endpoint.
+
+        Local inference tools expose an HTTP API on well-known ports: 11434 for Ollama, 1234 for LM Studio, and 1337 for Jan. The check reads the listening port table and fails when one of those ports is bound to any address other than `127.0.0.1` or `::1`. Binding to loopback is acceptable and passes.
 
         **Why this matters**
 
-        - **Network exposure:** If the server binds to a non-loopback interface, other hosts on the network can submit prompts to it.
-        - **Uncontrolled processing:** Data sent to a local inference API bypasses the review and logging applied to sanctioned tooling.
-        - **Inventory gaps:** An unsanctioned inference server leaves security teams without an accurate picture of how data is processed on the endpoint.
+        These APIs have no authentication. That is a deliberate design choice for a service intended to be reached only by applications on the same machine, and it becomes a serious exposure the moment the bind address changes.
+
+        An inference server listening on a routable address is an open endpoint that anyone who can reach it may use: to run inference at the machine owner's expense, to load or delete models, and depending on the tool, to reach other capabilities the API exposes. Internet-wide scanning for these specific ports is established and ongoing, and exposed instances are found and used.
+
+        The change is usually made for a reason that sounds harmless. A developer wants to reach the model from a container, from a second machine, or from a phone, sets the bind address to all interfaces, and the endpoint is then exposed on every network the laptop subsequently joins.
+
+        Where remote access is genuinely needed, put the server behind a reverse proxy that authenticates, or reach it over a VPN or an SSH tunnel, rather than binding it to all interfaces. The loopback default is the safe configuration and the check is deliberately tolerant of it.
       audit: |-
         To verify that no local LLM inference server is exposed beyond localhost:
 

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-edr-policy
     name: Mondoo Endpoint Detection and Response (EDR)
-    version: 1.6.2
+    version: 1.6.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -66,19 +66,20 @@ queries:
         tags:
           mondoo.com/filter-title: Windows
     docs:
-      desc: |-
-        A supported Endpoint Detection and Response (EDR) agent must be present on every Windows, Linux, and macOS endpoint. An endpoint with no EDR agent installed has no behavioral threat detection, no telemetry feeding the security operations team, and no path for automated containment.
+      desc: |
+        This check verifies that a supported endpoint detection and response agent is installed.
+
+        The check looks for the presence of a recognized EDR product across Windows, Linux, and macOS. It assesses installation only; a companion check in this policy confirms the agent is actually running.
 
         **Why this matters**
 
-        - **Threat detection:** An installed EDR agent provides the real-time behavioral monitoring needed to identify malware, ransomware, and hands-on-keyboard activity.
-        - **Incident response:** EDR telemetry gives responders the process, file, and network history required to scope and contain an intrusion.
-        - **Coverage parity:** A single endpoint without an agent becomes a blind spot that adversaries can use for initial access and persistence.
+        EDR is the control that assumes prevention failed. Antivirus asks whether a file matches something known bad; EDR records what processes did and gives an analyst the ability to ask questions afterward, which is how an intrusion using legitimate tools is found at all.
 
-        **Risk mitigation**
+        An endpoint without it is not merely less protected, it is invisible. There is no process lineage showing that a document spawned a shell, no record of the credential access that followed, and no telemetry reaching the team whose job is to notice. When that endpoint turns out to be the entry point, the investigation begins with nothing and has to be reconstructed from other machines' logs.
 
-        - **Visibility gaps:** Installing an agent on every endpoint removes the silent paths attackers rely on to operate undetected.
-        - **Compliance:** Demonstrable EDR deployment across the fleet satisfies malware-protection requirements in frameworks such as ISO 27001, NIST SP 800-53, and PCI DSS.
+        Coverage gaps are also where attackers end up by selection rather than by chance. An estate at ninety-five percent coverage has a five percent population that is disproportionately likely to host a compromise, because those are the machines built outside the standard process: lab systems, contractor laptops, servers stood up quickly, and the long-lived exception nobody revisited.
+
+        A failure here is a deployment question rather than a configuration one. Establish why the endpoint was missed, since the answer usually applies to more than one machine.
       audit: |-
         Confirm that a supported EDR agent is installed using the vendor's own management tooling.
 
@@ -278,19 +279,22 @@ queries:
         tags:
           mondoo.com/filter-title: Windows
     docs:
-      desc: |-
-        An installed EDR agent only protects an endpoint when its services are actively running and enabled to start at boot. A stopped or disabled agent leaves the endpoint unmonitored even though the software is present.
+      desc: |
+        This check verifies that the installed endpoint detection and response agent is running and enabled to start at boot.
+
+        The check assesses the agent's service state rather than its presence, so it fails on an endpoint where the software is installed but the service is stopped or disabled. A companion check in this policy confirms the agent is installed at all.
 
         **Why this matters**
 
-        - **Real-time protection:** A running agent continuously inspects process, file, and network activity so threats are detected and contained as they happen.
-        - **Endpoint visibility:** Active agent services stream telemetry to the security operations team, enabling swift incident response and forensic analysis.
-        - **Compliance:** An operational agent demonstrates the continuous malware protection required by frameworks such as ISO 27001, NIST SP 800-53, and PCI DSS.
+        An installed agent that is not running provides nothing while appearing to satisfy every inventory that counts installations. That gap is the reason this is a separate check: software asset management reports the endpoint as covered, and the endpoint is not.
 
-        **Risk mitigation**
+        Disabling the agent is also a deliberate step attackers take. It is well documented across ransomware operations, which is why the state of the service is worth monitoring rather than assuming, and why a stopped agent should be treated as a possible indicator rather than only as a fault.
 
-        - **Delayed detection:** Keeping agent services running closes the window in which malicious activity could proceed unobserved.
-        - **Persistence at boot:** Enabling the services ensures protection resumes automatically after a reboot, so an attacker cannot disable coverage by restarting the host.
+        The everyday causes are more common and matter just as much. Agents are stopped to troubleshoot a performance problem and not restarted, disabled during a software installation that asked for it, or broken by an update that failed partway. None of those produce an alert on the endpoint itself.
+
+        The distinction between running and enabled matters too. An agent running but not enabled stops protecting at the next reboot, which is precisely when a machine is most likely to be in a changed state.
+
+        Where this fails, establish whether the service was stopped deliberately, and by whom, before restarting it.
       audit: |-
         Confirm that the EDR agent services are running and enabled using the vendor's own tooling.
 

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-mcp-security
     name: Mondoo Model Context Protocol (MCP) Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -71,18 +71,21 @@ queries:
       )
     docs:
       desc: |
-        Tool and prompt metadata advertised by an MCP server is copied verbatim into the model's context window and into client and server logs. Person names, physical locations, and payment card numbers embedded in `name`, `title`, or `description` fields therefore leak into systems that were never scoped to hold personal data.
+        This check verifies that MCP tool and prompt metadata contains no personally identifiable information.
+
+        The check reads the `name` and `description` fields of every tool the server advertises and screens them for person names, physical locations, and payment card numbers.
 
         **Why this matters**
 
-        - **Privacy exposure:** Metadata strings reach the model context and audit logs, placing personal data in stores with weaker access controls than a customer database.
-        - **Regulatory scope creep:** Credit card numbers and identifiable personal data pull MCP servers and their logs into PCI DSS and data-protection audit scope.
-        - **Uncontrolled disclosure:** Tool definitions are returned to any connected client, so personal data in metadata is disclosed to every consumer of the server.
+        Tool metadata is not documentation that sits on a shelf. It is copied verbatim into the model's context window on every invocation that uses the server, and into client and server logs along the way.
 
-        **Risk mitigation**
+        That gives personal data in these fields an unusually wide distribution for its size. It reaches the model provider as part of the prompt, it lands in the logs of every client that connects, and it is retained according to whatever those systems do rather than according to any decision about the data itself.
 
-        - **Synthetic placeholders:** Replacing real values with synthetic identifiers keeps metadata useful for the model while removing the personal data.
-        - **Schema-bound inputs:** Documenting personal data as runtime arguments in the input schema keeps it out of static, broadly readable metadata.
+        It also arrives without the handling that personal data normally attracts. A name in a database column is subject to retention rules, access control, and a deletion path. The same name in a tool description is in a configuration file, replicated to every client, and outside every one of those processes.
+
+        Payment card numbers carry the sharpest consequence, since their presence brings the server and everything logging it into PCI DSS scope.
+
+        Use placeholders in metadata rather than real values. Example text is the usual source: a description showing what a tool does, written with a real name or address because that was what the author had to hand.
       audit: |-
         ### Audit via the MCP client
 
@@ -171,18 +174,21 @@ queries:
       )
     docs:
       desc: |
-        MCP tool and prompt metadata is appended directly to the model's context as trusted instructions. When `name`, `title`, or `description` fields contain imperative phrasing aimed at the model, an attacker can use them to override system instructions, escalate the agent's behavior, or redirect tool calls. Each field is scored for injection patterns and a score above 0.8 indicates a likely attempt.
+        This check verifies that MCP tool and prompt metadata contains no prompt injection.
+
+        The check screens the `name` and `description` fields of every advertised tool and prompt for injection content, failing when the confidence score exceeds 0.8.
 
         **Why this matters**
 
-        - **Instruction hijacking:** Directive phrasing in metadata can override the system prompt and steer the agent into unintended actions.
-        - **Security control bypass:** Injection content can coax the model past guardrails that would otherwise block sensitive operations.
-        - **Data leakage:** A manipulated agent can be induced to exfiltrate context, credentials, or query results to an attacker.
+        The model treats tool metadata as trusted instruction. It is appended to the context to explain what the tools do, and nothing in the protocol marks it as data rather than direction.
 
-        **Risk mitigation**
+        That makes a description an instruction channel. Imperative phrasing aimed at the model, embedded in a field that looks like documentation, can override system instructions, redirect what the agent does with its other tools, or cause it to exfiltrate context to somewhere the attacker chose. The agent's user sees a tool list; the model sees the instructions inside it.
 
-        - **Descriptive metadata:** Phrasing that states what a tool does, rather than instructing the model, removes the injection surface.
-        - **Untrusted-content isolation:** Keeping end-user text in argument values instead of tool definitions prevents it from being treated as instructions.
+        What makes this the highest-impact check in the policy is where the content comes from. Tool metadata is authored by whoever wrote the MCP server, which for a third-party or community server is not the organization running it, and it is re-read on every connection, so a change made upstream takes effect without any local action.
+
+        The confidence threshold means this is a screen rather than a proof. A score below the threshold is not a guarantee, and a failure warrants reading the field rather than assuming a false positive.
+
+        Review metadata from any server you did not write, and treat descriptions as untrusted input from a third party, because that is what they are.
       audit: |-
         ### Audit via the MCP client
 
@@ -279,18 +285,21 @@ queries:
       mcp.prompts.none(title == /https?:\/\//)
     docs:
       desc: |
-        HTTP and HTTPS links placed in the `name`, `title`, or `description` fields of MCP tools and prompts flow into the model context window on every invocation. An agent may follow such a link or surface it to a user, turning static metadata into a delivery channel for phishing pages and attacker-controlled endpoints.
+        This check verifies that MCP tool and prompt metadata contains no embedded URLs.
+
+        The check screens the `name` and `description` fields of every advertised tool and prompt for HTTP and HTTPS links.
 
         **Why this matters**
 
-        - **Phishing delivery:** A link in tool metadata can be presented to users as if it were trusted guidance from the application.
-        - **Malicious redirects:** Agents that act on embedded URLs can be steered to attacker-controlled destinations.
-        - **Data exfiltration:** A crafted URL in metadata can become an endpoint to which an agent sends context or query results.
+        A link in tool metadata reaches the model on every invocation that uses the server, and from there it reaches the user or the agent's own fetching behavior.
 
-        **Risk mitigation**
+        That turns static configuration into a delivery channel. An agent able to fetch may retrieve the link's contents and bring them into context, which makes the remote page an instruction source under someone else's control and updatable after the metadata was reviewed. A user shown the link in a tool listing may click it, in a context that carries the authority of the tooling rather than of an unknown sender.
 
-        - **Functional metadata:** Keeping tool and prompt descriptions focused on behavior removes the link as an attack vector.
-        - **Structured resources:** Exposing documentation as an MCP resource with a defined URI gives clients a controlled discovery path instead of free-text links.
+        The indirection is the problem. Metadata is reviewed once when the server is added, while the content behind a link changes at any time, so approving a description does not approve what it points at tomorrow.
+
+        The finding is deliberately broad and will flag legitimate documentation links. That is the intended trade for a field whose contents are treated as trusted instruction.
+
+        Where a tool genuinely needs to direct users somewhere, do it in the tool's output at invocation time, where it can be evaluated in context, rather than in metadata that is loaded unconditionally.
       audit: |-
         ### Audit via the MCP client
 
@@ -374,18 +383,21 @@ queries:
       )
     docs:
       desc: |
-        Every MCP tool must declare a non-empty `name` and `description` and an `inputSchema` whose JSON Schema `type` is `object`. A tool that ships with a missing or empty schema accepts arbitrary arguments, so the server has no structural contract to validate calls against before invoking the underlying capability.
+        This check verifies that every MCP tool declares a name, a description, and a structured input schema.
+
+        The check requires each advertised tool to have a non-empty `name` and `description` and an `inputSchema` whose JSON Schema `type` is `object`.
 
         **Why this matters**
 
-        - **Input validation gap:** Without an `object` schema, the server cannot reject malformed or unexpected arguments before they reach tool logic.
-        - **Injection surface:** Unconstrained arguments flow straight into downstream systems, widening the path for injection and overflow attacks.
-        - **Ambiguous contracts:** A missing `name` or `description` leaves clients and the model guessing what the tool does and what it expects.
+        The input schema is the tool's contract. It states what arguments exist and what shape they take, and it is what allows the server to reject a call that does not match before any handler runs.
 
-        **Risk mitigation**
+        A tool with a missing or unstructured schema has no such contract. It accepts whatever arguments arrive, so validation moves into the handler if it happens at all, and the failure mode is a tool invoked with arguments its author never anticipated. On a tool that reaches a filesystem, a database, or a shell, that is the gap an injected instruction aims for.
 
-        - **Schema-enforced contracts:** A declared `object` schema gives the server a definition to validate every call against.
-        - **Bounded arguments:** Constraints such as `maxLength`, `enum`, and `additionalProperties: false` reject unexpected input before it is processed.
+        The schema also constrains the model rather than only the server. It is how the model learns which arguments are valid, so an absent schema produces both an unvalidated call path and a model guessing at the interface, which is a reliability problem before it is a security one.
+
+        The `name` and `description` requirements matter for a related reason: an unnamed or undescribed tool cannot be reasoned about by a reviewer or by the model, so it is approved and invoked on trust.
+
+        This check asserts structure rather than strictness. A schema of type `object` with no property constraints satisfies it, so treat this as a floor and constrain types, ranges, and required properties in the schema itself.
       audit: |-
         ### Audit via the MCP client
 
@@ -480,18 +492,21 @@ queries:
       )
     docs:
       desc: |
-        The `name`, `title`, and `description` fields of MCP tools and prompts are part of every model invocation that uses the server. Explicit, hateful, violent, or promotional language in those fields becomes a recurring exposure that influences model output and is visible to every connected client.
+        This check verifies that MCP tool and prompt metadata contains no explicit content.
+
+        The check screens the `name` and `description` fields of every advertised tool and prompt for explicit, hateful, violent, or promotional language.
 
         **Why this matters**
 
-        - **Recurring exposure:** Tool metadata is replayed into the model context on each invocation, so inappropriate content is not a one-time event.
-        - **Reputational and policy risk:** Offensive metadata can surface in agent responses and breach organizational content and acceptable-use policies.
-        - **Output contamination:** Adult, hateful, or violent phrasing in definitions can steer model output toward the same content.
+        These fields are part of every model invocation that uses the server, which makes their contents a recurring input rather than a one-time embarrassment.
 
-        **Risk mitigation**
+        Content in the context window influences output. Language of this kind, present on every call, shifts what the model produces in ways that are hard to attribute afterward, because the cause is in a configuration file rather than in the conversation anyone is reading.
 
-        - **Professional metadata:** Descriptions focused on technical behavior, allowed inputs, and outputs keep content within policy.
-        - **Review gates:** Routing definition changes through code review and pre-commit content scanning keeps regressions out of the codebase.
+        It is also reproduced widely. Tool listings are surfaced to users, logged by clients and servers, and included in support bundles, so the material appears in places nobody reviewed and travels further than the server itself.
+
+        For a third-party MCP server, this doubles as a signal about provenance. Metadata is authored upstream, and content of this sort in a tool description says something about the care taken with the rest of the implementation.
+
+        Promotional language deserves its own mention: a description that advertises rather than describes is manipulating tool selection, steering the model toward one tool over another for reasons unrelated to the task.
       audit: |-
         ### Audit via the MCP client
 
@@ -570,18 +585,21 @@ queries:
       )
     docs:
       desc: |
-        The `name` and `description` fields of MCP tools are evaluated against the Unicode general category of every character. Symbol, surrogate, private-use, and unassigned code points almost never appear in legitimate metadata and are the building blocks of homograph, bidirectional-text, and hidden-character attacks against the model and the user.
+        This check verifies that MCP tool metadata uses only ordinary characters.
+
+        The check reads the Unicode general category of every character in each tool's `name` and `description`, and fails on symbol, surrogate, private-use, and unassigned code points.
 
         **Why this matters**
 
-        - **Homograph deception:** Visually similar characters from outside the basic Latin set let an attacker disguise a tool as a trusted one.
-        - **Hidden instructions:** Format-class code points such as zero-width and bidirectional controls can smuggle invisible content into the model context, while symbol characters enable markup and instruction injection in rendered metadata.
-        - **Malformed and ambiguous text:** Surrogate, private-use, and unassigned code points have no standard meaning and can break rendering or parsing.
+        These categories almost never appear in legitimate metadata, and they are the building blocks of the attacks that make text mean something other than it appears to.
 
-        **Risk mitigation**
+        Homograph substitution is the first. Characters that render identically to Latin letters let a tool masquerade as another, so a reviewer reading a tool list sees a familiar name while the model matches a different string. Private-use code points render inconsistently or not at all, which lets content appear in the model's context while being invisible in the interface a human reviews.
 
-        - **Restricted character set:** Limiting metadata to printable ASCII and well-known Unicode letters removes the deceptive and hidden-character surface.
-        - **Normalization and screening:** Normalizing to Unicode Form C and rejecting the four risky categories enforces the constraint at registration time.
+        That difference between what a reviewer sees and what the model receives is the whole point of the check, and it is exactly the gap an injected instruction hides in.
+
+        Unassigned and surrogate code points also cause inconsistent handling across clients, so the same metadata behaves differently depending on what connected, which makes the resulting behavior hard to reproduce and diagnose.
+
+        Legitimate metadata rarely needs anything outside ordinary letters, digits, and punctuation. Where a genuine use exists, such as a non-Latin script in a description, expect this check to flag it and treat the exemption as deliberate.
       audit: |-
         ### Audit via the MCP client
 
@@ -681,18 +699,21 @@ queries:
       )
     docs:
       desc: |
-        MCP resources and resource templates must each declare a non-empty `name` and `description`, and those descriptions must contain neither explicit content nor personally identifiable information. Resource metadata is returned to every connected client and flows into the model context, so an empty or unsafe definition both starves the agent of context and leaks unsafe content.
+        This check verifies that MCP resources and resource templates are properly described and free of sensitive or explicit content.
+
+        The check requires every advertised resource to declare a non-empty `name` and `description`, and screens those descriptions for explicit content and for personally identifiable information covering person names, locations, and payment card numbers.
 
         **Why this matters**
 
-        - **Ambiguous resources:** A missing `name` or `description` leaves clients and the model unable to determine what a resource provides.
-        - **Privacy exposure:** Personal data in a resource description flows into model context and logs that are not scoped to hold it.
-        - **Content policy breach:** Explicit content in resource metadata is replayed to every client and can surface in agent output.
+        Resources are the MCP server's data surface, where tools are its action surface. Their metadata is returned to every connected client and flows into the model context in the same way, so the same exposure applies with a different set of contents behind it.
 
-        **Risk mitigation**
+        The naming requirement carries more weight here than it does for tools. A resource is something the model may choose to read, and it makes that choice from the name and description alone. An unnamed or undescribed resource is either never used or used blindly, and the second is worse: the model pulls data into context without any basis for judging whether it should.
 
-        - **Complete definitions:** Requiring a name and description for every resource and template gives the agent reliable context.
-        - **Screened descriptions:** Validating descriptions for explicit content and personal data at registration time keeps unsafe content out of the catalog.
+        Resource templates extend this. A template describes a family of resources reachable through a parameter, so its description governs how the model constructs requests, and a vague one produces requests the author did not anticipate.
+
+        Personal data in these descriptions has the same wide distribution as in tool metadata, reaching every client and every log without any of the handling personal data normally attracts.
+
+        Describe what the resource contains and what it is for, precisely enough that the model's decision to read it is well founded, and use placeholders rather than real values in any example.
       audit: |-
         ### Audit via the MCP client
 


### PR DESCRIPTION
47 descriptions across three cross-platform agent policies, rewritten to the standard in `content/CLAUDE.md` (#3393).

| Policy | Checks |
|---|---|
| `mondoo-ai-security` | 38 |
| `mondoo-mcp-security` | 7 |
| `mondoo-edr-policy` | 2 |

## What changed

The opener now names the capability and its required state, the setting is named where the reader administers it rather than where the scanner reads it, and `**Why this matters**` is prose describing what an attacker does without the control. The `**Risk mitigation**` sections, which restated `docs.remediation`, are gone.

`mondoo-ai-security` had the heaviest duplication of the three: many descriptions differed only in the product name while describing the same generic risk.

## Verification

- `cnspec policy lint` on all three bundles — valid
- `typos` — clean
- `go test ./internal/bundle/...` — pass
- Structural diff against `origin/main` — trees identical apart from `docs.desc`

Descriptions only. No MQL, impact, or compliance tag is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)