### PR TITLE
📝 dockerfile: rewrite check descriptions as prose

### DIFF
--- a/content/mondoo-dockerfile-best-practices.mql.yaml
+++ b/content/mondoo-dockerfile-best-practices.mql.yaml
@@ -72,13 +72,19 @@ queries:
       docker.file.stages.all(run.all(commands.none(binary == "apt" && subcommand.in(["install", "update", "upgrade", "remove", "purge"]))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should invoke the `apt-get` CLI rather than `apt` for package management operations.
+        This check verifies that package operations in `RUN` instructions call `apt-get` rather than the bare `apt` command.
+
+        Debian ships two front ends over the same package system. `apt-get` is the scripting interface, with a command-line surface and exit behavior that Debian keeps stable across releases. `apt` is the interactive one, built for a person at a terminal, and its own maintainers state that it has no stable interface for scripts. The check requires that no `RUN` instruction call `apt` with install, update, upgrade, remove, or purge.
 
         **Why this matters**
 
-        - **Predictable behavior:** The `apt-get` CLI is designed for scripting and automation, offering consistent and reliable behavior in non-interactive Dockerfile contexts.
-        - **Stability:** `apt-get` maintains a stable command-line interface across releases, while `apt` is intended for interactive use and its output and behavior may change between versions.
-        - **Reduced risk of errors:** Using `apt-get` minimizes the chance of unexpected prompts or behavior changes interrupting the build process.
+        The instability is not theoretical. `apt` writes a progress bar and colored output that assume a terminal, so a build log captured to a file fills with control sequences instead of readable text. It prints a warning on every invocation saying it should not be scripted against, which trains everyone reading build output to ignore warnings there. Flags and defaults have changed between Debian and Ubuntu releases in ways `apt-get` did not, so a Dockerfile that works on one base image tag can stop working on the next.
+
+        The failure mode when it does change is worse than a broken build. `apt` may prompt where `apt-get` returns an error, resolve a dependency differently, or omit output that a later step in the same instruction greps for. A build that quietly installs a different set of packages is much harder to diagnose than one that stops.
+
+        There is a readability cost as well. Reviewers and linters recognize the update, install, and cleanup idiom built around `apt-get`, so a Dockerfile using it is scanned quickly. A bare `apt` line breaks the pattern and hides the fact that the same package hygiene rules apply to it.
+
+        Replace `apt` with `apt-get` and keep the install and the cleanup in the same instruction.
       audit: |
         Inspect the Dockerfile to confirm package management uses `apt-get`:
 
@@ -116,13 +122,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "apk" && subcommand == "update")).all(commands.any(binary == "apk" && subcommand == "add")))
     docs:
       desc: |
-        Package manager update commands (`apt-get update`, `apk update`) should run in the same `RUN` instruction as the corresponding install command, never alone in a separate layer.
+        This check verifies that a package index refresh runs in the same `RUN` instruction as the install that depends on it.
+
+        Every `RUN` instruction becomes its own image layer, and Docker caches layers independently, keyed on the instruction text and on the layers beneath it. Splitting `apt-get update` into one instruction and the install into the next makes them two separately cached units. The check requires that any `RUN` containing `apt-get update` also run an apt-get install in the same instruction, and that any `RUN` containing `apk update` also run an apk add in the same instruction.
 
         **Why this matters**
 
-        - **Stale package lists:** Docker caches each layer independently. If the update layer is cached but the install layer is rebuilt, the install uses outdated package indexes, potentially installing older versions with known vulnerabilities.
-        - **Non-reproducible builds:** Cached update layers create a false sense of freshness. Builds at different times produce different results depending on cache state.
-        - **Unnecessary layer bloat:** The update command creates a layer containing package index files that are only needed during installation and should be cleaned up afterward.
+        The two layers age apart. Adding a package to the install line changes that instruction's text, so its layer is rebuilt, but the update line is unchanged and its layer comes from cache. The install then resolves against a package index fetched whenever that layer was last built, which can be weeks or months earlier. The build asks for a package by name and gets whichever version the stale index knew about, so a fix published since then is silently not installed.
+
+        The failure is invisible in the build log. The install succeeds, the versions it reports look plausible, and nothing distinguishes a fresh index from a cached one. The mismatch surfaces later, as a scanner reporting a vulnerability the team believes was already patched, or as two engineers producing different images from the same commit because their caches diverged.
+
+        There is a size cost as well. The index files land in the update layer and stay there, so removing them in a later instruction adds a layer without recovering the space.
+
+        Join the refresh and the install with a shell operator in one instruction, and remove the index in that same instruction so it never becomes a layer of its own.
       audit: |
         Inspect the Dockerfile to confirm update and install are combined:
 
@@ -165,13 +177,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "apk" && subcommand == "add").all(flags.contains("--no-cache"))))
     docs:
       desc: |
-        Alpine's `apk add` command should always include the `--no-cache` flag in Dockerfile `RUN` instructions.
+        This check verifies that every `apk add` in a `RUN` instruction avoids leaving Alpine's package index in the image.
+
+        Alpine's package manager writes the repository index it downloads to `/var/cache/apk/`. The `--no-cache` flag fetches that index for the duration of the command without writing it to disk, which is also why it removes the need for a separate `apk update` beforehand. The check requires every `apk add` command in every build stage to pass `--no-cache`.
 
         **Why this matters**
 
-        - **Image bloat:** Without `--no-cache`, `apk add` downloads and stores a local package index in `/var/cache/apk/`, adding unnecessary size to the image layer and increasing storage costs and pull times.
-        - **Stale cache risk:** A cached index in a layer can become outdated, leading to confusing behavior if the layer is reused.
-        - **Simpler instructions:** The `--no-cache` flag fetches the index temporarily and discards it after the operation, eliminating the need for a separate `apk update` or manual `rm -rf /var/cache/apk/*` cleanup step.
+        The cost lands exactly where Alpine is usually chosen to avoid it. A base image is a few megabytes, and the index left behind by a plain `apk add` is comparable in size to the image itself, so an image picked for being small ships mostly package metadata. That size is paid on every pull, by every node that schedules the container, on every rollout.
+
+        A cached index also goes stale in a way that is hard to see. The files sit in a layer, and a later build that reuses that layer resolves package names against an index fetched whenever the layer was created. Two builds of the same Dockerfile then install different versions with nothing in the log to explain the difference.
+
+        Cleaning up afterward does not work. Image layers are additive, so running `rm -rf /var/cache/apk/*` in a later instruction records a deletion without reclaiming the bytes, and the files remain recoverable from the earlier layer.
+
+        Add `--no-cache` to each `apk add` and drop any preceding `apk update`, which the flag makes redundant. Where a build reinstalls the same packages often enough that download time matters, mount the cache directory as a build cache instead, so it is reused across builds without landing in a layer.
       audit: |
         Inspect the Dockerfile to confirm `apk add` uses `--no-cache`:
 
@@ -204,13 +222,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "apt-get" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/lib\/apt\/lists\/?$/) || commands.any(binary == "rm" && args.any(_ == /\/var\/lib\/apt\/lists/))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `apt-get install` should also clean up the apt package lists in the same layer, or keep them out of the image by mounting `/var/lib/apt/lists` as a BuildKit cache.
+        This check verifies that a `RUN` instruction which installs Debian packages does not leave the apt package lists in the image layer.
+
+        A package index refresh downloads the repository lists into `/var/lib/apt/lists/`, and `apt-get install` needs them only while it resolves and fetches. The check requires every `RUN` instruction containing `apt-get install` either to delete `/var/lib/apt/lists` within that same instruction or to mount it as a build cache so its contents never enter a layer.
 
         **Why this matters**
 
-        - **Image bloat:** After `apt-get install`, the downloaded package index files remain in `/var/lib/apt/lists/` and can add tens of megabytes to the image layer.
-        - **Unnecessary data:** The package lists are only needed during installation and serve no purpose at runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the files still exist in the install layer due to how Docker's union filesystem works, providing no actual size savings.
+        Union filesystem semantics are what make the same-instruction requirement matter. A layer records what a step wrote; a later step that deletes those files records a deletion marker on top. The bytes are still in the earlier layer, still transferred on every pull, and still extractable from the image. Splitting the cleanup into its own `RUN` therefore reads like housekeeping while saving nothing at all.
+
+        The size involved is not trivial. A full Debian index runs to tens of megabytes, often more than the packages the image actually installs, and it is paid on every pull, on every node that schedules the container, and on every layer push in CI. For a service that scales out during an incident, image pull time sits on the critical path of recovery.
+
+        The index is also dead weight at runtime. Nothing in a running container consults it, because containers do not install packages after they start, so it exists only to be shipped and stored.
+
+        Chain the removal onto the same instruction. Where fast rebuilds matter more than never fetching the index twice, a build cache mount on the lists directory keeps it out of the image entirely while still reusing it between builds, at the cost of disabling apt's own automatic cleanup so it stops emptying the mounted directory.
       audit: |
         Inspect the Dockerfile to confirm apt lists are cleaned in the install layer:
 
@@ -256,13 +280,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "yum" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/yum\/?$/) || commands.any(binary == "yum" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `yum install` should also run `yum clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/yum` as a BuildKit cache.
+        This check verifies that a `RUN` instruction which installs packages with `yum` does not leave the package cache in the image layer.
+
+        `yum install` downloads RPMs and repository metadata into `/var/cache/yum/` and keeps them after the install finishes. `yum clean all` removes both. The check requires every `RUN` instruction containing `yum install` either to run `yum clean all` in the same instruction or to mount `/var/cache/yum` as a build cache so nothing is written into a layer.
 
         **Why this matters**
 
-        - **Image bloat:** After `yum install`, cached package data and metadata remain in `/var/cache/yum/` and add significant size to the image layer.
-        - **Unnecessary data:** The cache is only needed during installation and serves no purpose at runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the cached files still exist in the install layer due to Docker's union filesystem.
+        The cache holds the full RPM files, not just metadata, so its size is roughly the download size of everything installed. On an enterprise Linux base with a handful of packages that is routinely hundreds of megabytes, which can be larger than the rest of the image put together.
+
+        Doing the cleanup one instruction later recovers none of it. Each instruction produces a layer, and a deletion in a later layer only masks the files; they remain in the layer that created them and are still pulled, still stored, and still recoverable by exporting the image. The Dockerfile then looks tidy while the image is unchanged, which is the worst combination, because it stops anyone from looking again.
+
+        The runtime value of the cache is zero. A container does not install packages after it starts, so the RPMs it carries are never read. What they do affect is pull time on every node that runs the image, registry storage for every tag retained, and the transfer cost of every push from CI.
+
+        Chain `yum clean all` onto the install so both happen in one instruction. If rebuild speed matters, a build cache mount on the cache directory keeps the downloads available across builds while leaving the image layer clean.
       audit: |
         Inspect the Dockerfile to confirm the yum cache is cleaned in the install layer:
 
@@ -302,13 +332,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "dnf" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/dnf\/?$/) || commands.any(binary == "dnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `dnf install` should also run `dnf clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/dnf` as a BuildKit cache.
+        This check verifies that a `RUN` instruction which installs packages with `dnf` does not leave the package cache in the image layer.
+
+        `dnf install` writes downloaded RPMs and the repository metadata it resolved against into `/var/cache/dnf/`, and it keeps them because the design assumes a long-lived machine that will install again. `dnf clean all` discards both. The check requires every `RUN` instruction containing `dnf install` either to run `dnf clean all` in the same instruction or to mount `/var/cache/dnf` as a build cache.
 
         **Why this matters**
 
-        - **Image bloat:** After `dnf install`, cached package data and metadata remain in `/var/cache/dnf/` and add significant size to the image layer.
-        - **Unnecessary data:** The cache is only needed during installation and serves no purpose at runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the cached files still exist in the install layer due to Docker's union filesystem.
+        An image is the opposite of the long-lived machine that default is tuned for. It is built once and started many times, and nothing inside a running container ever installs a package, so the cached RPMs are read exactly zero times over the life of the image while being copied to every node that pulls it.
+
+        The retained metadata is larger than people expect. Modern DNF repositories ship module and application stream data alongside the primary index, so even a build that installs two small packages can carry a few hundred megabytes of resolved metadata into the final layer.
+
+        Cleaning up in a following instruction achieves nothing measurable. Layers are append-only, so the deletion is recorded as a marker in a new layer while the original bytes stay where they were written. The image size the registry reports does not move, and the files are still readable by anyone who exports the image and walks its layers.
+
+        Put `dnf clean all` in the same instruction as the install. When repeated builds make redownloading painful, mount the cache directory as a build cache instead: the content persists between builds on the builder and never becomes part of any layer.
       audit: |
         Inspect the Dockerfile to confirm the dnf cache is cleaned in the install layer:
 
@@ -348,13 +384,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "zypper" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/zypp\/?$/) || commands.any(binary == "zypper" && subcommand == "clean")))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `zypper install` should also run `zypper clean` in the same layer, or keep the cache out of the image by mounting `/var/cache/zypp` as a BuildKit cache.
+        This check verifies that a `RUN` instruction which installs packages with `zypper` does not leave the package cache in the image layer.
+
+        `zypper install` stores downloaded RPMs and repository metadata under `/var/cache/zypp`, and on SUSE and openSUSE base images that directory persists for the life of the container unless something removes it. `zypper clean` discards the package cache, and asking it to clean everything discards the resolver metadata as well. The check requires every `RUN` instruction containing `zypper install` either to run `zypper clean` in the same instruction or to mount `/var/cache/zypp` as a build cache.
 
         **Why this matters**
 
