### PR TITLE
🐛 goreleaser: disable buildx provenance/sbom so docker manifest create succeeds

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -47,6 +47,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -60,6 +62,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -74,6 +78,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -87,6 +93,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -101,6 +109,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -115,6 +125,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -130,6 +142,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -143,6 +157,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -157,6 +173,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -170,6 +188,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -184,6 +204,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -198,6 +220,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -153,6 +153,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -165,6 +167,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -178,6 +182,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -190,6 +196,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -203,6 +211,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -216,6 +226,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -230,6 +242,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -242,6 +256,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -255,6 +271,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -267,6 +285,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -280,6 +300,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -293,6 +315,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,6 +159,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -173,6 +175,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -188,6 +192,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -202,6 +208,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -217,6 +225,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -232,6 +242,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -248,6 +260,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -262,6 +276,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -277,6 +293,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -291,6 +309,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -306,6 +326,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -321,6 +343,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
## Problem

The v13.34.0 release job fails during the `docker manifests` phase:

```
⨯ release failed after 3m21s
error=docker manifests: failed to publish artifacts: failed to create mondoo/cnspec:13.34.0-ubi:
exit status 1: docker.io/mondoo/cnspec:13.34.0-ubi-amd64@sha256:f71028a5755e6cdef8051d1a8251af773e59488d03bad47275b218e9f8aba56a is a manifest list
```

All individual images push fine; the failure is in the subsequent `docker manifest create` step, aborting at the first manifest in the list (the UBI one).

## Root cause

Docker Buildx ≥ 0.10 (Docker 23+) attaches a **provenance attestation by default** on `buildx build --push`. Because an attestation can't live in a plain image manifest, buildx wraps even a **single-platform** build into an OCI image index (a manifest list) containing the image + attestation manifests.

goreleaser assembles multi-arch tags with `docker manifest create`, which refuses to nest a manifest list inside another manifest list — hence `... is a manifest list`. It looks UBI-specific only because UBI is the first entry in `docker_manifests` and the step aborts there; the standard tags would fail identically.

## Fix

Add `--provenance=false` and `--sbom=false` to the `build_flag_templates` of **every** buildx docker build, so buildx pushes plain single-arch manifests that `docker manifest create` can consume. Applied across all three goreleaser configs (release, unstable, edge) since they share the same buildx + `docker_manifests` pattern — 12 `dockers` entries per file.

This is the same fix mql already shipped in mondoohq/mql#9827.

Trade-off: the published images no longer carry provenance/SBOM attestations. Restoring them later would mean switching to a single multi-platform `buildx build --platform ...,... --push` (which builds the index itself, no `docker manifest create`) — a larger restructure left for a follow-up.

## Releasing v13.34.0 after this merges

The `v13.34.0` tag and GitHub release already exist — goreleaser got through artifact upload and died at the manifest step. `release.replace_existing_artifacts: true` means a re-run re-uploads cleanly, but the tag currently points at a commit without this fix. mql handled the equivalent situation by moving the tag onto the fix commit (`v13.33.2` → the merge commit of #9827) and re-running the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)