### PR TITLE
📝 content: rewrite search and cloud database check descriptions as prose

### DIFF
--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -66,19 +66,20 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that no ClickHouse Cloud service is reachable from any IP address. A service is open to all IPs when its IP access list contains a wildcard entry such as `0.0.0.0/0` or `::/0`, which exposes the database endpoint to the entire internet.
+      desc: |
+        This check verifies that no ClickHouse Cloud service accepts connections from every address on the internet.
+
+        Each service carries an IP access list, edited in the ClickHouse Cloud console by opening the service, then Settings, then Security, then IP access list, and set through the `ipAccessList` field of the services API. An entry of `0.0.0.0/0` or `::/0` in that list means any source may open a connection. This check requires the list to name specific ranges instead, and the `clickhouse_service` Terraform resource expresses the same thing as an explicit `ip_access` list of approved CIDR blocks.
 
         **Why this matters**
 
-        - **Reduced exposure:** Restricting source IPs means only approved networks can even attempt to connect.
-        - **Credential-theft containment:** A leaked password cannot be used from outside the approved ranges.
-        - **Defense in depth:** Network restrictions complement authentication rather than replacing it.
+        A wildcard entry is usually added during setup to get a first client connected and then never removed, so a service opened for an afternoon of testing stays open to the internet for the life of the deployment. ClickHouse Cloud endpoints follow a predictable hostname pattern and answer on well-known ports, so finding them takes scanning rather than inside knowledge.
 
-        **Risk mitigation**
+        Once found, the only thing between an attacker and the tables is the service password, and passwords for managed databases leak through entirely ordinary means: a connection string in a repository, a value pasted into a chat thread, an environment file on a stolen laptop, a CI job that prints its configuration on failure. With a wildcard access list, any one of those is usable the moment it is found, from anywhere. With the list restricted to office, VPN, and application ranges, the same leaked password is useless from the attacker's address, which buys the time needed to notice and rotate it.
 
-        - **Blocked off-network access:** Connection attempts from unapproved addresses are rejected.
-        - **Smaller attack surface:** Only approved networks can reach the service endpoint.
+        The open list also removes the rate limit that network scoping provides for free. Password guessing runs from as many source addresses as an attacker cares to rent, continuously, against an endpoint with no application in front of it to slow the attempts down or record them.
+
+        Restricting the list will break anything connecting from an address nobody enumerated, so collect the egress ranges for the application, the analytics and BI tools, and the operators before removing the wildcard entry.
       audit: |-
         ### Audit via the ClickHouse Cloud console
 
@@ -185,19 +186,18 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that every ClickHouse Cloud service has transparent data encryption enabled, so data stored on disk is encrypted at rest. Transparent data encryption protects the stored data if the underlying storage is ever accessed outside the service.
+      desc: |
+        This check verifies that every ClickHouse Cloud service encrypts the data it holds on disk.
+
+        Transparent data encryption is selected when a service is created on the tiers that support it, and it appears in the ClickHouse Cloud console by opening the service, then Settings, then Security. The `clickhouse_service` Terraform resource carries it as a `transparent_data_encryption` block with `enabled = true`. Two further arguments, `encryption_key` and `encryption_assumed_role_identifier`, choose a customer-managed key in place of a ClickHouse-managed one; they select which key is used and do not switch the feature on by themselves. This check requires the feature to be enabled.
 
         **Why this matters**
 
-        - **Data-at-rest protection:** Encrypted storage is unreadable without the keys, limiting exposure from storage-layer compromise.
-        - **Compliance:** Many frameworks require sensitive data to be encrypted at rest.
-        - **Key management:** Transparent data encryption integrates key management with the service rather than leaving data in cleartext.
+        Encryption at rest defends the copy of the data that leaves the running service. The service's own access controls apply to queries; they do not apply to a snapshot, a backup file, or a block volume once something other than the service reads it. An attacker who reaches the storage layer, through a backup destination that was left readable, a credential for the underlying cloud account, or a support path they should not have had, gets the tables in whatever form they were written. Unencrypted, that is the data itself. Encrypted, it is ciphertext they also need a key for, and the key is held apart from the storage.
 
-        **Risk mitigation**
+        Customer-managed keys extend that separation in a way worth choosing deliberately. When the key lives in your own cloud key service, revoking it makes every stored copy unreadable no matter who holds the storage, which is the only form of deletion that reaches snapshots you cannot enumerate.
 
-        - **Neutralized storage theft:** A copy of the underlying storage is useless without the encryption keys.
-        - **Consistent coverage:** Every service, not just some, protects its stored data.
+        The setting is fixed when the service is created, so a service running without it cannot be updated in place. Bringing one into line means provisioning a replacement on a supporting tier and migrating the data across. That is worth scheduling rather than deferring, because the exposure covers not only the service as it stands but every backup taken of it in the meantime, and those backups outlive the decision to postpone.
       audit: |-
         ### Audit via the ClickHouse Cloud console
 

