### PR TITLE
📝 github: rewrite check descriptions as prose

### DIFF
--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -59,13 +59,17 @@ queries:
       }
     docs:
       desc: |
-        Repositories should include a SUPPORT.md file to let people know how to get help with the project.
+        This check verifies that the repository publishes support resources.
+
+        Support resources go in a `SUPPORT.md` file in the repository root or in the `.github` directory, and an organization can publish one shared copy in its own `.github` repository that covers every repository it owns. The file says where to get help: links to the documentation, the issue tracker, any community forum or chat channel, and a contact address for the maintainers. GitHub reads it and shows a link to your support resources on the new issue page, so the person about to file sees it while they are still deciding what to do. A copy stored under `docs` is rendered by GitHub but is not inspected by this check, so keep the file in the root or in `.github`.
 
         **Why this matters**
 
-        - **Faster help:** A documented support path directs users to the right channels instead of opening misrouted issues.
-        - **Maintainer focus:** Clear support resources reduce repetitive questions and let maintainers concentrate on the project.
-        - **Discoverability:** When someone creates an issue, GitHub surfaces a link to the SUPPORT.md file so help is one click away.
+        When no channel is documented, everything arrives in the issue tracker. Questions about how to configure the tool, reports that turn out to be a local misconfiguration, and requests for help with somebody's fork all land in the same queue as real defects, and maintainers spend their triage time separating them. The backlog stops being a picture of what is wrong with the project, and genuine bugs wait behind support requests for a reply.
+
+        Users lose too. Somebody with an urgent problem picks whichever channel they can find, which is often a comment on an unrelated closed issue or a direct message to whoever committed last, and the answer comes late or never.
+
+        Write down where each kind of question goes, and keep the addresses working. Vulnerability reports need their own route rather than this one. A `SECURITY.md` file gives researchers a private channel, and GitHub links it from the same part of the interface, so a reporter who finds neither file is left choosing between saying nothing and opening a public issue that describes the flaw to everyone.
       audit: |
         ### Audit via Console
 
@@ -155,13 +159,19 @@ queries:
       }
     docs:
       desc: |
-        Open source repositories should publish a CODE_OF_CONDUCT.md so contributors understand the standards of behavior expected in the project.
+        This check verifies that the repository publishes a code of conduct.
+
+        A code of conduct states the behavior expected of everyone who participates in the project and the process for reporting behavior that falls short of it. GitHub looks for a `CODE_OF_CONDUCT.md` file in the repository root or in the repository's `.github` directory, and an organization can publish one shared copy in its own `.github` repository that then applies to every repository it owns. This check passes when the file exists in any of those places. GitHub also renders a copy stored under `docs`, but this check does not look there, so keep the file in the root or in `.github`.
 
         **Why this matters**
 
-        - **Shared expectations:** A code of conduct clarifies the project's values and the behavior expected of every participant.
-        - **Inclusive community:** Documented standards help maintain a welcoming environment that attracts and retains contributors.
-        - **Clear enforcement:** It establishes how unacceptable behavior is reported and handled, reducing ambiguity during disputes.
+        Once the file exists, GitHub links it from the repository's Community Standards page and from the issue and pull request forms, so a first-time contributor sees the expectations before writing anything.
+
+        Without it, a maintainer who needs to remove a participant for abusive behavior has no written standard to point at. The decision becomes one person's judgment applied after the fact, the participant can argue that no rule was broken, and other contributors reading the thread have no way to tell whether the removal was fair. A published document turns that argument into a reference to a sentence everyone could have read in advance.
+
+        The absence also costs contributions that never arrive. Someone deciding whether to spend an evening on an unfamiliar project reads the repository for signals about how its maintainers treat people, and an empty answer is a reason to work somewhere else.
+
+        Adopting an existing text such as the Contributor Covenant is the usual route, because writing conduct rules from scratch is slow and the well-known texts already cover reporting and enforcement. Whichever text you choose, name a working contact address for reports. A code of conduct with nobody to report to does not do the job.
       audit: |
         ### Audit via Console
 
@@ -236,13 +246,17 @@ queries:
     mql: github.repository.description != empty
     docs:
       desc: |