-        - **Image bloat:** After `zypper install`, cached package data and metadata remain on disk and add significant size to the image layer.
-        - **Unnecessary data:** The cache is only needed during installation and serves no purpose at runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the cached files still exist in the install layer due to Docker's union filesystem.
+        SUSE repositories carry substantial solver metadata, and zypper keeps both that and the downloaded RPMs. An image built from a SUSE base with a modest package set commonly ships a cache comparable in size to everything else in it, which then has to be transferred on every pull and stored for every tag the registry retains.
+
+        None of it is used again. Containers are not patched in place; a new version means a new image built from a new Dockerfile, so the cached RPMs sit unread for the entire life of the image.
+
+        Doing the cleanup in a later instruction is the mistake worth naming. Image layers are additive, and a removal in a later layer only hides the files from the assembled filesystem. The bytes stay in the layer that wrote them, the registry still stores them, and anyone who exports the image reads them back.
+
+        Join the cleanup to the install so both land in the same instruction. Where rebuild speed matters, mounting the cache directory as a build cache keeps the downloads on the builder across builds while leaving nothing behind in the image.
       audit: |
         Inspect the Dockerfile to confirm the zypper cache is cleaned in the install layer:
 
@@ -393,13 +435,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "pip" && subcommand == "install")).all(mounts.any(type == "cache" && target == /pip/) || commands.where(binary == "pip" && subcommand == "install").all(flags.contains("--no-cache-dir"))))
     docs:
       desc: |
-        `pip install` commands in Dockerfile `RUN` instructions should include the `--no-cache-dir` flag, or mount the pip cache directory as a BuildKit cache so it never lands in an image layer.
+        This check verifies that a `RUN` instruction which installs Python packages with pip does not leave pip's download cache in the image layer.
+
+        pip caches downloaded distributions and locally built wheels under `~/.cache/pip/` so a later install can skip both the download and the rebuild. The `--no-cache-dir` flag turns that off for the invocation. The check requires every `RUN` instruction containing `pip install` either to pass `--no-cache-dir` on each such command or to mount the pip cache directory as a build cache so it never becomes part of a layer.
 
         **Why this matters**
 
-        - **Image bloat:** By default, pip caches downloaded packages and build artifacts in `~/.cache/pip/`, which can add tens or hundreds of megabytes to the image layer, especially for packages with large binary wheels.
-        - **Unnecessary data:** Cached packages serve no purpose in a container since packages are not reinstalled at runtime.
-        - **Layer persistence:** Even if the cache is deleted in a subsequent `RUN` instruction, it persists in the install layer.
+        The cache is often larger than what it installed. Packages with compiled extensions, such as scientific and machine learning libraries, ship wheels of several hundred megabytes each, and pip keeps both the downloaded wheel and any wheel it built from a source distribution, so the cache can hold two copies of the largest thing in the image.
+
+        That size is paid repeatedly. Every node that schedules the container pulls it, every registry copy stores it, and every push from CI transfers it. On an image whose useful content is a small application and its dependencies, the cache can be the majority of the bytes moved.
+
+        Removing it afterward shrinks nothing. Layers are immutable once written, so deleting the cache directory in a following instruction adds a layer recording the deletion while the original files stay in place and continue to be pulled.
+
+        Add `--no-cache-dir` to each `pip install`. If the rebuild cost of redownloading large wheels is the real concern, drop the flag and mount the cache directory as a build cache instead, which keeps the wheels on the builder between builds and still leaves them out of every layer.
       audit: |
         Inspect the Dockerfile to confirm `pip install` uses `--no-cache-dir`:
 
@@ -442,13 +490,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "yarn" && subcommand == "install")).all(mounts.any(type == "cache" && target == /yarn/) || commands.any(binary == "yarn" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `yarn install` should also run `yarn cache clean` in the same layer, or mount the yarn cache directory as a BuildKit cache so it never lands in an image layer. This check targets Yarn Classic (Yarn 1.x), where the cache lives in a global directory. Yarn Berry (Yarn 2 and later) manages its cache differently through Plug'n'Play and zero-installs, so the `yarn cache clean` step does not apply there.
+        This check verifies that a `RUN` instruction which installs JavaScript dependencies with yarn does not leave the yarn cache in the image layer.
+
+        `yarn install` populates a global cache of downloaded package tarballs outside the project directory so later installs can be served from disk. `yarn cache clean` empties it. The check requires every `RUN` instruction containing `yarn install` either to run `yarn cache clean` in the same instruction or to mount the cache directory as a build cache. This applies to Yarn Classic, the 1.x line, where the cache is a shared global directory. Yarn Berry, meaning Yarn 2 and later, resolves dependencies through Plug'n'Play and zero-installs and does not use that cache the same way.
 
         **Why this matters**
 
-        - **Image bloat:** After `yarn install`, a local cache of downloaded packages is stored on disk and can add significant size to the image layer, often exceeding the size of the installed packages themselves.
-        - **Unnecessary data:** The cache is only useful for speeding up future installs, which do not happen at container runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the cached files still exist in the install layer due to Docker's union filesystem.
+        A JavaScript dependency tree is large and the cache duplicates it. The tarballs cover every package resolved, including the ones needed only to build, so the cache is routinely bigger than the installed tree itself, and the installed tree is already the biggest thing in most Node images.
+
+        The bytes travel. Every pull on every node carries them, every registry replica stores them, and every push from CI uploads them, all for data no running container ever reads. A container does not install dependencies after it starts.
+
+        Cleaning up in a separate instruction does nothing. Docker layers are additive, so a removal in a later layer masks the files in the assembled filesystem while leaving them in the layer that wrote them, where they are still pulled and still recoverable.
+
+        Chain the cleanup onto the install. Where install speed across rebuilds matters more, mount the cache directory as a build cache: the tarballs then persist on the builder between builds and never enter a layer.
       audit: |
         Inspect the Dockerfile to confirm the yarn cache is cleaned in the install layer:
 
@@ -489,13 +543,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "npm" && subcommand == "ci")).all(mounts.any(type == "cache" && target == /npm/) || commands.any(binary == "npm" && subcommand == "cache" && args.contains("clean"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `npm install` or `npm ci` should also run `npm cache clean` in the same layer, or mount the npm cache directory as a BuildKit cache so it never lands in an image layer.
+        This check verifies that a `RUN` instruction which installs JavaScript dependencies with npm does not leave the npm cache in the image layer.
+
+        Both `npm install` and `npm ci` write every package tarball they fetch into a content-addressed store under `~/.npm/`, in addition to unpacking them into `node_modules`. `npm cache clean` empties that store. The check requires every `RUN` instruction containing `npm install` or `npm ci` either to run `npm cache clean` in the same instruction or to mount the npm cache directory as a build cache.
 
         **Why this matters**
 
-        - **Image bloat:** After `npm install` or `npm ci`, a local cache of downloaded packages is stored in `~/.npm/` and can add significant size to the image layer, often comparable to or exceeding the size of `node_modules` itself.
-        - **Unnecessary data:** The cache speeds up future installs but serves no purpose at container runtime.
-        - **Layer persistence:** If cleanup happens in a separate `RUN` instruction, the cached files still exist in the install layer due to Docker's union filesystem.
+        The cache holds a compressed copy of everything already unpacked, so the image ships each dependency twice. On a typical Node service the cache is comparable in size to `node_modules`, and `node_modules` is usually the largest thing in the image by a wide margin.
+
+        `npm ci` makes this easy to miss. It deletes and recreates the dependency tree on every run, which reads like a clean install, but the cache it populates on the way is untouched by that and persists into the layer.
+
+        A removal in a later instruction is not a fix. Image layers are append-only: deleting the cache in the next `RUN` writes a marker into a new layer while the files stay in the one that created them, so the image is exactly as large as before and the tarballs are still recoverable from it.
+
+        Append the cache cleanup to the install in the same instruction. For production images, prefer `npm ci` with development dependencies omitted, which installs the exact versions recorded in the lockfile and leaves the build-only packages out of the image. If rebuild speed is the priority, mount the cache directory as a build cache instead, so it is reused across builds without entering a layer.
       audit: |
         Inspect the Dockerfile to confirm the npm cache is cleaned in the install layer:
 
@@ -543,13 +603,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "apt-get" && subcommand == "install").all(flags.contains("--no-install-recommends"))))
     docs:
       desc: |
-        `apt-get install` commands in Dockerfile `RUN` instructions should include the `--no-install-recommends` flag.
+        This check verifies that every `apt-get install` in a `RUN` instruction declines Debian's recommended packages.
+
+        A Debian package declares hard dependencies and a softer set of recommendations, which describe what a typical desktop or server installation would also want. `apt-get install` treats those recommendations as dependencies by default and installs them. The `--no-install-recommends` flag limits the install to what the package actually requires to run. The check requires every `apt-get install` command in every build stage to pass it.
 
         **Why this matters**
 
-        - **Image bloat:** By default, `apt-get install` pulls in recommended packages such as documentation, man pages, and X11 libraries that are unnecessary in a container, which can add hundreds of megabytes to the image.
-        - **Increased attack surface:** Every additional package is a potential source of vulnerabilities that must be tracked and patched.
-        - **Slower builds and pulls:** Larger images take longer to build, push, and pull, increasing CI/CD cycle times and deployment latency.
+        The amount pulled in is not marginal. Recommendation chains drag in documentation, manual pages, locale data, editors, and in common cases graphical and font libraries behind a package that only needed a shared library, so a single install line can add hundreds of megabytes to an image meant to run one process.
+
+        Everything added has to be maintained. Each package carries its own vulnerability history, so a scanner reports findings for software the application never invokes, and someone has to triage each one and decide whether an unused documentation viewer justifies a rebuild. That triage cost recurs on every scan, indefinitely, for packages nobody chose.
+
+        Build and deployment times follow the size. Larger layers take longer to push from CI, longer to pull on every node that schedules the container, and longer to start a replacement during a rollout or an incident.
+
+        Add the flag to every `apt-get install`. If declining the recommendations breaks something, the missing piece is a real dependency: name it explicitly on the install line, which documents the requirement instead of relying on a chain that may resolve differently on the next base image.
       audit: |
         Inspect the Dockerfile to confirm `apt-get install` uses `--no-install-recommends`:
 