--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -54,19 +54,20 @@ queries:
     mql: |
       clickhousedb.instance.users.all(hasPassword == true)
     docs:
-      desc: |-
-        This check ensures that every ClickHouse account requires a password to authenticate. An account with no password can be reached with no credential at all, so anyone who can connect to the server is served as that account.
+      desc: |
+        This check verifies that every ClickHouse account requires a credential to authenticate.
+
+        ClickHouse accounts come from two places and both can define an account with none. A SQL-managed account is created with a `CREATE USER` or `ALTER USER` statement, and one written without an `IDENTIFIED WITH` clause authenticates with nothing at all. A file-managed account is defined under `users.xml` or a file in `users.d/`, and an entry carrying an empty password element does the same. Both forms report an authentication type of `no_password` in the `system.users` table, and this check requires that no account is in that state.
 
         **Why this matters**
 
-        - **No unauthenticated access:** Requiring a password stops anonymous connections from acting as a real account.
-        - **Attributable activity:** Authenticated sessions tie queries to a known identity.
-        - **Defense against network exposure:** If the port is reachable, a password is the control that still stands.
+        A password-less account makes network reachability the whole of the authentication control. Anyone who can open a connection to the native port, or send a request to the HTTP interface, is served as that account and runs queries as it. That includes the `default` account, which exists on a fresh install and is routinely left open on the reasoning that the server sits on a private network, right up until a security group change, a bridged container port, or a new bastion route makes it reachable.
 
-        **Risk mitigation**
+        What the caller can then do follows the account's grants, and grants on analytics servers are wide by habit. Reading is a select against any table the account can see, which on a ClickHouse cluster usually means event and clickstream data covering the entire user base. Destruction is a truncate or a drop against the same tables, and ClickHouse will not ask twice.
 
-        - **Blocked anonymous use:** A client that reaches the port cannot operate without valid credentials.
-        - **Reduced blast radius:** Compromise requires a credential rather than mere network reachability.
+        The account is also a foothold beyond the data. ClickHouse table engines reach outward, so an account with the right grants defines a table backed by a URL, an object store, or another database, and turns the server into a relay into networks the attacker cannot address directly.
+
+        Setting a password with `sha256_password`, or a `password_sha256_hex` element for file-managed accounts, closes the account but does not restrict where connections may come from. Pair this with the companion check in this policy that requires the secure native port, so the credential is not handed to the network in the clear once it exists.
       audit: |-
         ### Audit via clickhouse-client
 
@@ -121,19 +122,20 @@ queries:
     mql: |
       clickhousedb.instance.serverSettings.where(name == "tcp_port_secure").any(value != "0" && value != "")
     docs:
-      desc: |-
-        This check ensures that the secure (TLS) native TCP port is configured, so native-protocol clients can connect over an encrypted channel. When `tcp_port_secure` is set, credentials and query data are protected in transit rather than crossing the network in cleartext on the plain `tcp_port`.
+      desc: |
+        This check verifies that ClickHouse offers its native protocol over TLS.
+
+        The native protocol has two listeners. `tcp_port` is the plain one, conventionally 9000, and `tcp_port_secure` is the encrypted one, conventionally 9440. Setting `tcp_port_secure` to a non-zero port in `config.xml` or a file in `config.d/`, alongside an `openSSL` block naming a `certificateFile` and a `privateKeyFile`, brings the encrypted listener up. This check reads the effective value from the `system.server_settings` table and requires it to name a port rather than being zero or unset.
 
         **Why this matters**
 
-        - **Confidentiality in transit:** TLS protects credentials and result sets from network eavesdropping.
-        - **Integrity:** An encrypted channel resists tampering and session hijacking.
-        - **Compliance:** Frameworks require sensitive database traffic to be encrypted in transit.
+        Without the secure listener, native clients have nowhere to connect except the plain port, and the native protocol sends the credential at the start of the session. An attacker positioned anywhere on that path, on a compromised host in the same subnet, at a mirrored switch port, or on any hop between an application in one region and a cluster in another, captures the username and password from the handshake of a single connection and then authenticates as that account whenever they like, from wherever they like.
 
-        **Risk mitigation**
+        The same capture yields the data without the credential being used at all. Query text and result blocks travel in the clear on the plain port, so an observer reads exactly the rows the legitimate application is reading, for as long as they hold the position.
 