-        Repositories should set a description so users can understand the purpose of the project at a glance.
+        This check verifies that the repository has a description.
+
+        The description is the one-line summary shown in the "About" panel on the repository's main page. Maintainers set it through the gear icon beside that panel, and the same value appears on the repository record returned by the API. This check passes when the description is a non-empty string.
 
         **Why this matters**
 
-        - **Discoverability:** The description appears in search results and on the repository's main page, helping users find relevant projects.
-        - **Faster evaluation:** A concise summary lets potential users and contributors quickly decide whether the project fits their needs.
-        - **API consumers:** Tooling that lists repositories through the API surfaces the description, improving inventory and catalog views.
+        An organization's repository list shows the name and the description and little else. With the description blank, anyone scanning that list sees a column of names such as `platform-svc-2` and has to open each repository and read its README to learn what it is. On an account with a few hundred repositories that is the difference between finding the right one in seconds and giving up on the search.
+
+        The same text is what GitHub search matches and displays beneath each result, so an undescribed repository is harder to find even by someone who knows roughly what they are looking for. Inventory tooling that lists repositories through the API hits the same problem in a different shape: the catalog it produces has an empty summary column, and whoever owns that catalog ends up filling it in by hand.
+
+        A good description says what the project is and who it is for in one sentence, for example a command-line tool for managing cloud infrastructure, or a React component library for building accessible web applications. Keep it current afterward. A description that describes what the repository did two rewrites ago is worse than a blank one, because readers believe it.
       audit: |
         ### Audit via Console
 
@@ -297,13 +311,19 @@ queries:
     mql: github.repository.files.one( name == ".gitignore" )
     docs:
       desc: |
-        Repositories should include a .gitignore file so unintended files are not committed to version control.
+        This check verifies that the repository has a `.gitignore` file in its root.
+
+        `.gitignore` lists the path patterns that Git leaves untracked. Add it as a file in the repository root. GitHub offers a starting template per language from the "Add .gitignore" dropdown while you create a repository, and the matching Terraform attribute for those templates also applies only at creation, so an existing repository needs the file committed directly. This check passes when a file named `.gitignore` is present in the root.
 
         **Why this matters**
 
-        - **Repository hygiene:** Build artifacts, dependency directories, and OS-specific files are kept out of the repository, preventing bloat.
-        - **Cleaner diffs:** Excluding generated and editor files removes noise from pull requests and makes review faster.
-        - **Fewer conflicts:** Ignoring IDE and environment files avoids merge conflicts between contributors using different toolchains.
+        Without it, everything the build produces is a candidate for the next `git add .`. A dependency directory such as `node_modules` or `vendor` lands in a commit and the repository grows by hundreds of megabytes. Every clone after that pays the cost, and the pull request that introduced it shows thousands of changed files that no reviewer can read.
+
+        Editor and operating system files cause a smaller version of the same problem continuously. One contributor commits `.DS_Store`, another commits an `.idea` directory, and the two of them then produce a merge conflict in files that have nothing to do with the project.
+
+        The serious case is credentials. A `.env` file or a downloaded service account key sits in the working directory looking like any other file, gets swept up by a wildcard add, and becomes readable by everyone with access to the repository. Deleting it in a later commit does not undo that. The value stays in the history, and it has to be treated as compromised and rotated.
+
+        Start from the template for your language and extend it with the paths your build and tooling actually produce. A file that is already tracked keeps being tracked no matter what patterns you add later, so anything committed by accident has to be removed from the index as well.
       audit: |
         ### Audit via Console
 
@@ -386,13 +406,19 @@ queries:
       }
     docs:
       desc: |
-        The README file should name the people or teams responsible for the project.
+        This check verifies that the README names the people or teams responsible for the project.
+
+        The check reads `README.md` from the repository root and looks for an authors section. Add one by opening the file with the pencil icon on GitHub, or in a normal commit, and writing a short block headed Authors or Maintainers that names the person or team and gives a way to reach them, such as a team alias or a shared mailbox. GitHub renders the README on the repository's main page, so those names are visible without opening a file.
 
         **Why this matters**
 