@@ -584,12 +650,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "apt-get" && subcommand == "install").all(flags.any(_ == "--yes" || _ == "--assume-yes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
-        `apt-get install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--yes`) flag.
+        This check verifies that every `apt-get install` in a `RUN` instruction runs without waiting for confirmation.
+
+        `apt-get install` prompts before proceeding whenever the operation pulls in packages beyond the ones named, which covers almost every real install. The `-y` flag, spelled `--yes` in long form, answers that prompt in advance. The check requires every `apt-get install` command in every build stage to carry one of them.
 
         **Why this matters**
 
-        - **Build failure:** Docker builds run non-interactively. Without `-y`, `apt-get install` waits for confirmation input that never comes, causing the build to hang and eventually fail.
-        - **CI/CD reliability:** Automated build pipelines cannot provide interactive input, making builds unreliable without this flag.
+        A Docker build has no terminal attached and nothing supplies input to the prompt. The command reads end of input, treats it as a refusal, and aborts, so the instruction returns non-zero and the build fails. On some configurations it blocks instead, and the build sits doing nothing until a CI job timeout kills it, which costs a full runner slot for the length of the timeout and produces a log that ends mid-install with no error.
+
+        The behavior is not stable across images either. Whether a given install prompts depends on how many extra packages it resolves, so the same instruction can succeed on one base image and stop on the next after a dependency changed upstream. That produces a build that broke without a commit, which is the most expensive kind to diagnose.
+
+        Answering the prompt in the Dockerfile also makes the intent explicit. A reader can see the install is meant to proceed unattended rather than wondering whether an interactive step was left in by accident.
+
+        Add `-y` to each `apt-get install`. Some packages ask their own configuration questions through debconf rather than through apt, and those are silenced separately by selecting a non-interactive frontend for the build, which is worth doing in the same instruction when installing anything that configures a service.
       audit: |
         Inspect the Dockerfile to confirm `apt-get install` uses the `-y` flag:
 
@@ -622,12 +695,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "yum" && subcommand == "install").all(flags.any(_ == "--assumeyes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
-        `yum install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--assumeyes`) flag.
+        This check verifies that every `yum install` in a `RUN` instruction runs without waiting for confirmation.
+
+        `yum install` prints the transaction it intends to perform and then asks whether to continue. The `-y` flag, spelled `--assumeyes` in long form, answers yes in advance and lets the transaction proceed. The check requires every `yum install` command in every build stage to carry one of them.
 
         **Why this matters**
 
-        - **Build failure:** Docker builds run non-interactively. Without `-y`, `yum install` waits for confirmation input that never comes, causing the build to hang and eventually fail.
-        - **CI/CD reliability:** Automated build pipelines cannot provide interactive input, making builds unreliable without this flag.
+        Nothing answers the prompt during an image build. The instruction has no terminal, standard input is closed, and yum reads that as a refusal and exits with an error, so the `RUN` returns non-zero and the build stops at the install line. The log ends with a transaction summary and a question, which reads like a truncated build rather than a missing flag, so the first response is often to run the build again.
+
+        Whether the prompt appears is not fixed. Yum skips it for some transaction shapes and asks for others, and which shape a given install produces depends on what is already present in the base image and on how dependencies resolve at that moment. A Dockerfile that has built for a year can stop building because an upstream package gained a dependency, with nothing in the repository history to point at.
+
+        There is also a cost when it does not fail outright. A build that hangs at a prompt occupies a CI runner until the job timeout expires, and that timeout is usually set generously enough to waste far more time than a fast failure would.
+
+        Add `-y` to each `yum install` so the transaction proceeds unattended and the outcome does not depend on how dependencies happen to resolve on the day of the build.
       audit: |
         Inspect the Dockerfile to confirm `yum install` uses the `-y` flag:
 
@@ -658,12 +738,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "dnf" && subcommand == "install").all(flags.any(_ == "--assumeyes" || _ == /^-[a-z]*y/))))
     docs:
       desc: |
-        `dnf install` commands in Dockerfile `RUN` instructions should include the `-y` (or `--assumeyes`) flag.
+        This check verifies that every `dnf install` in a `RUN` instruction runs without waiting for confirmation.
+
+        `dnf install` resolves the transaction, prints what it will install, and then asks for approval before downloading anything. The `-y` flag, or `--assumeyes` written in full, supplies that approval up front. The check requires every `dnf install` command in every build stage to carry one of them.
 
         **Why this matters**
 
-        - **Build failure:** Docker builds run non-interactively. Without `-y`, `dnf install` waits for confirmation input that never comes, causing the build to hang and eventually fail.
-        - **CI/CD reliability:** Automated build pipelines cannot provide interactive input, making builds unreliable without this flag.
+        An image build is unattended by construction. There is no terminal on the `RUN` instruction and no way to type an answer, so dnf takes the closed input as a negative response and exits non-zero. The build fails at that line with output that looks like a completed dependency resolution followed by nothing, which is easy to misread as a network or repository problem.
+
+        The dependency on transaction shape makes it intermittent. Dnf proceeds without asking in some cases and asks in others, and which one applies depends on what the base image already contains and on how the repository resolves the request that day. An instruction that has worked in every build so far can begin failing after an upstream package adds a dependency, with no change on your side to explain it.
+
+        Where dnf blocks rather than exiting, the build occupies a CI runner until the job timeout fires. That converts a one-character omission into a long, silent pipeline stall and a log that has to be read to the end before the cause is visible.
+
+        Add `-y` to each `dnf install`. The equivalent setting can also be made permanent by writing it into the dnf configuration in the image, but putting it on the command line keeps the intent visible on the line it applies to.
       audit: |
         Inspect the Dockerfile to confirm `dnf install` uses the `-y` flag:
 
@@ -694,12 +781,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "zypper" && subcommand == "install").all(flags.contains("--non-interactive"))))
     docs:
       desc: |
-        `zypper install` commands in Dockerfile `RUN` instructions should include the `--non-interactive` flag.
+        This check verifies that every `zypper install` in a `RUN` instruction runs without waiting for confirmation.
+
+        `zypper install` presents the packages it will install and waits for a yes or no answer, and it also prompts on repository trust decisions and on license acceptance. The `--non-interactive` flag answers all of those with the default and lets the command run unattended. Zypper takes it as a global option, so it belongs before the subcommand rather than after it. The check requires every `zypper install` command in every build stage to carry it.
 
         **Why this matters**
 
-        - **Build failure:** Docker builds run non-interactively. Without `--non-interactive`, `zypper install` waits for confirmation input that never comes, causing the build to hang and eventually fail.
-        - **CI/CD reliability:** Automated build pipelines cannot provide interactive input, making builds unreliable without this flag.
+        A build has no terminal to answer with. Depending on where zypper stops, the instruction either exits non-zero and fails the build or waits, in which case the job holds a CI runner until the pipeline timeout kills it and the log ends mid-transaction with a question and no error.
+
+        Zypper prompts in more situations than apt or dnf, which makes the omission more likely to surface. A repository whose signing key is unknown, a package under a license that requires acceptance, and a vendor change on an update each produce their own question, and whether any of them appears depends on the base image and the repository state at build time rather than on the Dockerfile. An instruction that has always worked can stop after an upstream key rotation.
+
+        The flag also decides the answers, not just whether the question is asked. It selects the default response for each one, so a build that would have paused on a trust decision now proceeds with zypper's default. That is the right behavior for an automated build, and it is a reason to be explicit elsewhere in the Dockerfile about which repositories the image trusts.
+
+        Put `--non-interactive` on every `zypper install`.
       audit: |
         Inspect the Dockerfile to confirm `zypper install` uses the `--non-interactive` flag:
 
@@ -730,16 +824,19 @@ queries:
       docker.file.finalStage.hasHealthcheck
     docs:
       desc: |
-        The final stage of a Dockerfile should include a HEALTHCHECK instruction so orchestrators can determine whether the application inside the container is actually working.
+        This check verifies that the final build stage of the Dockerfile defines a `HEALTHCHECK` instruction.
+
+        `HEALTHCHECK` records a command the container runtime runs on a schedule, together with an interval, a timeout, and a retry count. Its exit status sets the container's health state, which Docker, Docker Compose, and Docker Swarm all read. The check requires the final stage to declare one, since only the final stage's configuration is carried into the published image.
 
         **Why this matters**
 
-        - **Silent failures:** A container can remain in a "running" state even when the application has crashed, deadlocked, or become unresponsive.
-        - **Traffic to broken containers:** Load balancers and orchestrators continue routing traffic to unhealthy containers, causing user-facing errors.
-        - **Delayed recovery:** Without health information, orchestrators cannot automatically restart or replace failed containers, increasing downtime.
-        - **Monitoring blind spots:** Container health status provides a basic monitoring signal that integrates with orchestrator dashboards and alerting.
+        Without it, the only signal the runtime has is whether the main process is still alive, and that is a weak proxy for whether the application works. A process that has deadlocked on a lock, exhausted its connection pool, lost its database and is retrying forever, or wedged its event loop stays alive and reports as running. Compose keeps it in service, Swarm keeps routing to it, and dependent containers configured to wait for it start against a service that cannot answer.
 
-        Note that Kubernetes ignores the Dockerfile HEALTHCHECK instruction. Kubernetes determines container health through its own liveness, readiness, and startup probes defined in the pod specification. A HEALTHCHECK still benefits Docker, Docker Compose, and Docker Swarm, so it remains worth defining, but on Kubernetes you must configure the equivalent probes separately.
+        The absence also breaks orchestration ordering. A Compose dependency that waits for a service to become healthy has nothing to wait on when no health check is defined, so the dependent container starts immediately and fails on its first request, producing a startup race that reproduces on some machines and not others.
+
+        Health history is useful after the fact as well. When a container is investigated, the record of when it last passed narrows the window to look at; without a check, the timeline starts wherever a human first noticed.
+
+        Define a check that exercises the application rather than the process, and make sure the command it runs exists in the final image, because minimal and distroless bases often ship without an HTTP client and a probe that cannot execute reports unhealthy forever. Kubernetes ignores this instruction entirely and uses its own liveness, readiness, and startup probes, so define those separately on that platform.
       audit: |
         Inspect the Dockerfile to confirm a HEALTHCHECK is defined:
 
@@ -782,14 +879,19 @@ queries:
       docker.file.stages.all(healthcheck == null || healthcheck.none == false)
     docs:
       desc: |
-        No Dockerfile stage should use `HEALTHCHECK NONE` to explicitly disable health checking.
+        This check verifies that no build stage disables health checking with `HEALTHCHECK NONE`.
+
+        `HEALTHCHECK NONE` is the instruction form that removes a health check rather than defining one. It exists because image configuration is inherited: a stage built on a base that declares a check carries that check forward, and this form is how a Dockerfile discards it. The check requires that no stage in the Dockerfile use it.
 
         **Why this matters**
 
-        - **Overrides base image checks:** Many well-maintained base images include appropriate HEALTHCHECK instructions. `HEALTHCHECK NONE` discards these intentionally configured checks.
-        - **Intentional degradation:** While a missing HEALTHCHECK might be an oversight, `HEALTHCHECK NONE` is a deliberate decision to remove health monitoring.
-        - **Orchestrator impact:** Containers without health checks cannot benefit from automatic restart policies or health-aware load balancing.
-        - **Debugging difficulty:** When a container becomes unresponsive, the lack of health check history makes it harder to determine when the problem started.
+        The inherited check is usually the better one. Publishers of database, message broker, and web server images write probes against the protocol their service speaks, using a client they know is present in the image, and they update the probe when the service changes. Discarding it replaces a maintained, protocol-aware check with nothing at all.
+
+        Once it is gone, the runtime falls back to process liveness, which reports a wedged or deadlocked service as running. Compose leaves it in the rotation, Swarm keeps routing to it, and any container waiting for this one to become healthy has nothing to wait on and starts against a service that cannot answer.
+
+        This is also a different problem from an image that never had a check. A missing health check is usually an oversight and reads as one. `HEALTHCHECK NONE` is a deliberate line someone added, typically to stop a probe that was failing. The failing probe was reporting something real, and turning it off leaves that cause in place while removing the only signal that would have shown it recurring.
+
+        If the inherited check does not fit the application, override it with one that does rather than removing it. A probe that fails because the base image's client is missing from a slimmed final stage is fixed by supplying a probe that uses a command the image actually has.
       audit: |
         Inspect the Dockerfile to confirm no stage disables health checking:
 