-        - **No cleartext credentials:** Login credentials are not exposed to anyone on the network path.
-        - **Man-in-the-middle resistance:** With a trusted certificate, TLS prevents interception and impersonation.
+        Cleartext also permits modification rather than only observation. An on-path attacker who can rewrite packets alters a query before it reaches the server or alters the result on its way back, which is the difference between someone who learns what a dashboard says and someone who decides what it says.
+
+        Bringing up `tcp_port_secure` does not stop clients using the plain listener. Once the secure port is serving and clients have moved to it, remove or zero `tcp_port` as well. Use a certificate from an authority the clients actually verify rather than a self-signed one they are configured to ignore, because an unverified certificate encrypts the session while leaving impersonation wide open.
       audit: |-
         ### Audit via clickhouse-client
 

--- a/content/mondoo-elasticsearch-security.mql.yaml
+++ b/content/mondoo-elasticsearch-security.mql.yaml
@@ -68,19 +68,20 @@ queries:
     mql: |
       elasticsearch.cluster.security.enabled == true
     docs:
-      desc: |-
-        This check ensures that the Elasticsearch security features (X-Pack security) are enabled. When security is disabled, the cluster performs no authentication or authorization, so any client that can reach it has full access to every index and cluster operation.
+      desc: |
+        This check verifies that the Elasticsearch security features are enabled on every node in the cluster.
+
+        X-Pack security is the subsystem that gives Elasticsearch its users, roles, TLS settings, and audit trail. It is switched on with `xpack.security.enabled: true` in each node's `elasticsearch.yml`, and the cluster reports the resulting state through the X-Pack usage API. This check requires that state to be enabled.
 
         **Why this matters**
 
-        - **No access control when off:** With security disabled, there are no users, roles, or permissions; the network path is the only thing standing between an attacker and all of your data.
-        - **Foundation for other controls:** Authentication, authorization, TLS, and audit logging all depend on the security features being turned on first.
-        - **Defaults are not safe everywhere:** Some distributions and older versions ship with security off, leaving a fresh cluster fully open.
+        With security off, the cluster authenticates nothing and authorizes nothing. Every request that arrives on the REST port is executed with full privileges, so an attacker who can route a packet to it runs a search across all indices and reads every document the cluster holds, including the application logs that commonly carry session tokens, API keys, and personal data.
 
-        **Risk mitigation**
+        Reading is the mild case. The same unauthenticated caller can register a snapshot repository pointing at storage they control and then trigger a snapshot, which copies the entire cluster out in a single call. They can delete by query or drop indices outright, and because the security features are what enable the audit trail, nothing in the cluster records that any of it happened.
 
-        - **Authenticated access only:** Enabling security forces every request to present a credential tied to a known identity.
-        - **Role-based restrictions:** With security on, roles and privileges can limit what each authenticated identity may read or change.
+        Older distributions and the basic tier of some releases shipped with security off by default, so a cluster nobody has explicitly configured is usually in exactly this state rather than in a hardened one. The absence of a login prompt is not evidence that the network is trusted; it is evidence that the cluster would serve anyone who arrives.
+
+        Turning the features on is only the first step. Set the built-in user passwords afterwards with `elasticsearch-setup-passwords` on a new cluster or `elasticsearch-reset-password` on an existing one, or clients will be authenticating against accounts whose credentials nobody controls. Companion checks in this policy then cover anonymous access, transport encryption, and audit logging, each of which depends on this setting being on first.
       audit: |-
         ### Audit via cURL
 
@@ -139,19 +140,20 @@ queries:
     mql: |
       elasticsearch.cluster.security.anonymousAccessEnabled == false
     docs:
-      desc: |-
-        This check ensures that no anonymous role is configured, so unauthenticated requests are rejected rather than served as an anonymous user. When anonymous access is enabled, any request that arrives without credentials is treated as the anonymous role and carries whatever privileges that role was granted.
+      desc: |
+        This check verifies that Elasticsearch rejects requests arriving without credentials rather than serving them as an anonymous user.
+
+        Elasticsearch can be given an anonymous role through the `xpack.security.authc.anonymous` settings in `elasticsearch.yml`. Any request with no authorization header is then executed with whatever privileges that role carries. This check requires that no such fallback is in effect, so an unauthenticated request is answered with `401` instead of data. Setting `xpack.security.authc.anonymous.authz_exception: true` forces that rejection, and removing the anonymous `roles` setting removes the anonymous identity altogether.
 
         **Why this matters**
 
-        - **Unauthenticated data access:** An anonymous role with read privileges lets anyone on the network path query indices without ever presenting a credential.
-        - **Privilege inheritance:** The anonymous user gets exactly the permissions of its configured roles, which are easy to over-grant and hard to notice.
-        - **Weakens every other control:** Anonymous access bypasses the identity model that authorization, auditing, and rate limiting all rely on.
+        An anonymous role is granted like any other role, and the roles people reach for are broad. Built-in roles such as the monitoring and viewer roles both allow reading index contents, so a caller who has never presented a credential sends a search to the REST port and gets documents back. On a logging cluster that is often the fastest route to credentials for other systems, because applications log request headers, connection strings, and stack traces containing secrets.
 