-        - **Transparency:** Naming authors tells users who built the project before they adopt it in their environments.
-        - **Accountability:** Listed authors give users and contributors a clear point of contact for questions and ownership.
-        - **Trust:** Attribution signals an actively stewarded project, which increases confidence for downstream consumers.
+        Attribution is the difference between a question that gets answered and one that does not. Someone who hits a bug, needs a release cut, or wants to know whether a pull request will ever be looked at otherwise has to guess from the commit log, where the most recent committer is often a person who fixed a typo two years ago.
+
+        Internal repositories lose their owner quietly. A team reorganizes, the engineers who wrote the service move on, and a year later somebody on call is reading unfamiliar code at three in the morning with no idea which team to page. A named team alias survives that. A name in a commit signature usually does not.
+
+        For anyone evaluating the project from outside, the names answer a different question. A repository with an identified maintainer or a sponsoring team reads as something a person is accountable for, and one without reads as code that was published and abandoned. That judgment gets made in the first minute of looking, and it decides whether the evaluation continues at all.
+
+        Prefer roles and shared addresses over individual names wherever you can, so the section stays accurate after people change jobs.
       audit: |
         ### Audit via Console
 
@@ -468,13 +494,17 @@ queries:
     mql: github.repository.files.one( name.downcase == "readme.md" )
     docs:
       desc: |
-        Repositories should include a README.md file that provides the essential information needed to understand and use the project.
+        This check verifies that the repository has a `README.md` file in its root.
+
+        The README is the page GitHub renders below the file list on the repository's main page, and for most visitors it is the entire documentation set. Create it as `README.md` in the root through the "Add file" menu or in an ordinary commit. This check looks for that exact name, so a project documented in `README.rst` or `README.txt` does not satisfy it even though GitHub renders those formats too.
 
         **Why this matters**
 
-        - **First impression:** The README is the first file most visitors see and serves as the primary documentation for the project.
-        - **Adoption:** Explaining what the project does and how to install and use it helps users decide whether to adopt it.
-        - **Contribution:** Documenting how to contribute lowers the barrier for new contributors to get involved.
+        Without a README the repository page shows a list of directories and nothing else. A visitor has to infer the project from file names, open the source, and read enough of it to work out what the code does and whether it does what they need. Almost nobody does this. They arrived from a search result or a link, they had a specific question, and an unexplained file tree does not answer it.
+
+        The cost inside a company is a slower version of the same thing. New team members reconstruct build and run instructions by reading configuration files and asking colleagues, and every answer is given verbally to one person, so the next new hire asks the same question again.
+
+        A useful README states what the project does, how to install it, how to run it, and how to contribute. Two companion checks in this policy look for a getting started section and a named set of authors inside that same file, so treat those as the sections to write first. Keep the installation steps runnable. A README whose commands fail on a clean machine costs more trust than one that leaves them out.
       audit: |
         ### Audit via Console
 
@@ -549,13 +579,19 @@ queries:
       }
     docs:
       desc: |
-        The README file should contain a getting started guide that walks new users through installing and using the project.
+        This check verifies that the README includes a getting started guide.
+
+        The check reads `README.md` from the repository root and looks for a getting started or quick start section. Write it by editing the file on GitHub with the pencil icon or in an ordinary commit, under a heading such as "Getting started", and cover the path a newcomer actually walks: install the project, set whatever configuration it requires, and run it once successfully.
 
         **Why this matters**
 
-        - **Onboarding:** A getting started guide gives new users a clear, repeatable path from clone to first successful run.
-        - **Reduced support load:** Documented setup steps cut down on repetitive setup questions for maintainers.
-        - **Adoption:** Users are more likely to adopt a project when the initial experience is well documented and frictionless.
+        A README that explains what a project does but not how to start it leaves the reader to assemble the sequence themselves out of the build files, the test configuration, and whatever the last blog post said. The steps do exist. They are just distributed across the repository in the order the code needed them rather than the order a person needs them. Most evaluators give up at this point, and the maintainer sees a clone with no follow-up rather than a question.
+
+        The maintainers pay for the omission as well. Everyone who does persist asks in an issue or a chat channel, and each answer gets written once, for one person, and is then lost. The same three questions keep arriving for years, which is expensive in a way that never appears as a task on anybody's board.
+
+        Write the steps against a clean machine and run them yourself before committing them. Instructions written from memory tend to assume a tool the author installed years ago and a configuration file that exists only on their laptop, and a guide that fails at step two is worse than no guide, because the reader concludes the project is broken rather than that the documentation is stale.
+
+        Keep it short. This section is the shortest route to one working run, not a manual. Deeper material belongs in the rest of the README or in a documentation directory.
       audit: |
         ### Audit via Console
 