@@ -823,14 +925,19 @@ queries:
       docker.file.stages.all(workdir.all(path == /^\//))
     docs:
       desc: |
-        Every WORKDIR instruction in the Dockerfile should use an absolute path rather than a relative path.
+        This check verifies that every `WORKDIR` instruction in the Dockerfile uses an absolute path.
+
+        `WORKDIR` sets the directory that subsequent instructions in the stage resolve relative paths against, and it creates that directory if it does not exist. A relative argument is resolved against whatever the working directory happened to be at that point, which may come from an earlier `WORKDIR` in the same stage or from the base image's own configuration. The check requires every `WORKDIR` path in every stage to begin with a slash.
 
         **Why this matters**
 
-        - **Context dependence:** A relative WORKDIR is resolved against the current working directory, which may differ depending on the base image or preceding WORKDIR instructions.
-        - **Build fragility:** Changing the base image or reordering instructions can silently change where files are copied and commands are executed.
-        - **Harder to audit:** With relative paths, determining the actual working directory at any point in the Dockerfile requires tracing through all preceding instructions.
-        - **Unexpected file placement:** Files added with COPY or ADD may end up in unintended locations when the working directory is ambiguous.
+        The starting point is not under the Dockerfile's control. A base image sets its own working directory, so a relative `WORKDIR` lands in a different place depending on which image the stage builds on. Changing a base image tag, or switching from one language image to another, silently moves every path in the file without a single line of the Dockerfile changing.
+
+        Relative paths compound. Each one is applied to the result of the previous one, so inserting, removing, or reordering a `WORKDIR` moves everything after it. A reviewer looking at a diff that adds one instruction cannot tell it relocated the application, and the build still succeeds, because `WORKDIR` creates whatever directory it names.
+
+        The consequences show up as files in the wrong place. A `COPY` lands outside the directory the entrypoint runs in, a build artifact is written where nothing looks for it, and the container starts and fails with a missing-file error that points at the application rather than at the Dockerfile.
+
+        Reading the file also becomes an exercise in simulation. Answering where a given `RUN` executes means tracing every preceding instruction, including whatever the base image configured. Writing each path in full makes each instruction independently readable.
       audit: |
         Inspect the Dockerfile to confirm WORKDIR paths are absolute:
 
@@ -865,16 +972,17 @@ queries:
       docker.file.stages.all(run.all(commands.none(binary == "cd")))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should use the WORKDIR instruction to change directories rather than calling `cd`.
+        This check verifies that `RUN` instructions do not use `cd` to change directories.
+
+        `WORKDIR` sets the working directory for every instruction that follows it in the stage, and the setting is recorded in the image configuration. `cd` inside a `RUN` instruction changes the directory only for the shell that instruction spawns, and that shell exits when the instruction finishes, so subsequent `RUN`, `COPY`, and `ADD` instructions are unaffected. The check requires that no `RUN` instruction in any build stage invoke `cd`.
 
         **Why this matters**
 
-        - **Non-persistent:** `cd` in a `RUN` instruction only changes the directory for that single command and does not affect subsequent `RUN`, `COPY`, or `ADD` instructions.
-        - **Error-prone:** Developers may expect `cd` to persist across instructions, leading to files being placed in the wrong location or commands failing.
-        - **Readability:** WORKDIR makes the current directory explicit and visible, while `cd` buried in a `RUN` command is easy to miss.
-        - **Idiomatic Dockerfiles:** The WORKDIR instruction is purpose-built for setting the working directory and is the recommended approach.
+        The mismatch between what the line looks like and what it does is the whole problem. A Dockerfile whose first instruction changes into an application directory and whose second installs dependencies looks like it installs there, and it does not; the second instruction runs wherever the stage's working directory was before. The install succeeds in the wrong place, later copies resolve somewhere else again, and the failure appears at container start as a missing file.
 
-        This check flags any `RUN` instruction containing `cd`. Using `cd` within a compound command such as `cd /tmp && make && cd /app && make install` is acceptable practice to avoid extra layers but will still trigger this check. Set WORKDIR before the `RUN` instruction where possible.
+        It also hides the working directory from anything that reads the image rather than the source. Image inspection reports the configured working directory, so a `WORKDIR` is visible to tooling and to anyone debugging a container, while a `cd` buried in a shell line is not. The same applies to a person scanning the file: `WORKDIR` sits at the start of a line, `cd` sits in the middle of a long chained command.
+
+        This check flags any `cd` in a `RUN` instruction, including the compound form `cd /tmp && make && cd /app && make install`. Chaining that way is a reasonable technique for keeping the layer count down, so treat a finding here as a prompt to move the directory change into a `WORKDIR` where the structure allows it. Where a step really must move between directories, setting `WORKDIR` before the instruction and again afterward costs at most an empty directory in the image.
       audit: |
         Inspect the Dockerfile to confirm `RUN` instructions do not use `cd`:
 
@@ -916,13 +1024,19 @@ queries:
       docker.file.stages.all(run.where(commands.any(binary == "microdnf" && subcommand == "install")).all(mounts.any(type == "cache" && target == /^\/var\/cache\/(dnf|yum)\/?$/) || commands.any(binary == "microdnf" && subcommand == "clean" && args.contains("all"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions that use `microdnf install` should also run `microdnf clean all` in the same layer, or keep the cache out of the image by mounting `/var/cache/dnf` as a BuildKit cache. microdnf is a minimal DNF implementation used in Red Hat UBI micro images, and like other package managers it caches downloaded packages and metadata.
+        This check verifies that a `RUN` instruction which installs packages with `microdnf` does not leave the package cache in the image layer.
+
+        `microdnf` is the stripped-down package manager shipped in Red Hat's Universal Base Image micro images, built without the Python stack that DNF requires. It is smaller, but it caches the same way: downloaded RPMs and repository metadata land in `/var/cache/dnf` or `/var/cache/yum` and stay there. The check requires every `RUN` instruction containing `microdnf install` either to run `microdnf clean all` in the same instruction or to mount the cache directory as a build cache.
 
         **Why this matters**
 
-        - **Image bloat:** microdnf caches downloaded packages and metadata in `/var/cache/yum` or `/var/cache/dnf`, which can add significant size to the image layer.
-        - **Consistency:** All other package manager checks (apt, yum, dnf, zypper) require cache cleanup; microdnf should not be an exception.
-        - **Layer optimization:** Combining install and cleanup in a single `RUN` instruction ensures the cache never persists in any layer.
+        The whole point of a micro base image is size. It exists so an image is a few tens of megabytes rather than a few hundred, and a package cache left in a layer can be larger than the base image it was added to. The saving the base image was chosen for is spent on metadata for packages nobody will install again.
+
+        Nothing reads the cache after the build. Containers are replaced rather than patched, so a new package version means a new image from a new build, and the cached RPMs sit unread while being pulled to every node that runs the image.
+
+        Cleaning up in a following instruction shrinks nothing. Layers are append-only, so a deletion is recorded on top while the files remain in the layer that wrote them, still transferred on pull and still readable from an exported image.
+
+        Chain `microdnf clean all` onto the install so both land in one instruction, or mount the cache as a build cache if repeated builds make redownloading costly. The sibling checks in this policy ask the same of apt, yum, dnf, and zypper, so applying it here keeps every install path in the Dockerfile consistent.
       audit: |
         Inspect the Dockerfile to confirm the microdnf cache is cleaned in the install layer:
 
@@ -962,13 +1076,19 @@ queries:
       docker.file.stages.all(copy.where(src.length > 1).all(dst == /\/$/))
     docs:
       desc: |
-        COPY instructions with more than one source argument should use a destination path ending with `/`. When COPY has multiple source files but the destination does not end with a slash, the build may fail or produce unexpected results depending on the Docker version.
+        This check verifies that a `COPY` instruction with more than one source path names a destination directory.
+
+        `COPY` accepts several sources and one destination. When more than one source is given, the destination has to be a directory, and Dockerfile syntax marks a directory by ending the path with `/`. Without it the builder cannot tell whether the last argument is a directory to copy into or a filename to rename onto. The check requires every `COPY` with two or more sources to end its destination with a slash.
 
         **Why this matters**
 
-        - **Build failures:** With multiple source files, Docker expects the destination to be a directory indicated by a trailing slash. Without it, the build may fail with an ambiguous error.
-        - **Required by Docker:** When a COPY instruction lists multiple sources, Docker requires the destination to be a directory ending with `/` and rejects the instruction with a build error otherwise.
-        - **Clarity:** A trailing slash explicitly communicates that the destination is a directory, making the Dockerfile easier to understand and maintain.
+        The build fails, and the message does not name the cause clearly. The builder reports that the destination must be a directory when copying multiple files, which sends the reader looking at whether the directory exists rather than at the missing character. That is a slow diagnosis for a one-character fix, and it happens at a point where CI is already several minutes into a build.
+
+        The instruction is also fragile in a way that is easy to introduce. A `COPY` with one source and no trailing slash is legal and writes to a file of that name, so a working line becomes a broken one the moment a second source is added, and the diff that broke it looks like it only added a filename.
+
+        Where behavior differs across builder versions the outcome is worse than a failure. An ambiguous destination can be treated as a directory by one builder and as a rename target by another, so the same Dockerfile produces different filesystem layouts depending on where it is built, and the difference only appears when something tries to read the file at runtime.
+
+        Ending every multi-source destination with a slash removes the ambiguity and states the intent on the line, so a reader knows the arguments land inside a directory rather than replacing one.
       audit: |
         Inspect the Dockerfile to confirm multi-source COPY destinations end with `/`:
 

--- a/content/mondoo-dockerfile-security.mql.yaml
+++ b/content/mondoo-dockerfile-security.mql.yaml
@@ -101,14 +101,21 @@ queries:
       docker.file.stages.all(expose.all(port != 6443))
     docs:
       desc: |
-        Dockerfiles should not declare `EXPOSE` instructions for management ports such as SSH (22), the Docker Remote API (2375), Consul (8500), or the Kubernetes API (6443).
+        This check verifies that no `EXPOSE` instruction in the Dockerfile advertises a management port.
+
+        `EXPOSE` records the ports an image intends to serve. It does not publish anything by itself, but `docker run -P` publishes every exposed port to a host port, and orchestrators, service meshes, and compose files read the same metadata to decide what to wire up. The check requires that no build stage expose port 22 for SSH, 2375 for the unencrypted Docker Remote API, 8500 for the Consul HTTP API, or 6443 for the Kubernetes API server.
 
         **Why this matters**
 
-        - **Unauthorized access:** These ports are commonly targeted by attackers to gain access to containerized environments.
-        - **Increased attack surface:** Exposing management ports unnecessarily expands the attack surface and makes vulnerabilities easier to reach.
-        - **Operational risks:** Misconfigured or exposed management ports can lead to unintended access, service disruptions, or data breaches.
-        - **Compliance risks:** Many security standards require restricting access to management ports to reduce potential threats.
+        Port 2375 is the one that ends worst. The Docker Remote API listens there without TLS and without authentication, so anyone who reaches it can create a container that bind-mounts the host root filesystem and then write to `/etc/shadow` or drop a service unit file. That is root on the node rather than root inside one container.
+
+        Port 8500 hands an attacker the Consul HTTP API. They read the key-value store, which in most deployments holds database passwords and service tokens, then rewrite a service registration so traffic intended for a healthy backend is routed to a host they control.
+
+        Port 6443 matters when the image also carries a kubeconfig or a mounted service account token. Reaching the API server with that credential lets an attacker list secrets across every namespace the token can see and schedule a privileged pod on another node.
+
+        Port 22 turns the container into a login target. Whatever key or password the image baked in becomes a shell, and from that shell the attacker reaches every internal address the container network can route to.
+
+        Expose only the ports the application itself serves. Management access belongs on runtime-managed channels such as an orchestrator exec path, not on a port recorded in the image.
       audit: |
         Inspect the Dockerfile to confirm management ports are not exposed:
 
@@ -159,14 +166,19 @@ queries:
       docker.file.stages.all(run.all(commands.none(flags.contains("--allow-insecure-repositories"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not pass the `--allow-insecure-repositories` option to the APT package manager.
+        This check verifies that no `RUN` instruction disables APT's repository signature verification.
+
+        APT refuses to install from a repository whose release metadata is not signed by a key it trusts. The `--allow-insecure-repositories` option removes that refusal and downgrades it to a warning, so an index that is unsigned or that cannot be verified is accepted and the install that follows proceeds from it. The check requires that no `RUN` instruction in any build stage pass this option.
 
         **Why this matters**
 
-        - **Man-in-the-middle attacks:** Without repository validation, attackers can intercept and modify package data during download, potentially injecting malicious code.
-        - **Integrity issues:** Using insecure repositories undermines the integrity of the software being installed, as there is no guarantee that packages come from trusted sources.
-        - **Operational risks:** Installing packages from insecure repositories can pull in compromised or outdated software, increasing the risk of vulnerabilities in the container.
-        - **Compliance risks:** Many security standards require repository and certificate validation to ensure secure communication and package integrity.
+        Repository signing is the only thing tying a package to its publisher. Without it, an attacker who can answer for the repository host, whether through DNS poisoning on the build network, a compromised mirror, or a typo-squatted hostname in the Dockerfile, serves an index of their choosing and APT installs whatever it names. The payload lands as an ordinary package with a maintainer script, which runs as root during the build and can write anywhere in the image.
+
+        That code then ships. Every container started from the image runs it, in every environment the image reaches, and the compromise is invisible to a scanner comparing installed package versions against a vulnerability database, because the attacker chose a version string that looks ordinary.
+
+        The bypass also hides its own cause. A build that needs this option is a build whose repository key was never imported, so the error it suppresses is the one worth reading.
+
+        The fix is to make verification succeed rather than to skip it. Import the publisher's signing key into a keyring, pin it to the repository so only that key can authorize packages from that source, then remove the option. Dropping the option on its own breaks the install against an unsigned repository, which is exactly why it tends to be added back.
       audit: |
         Inspect the Dockerfile to confirm APT does not skip repository validation:
 
@@ -224,14 +236,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "curl").none(flags.contains("--insecure") || flags.any(_ == /^-[a-zA-Z]*k[a-zA-Z]*$/))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not pass the `--insecure` or `-k` options to `curl`. The `-k` option also counts when it is bundled into a short-option cluster such as `-fsSLk`.
+        This check verifies that no `curl` invocation in a `RUN` instruction disables TLS certificate validation.
+
+        `curl` validates the server certificate against its trust store by default and aborts the transfer when validation fails. The `--insecure` option, and its short form `-k`, turn that abort into silent acceptance of any certificate, including one the attacker signed themselves. The check reads every `RUN` instruction, finds the `curl` commands, and requires that neither form is present. The short form counts when it is bundled into an option cluster such as `-fsSLk`, which is how it most often reaches a Dockerfile, because it reads as part of a familiar download idiom rather than as a decision.
 
         **Why this matters**
 
-        - **Man-in-the-middle attacks:** Without TLS certificate validation, attackers can intercept and modify data during transmission, potentially injecting malicious content.
-        - **Integrity issues:** Disabling certificate checks undermines the integrity of the data being transferred, as there is no guarantee that it comes from trusted sources.
-        - **Operational risks:** Fetching content over unvalidated connections can pull in compromised or outdated data, increasing the risk of vulnerabilities in the container.
-        - **Compliance risks:** Many security standards require TLS certificate validation to ensure secure communication.
+        Almost every Dockerfile that calls `curl` is downloading something it then executes: a binary, an installer script piped to a shell, a release tarball unpacked into the image. Certificate validation is what makes the response come from the host named in the URL rather than from whoever is on the path.
+
+        With validation off, anyone who can answer for that hostname on the build network serves their own payload. On a shared CI runner or a build reached through an intercepting proxy, that is a realistic position to hold. The substituted binary is baked into a layer and runs with whatever privileges the container is later given.
+
+        The failure is silent in both directions. `curl` exits zero, the build succeeds, and the resulting layer looks identical to a clean one. Nothing in the image records that the download was unverified.
+
+        Remove the option and fix the underlying trust problem instead. If the endpoint presents a certificate from an internal authority, install that authority's certificate into the image so validation succeeds on its own.
       audit: |
         Inspect the Dockerfile to confirm `curl` validates certificates:
 
@@ -279,14 +296,19 @@ queries:
       docker.file.stages.all(run.all(commands.none(flags.contains("--no-check-certificate"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not pass the `--no-check-certificate` option to `wget`.
+        This check verifies that no `wget` invocation in a `RUN` instruction disables TLS certificate validation.
+
+        `wget` verifies the server certificate against the system trust store and refuses the transfer when verification fails. The `--no-check-certificate` option removes that refusal and accepts any certificate, whether expired, self-signed, or issued for a different host. The check requires that no `RUN` instruction in any build stage pass this option.
 
         **Why this matters**
 
-        - **Man-in-the-middle attacks:** Without TLS certificate validation, attackers can intercept and modify data during transmission, potentially injecting malicious content.
-        - **Integrity issues:** Disabling certificate checks undermines the integrity of the data being transferred, as there is no guarantee that it comes from trusted sources.
-        - **Operational risks:** Fetching content over unvalidated connections can pull in compromised or outdated data, increasing the risk of vulnerabilities in the container.
-        - **Compliance risks:** Many security standards require TLS certificate validation to ensure secure communication.
+        The `wget` calls in a Dockerfile fetch the things the image is built out of: language runtimes, release archives, install scripts, static binaries. With certificate verification disabled, the only remaining guarantee is that something answered the connection, not that the thing answering is the publisher named in the URL.
+
+        An attacker positioned between the builder and that host, on a shared runner, behind a poisoned resolver, or on an intercepting proxy, answers with their own archive. It is unpacked into the image and, in the common install-script case, executed as root during the build. The result is a working image that passes its tests and carries an implant in a layer nobody rereads.
+
+        The option is usually added to get past a real error: an expired certificate on an internal mirror, or a private certificate authority the base image does not trust. Suppressing the error leaves that root cause in place, and every later build inherits both the broken trust configuration and the bypass.
+
+        Remove the option so verification runs again. If the download target uses an internal certificate authority, add that authority's certificate to the image's trust store before the fetch. If the certificate is genuinely expired, renewing it is the fix, because a build that succeeds against an expired certificate is a build that cannot tell a lapsed certificate from an attacker's.
       audit: |
         Inspect the Dockerfile to confirm `wget` validates certificates:
 
@@ -334,14 +356,19 @@ queries:
       docker.file.stages.all(run.all(commands.none(binary == "sudo")))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not use `sudo` to run commands.
+        This check verifies that no `RUN` instruction invokes `sudo`.
+
+        Build steps in a Dockerfile already run as root unless an earlier `USER` instruction changed that, so `sudo` is not what grants a step its privileges. The check requires that no `RUN` instruction in any build stage call `sudo`.
 
         **Why this matters**
 
-        - **Privilege escalation:** `sudo` grants elevated permissions that can be exploited if not handled properly.
-        - **Inconsistent behavior:** Commands requiring `sudo` may fail in environments where `sudo` is not configured or available.
-        - **Least privilege:** Docker containers are designed to run with the least privileges necessary, and using `sudo` contradicts this principle and increases the attack surface.
-        - **Operational risks:** Overuse of `sudo` can lead to misconfigurations or unintended privilege escalations, compromising container security.
+        The reason to care is what `sudo` leaves in the image rather than what it does during the build. For it to work at all, the package has to be installed, and it ships a setuid root binary alongside a policy file. Once a container from that image is running as a non-root user, that binary is the shortest path back to root inside the container.
+
+        An attacker who reaches code execution as the application user, through a deserialization bug, a template injection, or an uploaded file, looks for exactly this. A permissive rule left in the sudoers policy, a passwordless entry inherited from a base image, or a `sudo` release with a known local privilege escalation turns a limited foothold into root in the container. From root in the container, a writable Docker socket, a relaxed seccomp profile, or a retained kernel capability becomes reachable in a way it was not before.
+
+        There is a build-time cost too. A step that needs `sudo` assumes an interactive shell and a configured sudoers policy, so the same Dockerfile behaves differently on a base image that does not ship it, and the build fails in a way that reads as a missing command rather than as a design problem.
+
+        Run privileged steps while the build is still root, then drop to a non-root account with `USER` for the stages that follow. Nothing in a build needs `sudo` to reach root.
       audit: |
         Inspect the Dockerfile to confirm `sudo` is not used:
 
@@ -391,14 +418,19 @@ queries:
       docker.file.stages.all(run.all(commands.none(flags.contains("--nogpgcheck") || flags.contains("--no-gpg-checks"))))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not pass GPG signature verification bypass options to package managers: `--nogpgcheck` for YUM and DNF, or `--no-gpg-checks` for zypper.
+        This check verifies that no `RUN` instruction disables GPG signature verification for RPM package installs.
+
+        YUM, DNF, and zypper verify each package against a signing key imported into the RPM keyring before installing it. The `--nogpgcheck` option for YUM and DNF, and `--no-gpg-checks` for zypper, skip that verification. The check requires that no `RUN` instruction in any build stage pass either option.
 
         **Why this matters**
 
-        - **Integrity issues:** Without GPG validation, there is no guarantee that installed packages come from trusted sources, increasing the risk of installing compromised or malicious software.
-        - **Man-in-the-middle attacks:** Disabling GPG checks makes it easier for attackers to intercept and modify package data during download.
-        - **Operational risks:** Skipping signature checks can pull in outdated or tampered packages, increasing the risk of vulnerabilities in the container.
-        - **Compliance risks:** Many security standards require GPG validation to ensure the integrity and authenticity of software packages.
+        Signature verification is what binds an RPM to the organization that built it. It survives an untrusted transport, a mirror the publisher does not control, and a caching proxy in between, because the check runs over the package contents rather than over the connection.
+
+        Turning it off returns the decision to whoever served the file. An attacker who controls a mirror, poisons the build network's resolver, or answers for a repository host publishes a package that installs cleanly. RPM scriptlets run as root during the build, so the package does not even need to contain a malicious binary; the install itself is enough to add a user, drop a key, or rewrite a service file inside the image.
+
+        The compromise then travels with the image. Package version reporting still looks correct, because the attacker chose the version string, so a vulnerability scan of the finished image finds nothing to report.
+
+        The correct fix is to make verification pass. Import the publisher's key into the RPM keyring, then install without the bypass. Removing the option on its own breaks the build against an unsigned or keyless repository, which is exactly why the bypass tends to reappear. If a repository genuinely publishes no signatures, that is a fact about the repository worth escalating rather than working around inside a Dockerfile.
       audit: |
         Inspect the Dockerfile to confirm GPG validation is not bypassed:
 
@@ -464,14 +496,21 @@ queries:
       docker.file.finalStage.runsAsRoot == false
     docs:
       desc: |
-        The final stage of the Dockerfile should set a `USER` instruction that specifies a non-root user, so container processes do not run as root. This check fails when the final stage omits `USER` entirely or sets it to `root` or UID `0`.
+        This check verifies that the final build stage of the Dockerfile switches to a non-root user.
+
+        The `USER` instruction sets the account that later build steps and, more importantly, the container's entrypoint run as. Docker defaults to root when no stage sets it. The check reads the final stage and requires a `USER` instruction naming something other than `root` or UID `0`. A final stage that omits `USER` entirely fails, and so does one that switches back to root after an earlier stage dropped privileges.
 
         **Why this matters**
 
-        - **Privilege escalation:** If an attacker gains access to a container running as root, they may exploit it to gain elevated privileges on the host system.
-        - **Increased attack surface:** Containers running as root have access to more system resources, increasing the potential impact of a security breach.
-        - **Least privilege:** Security standards recommend running containers with the least privileges necessary to perform their tasks.
-        - **Operational risks:** Misconfigurations or vulnerabilities in containers running as root can lead to unintended access, data breaches, or service disruptions.
+        Root in a container is not root on the host, but the gap is thinner than it looks. Root in the container holds the default capability set, which includes the ability to change ownership, become any user the image defines, and override file permission checks outright, so an attacker with code execution can read and rewrite any file in the image regardless of how it is protected.
+
+        That is what turns a single application bug into a persistent foothold. An attacker who lands as an unprivileged user can only modify what that user owns. As root they rewrite the entrypoint, patch a binary in place, and install whatever they want to survive a restart.
+
+        The blast radius grows with anything the container is given. A host path mounted into the container is written with root's identity, so a bind-mounted configuration directory becomes host-writable. A mounted Docker socket becomes full control of the node. A kernel vulnerability that needs a capability an unprivileged user lacks becomes reachable.
+
+        Orchestrators enforce this as well. A Kubernetes pod configured to require a non-root user refuses to start an image whose user resolves to UID 0, so an image without a `USER` instruction is rejected at admission rather than caught in review.
+
+        Create a dedicated account in the image, give it ownership of the paths the application writes at runtime, and place the `USER` instruction after the steps that need root. A numeric UID is preferable where a platform must confirm the user is non-root without resolving names.
       audit: |
         Inspect the Dockerfile to confirm the final stage runs as a non-root user:
 
@@ -542,13 +581,19 @@ queries:
       docker.file.stages.all(add == empty)
     docs:
       desc: |
-        Dockerfiles should use the `COPY` instruction instead of `ADD`, unless `ADD`'s specific features are genuinely required.
+        This check verifies that no build stage in the Dockerfile uses the `ADD` instruction.
+
+        `COPY` moves files from the build context or an earlier stage into the image and does nothing else. `ADD` does that too, but it also fetches remote URLs, clones git repositories, and silently unpacks local tar archives into the destination. The check requires that no stage contain an `ADD` instruction.
 
         **Why this matters**
 
-        - **Security risks:** `ADD` can fetch files from remote URLs and automatically extract tar archives, which can expose the container to malicious files or unintended behavior if misused.
-        - **Predictability:** `COPY` only copies files from source to destination, providing straightforward and consistent behavior and reducing the risk of unexpected outcomes during the build.
-        - **Best practices:** Security standards and Dockerfile best practices recommend `COPY` for file copying tasks to minimize potential vulnerabilities.
+        The automatic extraction is the part that surprises people. Any local file whose contents look like a tar archive is unpacked rather than copied, and the archive itself decides where its members land. A crafted archive with entries that traverse upward writes outside the destination directory, so adding an artifact that arrived from a build system or an outside contributor can rewrite paths the Dockerfile never mentions.
+
+        The remote fetch is the other half. Pointing `ADD` at an HTTPS URL downloads over the network at build time with no integrity check unless a checksum is supplied, and the result is baked into a layer. If the host is taken over, or the release asset is replaced in place, the next build pulls the substituted content and nothing in the Dockerfile changes to signal it.
+
+        Both behaviors are invisible at review. `ADD` and `COPY` read almost identically in a diff, so a reviewer scanning for a network fetch or an extraction step does not see one.
+
+        Replace `ADD` with `COPY` for anything that comes from the build context. When a remote artifact really is needed, download it in a `RUN` step and verify its checksum against a value committed to the repository, so a substituted file fails the build. When a local archive must be unpacked, copy it and extract it explicitly, so the extraction is a line a reviewer can see.
       audit: |
         Inspect the Dockerfile to confirm `ADD` is not used:
 
@@ -610,14 +655,19 @@ queries:
       docker.file.stages.all(from.tag != "latest")
     docs:
       desc: |
-        Dockerfile `FROM` instructions should not use the `latest` tag for base images.
+        This check verifies that no `FROM` instruction in the Dockerfile builds on a base image tagged `latest`.
+
+        A tag is a mutable pointer to an image digest. `latest` is the tag most projects move most often, and it carries no promise about which release it points at; it is the default name applied when a publisher pushes without specifying one. The check requires every `FROM` instruction in every build stage to name something other than `latest`.
 
         **Why this matters**
 
-        - **Unpredictable builds:** The `latest` tag may point to different versions of the base image over time, leading to inconsistent and unreliable builds.
-        - **Security risks:** Newer versions of the base image may introduce vulnerabilities or breaking changes that affect the container's functionality.
-        - **Lack of control:** Specifying an explicit version tag ensures the container is built with a known and tested base image.
-        - **Compliance risks:** Many security standards recommend fixed version tags to ensure predictable and secure builds.
+        Because the tag is mutable, the image a build produces is decided by whoever last pushed to the upstream repository rather than by the Dockerfile. An attacker who obtains a push credential for that repository, or who takes over an abandoned namespace on a public registry, repoints `latest` and every downstream build consumes their image on its next run. Nothing in the Dockerfile changes, so there is no diff, no review, and no signal in the pipeline.
+
+        The same mutability breaks incident response. When a base image is found to be compromised, the question is which of your images were built from the affected digest. With a moving tag there is no way to answer that from source; the record exists only in whatever the registry retained about each build.
+
+        The everyday cost is a broken build with no apparent cause. `latest` moves to a new major release, the runtime or system library the application links against changes underneath it, and the failure appears in a pipeline whose last commit touched something unrelated.
+
+        Name an explicit version tag so the base image is a reviewable line in the Dockerfile. Pin by digest where reproducibility must survive a retagged release, and let a dependency update tool raise the pin as a pull request a person approves.
       audit: |
         Inspect the Dockerfile to confirm base images do not use the `latest` tag:
 
@@ -665,16 +715,19 @@ queries:
       docker.file.stages.all(from.tag != empty || from.digest != empty || from.image == "scratch")
     docs:
       desc: |
-        Every `FROM` instruction in the Dockerfile should specify an explicit image tag or digest. When neither is provided, Docker implicitly uses the `:latest` tag, which defeats the purpose of version pinning. The reserved `scratch` base image is exempt because it is an empty starting point with no published tags.
+        This check verifies that every `FROM` instruction in the Dockerfile names an explicit tag or digest.
+
+        An image reference with no tag is not an error. The registry client fills in `:latest` and resolves that, so a bare image name and the same name with the `latest` tag build identically while only one of them says so. The check requires each `FROM` instruction to carry a tag or a digest. The reserved `scratch` base is exempt, because it is an empty filesystem with nothing published to tag.
 
         **Why this matters**
 
-        - **Silent version drift:** Builds silently pull whatever version is currently tagged as `latest`, leading to unpredictable behavior across environments.
-        - **Supply chain risk:** An attacker who compromises an image registry can push a malicious image as the default tag, affecting all untagged `FROM` references.
-        - **Harder to audit:** Without an explicit tag, it is difficult to determine which version of the base image was used, complicating incident response and vulnerability tracking.
-        - **Reproducibility:** Builds are not reproducible over time since the underlying image changes without any change to the Dockerfile.
+        The omission is harder to catch than the explicit case. A companion check in this policy flags `FROM image:latest`, which a reviewer also spots by eye. A bare image name reads like a deliberate choice and gets waved through, while resolving to exactly the same mutable pointer.
 
-        This check differs from the `latest` tag check: that check catches explicit use of `FROM image:latest`, while this check catches the implicit case where no tag is specified at all.
+        That pointer is controlled by whoever can push to the upstream repository. Someone who obtains a publisher's credential, or who registers an abandoned name on a public registry, changes what the default tag resolves to, and the next build of an untagged `FROM` consumes it. The Dockerfile is unchanged, so nothing in review or in the pipeline marks the substitution.
+
+        Reproducibility goes with it. Rebuilding a release from its commit produces whatever the registry serves that day, so a bug that reproduces in production may not reproduce in a rebuild, and a bill of materials describes one build rather than the source it came from.
+
+        Add the version tag the image is actually tested against. For builds that must be reproducible over time, pin the digest as well, so the tag documents intent and the digest fixes the content. Automated dependency updates keep the pin current and turn each base image change into a reviewable commit.
       audit: |
         Inspect the Dockerfile to confirm every base image specifies a tag:
 
@@ -728,14 +781,19 @@ queries:
       docker.file.stages.all(env.none(name == /(?i)(password|passwd|secret|token|private[_.\-]key|access[_.\-]key|api[_.\-]key|apikey|credential)/))
     docs:
       desc: |
-        Dockerfile `ENV` instructions should not define environment variables with names that suggest they contain secrets, such as passwords, API keys, tokens, or credentials.
+        This check verifies that no `ENV` instruction declares a variable whose name indicates it holds a secret.
+
+        `ENV` writes a name and value into the image configuration, where it becomes a default environment variable for every container started from that image. The check reads every `ENV` instruction in every build stage and fails any whose variable name suggests a credential, matching names that contain password, passwd, secret, token, private key, access key, api key, or credential in any capitalization.
 
         **Why this matters**
 
-        - **Image inspection:** Anyone with access to the image can run `docker inspect` or `docker history` to view all environment variables, including their values.
-        - **Container leakage:** Environment variables are inherited by all processes in the container and may appear in logs, error reports, or debug output.
-        - **Registry exposure:** Images pushed to registries, even private ones, carry all `ENV` values, expanding the blast radius of a registry compromise.
-        - **Layer persistence:** Even if a subsequent layer unsets the variable, the value remains in the earlier image layer and can be extracted.
+        The value does not stay in the container. It is stored in the image configuration blob, so `docker inspect` prints it, `docker history` prints the instruction that set it, and anyone who can pull the image reads both without ever starting it. Pulling is usually far easier than getting code execution: a registry credential lifted from a CI job, a leaked pull secret from a Kubernetes namespace, or a registry that turned out to allow anonymous reads are each enough.
+
+        Deleting the value later does not help. Image layers are immutable and additive, so a subsequent `ENV` that clears the variable, or a `RUN` that unsets it, only adds a layer on top. The original value is still in the earlier layer and is recovered by exporting the image and reading it.
+
+        Inside a running container the exposure widens again. Environment variables are inherited by every child process, so they appear in the process filesystem to anything that can read it, in crash dumps, in exception traces that many frameworks render with the full environment attached, and in debug endpoints that print configuration.
+
+        Inject credentials at run time from the orchestrator's secret store, and for values needed only during the build, use a build secret mount so nothing is written into a layer.
       audit: |
         Inspect the Dockerfile to confirm `ENV` instructions do not declare secrets:
 
@@ -799,15 +857,21 @@ queries:
       docker.file.stages.all(volumes.none(path == /^\/(etc|proc|sys|dev|boot|root)(\/|$)/ || path == "/"))
     docs:
       desc: |
-        Dockerfiles should not declare `VOLUME` instructions for sensitive host directories such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, or `/root`, including their subpaths. The `VOLUME` instruction declares a mount point within the image, and declaring sensitive paths creates a persistent risk when containers are later launched with host bind mounts.
+        This check verifies that no `VOLUME` instruction in the Dockerfile declares a sensitive system directory as a mount point.
+
+        `VOLUME` marks a path inside the image as a mount point. At runtime the container engine either creates an anonymous volume there or binds whatever the operator supplies, and the declaration in the image is what makes that path a candidate in the first place. The check requires that no build stage declare `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, or `/root`, or any path beneath them.
 
         **Why this matters**
 
-        - **Host filesystem exposure:** If `/` or `/etc` is declared as a volume and later bound to the host, it can expose host configuration files, credentials, and system secrets to the container.
-        - **Kernel interface access:** Declaring `/proc` or `/sys` as volumes creates mount points that, when bound at runtime, provide access to kernel parameters and system information usable for container escapes.
-        - **Device access:** A `/dev` volume declaration, combined with host bind mounts, can expose host devices and enable direct hardware access from within the container.
-        - **Privilege escalation:** Sensitive directory mount points can be chained with other vulnerabilities to escalate privileges and escape the container.
-        - **Data integrity:** Write access to host system directories through runtime-bound volumes can corrupt the host operating system.
+        The declaration is an instruction to whoever runs the image. Operators and compose files bind host paths to declared mount points because that is what the image says it needs, so a declared `/etc` is how a host `/etc` ends up inside a container.
+
+        Once it is there, the container reads the host's `/etc/shadow` and any credential file the host keeps alongside it, and if the mount is writable it appends a root account or drops an authorized key. A `/root` mount reaches the host administrator's SSH keys and shell history directly.
+
+        `/proc` and `/sys` bound from the host are the classic container escape surface. A writable cgroup filesystem lets an attacker register a release agent that the kernel then executes on the host, and `/proc` exposes the host process table, kernel command line, and tunables that a sandboxed container is not meant to see.
+
+        A `/dev` mount reaches raw block devices, so an attacker reads or rewrites the host filesystem underneath the operating system's own view of it, and `/boot` reaches the kernel and initramfs the host loads at next start.
+
+        Declare only the directories the application stores its own data in. If a container genuinely needs host information, mount the specific path read-only at run time rather than advertising it in the image.
       audit: |
         Inspect the Dockerfile to confirm no sensitive directories are declared as volumes:
 
@@ -860,13 +924,19 @@ queries:
       docker.file.stages.all(expose.all(port > 0 && port <= 65535))
     docs:
       desc: |
-        Every port exposed in the Dockerfile should fall within the valid TCP/UDP port range of 1 to 65535. An exposed port outside this range indicates a misconfiguration that causes unexpected behavior at runtime.
+        This check verifies that every port number declared in an `EXPOSE` instruction falls inside the valid TCP and UDP port range.
+
+        `EXPOSE` takes a port number and an optional protocol. A port number is a 16-bit value, so the only legal values are 1 through 65535. The check reads every `EXPOSE` instruction in every build stage and requires each port to fall in that range. A value of 0, or anything above 65535, fails.
 
         **Why this matters**
 
-        - **Silent failures:** Docker may silently ignore or misinterpret out-of-range port values, leading to containers that appear to start correctly but are not accessible on the expected port.
-        - **Configuration errors:** Out-of-range ports typically indicate a typo or copy-paste error in the Dockerfile.
-        - **Orchestration failures:** Container orchestration platforms and service meshes may silently ignore or reject containers with invalid port mappings, leading to deployment failures.
+        An out-of-range port is almost always a typo or a copied line that was never adjusted, and the failure it produces is quiet. The image builds, the container starts, and the process reports healthy, but nothing is listening where the deployment expects it. The first signal is usually a load balancer marking the backend down or a client timing out, long after the change shipped.
+
+        Tooling that consumes image metadata compounds the problem. Compose files, orchestrator manifests, and service meshes read the exposed port list to generate service definitions and network policy. A port they cannot parse tends to be dropped rather than rejected, so the generated policy silently covers fewer ports than the author believed, and a rule meant to constrain traffic to one port ends up constraining nothing.
+
+        Publishing with `docker run -P` has the same shape. The runtime maps each valid exposed port to a host port and skips the rest, so an operator reading the port mapping sees a shorter list than the Dockerfile appears to declare and has no error to explain the difference.
+
+        Correct the port number to the one the application actually binds. If the instruction was copied from another image, confirm the application's listener rather than assuming the value transferred.
       audit: |
         Inspect the Dockerfile to confirm exposed ports are within the valid range:
 
@@ -913,14 +983,19 @@ queries:
       docker.file.stages.all(run.all(commands.where(binary == "apt-get" || binary == "apt").none(subcommand == "dist-upgrade" || subcommand == "full-upgrade")))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not use `apt-get dist-upgrade` or its equivalent spellings `apt dist-upgrade` and `apt full-upgrade`. Unlike `apt-get upgrade`, `dist-upgrade` can remove existing packages, install new dependencies, and make major changes to the package configuration, leading to unpredictable and unreproducible builds.
+        This check verifies that no `RUN` instruction performs a distribution upgrade with APT.
+
+        `apt-get upgrade` installs newer versions of packages that are already present and never removes anything. `dist-upgrade` is allowed to resolve conflicts by removing packages, pulling in new dependencies, and changing which package satisfies a dependency at all. The check requires that no `RUN` instruction call `apt-get dist-upgrade`, `apt dist-upgrade`, `apt full-upgrade`, or `apt-get full-upgrade` in any build stage.
 
         **Why this matters**
 
-        - **Unpredictable builds:** `dist-upgrade` may remove or replace packages the application depends on, causing builds to break non-deterministically.
-        - **Reproducibility impact:** Non-deterministic package changes undermine the ability to audit and verify container contents, weakening supply chain security.
-        - **Image bloat:** Distribution upgrades pull in many unnecessary packages, increasing image size and attack surface.
-        - **Maintainability:** Container images should be deterministic; pinning specific package versions is preferable to running broad upgrades.
+        The set of packages a distribution upgrade installs is decided by the repository index at the moment the build runs, not by anything written in the Dockerfile. Two builds of the same commit a week apart produce different images, and neither one records what changed. When a container starts misbehaving, there is no diff to read and no way to reconstruct the earlier image.
+
+        That undermines the audit trail an image is supposed to have. A bill of materials generated from the image describes one particular build; it does not describe the Dockerfile, so the next build invalidates it. If a package pulled in by the upgrade turns out to be backdoored, there is no record of which images received it and which were built before the change.
+
+        The removal behavior is the sharper edge. A dependency conflict can remove a package the application needs, and the build still succeeds, because removal is a normal outcome for the command. The failure surfaces at runtime, in whichever environment happens to start the image first.
+
+        Install the specific packages the image needs and pin their versions. If the goal is to pick up security updates, rebuild against a newer base image tag, where the change is a visible line in the Dockerfile and reviewable in a diff.
       audit: |
         Inspect the Dockerfile to confirm `apt-get dist-upgrade` is not used:
 
@@ -969,14 +1044,19 @@ queries:
       docker.file.finalStage.oci.source != empty
     docs:
       desc: |
-        The final stage of the Dockerfile should set the `org.opencontainers.image.source` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the URL of the source code repository that produced the image, so any running container can be traced back to the repository it was built from.
+        This check verifies that the final build stage sets the `org.opencontainers.image.source` label to the URL of the repository that produced the image.
+
+        A label writes arbitrary key-value metadata into the image configuration, and the OCI image specification reserves a set of annotation keys with agreed meanings. `org.opencontainers.image.source` is the one that records the source code repository. The check reads the final stage and requires the label to be present and non-empty.
 
         **Why this matters**
 
-        - **Vulnerability response:** When a CVE is published, the source label is the canonical machine-readable link from a deployed digest back to a git repo, so the right repository can be found and rebuilt.
-        - **Incident response:** Responders inspecting a running pod can read the source URL directly from image metadata instead of correlating image names with an internal service catalog.
-        - **Asset inventory:** Compliance frameworks require maintaining an inventory of software components in production, and the source label makes that inventory self-describing.
-        - **Supply chain integrity:** Combined with a SLSA provenance attestation pointing to the same repo, the source label provides defense in depth.
+        The question this answers comes up under time pressure. A vulnerable package is announced, a scanner flags a digest running in production, and the first thing anyone needs is the repository to change and rebuild. Without the label, that mapping lives in tribal knowledge or a wiki page, and the image name is often no help: repository names drift from image names, one repository builds several images, and images inherited from a team that reorganized have no obvious owner at all.
+
+        The cost is measured in the wrong units. Time spent identifying which repository built a digest is time the vulnerable image keeps running, and the search is unreliable enough that a guess sometimes produces a rebuild of the wrong thing.
+
+        The label also makes automation possible. Vulnerability tooling that reads image metadata can open a pull request against the right repository without a separate service catalog to maintain, and a catalog maintained by hand drifts out of date exactly when it is needed.
+
+        Set the label in the final stage, since only that stage's metadata survives into the published image. Sourcing the value from a build argument that CI populates keeps it correct automatically, so a repository that is renamed or moved does not leave stale metadata behind in the next build.
       audit: |
         Inspect the Dockerfile to confirm the source label is set:
 
@@ -1036,14 +1116,19 @@ queries:
       docker.file.finalStage.oci.authors != empty
     docs:
       desc: |
-        The final stage of the Dockerfile should set the `org.opencontainers.image.authors` label. This [OCI image annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) records the contact information for the people or team responsible for the image, so any running container can be traced back to a clear owner.
+        This check verifies that the final build stage sets the `org.opencontainers.image.authors` label to a contact for the team responsible for the image.
+
+        `org.opencontainers.image.authors` is one of the annotation keys reserved by the OCI image specification, and it holds contact details for the people accountable for the image. The check reads the final stage and requires the label to be present and non-empty. A shared team address is what makes it durable; an individual address stops resolving the moment that person changes roles.
 
         **Why this matters**
 
-        - **Faster remediation:** An owner contact embedded in image metadata lets vulnerability tooling auto-route findings to the right team without a separate catalog lookup.
-        - **Incident routing:** Pages, alerts, and dashboards can surface the owner directly from image metadata, cutting time-to-acknowledge.
-        - **Asset accountability:** NIST 800-171 3.4.1 explicitly calls out component owners as required inventory metadata, and this label attaches that information to the artifact itself.
-        - **Lifecycle management:** Mandating an authors label forces ownership decisions at build time rather than after an incident, reducing the long-tail risk of orphaned images.
+        A missing owner is what stalls remediation. A scanner reports a vulnerable digest, the finding lands in a queue, and nobody can route it because the image name does not identify a team. Findings that cannot be routed are the ones that sit unaddressed for months, and the ones that get reassigned several times before reaching someone who can act.
+
+        Incident response has the same shape on a shorter clock. A container is misbehaving in the middle of the night and the responder needs whoever owns it. Reading the contact out of image metadata takes one command; finding it through a service catalog takes a working catalog, and catalogs maintained by hand are stale in exactly the corners where ownership is unclear.
+
+        Requiring the label also forces the ownership conversation at build time rather than after an incident. An image nobody will put a contact address on is an image nobody owns, and that is worth knowing before it is running in production.
+
+        Pair the label with the repository source label so a single inspection of the image yields both the code and the team. Use a mailing list or shared inbox rather than a personal address, and populate it from a build argument so an ownership change updates the metadata on the next build.
       audit: |
         Inspect the Dockerfile to confirm the authors label is set:
 
@@ -1094,13 +1179,19 @@ queries:
       docker.file.stages.all(workdir.none(path == /^\/(proc|sys|dev|sbin|boot)(\/|$)/ || path == "/"))
     docs:
       desc: |
-        WORKDIR should not be set to the filesystem root (`/`) or sensitive system directories such as `/proc`, `/sys`, `/dev`, `/sbin`, or `/boot`, including their subpaths. Setting the working directory to a system path can cause build or runtime commands to inadvertently modify critical system files or interfere with kernel interfaces.
+        This check verifies that no `WORKDIR` instruction in the Dockerfile points at the filesystem root or a system directory.
+
+        `WORKDIR` sets the directory that every subsequent `RUN`, `CMD`, `ENTRYPOINT`, `COPY`, and `ADD` in that stage resolves relative paths against, and it persists until the next `WORKDIR`. The check requires that no stage set it to `/` or to a path under `/proc`, `/sys`, `/dev`, `/sbin`, or `/boot`.
 
         **Why this matters**
 
-        - **System corruption:** Commands that create temporary files, write logs, or extract archives into the working directory could corrupt system paths.
-        - **Security exposure:** `/proc` and `/sys` expose kernel parameters and process information, so using them as a working directory increases the risk of accidental information disclosure or privilege escalation.
-        - **Unexpected behavior:** Build tools and package managers may create files in the working directory, leading to unpredictable results when that directory is a system path.
+        Whatever the working directory is becomes the default landing place for anything a build step writes without an explicit path. A recursive copy of the build context with the working directory set to `/` unpacks the repository over the root filesystem, replacing whatever names happen to collide. A tarball extracted with relative paths does the same. The build succeeds; the image is quietly broken, or quietly modified in ways nobody reviews, because the diff a reader sees is a one-line change.
+
+        `/sbin` is the sharper case. Dropping files there puts accidental executables into a directory that runs with privilege, and a name collision with an existing system binary replaces it outright.
+
+        `/proc` and `/sys` are kernel interfaces, not directories. Writes to them set kernel and process tunables rather than creating files, so a build step that expects to write a temporary file instead changes runtime behavior or fails for reasons that have nothing to do with the file it meant to create. `/boot` and `/dev` have the same problem with different consequences: one holds what the system loads at start, the other holds device nodes.
+
+        Set the working directory to a path the application owns, and create it explicitly so a typo produces a new empty directory rather than a silent write into a system location.
       audit: |
         Inspect the Dockerfile to confirm WORKDIR is not a system directory:
 
@@ -1149,14 +1240,19 @@ queries:
       docker.file.stages.all(run.none(security == "insecure"))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not use the BuildKit `--security=insecure` flag. This flag disables seccomp and AppArmor confinement for the build step, granting the command the same capabilities as the BuildKit daemon, including raw device access and unrestricted system calls.
+        This check verifies that no `RUN` instruction requests BuildKit's insecure security mode.
+
+        BuildKit executes each `RUN` step in a sandbox with a seccomp profile and, on hosts that support it, AppArmor confinement. The `--security=insecure` flag on a `RUN` instruction removes both, giving the step the full capability set of the BuildKit daemon, raw device access, and unrestricted system calls. The check requires that no `RUN` instruction in any build stage set it.
 
         **Why this matters**
 
-        - **Build host compromise:** A `RUN --security=insecure` step executes with the privileges of the BuildKit daemon, so a malicious or compromised command can read host files, attach to host processes, and modify the build environment.
-        - **Untrusted dependencies:** Build steps often invoke third-party scripts and package installers. Running them outside the default sandbox turns any supply-chain compromise in those tools into a build-host compromise.
-        - **Audit trail:** BuildKit emits no special record when `insecure` is used; reviewers reading scan output, not the Dockerfile, will miss that the build ran without confinement.
-        - **Least privilege:** The flag exists for narrow cases like nested containerization. Defaulting to it for convenience violates the principle of least functionality required by hardened build pipelines.
+        A `RUN` step almost never runs code the author wrote. It runs package managers, install scripts fetched over the network, and compiler toolchains pulled from a language ecosystem, all of which execute arbitrary code from third parties. The sandbox is what keeps that code inside the build.
+
+        Without it, that code holds the daemon's privileges on the build machine. It reads the build host's filesystem, including the credentials the runner uses to push images and the cache directories of every other build on that runner. It attaches to processes belonging to concurrent builds and reads their memory, which is where build secrets live while they are in use. On a shared runner, one project's compromised dependency reaches every other project built there.
+
+        The escalation is quiet. BuildKit emits no distinct record when the flag is used, and the resulting image looks like any other, so a reviewer working from scan results rather than from the Dockerfile has nothing to notice. Using `RUN --security=insecure` also requires the builder to be started with the matching entitlement, which means somebody relaxed the build environment as well, and that relaxation stays in place for every later build.
+
+        Remove the flag. If a step genuinely needs privileged operations, run it in a controlled job outside the image build and copy the resulting artifact in.
       audit: |
         Inspect the Dockerfile to confirm no `RUN` instruction requests the insecure security mode:
 
@@ -1206,14 +1302,19 @@ queries:
       docker.file.stages.all(run.none(network == "host"))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not use the BuildKit `--network=host` flag. This flag attaches the build step directly to the build host's network namespace, removing the network isolation that BuildKit applies by default.
+        This check verifies that no `RUN` instruction joins the build host's network namespace.
+
+        BuildKit runs each `RUN` step in its own network namespace with outbound access through the builder. The `--network=host` flag places the step directly in the host's namespace instead, so it shares the host's loopback interface, routes, and link-local addresses. The check requires that no `RUN` instruction in any build stage set it.
 
         **Why this matters**
 
-        - **Host network exposure:** A build step running in the host network namespace can reach loopback services, link-local metadata endpoints (`169.254.169.254`), and other internal addresses that are normally unreachable from a sandboxed build.
-        - **Credential and token theft:** Cloud-hosted build environments often expose instance metadata or workload identity tokens on loopback or link-local addresses. Host networking lets any installer script or malicious dependency exfiltrate them.
-        - **Reproducibility loss:** A build that depends on the host network behaves differently on developer laptops, CI runners, and air-gapped builders, undermining reproducible images.
-        - **Least privilege:** Host networking should be reserved for narrow cases like building network drivers; using it as a default convenience violates the principle of least functionality.
+        The addresses this reaches are the ones nothing else can. Cloud builders serve instance credentials from the link-local metadata endpoint at `169.254.169.254`, and a step in the host namespace requests them with an ordinary HTTP call. Those credentials belong to the build machine's role, which in most pipelines can push to the image registry and read the artifact store, so a malicious install script in a `RUN` step trades a build-time foothold for durable access to the software supply chain.
+
+        Loopback is the second target. Agents, sidecars, local databases, and unauthenticated admin endpoints bound to the loopback address are unreachable from a sandboxed build precisely because they assume anything on loopback is trusted. Host networking removes that assumption for every third-party script the build executes.
+
+        There is a correctness cost as well. A build that resolves a hostname or reaches a service through the host's network produces a different image on a developer laptop, on a CI runner, and on an isolated builder, and the Dockerfile records nothing about the dependency. The build that worked yesterday fails on a runner in another subnet with an error about a package rather than about networking.
+
+        Let BuildKit use its own network. When a build needs a private mirror, configure it as a build argument or stage the dependency in an earlier stage rather than removing the isolation.
       audit: |
         Inspect the Dockerfile to confirm no `RUN` instruction joins the host network:
 
@@ -1263,16 +1364,19 @@ queries:
       docker.file.stages.all(run.all(mounts.where(from == empty).where(type == "bind" || type == empty).none(source == /^\/(etc|proc|sys|dev|boot|root|home|tmp|var|run)?(\/|$)/)))
     docs:
       desc: |
-        Dockerfile `RUN` instructions should not declare bind mounts whose `source` points at sensitive system paths such as `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/tmp`, `/var`, or `/run`, or at sub-paths beneath them such as `/etc/shadow`, `/root/.ssh`, or `/var/run/docker.sock`. A bind mount in a `RUN` instruction resolves its `source` inside the build context, or inside the stage or image named by `from`, never on the build host. A sensitive-looking absolute source therefore signals one of two problems: the author misunderstands the mount semantics and believes the build reads host files, or copies of sensitive system files and credentials were placed in the build context.
+        This check verifies that no `RUN` instruction bind-mounts a sensitive system path out of the build context.
+
+        BuildKit lets a `RUN` instruction mount data into the step. A bind mount resolves its `source` inside the build context, or inside the stage or image named by `from`, never on the build host. The check inspects mounts of `type=bind`, and mounts that omit the type because BuildKit treats those as bind mounts, that do not set `from=`, and requires the source not to be `/` or a path under `/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/home`, `/tmp`, `/var`, or `/run`. Sub-paths fail too, so `/etc/shadow`, `/root/.ssh`, and `/var/run/docker.sock` are all violations. Cache mounts written as `--mount=type=cache` are not affected.
 
         **Why this matters**
 
-        - **Secrets in the build context:** For such a mount to resolve, files like shadow copies, SSH keys, or credential stores must exist inside the build context. Everything in the context is sent to the builder, is readable by every build step, and is exposed to anyone who can read the context or the repository it comes from.
-        - **Supply-chain blast radius:** Build steps run third-party package managers and installers. Any sensitive material reachable through the mounted context can be exfiltrated by a compromised dependency during the build.
-        - **Misleading intent:** A Dockerfile that appears to mount host system paths confuses reviewers and incident responders, and the build silently reads different data than the author intended, which can mask broken or missing build inputs.
-        - **Wrong tool for the job:** Builds that genuinely need host resources, such as a Docker socket for Docker-in-Docker workflows, belong in dedicated CI jobs. An image build step can never reach those resources through a bind mount.
+        A source like this resolves only if a copy of those files was placed in the build context, and everything in the context is uploaded to the builder and readable by every step of the build. An SSH key or a shadow file that reaches the context reaches every `RUN` instruction in the Dockerfile, including the ones that execute third-party install scripts, so a single compromised dependency reads the credential and sends it out over the same connection it uses to fetch packages.
 
-        Mounts that set `from=` to an earlier build stage or a named image resolve inside that stage and are not flagged. Legitimate BuildKit caching uses `--mount=type=cache`, so this check only flags `type=bind` and the omitted-type case that BuildKit treats as `bind`.
+        The context also tends to be the repository. Files copied there to satisfy a mount get committed, and then the credential is in the git history of every clone.
+
+        When the files are not in the context, the mount resolves to an empty directory and the build reads nothing. That is worse than an error, because the step appears to succeed while operating on data that is not there, and a reviewer reading the Dockerfile believes the build inspects host state it never sees.
+
+        Mount only the specific build inputs the step needs, stage them in an earlier stage and reference it with `from`, and pass credentials through a secret mount instead of placing them in the context.
       audit: |
         Inspect the Dockerfile to confirm no `RUN` instruction bind-mounts a sensitive source path from the build context:
 


### PR DESCRIPTION
Rewrites `docs.desc` for all 41 checks in the two Dockerfile bundles into the house prose format. Nothing else in either bundle changes.

## What changed

Every description now opens with `This check verifies that ...`, follows with a paragraph naming the Dockerfile instruction the reader edits and the form it has to take, and replaces the bolded bullet labels under `**Why this matters**` with prose that says what actually happens. The old bullets named a *category* of concern (`**Unauthorized access:**`, `**Image bloat:**`, `**Compliance risks:**`) without ever saying what goes wrong; each one is now the sentence it was standing in for.

The two bundles are deliberately written differently.

**`mondoo-dockerfile-security`** (`mondoo.com/category: security`) names the attacker step. Port 2375 is the unauthenticated Docker Remote API, so the description says the attacker creates a container that bind-mounts the host root and writes to `/etc/shadow`, which is root on the node rather than root in one container. `--network=host` reaches the link-local metadata endpoint at `169.254.169.254` and trades a build foothold for the runner's registry push credential. A missing `USER` means an attacker who lands through a deserialization bug holds the default capability set and rewrites the entrypoint to survive a restart. A repointed `latest` tag substitutes the base image with no diff and no review.

**`mondoo-dockerfile-best-practices`** (`mondoo.com/category: best-practices`) does not invent a threat, because most of these checks do not have one. `use-apt-get` is about `apt` having no stable scripted interface and printing a warning on every invocation that trains readers to ignore warnings, not about an attacker. The consequences named are engineering ones and are as concrete as the security ones: an install resolving against a package index cached in a layer built months ago, a `rm -rf` in a later instruction that records a deletion marker and reclaims no bytes because layers are append-only, an `apt-get install` without `-y` that holds a CI runner until the job timeout fires, a relative `WORKDIR` that silently relocates every path in the file when the base image tag changes, a multi-source `COPY` whose error message sends the reader looking at whether the directory exists rather than at the missing slash.

Instruction names stay in backticks throughout, because the thing being administered here is the Dockerfile instruction: `EXPOSE`, `RUN`, `USER`, `VOLUME`, `WORKDIR`, `COPY`, `ADD`, `ENV`, `HEALTHCHECK`, `FROM`, and the flags and paths that go with them.

## Size

| Bundle | Checks | Median words before | after |
|---|---|---|---|
| `mondoo-dockerfile-security` | 20 | 116 | 293 |
| `mondoo-dockerfile-best-practices` | 21 | 100 | 290 |

No description is shorter than 270 words or longer than 341.

## Not changed

No policy version bump, and no change to any query, `filters`, `impact`, `tags`, `docs.audit`, `docs.remediation`, or `refs` in either file. The structural diff below is the proof.

## Gates

Run against both files:

- `cnspec policy lint ./content/mondoo-dockerfile-security.mql.yaml` -> `valid policy bundle(s)`
- `cnspec policy lint ./content/mondoo-dockerfile-best-practices.mql.yaml` -> `valid policy bundle(s)`
- `typos` on both files -> silent
- `go test -count=1 ./internal/bundle/...` -> `ok`
- Structural diff against `origin/main`, run once per file -> `trees identical apart from docs.desc and policy version` for both
- Substance gate, `mondoo-dockerfile-best-practices` -> **0 specifics lost across 21 checks**
- Substance gate, `mondoo-dockerfile-security` -> **4 specifics lost across 1 check of 20**

All four losses are on `mondoo-docker-security-image-authors-label`, and all four are fragments of one compliance framework citation the old prose carried: `800`, `171`, `3.4`, and `1`, from a NIST 800-171 control reference. Framework citations are carried by the `compliance/*` tags rather than by description prose, and the fact the sentence was making, that an asset inventory has to record who owns a component, survives in words. Every backticked literal in both bundles survives, including the full sensitive-path lists, `--allow-insecure-repositories`, `-fsSLk`, `/var/run/docker.sock`, `--mount=type=cache`, `169.254.169.254`, and the port numbers 22, 2375, 8500, 6443, 1, and 65535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