-        **Risk mitigation**
+        If the role carries write privileges, the same caller indexes documents, so dashboards and alerting rules that read those indices report whatever the attacker chose to put there. Deletion is available on the same terms, and an attacker who wants the cluster quiet rather than plundered can take it out with one request.
 
-        - **Credential enforcement:** Disabling anonymous access forces every client to authenticate before any data is returned.
-        - **Attribution:** Rejecting unauthenticated requests ensures each served request maps to a known identity that can be logged and investigated.
+        Anonymous requests also break attribution. Audit records for them name the anonymous role and not a person or service, so an investigator can establish that data was read and cannot tell which client read it or whose access to revoke.
+
+        The legitimate use for an anonymous role is narrow, such as an unauthenticated health endpoint for a load balancer. Where that is the requirement, scope the load balancer to the cluster health endpoint through a proxy rather than granting an anonymous role inside the cluster, because the role applies to every request that reaches the node and not only to the one you had in mind.
       audit: |-
         ### Audit via cURL
 
@@ -205,19 +207,20 @@ queries:
       elasticsearch.cluster.security.httpTlsEnabled == true
       elasticsearch.cluster.security.transportTlsEnabled == true
     docs:
-      desc: |-
-        This check ensures that TLS is enabled on both the HTTP/REST layer, which protects client credentials and query data, and the transport layer, which protects node-to-node traffic and prevents rogue nodes from joining the cluster. Both layers must be encrypted for the cluster to be safe on an untrusted network.
+      desc: |
+        This check verifies that Elasticsearch encrypts both the HTTP layer that clients use and the transport layer that nodes use to reach each other.
+
+        Two settings control this and the check requires both. `xpack.security.http.ssl.enabled: true` in `elasticsearch.yml` puts the REST API behind TLS. `xpack.security.transport.ssl.enabled: true` does the same for the internal transport port and, together with `xpack.security.transport.ssl.verification_mode: certificate`, requires a joining node to present a certificate signed by the cluster's own certificate authority.
 
         **Why this matters**
 
-        - **Confidentiality of client traffic:** HTTP-layer TLS encrypts the credentials and query data that clients send to the REST API, keeping them off the wire in cleartext.
-        - **Cluster integrity:** Transport-layer TLS authenticates and encrypts node-to-node communication, so an attacker cannot read replicated data or introduce a rogue node into the cluster.
-        - **Defense in depth:** Encrypting only one layer leaves the other exposed; both are needed to protect the full data path.
+        Without HTTP TLS, every client request crosses the network in cleartext, and Elasticsearch clients authenticate with HTTP basic auth. An attacker with a position on the path, a compromised host on the same segment or a switch port they can mirror, reads the encoded username and password out of a single request header and then connects as that user whenever they choose. Query bodies and result sets are readable in the same capture, so the data is exposed even before the credential is reused.
 
-        **Risk mitigation**
+        Without transport TLS the exposure is worse, because the transport port carries replication traffic in the clear and, with no certificate verification, accepts any process that speaks the protocol and knows the cluster name. An attacker starts a node of their own, joins the cluster, and is handed shard copies through ordinary replication. At that point they hold the data without ever having authenticated to the REST API, and the cluster considers them a member in good standing.
 
-        - **No cleartext credentials:** With HTTP TLS on, authentication material is never sent in the clear to the REST API.
-        - **Rogue-node resistance:** Transport TLS with certificate verification blocks unauthorized nodes from joining and intercepting cluster data.
+        Encrypting one layer and leaving the other open protects nothing, since the unencrypted half still carries the same documents.
+
+        Generate the certificates with `elasticsearch-certutil`, which produces a certificate authority and node certificates in the keystore format these settings expect, then restart each node so both layers come up encrypted. Keep the verification mode at certificate or stronger, because TLS without verification encrypts the traffic while still admitting whoever presents any certificate at all.
       audit: |-
         ### Audit via cURL
 
@@ -282,19 +285,20 @@ queries:
     mql: |
       elasticsearch.cluster.security.auditLoggingEnabled == true
     docs:
-      desc: |-
-        This check ensures that security audit logging is enabled so the cluster records authentication successes and failures and access events for detection and investigation. Audit logging is off by default, so a cluster left at its defaults keeps no record of who accessed what.
+      desc: |
+        This check verifies that Elasticsearch records security audit events.
+
+        Audit logging is turned on with `xpack.security.audit.enabled: true` in `elasticsearch.yml` on each node. Once on, the cluster writes an entry for each authentication success, authentication failure, access grant, and access denial, and `xpack.security.audit.logfile.events.include` narrows or widens that set. The setting is off by default, so a cluster nobody has explicitly configured keeps no security record at all.
 
         **Why this matters**
 