@@ -629,13 +665,17 @@ queries:
     mql: github.repository.files.any(name == /^LICENSE/i)
     docs:
       desc: |
-        Repositories should publish a license file so users know how the source code may be used, modified, and redistributed.
+        This check verifies that the repository declares a license.
+
+        Publishing source code does not grant anyone permission to use it. Absent an explicit license the code is under exclusive copyright, and the only rights a reader has are the ones GitHub's terms of service provide, which amount to viewing the code and forking it within GitHub itself. Add the grant as a file in the repository root whose name starts with `LICENSE`, such as `LICENSE`, `LICENSE.txt`, or `LICENSE.md`. GitHub's license detection reads that file and shows the identifier it recognizes in the "About" panel. The Terraform attribute for selecting a license template applies only when the repository is created, so an existing repository needs the file committed directly.
 
         **Why this matters**
 
-        - **Legal clarity:** A license tells users how the source code may or may not be used, removing legal ambiguity.
-        - **Adoption:** Without a license, potential users face legal risk and many organizations will not adopt the project.
-        - **Review and audit:** The absence of a license impedes security review or audit of the codebase by third parties.
+        The consequence lands on the people who want to use the project. An engineer at a company that scans its dependencies adds the package, the scanner reports the license as unknown, and policy blocks the build until legal signs off. Most of the time nobody asks legal. They find another library and move on, and the maintainer never learns that the evaluation happened.
+
+        Everything downstream inherits the problem. A distribution cannot package unlicensed code, a vendor cannot ship it inside a product, and a contributor cannot be confident they are permitted to publish a fork carrying their own fix. Even reading the code for a security review stands on uncertain ground in organizations that take copyright seriously.
+
+        Pick the license from the project's goals. A permissive license such as MIT or Apache 2.0 suits code meant to be embedded in commercial products, and a copyleft license such as GPL suits projects where derived work should stay open. Add the file early. Relicensing later needs agreement from everyone who has contributed since, which gets harder with every merged pull request.
       audit: |
         ### Audit via Console
 


### PR DESCRIPTION
## What changed

Rewrites `docs.desc` for all 8 checks in `mondoo-github-best-practices` into the house prose format. Queries, filters, titles, impacts, audit sections, and remediation blocks are untouched, and the policy version is not bumped.

Each description now:

- opens with the literal `This check verifies that ...` and leads with the capability rather than the field being read;
- names the artifact the reader creates with its conventional filename and location, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `LICENSE`, `README.md`, `.gitignore`, and says where GitHub surfaces it, the "About" panel, the Community Standards page, the new issue page;
- replaces the bulleted bold labels with prose that says what actually goes wrong.

## Best-practices framing

This policy is `mondoo.com/category: best-practices`, so the descriptions do not invent an attacker. They name the concrete failure instead: someone scanning a few hundred repositories sees a column of names and gives up; an engineer whose dependency scanner reports the license as unknown picks a different library rather than asking legal; an on-call engineer reads unfamiliar code with no team alias to page; support questions land in the same queue as real defects, so genuine bugs wait behind them.

Two real security consequences do exist here, and both are stated plainly rather than reached for. A `.env` file or a downloaded service account key swept up by a wildcard add stays in the history after it is deleted and has to be rotated. And a reporter who finds neither a support contact nor a `SECURITY.md` is left choosing between saying nothing and opening a public issue that describes the flaw to everyone.

Median description length goes from **75 words to 302**.

## Gates

| Gate | Result |
| --- | --- |
| `cnspec policy lint ./content/mondoo-github-best-practices.mql.yaml` | `valid policy bundle(s)` |
| `typos content/mondoo-github-best-practices.mql.yaml` | silent |
| `go test -count=1 ./internal/bundle/...` | `ok` |
| structural diff vs `origin/main` | trees identical apart from `docs.desc` and policy version |
| substance gate | **0** specifics lost across 0 of 8 checks |

The substance gate reports zero losses, so there are no waivers to justify: every backticked literal in the old text survives into the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