-        - **Attributable access:** Audit records tie authentication and access events to source addresses and identities, which is essential for investigating misuse.
-        - **Detection of attacks:** Logged authentication failures reveal brute-force and credential-stuffing attempts that would otherwise go unnoticed.
-        - **Compliance evidence:** Audit frameworks require a record of access to systems that hold sensitive data.
+        Without the audit log there is no way to answer the question that matters after a credential leaks: what did the holder of that credential read. The cluster keeps slow-query and indexing logs, but neither names the authenticated user or the source address, so an investigation can establish that an API key existed and not what it touched. The practical result is that a scoped incident becomes an unscoped one, and every index the key could reach has to be treated as exposed and every downstream secret in those indices rotated.
 
-        **Risk mitigation**
+        The absence is felt before an incident as well. Credential stuffing and brute forcing against the REST API produce nothing but a stream of authentication failures, and those failures are exactly what the audit log records and nothing else does. Without it, an attacker works through a password list against the built-in superuser account for as long as they like and generates no signal anyone can alert on.
 
-        - **Faster incident response:** A record of authentication and access events narrows down the source and timeline of suspicious activity.
-        - **Deterrence and detection:** Auditing supports alerting on anomalous access patterns and off-hours activity.
+        Audit records also capture the case authentication alone cannot: a valid user reading indices outside their normal pattern, at an unusual hour, from an unfamiliar address. Nothing about those requests is malformed, so only the pattern gives them away, and only the log holds the pattern.
+
+        Audit logs are useful in proportion to how far they travel. Ship them to a collector that the cluster's own administrators cannot rewrite, because an attacker who reaches the host reaches the local log file on it just as easily as the data.
       audit: |-
         ### Audit via cURL
 

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -59,19 +59,20 @@ queries:
     mql: |
       neon.organizations.all(requireMfa == true)
     docs:
-      desc: |-
-        This check ensures that every Neon organization the API key can see requires members to use multi-factor authentication. When MFA is required at the organization level, a stolen or guessed password alone cannot access the control plane, because a second factor is always demanded.
+      desc: |
+        This check verifies that every Neon organization requires its members to sign in with a second factor.
+
+        The requirement is set in the Neon Console by opening Organization and then Settings, where multi-factor authentication is turned on for the organization as a whole rather than left to each member. The organization record returned by the Neon API carries the same value as `require_mfa`. This check requires the setting to be on for each organization the API key can see.
 
         **Why this matters**
 
-        - **Credential theft resistance:** Passwords are phished, reused, and leaked constantly; a mandatory second factor stops a valid password from being enough to sign in.
-        - **Organization-wide coverage:** Requiring MFA at the organization level closes the gap left when it is only encouraged, so no member can opt out.
-        - **Control-plane protection:** Organization members can create projects, rotate credentials, and reach databases, so their accounts are high-value targets that warrant strong authentication.
+        A Neon organization member holds the control plane, and for a managed database the control plane is a route to the data rather than a layer above it. A member creates and deletes projects, resets the password of any database role, and reads connection details. So an attacker who signs in as a member never has to break the database itself. They reset a role password from the console, take the connection string, and connect to production Postgres as that role.
 
-        **Risk mitigation**
+        Without a required second factor, the password is the whole of that defense, and passwords leave the user's control routinely. They are reused on sites that get breached, typed into phishing pages that copy the Neon sign-in screen, and scraped out of browsers by infostealer malware. Any one of those hands over a working sign-in, and none of them is visible to you until it is used.
 
-        - **Account-takeover containment:** Even after a password compromise, an attacker without the second factor cannot access the organization.
-        - **Consistent enforcement:** A single organization setting guarantees the control applies to current and future members alike.
+        Branch history makes the exposure larger than the current state of the database. Neon keeps branches and point-in-time history, so a member account also reaches earlier states of the data, including rows that were deleted precisely because they should no longer exist anywhere.
+
+        Set the requirement at the organization rather than asking members to enroll individually, because an organization-wide requirement covers people who join later and leaves nobody able to opt out. Confirm that existing members enroll after the change, since an account that has not yet added a factor is the one an attacker will go looking for.
       audit: |-
         ### Audit via the Neon Console
 
@@ -140,19 +141,20 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that every Neon project blocks public connections. When public connections are blocked, the database is reachable only through the configured private networking or allowed IP ranges rather than from anywhere on the internet.
+      desc: |
+        This check verifies that every Neon project refuses connections arriving from the public internet.
+
+        Neon exposes a project's Postgres endpoint to the internet unless told otherwise. The block is set in the Neon Console by opening the project, then Settings, then Network Security, the same page that holds the allowed IP ranges and the private networking configuration legitimate clients use instead. The Neon CLI sets it with `neon projects update <project_id> --block-public-connections`, and the `neon_project` Terraform resource takes `block_public_connections = "yes"`. This check requires the block to be in effect.
 
         **Why this matters**
 
-        - **Reduced attack surface:** A database open to the public internet is exposed to credential-stuffing, brute-force, and exploitation attempts from any source; blocking public connections removes that exposure.
-        - **Network-layer control:** Restricting access to private networking or an allowlist confines connectivity to known application and operator networks.
-        - **Defense in depth:** Even with strong authentication, keeping the database off the public internet removes an entire class of remote attacks.
+        An open Postgres endpoint is found by scanning, not by leaking. Internet-wide scanners sweep the Postgres port continuously and record every host that completes a handshake, so a project reachable from anywhere lands on a target list within hours of being created, whether or not its hostname was ever published.
 
-        **Risk mitigation**
+        From there an attacker needs only a credential, and credentials escape constantly. A connection string committed to a repository, pasted into an issue, or read out of an application's environment is enough on its own when the endpoint accepts connections from any source. With public connections blocked, that same leaked string is inert from an address the project does not know, which turns a credential leak from an immediate compromise into an incident with room to rotate.
 
-        - **Smaller exposure window:** An attacker who obtains a connection string still cannot reach the database from an unapproved network.
-        - **Contained blast radius:** Private-only connectivity limits lateral movement toward the data even if other controls fail.
+        The open endpoint also hands the attacker unlimited attempts. Password guessing against a database role runs at whatever rate they choose, from as many addresses as they care to rent, with no application in front of it to rate-limit the attempts or record them.
+
+        Blocking public connections needs the private path to exist first, so configure the allowed IP ranges or private networking for the application and for operators before switching it on. Otherwise the change takes the database away from its legitimate clients along with everyone else, and the pressure to reopen it will be immediate.
       audit: |-
         ### Audit via the Neon Console
 
@@ -260,19 +262,20 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that no Neon project has password storage enabled, so Neon does not retain role passwords in a form its API can return. Retaining role passwords widens the blast radius of a control-plane or API-key compromise, because an attacker who reaches the API could read them. Note that some workflows rely on stored passwords for connection-string retrieval, so treat this as a hardening control weighed against that need.
+      desc: |
+        This check verifies that a Neon project does not retain its database role passwords in a form the control plane can hand back.
+
+        When password storage is on, Neon keeps role passwords so that the console and API can return a complete connection string on demand. With it off, a password is shown once when the role is created and never again. The API accepts `store_passwords` only in the request that creates the project, and the `neon_project` Terraform resource takes `store_password = "no"` on the same terms, so this is a decision made at creation rather than a setting to be flipped later. This check requires storage to be off.
 
         **Why this matters**
 
-        - **Reduced secret exposure:** A password that is never stored cannot be read back from the control plane, so an API-key or account compromise does not hand over usable database credentials.
-        - **Smaller blast radius:** Not retaining role passwords limits how far a single control-plane compromise can reach into the databases themselves.
-        - **Least retention:** Keeping only what is necessary reduces the set of secrets an attacker can ever obtain from the platform.
+        Retained passwords turn one leaked API key into database access. A Neon API key that ends up in a CI log, a committed file, or a compromised laptop is by itself control-plane reach and nothing more. Where passwords are stored, the holder of that key queries the projects endpoint, reads back the connection strings for every role in every project the key covers, and connects straight to Postgres with credentials that were never theirs. Nothing is reset, so nothing breaks, and the legitimate application keeps running alongside them with no sign that anyone else is connected.
 
-        **Risk mitigation**
+        With storage off, the same key still permits damage, but the attacker has to reset a role password before they can use the database, and a reset breaks the running application. The noise is the point: it turns a silent read of production data into an outage somebody investigates within minutes.
 
-        - **Credential-theft containment:** With no stored passwords, a leaked API key cannot be turned directly into database access.
-        - **Deliberate trade-off:** Where a workflow needs connection-string retrieval, the exception is explicit and can be scoped rather than applied by default everywhere.
+        The control has a genuine cost. Deploy workflows that fetch a connection string from the API, and console users who expect to copy credentials whenever they need them, both stop working. Route those to a secret manager holding the password captured at creation before turning storage off.
+
+        Because the choice is fixed when the project is created, bringing an existing project into line means creating a replacement with storage off, migrating its databases and roles, and then deleting the original.
       audit: |-
         ### Audit via the Neon Console
 

--- a/content/mondoo-opensearch-security.mql.yaml
+++ b/content/mondoo-opensearch-security.mql.yaml
@@ -61,19 +61,20 @@ queries:
     mql: |
       opensearch.cluster.security.anonymousAccessEnabled == false
     docs:
-      desc: |-
-        This check ensures that anonymous authentication is disabled in the security plugin, so unauthenticated requests are rejected rather than served as the anonymous user. When anonymous access is enabled, any client that can reach the network endpoint is mapped to the anonymous backend role and can act without presenting credentials.
+      desc: |
+        This check verifies that the OpenSearch Security plugin rejects unauthenticated requests instead of mapping them to the anonymous user.
+
+        Anonymous authentication is controlled by `anonymous_auth_enabled` under `config.dynamic.http` in the security plugin's `config.yml`, and this check requires it to be off. The setting lives in the plugin's dynamic configuration rather than in `opensearch.yml`, so an edit takes effect only once it is pushed into the cluster's security index with `securityadmin.sh`. Until that push happens the running cluster keeps its old value no matter what the file on disk says.
 
         **Why this matters**
 
-        - **Data exposure:** Indices often hold logs, application data, and other sensitive records; anonymous read access leaks that data to anyone on the network.
-        - **Data tampering:** Without authentication, an attacker can index, modify, or delete documents that applications depend on.
-        - **Attribution:** Requests served as the anonymous user cannot be tied to a specific identity, undermining detection and investigation.
+        When anonymous authentication is on, a request carrying no credentials is not rejected. It is given the plugin's anonymous backend role and evaluated against whatever roles map to it, so the caller acts inside the cluster's own permission model without ever having proved an identity. Whether that means read access, write access, or both depends entirely on a roles mapping that is easy to widen and hard to notice, because nothing about the mapping announces that it applies to unauthenticated traffic.
 
-        **Risk mitigation**
+        Read access alone is enough for real damage on a search cluster. Indices in these deployments typically hold application and access logs, which carry session identifiers, authorization headers, and internal hostnames. An attacker who can reach the REST port issues a search, pages through the hits, and leaves with the material for the next step of an intrusion.
 
-        - **Authenticated access only:** Rejecting anonymous requests ensures every operation is tied to a known identity.
-        - **Reduced exposure:** Combined with tight network rules, this prevents unauthenticated clients from reaching cluster data.
+        Where the mapping grants writes, the same caller modifies or deletes documents that dashboards and alerting rules depend on, so the detection built on those indices reports whatever the attacker chose to leave behind.
+
+        Requests served anonymously also cannot be attributed. The audit trail records the anonymous role rather than a client, so after the fact there is no credential to revoke and no session to trace back to a source. Turning anonymous authentication off is what makes the plugin's other controls meaningful, since a mapped anonymous role bypasses the authentication domains entirely.
       audit: |-
         ### Audit via cURL
 
@@ -129,19 +130,18 @@ queries:
     mql: |
       opensearch.cluster.security.enabledAuthRealms != empty
     docs:
-      desc: |-
-        This check ensures that at least one authentication realm is enabled in the security plugin, so clients must present credentials that are actually verified against a backend rather than the cluster having no configured authenticator. An authentication domain (authc) ties an HTTP authenticator to a backend that validates the supplied credentials.
+      desc: |
+        This check verifies that the OpenSearch Security plugin has at least one authentication domain enabled, so that credentials a client presents are actually verified against a backend.
+
+        Authentication domains are defined under `config.dynamic.authc` in the security plugin's `config.yml`. Each domain pairs an HTTP authenticator, such as basic authentication with `challenge: true`, with an authentication backend that validates the credential, such as the internal user database, LDAP, or an identity provider reached through SAML or OpenID Connect. A domain participates only when `http_enabled: true` is set on it. This check requires at least one enabled domain, and an edit to the file reaches the cluster only after `securityadmin.sh` pushes the configuration into the security index.
 
         **Why this matters**
 
-        - **Verified identity:** An enabled realm forces clients to prove who they are against an internal user database, LDAP, or an identity provider.
-        - **No open cluster:** Without an enabled realm, credentials are never checked and the cluster effectively accepts any caller.
-        - **Foundation for authorization:** Roles and permissions can only be enforced once a client's identity has been established.
+        A security plugin with no enabled domain never gets to the step where a password is compared against anything. Requests carrying credentials are not checked against a backend, and requests carrying none have nothing to be measured against, so the cluster stops distinguishing between clients. An attacker on the network path sends a search request to the REST port and receives documents, having supplied either nothing at all or a credential that was never validated.
 
-        **Risk mitigation**
+        Everything layered above authentication stops working with it. Role mappings key off a verified username or backend role, so with no verified identity the authorization layer has no subject to evaluate, and the per-index and per-document restrictions that operators believe are shielding sensitive fields do not apply to the request. Audit records have no user to name, which leaves an operator able to see that data moved and unable to say who moved it.
 
-        - **Credential enforcement:** Every request is authenticated against a backend before it is served.
-        - **Attribution:** Verified identities can be logged and tied to actions, supporting detection and investigation.
+        Enabling a domain is the point at which the rest of the plugin becomes enforceable, so pair it with the companion checks in this policy that turn off anonymous authentication and turn on the audit trail. An enabled domain sitting alongside anonymous authentication still lets a caller skip the domain entirely, which is the configuration that looks secure in a review and is not.
       audit: |-
         ### Audit via cURL
 
@@ -203,19 +203,20 @@ queries:
     mql: |
       opensearch.cluster.security.auditLoggingEnabled == true
     docs:
-      desc: |-
-        This check ensures that the security plugin's audit logging is enabled, recording authentication and access events for detection and investigation. Audit logs capture who connected, what they requested, and whether the request was authorized, producing the trail needed to reconstruct activity after an incident.
+      desc: |
+        This check verifies that the OpenSearch Security plugin records audit events.
+
+        Two pieces are involved. `plugins.security.audit.type` in `opensearch.yml` names the sink that receives events, `internal_opensearch` for example writing them to an index inside the cluster, and `config.enabled` in `audit.yml` turns the recording on. This check requires auditing to be enabled, and as with the plugin's other dynamic settings, an edited `audit.yml` reaches the running cluster only when `securityadmin.sh` pushes it.
 
         **Why this matters**
 
-        - **Attributable access:** Audit records tie requests to identities and source addresses, which is essential for investigating misuse.
-        - **Detection:** Logged authentication failures and privileged actions support alerting on brute-force and anomalous activity.
-        - **Compliance evidence:** Audit frameworks require logging of access to systems that hold sensitive data.
+        Audit records are the only source in the cluster that names who made a request. Slow-query and indexing logs show that work happened; they do not carry the authenticated user, the source address, or the privilege decision. So when a credential leaks, an operator with no audit trail cannot bound the incident. Every index that credential could reach has to be assumed read, which turns a contained problem into a full disclosure exercise across whatever those indices held.
 
-        **Risk mitigation**
+        The trail is also what makes an attack visible while it is still running. Password guessing against the REST API shows up as a run of failed authentications and nothing else, and privilege probing shows up as a run of denied requests. Both are recorded only here, so with auditing off an attacker works through a credential list at their own pace and produces no signal for anyone to alert on.
 
-        - **Faster incident response:** A record of requests narrows down the source and timeline of suspicious activity.
-        - **Deterrence and accountability:** Logged access discourages misuse and supports after-the-fact review.
+        The insider case needs it just as much. A valid user reading indices they never normally touch is indistinguishable from ordinary traffic unless requests are attributed and retained long enough to compare against.
+
+        Choose the sink with retention in mind. Writing events to an index in the same cluster is the quickest thing to configure, but an attacker who gains write privileges there can edit the record of their own activity, so an external destination is the stronger choice wherever the organization already collects logs centrally.
       audit: |-
         ### Audit via cURL
 


### PR DESCRIPTION
Rewrites `docs.desc` for all 14 checks across five bundles: `mondoo-elasticsearch-security`, `mondoo-opensearch-security`, `mondoo-neon-security`, `mondoo-clickhousedb-security`, and `mondoo-clickhousecloud-security`.

Every description carried the full generated skeleton: a bulleted `**Why this matters**` list of bold category labels followed by a `**Risk mitigation**` section that restated `docs.remediation`. Both are gone. Each description now opens by naming what is verified, says where the reader administers the setting and what the console, CLI, API, or configuration file calls it, then explains in prose what an attacker concretely does without the control and what to pair the check with.

Each bundle is written from its own product's configuration surface rather than from a shared template. Elasticsearch names the X-Pack settings in `elasticsearch.yml`; OpenSearch names the Security plugin's `config.yml` and `audit.yml` and the `securityadmin.sh` push that makes a dynamic edit take effect. Self-hosted ClickHouse names `config.xml`, `users.xml`, and the `system` tables; ClickHouse Cloud names the console IP access list and the service API, which have no such files. Neon is described as the managed control plane it is, including the branch history a compromised member account reaches and the creation-time-only nature of project password storage.

Median description length per bundle, before and after:

| Bundle | Checks | Before | After |
|---|---|---|---|
| elasticsearch | 4 | 154.0 | 314.0 |
| opensearch | 3 | 145.0 | 323.0 |
| neon | 3 | 156.0 | 329.0 |
| clickhousedb | 2 | 113.5 | 341.0 |
| clickhousecloud | 2 | 115.0 | 335.5 |

Gates run:

- `cnspec policy lint`: valid policy bundle(s) for all five files
- `typos`: silent on all five files
- `go test -count=1 ./internal/bundle/...`: ok
- structural diff against `origin/main`: trees identical apart from docs.desc and policy version, for all five files
- substance gate: 0 specifics lost, 0 of 14 checks affected

No policy version bump, matching the sibling PRs in this campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
