### PR TITLE
📝 content: rewrite database check descriptions as prose

### DIFF
--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -66,19 +66,20 @@ queries:
     mql: |
       cassandra.cluster.security.authenticationEnabled == true
     docs:
-      desc: |-
-        This check ensures that the configured authenticator is not `AllowAllAuthenticator`, so clients must present valid credentials before they can connect. With `AllowAllAuthenticator`, any client that reaches the cluster connects with no credentials at all.
+      desc: |
+        This check verifies that a client must present credentials before the cluster will open a session.
+
+        The `authenticator` setting in `cassandra.yaml` names the class that validates connections. The check fails on `AllowAllAuthenticator`, which is the shipped default and accepts anyone, and passes on a real implementation such as `PasswordAuthenticator`. Changing it needs a rolling restart so every node picks it up, and roles with passwords have to exist before authorized clients can reconnect.
 
         **Why this matters**
 
-        - **No anonymous access:** Requiring authentication ties every connection to a known role rather than allowing open access to anyone on the network.
-        - **Credential enforcement:** `PasswordAuthenticator` validates a username and password before granting a session.
-        - **Foundation for authorization:** Permission enforcement is meaningless without an authenticated identity to enforce it against.
+        With the permissive class in place, reaching the client port is the entire attack. There is nothing to guess and nothing to steal: an attacker points a driver or the interactive shell at a node and holds a session. From there they list the keyspaces, read every table in them, and issue writes and deletes, all of it indistinguishable from legitimate traffic.
 
-        **Risk mitigation**
+        Clusters get reached this way more often than their operators expect, because Cassandra is usually deployed on an internal network with the assumption that the network is the control. A compromised application host, a container on the same overlay, or a monitoring box with broader reach than anyone intended is enough, and an open cluster treats each of them exactly as it treats the application.
 
-        - **Reduced exposure:** An attacker who reaches the CQL port can no longer connect without stealing or guessing a credential.
-        - **Attributable access:** Authenticated sessions can be tied to a role for logging and investigation.
+        The absence of authentication also leaves nothing to investigate with. Sessions are anonymous, so a log or an audit record cannot say which client did what, and there is no failed attempt to alert on because nothing can fail.
+
+        Enabling it is also what makes permissions possible. Grants are evaluated against an authenticated role, so there is no way to limit what a session can reach until each session is tied to one. A companion check in this policy covers the permission side.
       audit: |-
         ### Audit via cqlsh
 
@@ -132,19 +133,20 @@ queries:
     mql: |
       cassandra.cluster.security.authorizationEnabled == true
     docs:
-      desc: |-
-        This check ensures that the configured authorizer is not `AllowAllAuthorizer`, so that `GRANT` and `REVOKE` permissions are actually enforced. With `AllowAllAuthorizer`, every authenticated role has full access to every keyspace and table, defeating least privilege.
+      desc: |
+        This check verifies that the permissions granted to a role actually constrain what that role can reach.
+
+        The `authorizer` setting in `cassandra.yaml` names the class that evaluates permissions, and it is separate from the authenticator. The check fails on `AllowAllAuthorizer`, the shipped default, and passes on `CassandraAuthorizer`. A rolling restart applies the change, after which each role needs explicit grants for the keyspaces and tables it uses.
 
         **Why this matters**
 
-        - **Least privilege:** `CassandraAuthorizer` lets you grant each role only the permissions it needs rather than full access to everything.
-        - **Separation of duties:** Distinct roles for application access and administration limit what a single credential can do.
-        - **Enforced permissions:** `GRANT` and `REVOKE` statements have no effect unless a real authorizer evaluates them.
+        Under the permissive class, `GRANT` and `REVOKE` statements are accepted and then ignored. That is worse than having no permission model at all, because the cluster reports a least-privilege configuration that it does not enforce, and a review of the grants produces a clean answer while every authenticated role holds full access to every keyspace and table.
 
-        **Risk mitigation**
+        The consequence shows up the moment any credential is exposed. Application credentials live in configuration files, container images, and deployment pipelines, so they are the ones that get out. A role scoped to the one keyspace its service uses limits an attacker to that keyspace; the same role with unenforced grants hands them everything the cluster stores, including the keyspaces belonging to other services and the system tables that describe the topology.
 
-        - **Contained credentials:** A leaked application credential cannot read or alter data outside the permissions granted to its role.
-        - **Blast radius:** Compromise of one role no longer implies control of the entire cluster.
+        The same boundary contains a compromised application. An injection flaw lets an attacker run statements as that service, and whether that ends at one table or at the entire cluster is decided by this setting.
+
+        Grant each role only the operations it performs on the keyspaces it owns, keep administrative capability on separate roles that applications never use, and confirm the grants are enforced after the restart rather than assuming the statements took effect.
       audit: |-
         ### Audit via cqlsh
 
@@ -196,19 +198,20 @@ queries:
     mql: |
       cassandra.cluster.security.clientEncryptionEnabled == true
     docs:
-      desc: |-
-        This check ensures that client-to-node TLS is enabled so that credentials and query data are encrypted in transit between drivers and nodes. Without it, everything a client sends and receives crosses the network in cleartext.
+      desc: |
+        This check verifies that traffic between drivers and nodes is encrypted.
+
+        Client-to-node encryption is configured through the `client_encryption_options` block in `cassandra.yaml`. Set its enabled flag and point it at a keystore holding the node's certificate and key and a truststore holding the authorities the node should accept. A rolling restart applies the change across the cluster.
 
         **Why this matters**
 
-        - **Confidentiality in transit:** TLS protects credentials, CQL statements, and result sets from network eavesdropping.
-        - **Integrity in transit:** It prevents tampering with statements and responses on the wire.
-        - **Compliance:** Many frameworks require encryption of sensitive data in transit for database traffic.
+        Without it, everything a driver sends and everything a node returns crosses the network in cleartext. In a database that traffic is the data: the statements name the tables and the partition keys, and the responses carry the rows themselves. Anyone with a position on the path reads it without authenticating to anything.
 
-        **Risk mitigation**
+        That position is easier to obtain than it sounds for a cluster on an internal network. A compromised host on the same segment, a monitoring appliance with a span port, an overlay network shared with other workloads, or a link between two data centers all give an attacker a copy of the traffic. The capture is passive, so nothing on the cluster records it and nothing about the cluster's behavior changes.
 
-        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
-        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+        The authentication exchange travels the same way. A password validated at connection time is observable in transit, so an attacker who captures one session can then open their own, as that role, from anywhere the cluster accepts connections. Encrypting the transport is what stops a network foothold from becoming a credential.
+
+        Roll the change out node by node and confirm the drivers trust the issuing authority before requiring encryption everywhere, since a client that cannot complete the handshake is refused rather than downgraded. Internode traffic is configured separately and carries the same data.
       audit: |-
         ### Audit via cqlsh
 
@@ -263,19 +266,20 @@ queries:
     mql: |
       cassandra.cluster.security.auditLoggingEnabled == true
     docs:
-      desc: |-
-        This check ensures that audit logging is on, producing a trail of authentication, DML, and DDL events for detection and investigation. Without it, there is no record of who connected, what they queried, or what schema changes were made.
+      desc: |
+        This check verifies that the cluster keeps a record of who connected and what they ran.
+
+        Audit logging is configured through the `audit_logging_options` block in `cassandra.yaml`, where the enabled flag and a logger class such as the binary audit logger are set. A rolling restart applies it, and it can also be switched on for a single node at runtime with the `nodetool` audit log command, which does not survive a restart.
 
         **Why this matters**
 
-        - **Attributable activity:** Audit records tie authentication, queries, and schema changes to a role and source, which is essential for investigating misuse.
-        - **Detection:** A log of login and query activity supports alerting on anomalous or unauthorized behavior.
-        - **Compliance evidence:** Audit frameworks require logging of access to systems that hold sensitive data.
+        With it off, the cluster keeps no record of authentication, of the statements that read data, or of the schema and permission changes made against it. An attacker holding a valid credential then operates entirely without trace: they connect, read the tables that role can reach, grant themselves more, and disconnect, and the cluster retains nothing that would show any of it happened.
 
-        **Risk mitigation**
+        That absence is felt hardest after the fact. When an exposure is discovered through some other route, the first questions are when the access began, which role was used, which tables were read, and whether anything was altered. Audit records answer all four directly. Without them the investigation cannot bound the incident, so every table the compromised role could reach has to be treated as taken.
 
-        - **Faster incident response:** A trail of events narrows down the source and timeline of suspicious activity.
-        - **Deterrence:** Logged, attributable access discourages misuse by authorized users.
+        Records also make ongoing detection possible. A role that suddenly reads a keyspace it has never touched, or a burst of failed authentications against one role name, is visible only if the events are written down somewhere.
+
+        Audit logging is not free. It adds write volume and disk usage on every node, so scope it to the categories and keyspaces that warrant it and ship the output off the nodes, where an attacker who reaches one of them cannot edit it.
       audit: |-
         ### Audit via cqlsh
 

--- a/content/mondoo-mongodb-security.mql.yaml
+++ b/content/mondoo-mongodb-security.mql.yaml
@@ -66,19 +66,20 @@ queries:
     mql: |
       mongo.instance.authenticationEnabled == true
     docs:
-      desc: |-
-        This check ensures that the server is started with authorization enabled (`security.authorization: enabled` or `--auth`), so that clients must authenticate before they can run commands. Without it, anyone who can reach the MongoDB port connects with full access and no credentials.
+      desc: |
+        This check verifies that clients must prove who they are before the server will run a command for them.
+
+        Access control is turned on with `security.authorization: enabled` in `mongod.conf`, or with `--auth` on the command line, and the `mongod` service has to be restarted for it to take effect. Create an administrative user while access is still open, before enabling it, or the restart leaves nobody able to log in.
 
         **Why this matters**
 
-        - **No anonymous access:** Requiring authentication ties every connection to a known user rather than allowing open access to anyone on the network.
-        - **Credential enforcement:** Clients must present a valid username and password (or another configured mechanism) before a session is granted.
-        - **Foundation for authorization:** Role-based access control is meaningless without an authenticated identity to enforce it against.
+        Until it is on, reaching the port is the whole attack. There is no credential to steal or guess: a client connects and issues commands with full authority, which means reading every collection in every database, writing to them, and dropping them.
 
-        **Risk mitigation**
+        This is not hypothetical exposure. Automated campaigns scan for MongoDB deployments that answer without credentials, and the pattern that follows is well established: enumerate the databases, copy what is worth copying, drop the collections, and leave a document demanding payment for their return. Deployments have been found and emptied within hours of first becoming reachable, and the operators frequently learn of it from the ransom note rather than from any alert.
 
-        - **Reduced exposure:** An attacker who reaches the MongoDB port can no longer connect without stealing or guessing a credential.
-        - **Attributable access:** Authenticated sessions can be tied to a user for logging and investigation.
+        The path in is usually not the public internet but the network the deployment already sits on. A compromised application container, a build agent, or a developer laptop on the same segment is enough, and an unauthenticated server draws no distinction between it and the application that is supposed to connect.
+
+        Every other access control depends on this one. Roles, privileges, and per-database grants describe what an identity may do, and none of it is enforced while there is no identity. Turning it on is the point at which the rest of the security configuration starts to mean anything.
       audit: |-
         ### Audit via mongosh
 
@@ -154,19 +155,20 @@ queries:
     mql: |
       mongo.instance.authorizationEnabled == true
     docs:
-      desc: |-
-        This check ensures that role-based access control is enforced, so that users receive only the privileges their roles grant. Without it, every authenticated client has full access to every database, defeating least privilege.
+      desc: |
+        This check verifies that the privileges attached to a user's roles are what bound what that user can do.
+
+        Role-based access control is activated by the same authorization setting in the `security` section of `mongod.conf`, and it applies once the `mongod` service is restarted. With it active, each user gets only the built-in or custom roles granted to them, scoped to the databases named in the grant.
 
         **Why this matters**
 
-        - **Least privilege:** Role-based access control lets you grant each user only the permissions it needs rather than full access to everything.
-        - **Separation of duties:** Distinct roles for application access and administration limit what a single credential can do.
-        - **Enforced permissions:** Built-in and custom roles have effect only when access control is active.
+        Without enforcement, every user that connects holds the same authority as every other one, so the roles recorded against them are documentation rather than a control. The account an application uses to read one collection can read all of them, write to any of them, and drop a database.
 
-        **Risk mitigation**
+        That turns any credential leak into a full compromise. Application credentials are the ones that leak, because they live in environment variables, container images, configuration repositories, and the logs of a deployment tool. When the credential is bounded by a role, an attacker who takes it gets exactly the collection that application reads. When it is not, the same leak hands over the entire deployment, including the collections holding the data the application was never meant to see.
 
-        - **Contained credentials:** A leaked application credential cannot read or alter data outside the permissions granted to its role.
-        - **Blast radius:** Compromise of one user no longer implies control of the entire deployment.
+        Scoped roles also contain a compromised application. An injection flaw or a deserialization bug in one service lets an attacker issue commands as that service; whether that ends at one collection or at the whole cluster is decided here.
+
+        Grant each user the narrowest built-in role that covers its work, scoped to the specific database, and give administrative roles only to accounts used for administration. A deployment where every user holds a cluster-wide role is enforcing nothing in practice even with the setting active.
       audit: |-
         ### Audit via mongosh
 
@@ -224,19 +226,20 @@ queries:
     mql: |
       mongo.instance.tlsMode == "requireTLS"
     docs:
-      desc: |-
-        This check ensures that the server's `net.tls.mode` is `requireTLS`, so that all client and intra-cluster connections are encrypted in transit. Weaker modes such as `allowTLS` and `preferTLS` still accept plaintext connections, leaving credentials and query data exposed on the network.
+      desc: |
+        This check verifies that the server refuses any connection that is not encrypted.
+
+        The TLS posture is set with `net.tls.mode` in `mongod.conf` and needs a certificate and key file the `mongod` user can read. This check requires `requireTLS`. The permissive modes `allowTLS` and `preferTLS` still accept plaintext connections, and a disabled setting accepts nothing else. Restart the `mongod` service after changing it.
 
         **Why this matters**
 
-        - **Confidentiality in transit:** TLS protects credentials, commands, and result sets from network eavesdropping.
-        - **Integrity in transit:** It prevents tampering with statements and responses on the wire.
-        - **No plaintext fallback:** `requireTLS` rejects unencrypted connections outright, unlike the permissive modes that still allow them.
+        The permissive modes are the trap. They report that TLS is configured, they show encrypted sessions when a client asks for one, and they quietly accept every client that does not. Clients do not ask constantly: a connection string that omits the option, a driver upgraded across a release where the default changed, a retry path that falls back when a handshake fails. Each of those sessions carries its authentication exchange, its commands, and its result documents in the clear, and neither end reports anything wrong.
 
-        **Risk mitigation**
+        An attacker on the path exploits that deliberately. They disrupt the handshake until the client retries without encryption, the server accepts because the mode permits it, and they read the credential out of the authentication exchange and the documents out of the responses. They then connect as that user themselves from wherever they like.
 
-        - **No cleartext credentials:** Passwords exchanged during authentication are no longer exposed to anyone on the network path.
-        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+        The same applies between cluster members. Replication and shard traffic carries the same documents, so a permissive mode leaves the internal network exposed even when application clients happen to be well behaved.
+
+        Verify certificates and client configuration before switching, because the strict mode rejects every client that cannot negotiate, and a partial rollout takes the application down rather than protecting it.
       audit: |-
         ### Audit via mongosh
 
@@ -291,19 +294,20 @@ queries:
     mql: |
       mongo.instance.javascriptEnabled == false
     docs:
-      desc: |-
-        This check ensures that server-side JavaScript execution (`security.javascriptEnabled`) is disabled, removing the `$where`, `mapReduce`, and `$function` attack surface when the application does not need it. Server-side JavaScript lets a query run arbitrary code inside the database process.
+      desc: |
+        This check verifies that the server will not execute JavaScript submitted with a query.
+
+        Server-side execution is controlled by `security.javascriptEnabled` in `mongod.conf`. It is on by default, so the check fails when the setting is absent as well as when it is explicitly true. Restart the `mongod` service after disabling it.
 
         **Why this matters**
 
-        - **Reduced attack surface:** Disabling server-side JavaScript removes operators that can execute arbitrary code, closing an injection path.
-        - **Hardened defaults:** Most applications never use `$where`, `mapReduce`, or `$function`, so the feature is pure exposure when left on.
-        - **Defense in depth:** It limits what an attacker can do even if a malicious query reaches the server.
+        While it is on, several operators accept code rather than data. The `$where` operator takes a JavaScript expression evaluated per document, `$function` runs a supplied function body inside an aggregation pipeline, and `mapReduce` executes both of its stages as JavaScript. In each case the code runs inside the database process.
 
-        **Risk mitigation**
+        That gives query injection somewhere to go. An application that builds a filter from user input and passes it through without validation lets an attacker replace a comparison with an expression of their choosing. Instead of returning the one document the application intended, the expression walks the collection, tests characters of a field one at a time, and leaks the contents through the true and false answers it produces. The same expression can be written to loop, which stalls the query thread and takes the deployment down.
 
-        - **No arbitrary code execution:** A crafted `$where` or `$function` payload can no longer run JavaScript inside the database.
-        - **Contained injection:** Query injection that relies on server-side JavaScript is neutralized.
+        Turning the feature off closes the whole class at once. The operators are refused outright, so an injected expression is an error rather than an execution, and the application's own queries are unaffected because they never used them.
+
+        Confirm before disabling that nothing in the workload depends on those operators. Most applications never touch them, and aggregation stages cover almost everything the older map-reduce pipelines were written for.
       audit: |-
         ### Audit via mongosh
 

--- a/content/mondoo-mssql-security.mql.yaml
+++ b/content/mondoo-mssql-security.mql.yaml
@@ -66,19 +66,20 @@ queries:
     mql: |
       mssql.server.forceEncryption == true
     docs:
-      desc: |-
-        This check ensures that the SQL Server instance has Force Encryption enabled, so the server requires an encrypted TLS channel for all client connections rather than leaving encryption to each client's discretion.
+      desc: |
+        This check verifies that the instance requires an encrypted channel for every client connection instead of leaving the decision to each client.
+
+        Force Encryption is a server-level protocol setting. Open SQL Server Configuration Manager, expand SQL Server Network Configuration, open the properties of the protocols for the instance, and set the flag on the Flags tab. It works only once a trusted server certificate has been installed and selected on the Certificate tab and the service account can read that certificate's private key, and the SQL Server service must be restarted before the change takes effect.
 
         **Why this matters**
 
-        - **Confidentiality in transit:** TLS protects credentials, query text, and result sets from network eavesdropping.
-        - **No opportunistic downgrade:** Forcing encryption at the server prevents a client from negotiating an unencrypted session.
-        - **Compliance:** Frameworks require sensitive database traffic to be encrypted in transit.
+        Without it the server accepts whatever the client asks for, and clients ask for plaintext constantly. A connection string that omits the encryption setting, an older driver whose default was permissive, a linked server configured years ago: each produces a session that carries the login and the traffic in the clear.
 
-        **Risk mitigation**
+        What crosses that wire is the whole point of the database. An attacker with a position on the network path, a mirrored switch port, a compromised jump host, or a hypervisor under someone else's control, reads the login credentials as they are presented and then the statement text and the result rows behind them. They do not need to authenticate, they do not appear in any login record, and the capture keeps working until someone notices the tap.
 
-        - **No cleartext credentials:** Login credentials are no longer exposed to anyone on the network path.
-        - **Man-in-the-middle resistance:** Combined with a trusted server certificate, TLS prevents interception and impersonation.
+        Forcing encryption at the server also removes the downgrade. An attacker who can interfere with the connection cannot push a client onto an unencrypted session, because the server refuses it outright rather than accommodating the request.
+
+        Pair this with a certificate the clients actually trust. When clients fall back to trusting the self-signed certificate the instance generates, the session is encrypted but unauthenticated, and an interceptor can still present themselves as the server.
       audit: |-
         ### Audit via SQL Server Configuration Manager
 
@@ -121,19 +122,20 @@ queries:
     mql: |
       mssql.server.isMixedModeAuthEnabled == false
     docs:
-      desc: |-
-        This check ensures that the instance uses Windows Authentication mode rather than mixed mode. In mixed mode, SQL logins authenticate with a username and password managed by SQL Server; in Windows Authentication mode, only Windows and Active Directory principals may connect, so identity is centralized in the directory.
+      desc: |
+        This check verifies that only directory principals can log in to the instance, rather than accounts whose passwords the database itself holds.
+
+        Server authentication is set in SQL Server Management Studio through the server's properties on the Security page, or through the `LoginMode` server registry value, where `1` selects Windows Authentication and `2` selects mixed mode. Either way the SQL Server service must be restarted. Confirm a Windows login with administrative rights exists before switching, or the change locks everyone out.
 
         **Why this matters**
 
-        - **Centralized identity:** Windows Authentication delegates authentication to Active Directory, which enforces password policy, lockout, and Kerberos protections that SQL logins do not receive by default.
-        - **Smaller credential surface:** SQL logins add a separate set of passwords that can be brute-forced against the database endpoint directly.
-        - **Stronger protocols:** Windows Authentication uses Kerberos or NTLM rather than passing SQL-login credentials to the server.
+        In mixed mode the instance carries its own set of usernames and passwords, and those accounts are reachable from anywhere the port is. An attacker who can open a socket guesses against them directly, and the well-known administrative login is on every wordlist in use. There is no directory in the path to apply a lockout threshold or a complexity rule, so the attempts continue at whatever rate the network allows.
 
-        **Risk mitigation**
+        Those passwords are also the ones that end up in configuration files, deployment scripts, and repositories, because an application needs to present them. One leaked file yields a credential that works from any host that can route to the instance, with nothing else required.
 
-        - **No standalone SQL passwords:** Removing SQL logins eliminates a common brute-force and credential-stuffing target.
-        - **Policy enforcement:** Directory-managed accounts inherit enterprise password and lockout policy.
+        Directory authentication removes the standalone secret. The exchange uses Kerberos or the older challenge-response protocol rather than sending a password the server stores, account policy and lockout are enforced centrally, and disabling a person's directory account removes their database access at the same moment rather than whenever someone remembers to drop the login.
+
+        Applications that genuinely cannot use a directory identity are the reason to keep mixed mode. Where that is the case, restrict the accounts to the minimum privileges, rotate them, and keep the administrative login disabled.
       audit: |-
         ### Audit via T-SQL
 
@@ -187,19 +189,20 @@ queries:
     mql: |
       mssql.server.configurations.where(name == "xp_cmdshell").all(valueInUse == 0)
     docs:
-      desc: |-
-        This check ensures that the `xp_cmdshell` server configuration option is disabled. When enabled, `xp_cmdshell` lets a sufficiently privileged database session run arbitrary operating-system commands under the SQL Server service account.
+      desc: |
+        This check verifies that the instance cannot be used to run operating system commands on the host.
+
+        `xp_cmdshell` is a surface-area option in the server configuration. It is disabled by default and is turned on and off with `sp_configure`, which requires `show advanced options` to be enabled first and a `RECONFIGURE` afterwards for the change to become the running value. The same setting is exposed in Management Studio through the Surface Area Configuration facet on the server. This check reads the running value rather than the configured one, so a pending change that was never reconfigured does not count.
 
         **Why this matters**
 
-        - **Blocks OS command execution from SQL:** With `xp_cmdshell` off, a compromised database login or a SQL injection flaw cannot pivot into shell commands on the host.
-        - **Reduces surface area:** It is disabled by default; leaving it on keeps a powerful, rarely needed capability available to attackers.
-        - **Limits blast radius:** Commands would otherwise run with the privileges of the SQL Server service account, not the caller.
+        When it is on, the database stops being a boundary. A session with sufficient privilege runs shell commands on the host, and those commands execute as the SQL Server service account rather than as the caller, so the caller's operating system privileges are irrelevant.
 
-        **Risk mitigation**
+        That is the step an attacker is looking for. An injection flaw in an application, or a login they obtained from a configuration file, becomes command execution on a Windows server that usually sits inside the network rather than at its edge. From there they read files the service account can reach, add a local account, dump credentials from memory, and move to the next host. A database compromise turns into a foothold on the domain.
 
-        - **Injection containment:** A SQL injection vulnerability can no longer escalate to host command execution through this path.
-        - **Least functionality:** Removing unused capabilities shrinks the attack surface of the instance.
+        The capability is rarely needed. Most instances that have it enabled did so once for a scheduled task that has since been replaced by an agent job or a service.
+
+        Where a job genuinely requires it, enable it for the duration of that job and turn it off again, rather than leaving it on permanently for a task that runs once a week.
       audit: |-
         ### Audit via T-SQL
 
@@ -253,19 +256,20 @@ queries:
     mql: |
       ["Failed", "All"].contains( mssql.server.loginAuditLevel )
     docs:
-      desc: |-
-        This check ensures that the instance's login auditing level records failed login attempts (a level of `Failed` or `All`). SQL Server writes these records to the SQL Server error log, producing an audit trail of authentication activity.
+      desc: |
+        This check verifies that the instance records login attempts that fail.
+
+        Login auditing is a server-level setting, configured in Management Studio through the server's properties on the Security page under Login auditing. This check requires the level to be `Failed` or `All`; recording only successful logins, or nothing at all, fails it. The SQL Server service must be restarted before a change takes effect. Records are written to the SQL Server error log.
 
         **Why this matters**
 
-        - **Brute-force detection:** A record of failed logins is the primary signal for password-guessing and credential-stuffing against SQL logins.
-        - **Attributable access:** Login records tie authentication attempts to accounts and times, supporting investigations.
-        - **Compliance evidence:** Audit frameworks require logging of access attempts to systems holding sensitive data.
+        A run of failed logins is the clearest signal a database produces. Password guessing against the administrative login, credential stuffing with pairs from an unrelated breach, and an attacker working through the account names they found in a configuration file all look the same from inside the instance: many attempts, few accounts, one source. With the level set to record nothing, all of that happens in silence and the first evidence of the campaign is the session that finally succeeded.
 
-        **Risk mitigation**
+        The absence also removes the timeline. When a compromise is found later, failed attempts are what establish when the attacker started, which accounts they knew about, and where they were connecting from, and none of that can be reconstructed after the fact if it was never written.
 
-        - **Faster incident response:** A trail of failed logins narrows down the source and timeline of an attack.
-        - **Alerting:** Logged failures can drive alerts on repeated or off-hours attempts.
+        Recording failures rather than successes keeps the volume low, since a healthy instance produces very few, which in turn makes an alert on a sudden burst practical rather than noisy.
+
+        Recording both is better where the error log is shipped to a collector that can hold the volume, since successful logins are what let a suspicious source address be traced through to what it actually did.
       audit: |-
         ### Audit via T-SQL
 

--- a/content/mondoo-postgresql-security.mql.yaml
+++ b/content/mondoo-postgresql-security.mql.yaml
@@ -107,20 +107,19 @@ queries:
       postgresql.conf.listenAddresses.none(_ == "*" || _ == "0.0.0.0" || _ == "::")
     docs:
       desc: |
-        This check ensures that `listen_addresses` names specific interfaces instead of binding the server to every address on the host. A value of `*`, `0.0.0.0`, or `::` makes the PostgreSQL port reachable from every network the host is attached to, including networks the database was never meant to serve.
+        This check verifies that the server binds only to the network interfaces an operator named, instead of to every address the host holds.
 
-        PostgreSQL defaults to `localhost`, which is safe. Packaged installations and container images frequently widen this to `*` so the server is reachable during setup, and that widened value is rarely narrowed again afterwards.
+        `listen_addresses` in `postgresql.conf` decides which interfaces the postmaster opens a socket on. The check fails on the wildcard forms `*`, `0.0.0.0`, and `::`, and passes when the value lists `localhost` or the specific private addresses the database is meant to serve. PostgreSQL reads this setting only at startup, so a restart is required; a reload leaves the existing sockets bound.
 
         **Why this matters**
 
-        - **Smaller network surface:** Only the interfaces you name can carry a connection attempt, so an unexpected management or public network cannot reach the port at all.
-        - **Defense in depth behind the firewall:** Host and network firewall rules change over time. Binding narrowly means a firewall mistake does not immediately expose the database.
-        - **Clear intent:** An explicit address list documents which networks the database is expected to serve, which makes later review straightforward.
+        A wildcard bind puts port 5432 on every network the host touches, including a management VLAN, a second interface added months later, and the public address of a cloud instance. Internet-wide scanners sweep that port continuously, and PostgreSQL answers an unauthenticated startup packet with enough detail to fingerprint the server, so a newly exposed cluster is catalogued within hours of becoming reachable.
 
-        **Risk mitigation**
+        Once an attacker can open a socket, they spray passwords against `postgres` and against the application roles whose names they harvested from a leaked connection string or a public repository. Every attempt reaches the authentication code path directly, and if any host-based authentication rule is broad enough to match their source address, the credential is the only thing left between them and the tables.
 
-        - **Blocks opportunistic scanning:** Internet-wide scanners routinely probe port 5432 and fingerprint the server version from its response.
-        - **Contains credential attacks:** Brute-force and password-spraying attempts cannot start against an address that never accepts the connection.
+        Packaged installations and container images widen this to `*` so the server answers during setup, and the widened value is rarely narrowed once the deployment works.
+
+        Keep the list to loopback plus the application subnets, and confirm what the server is actually listening on after the restart rather than trusting the file alone. A host that genuinely serves several networks should name each address explicitly rather than falling back to the wildcard.
       audit: |
         ### Audit via CLI
 
@@ -233,20 +232,19 @@ queries:
       postgresql.conf.sslEnabled == true
     docs:
       desc: |
-        This check ensures that the `ssl` directive is turned on so PostgreSQL can negotiate TLS with connecting clients. PostgreSQL ships with `ssl` set to off, and a server built that way carries every session in cleartext, including the authentication exchange.
+        This check verifies that the server offers an encrypted channel to connecting clients.
 
-        Turning TLS on is a prerequisite for the rest of the transport controls in this policy. Minimum protocol version, cipher selection, and client certificate verification have no effect while `ssl` remains off.
+        The `ssl` directive in `postgresql.conf` turns the TLS listener on. It needs a server certificate and private key the server account can read, and a reload applies the change once those files are in place. PostgreSQL ships with the directive off.
 
         **Why this matters**
 
-        - **Confidential query traffic:** Query text and result sets frequently contain the most sensitive data in an environment. TLS keeps that content unreadable in transit.
-        - **Credential protection:** Without TLS, password based authentication exchanges are observable by anything on the network path.
-        - **Tamper detection:** TLS integrity protection means an attacker cannot silently rewrite statements or results in flight.
+        While it is off, every session runs in cleartext from the first packet. In a database the traffic is the data rather than a pointer to it, so anyone on the network path reads the statement text and the result rows: personal records, payment details, session tokens. A span port on a switch, a compromised hypervisor, or a cloud traffic mirror yields the contents of the tables without the attacker ever authenticating to the server.
 
-        **Risk mitigation**
+        The authentication exchange rides the same wire. An attacker who captures a session recovers whatever the configured method exposes, and where cleartext password authentication is permitted that is the password itself, reusable against this cluster and against every other system that shares the credential.
 
-        - **Defeats passive interception:** A compromised switch, hypervisor, or cloud network tap yields no readable database traffic.
-        - **Defeats connection hijacking:** An active attacker cannot inject statements into an authenticated session.
+        Cleartext also means the attacker can write and not only read. Without integrity protection they can inject a statement into an established session or rewrite a result set on its way back to the application, so the application acts on data the database never returned.
+
+        This directive is the prerequisite for the rest of the transport controls in this policy. Minimum protocol version, cipher selection, and client certificate verification have no effect while it remains off. Because `ALTER SYSTEM` writes to `postgresql.auto.conf` and that file is applied last, clear any override there so the value in the main file is the one the server uses.
       audit: |
         ### Audit via CLI
 
@@ -389,20 +387,19 @@ queries:
       postgresql.conf.sslMinProtocolVersion == /^TLSv1\.[23]$/
     docs:
       desc: |
-        This check ensures that `ssl_min_protocol_version` explicitly pins the lowest TLS version the server will negotiate to `TLSv1.2` or `TLSv1.3`. TLS 1.0 and TLS 1.1 are deprecated, rely on obsolete hashing and cipher constructions, and are no longer considered adequate for protecting authentication material.
+        This check verifies that the server refuses to negotiate an obsolete TLS version.
 
-        Recent PostgreSQL releases default to `TLSv1.2`, but the directive is frequently set to a lower value in configurations carried forward from older versions. Setting it explicitly keeps the floor from drifting downward when a configuration file is copied to a new host.
+        `ssl_min_protocol_version` in `postgresql.conf` sets the floor for the handshake. The check passes on `TLSv1.2` and `TLSv1.3` and fails on the older values or on an unset directive. A reload applies the new floor to connections established afterwards.
 
         **Why this matters**
 
-        - **Removes downgrade room:** A client cannot negotiate a weak protocol version that the server refuses to offer.
-        - **Modern cipher suites only:** TLS 1.2 and above provide authenticated encryption modes that older versions lack.
-        - **Audit clarity:** An explicit floor is verifiable from the configuration file without inferring a version-specific default.
+        TLS 1.0 and TLS 1.1 build their handshake on MD5 and SHA-1 and their record layer on CBC modes without authenticated encryption. Those constructions are broken in practice, not merely deprecated, and the published attacks against them target exactly the part of the session an attacker wants: the early records, where the authentication exchange sits.
 
-        **Risk mitigation**
+        An attacker in the network path does not need to break the server to use them. They interfere with the handshake so the client retries with a lower version, and if the server still accepts TLS 1.0 the session proceeds on a protocol whose padding and record structure leak plaintext block by block. The credential exchanged at the start of the session is recovered from that leak, and the attacker then connects as the role with a normal client.
 
-        - **Blocks protocol downgrade attacks:** An attacker who can influence the handshake cannot force the session onto a deprecated version.
-        - **Prevents weak-cipher exposure:** Attacks against obsolete cipher constructions in TLS 1.0 and 1.1 no longer apply.
+        Recent PostgreSQL releases default to `TLSv1.2`, but the directive is often carried forward at a lower value in a configuration file copied from an older host, and a version upgrade does not correct an explicit setting.
+
+        Pin the floor explicitly so it cannot drift downward with the file. Raise it to `TLSv1.3` where every client library supports it, and confirm the client fleet before doing so, because a client that cannot reach the floor is refused rather than downgraded.
       audit: |
         ### Audit via CLI
 
@@ -511,20 +508,19 @@ queries:
       postgresql.conf.sslCiphers == /!aNULL/
     docs:
       desc: |
-        This check ensures that `ssl_ciphers` is set to a list built on the `HIGH` cipher grouping and that it explicitly excludes the `aNULL` suites. The `aNULL` group performs key exchange without authenticating the server, which allows a machine-in-the-middle to terminate the session while the client still believes it reached the database.
+        This check verifies that the server offers only cipher suites that authenticate it and provide adequate key strength.
 
-        The value is passed through to the TLS library, so a permissive list such as `ALL` silently re-admits export grade and unauthenticated suites that the library still carries for compatibility.
+        `ssl_ciphers` in `postgresql.conf` is handed straight to the TLS library. The check requires the value to be set, to be built on the `HIGH` grouping, and to exclude the unauthenticated `aNULL` suites explicitly. A reload applies the list to subsequent handshakes.
 
         **Why this matters**
 
-        - **Server authenticity:** Excluding `aNULL` guarantees the server proves its identity during every handshake.
-        - **Adequate key strength:** The `HIGH` grouping restricts negotiation to suites with acceptable key lengths.
-        - **Predictable negotiation:** A narrow list means every client converges on a small, reviewed set of suites.
+        The `aNULL` suites perform key exchange with no server certificate at all. When one is negotiated the client encrypts the session to whoever answered the socket, which is exactly what an attacker sitting between the application and the database wants. They terminate the connection on their own host, present a session the client accepts as encrypted, read the credential and every statement and result, and forward the traffic on so nothing looks broken.
 
-        **Risk mitigation**
+        A permissive value such as `ALL` re-admits those suites along with the export-grade and single-DES suites the library still carries for compatibility. Those keys are recoverable with rented compute, so an attacker who records the traffic decrypts it afterwards even without an active position on the path.
 
-        - **Prevents anonymous key exchange:** A machine-in-the-middle cannot present an unauthenticated session as a legitimate one.
-        - **Removes weak and export suites:** Cipher suites vulnerable to practical cryptanalysis are never offered.
+        The `HIGH` grouping keeps negotiation to suites with acceptable key lengths, and naming the exclusions after it means a library update that adds a weak suite to a broader group does not silently widen what this server accepts.
+
+        Extend the list with the other exclusions your platform needs rather than replacing it with a permissive one, and expand the value with your TLS tooling after a change to confirm no suite without server authentication survives.
       audit: |
         ### Audit via CLI
 
@@ -631,20 +627,19 @@ queries:
       postgresql.conf.params["ssl_prefer_server_ciphers"] == empty || postgresql.conf.params["ssl_prefer_server_ciphers"].downcase == "on"
     docs:
       desc: |
-        This check ensures that `ssl_prefer_server_ciphers` is left at its secure default of on, so the server's cipher ordering decides the negotiated suite rather than the client's. PostgreSQL enables this by default, and the check treats an absent directive as compliant. It fails only when the setting has been explicitly turned off.
+        This check verifies that the server's cipher ordering, not the client's, decides which suite a session uses.
 
-        When the client's preference wins, a misconfigured or deliberately hostile client can steer every session onto the weakest suite the server still admits, which undermines the ordering established by `ssl_ciphers`.
+        `ssl_prefer_server_ciphers` in `postgresql.conf` controls whose preference wins during the handshake. PostgreSQL enables it by default, so the check treats an absent directive as compliant and fails only when the setting has been turned off explicitly. A reload restores it.
 
         **Why this matters**
 
-        - **Server controls strength:** The database operator decides which suite is preferred, not the connecting application.
-        - **Consistent posture:** Every client converges on the same preferred suite regardless of its own library defaults.
-        - **Makes cipher ordering meaningful:** The order expressed in `ssl_ciphers` only takes effect when the server's preference is honored.
+        When the client's preference wins, the client chooses from the intersection of the two lists, and a client is free to prefer the weakest suite in that set. Any of them is acceptable to the library on the far side, so a hostile or badly configured client steers every one of its sessions onto the oldest construction the server still admits, and the ordering an administrator expressed in `ssl_ciphers` never takes effect.
 
-        **Risk mitigation**
+        That is a downgrade an attacker can arrange without touching the server. Malware on an application host, or a driver configured from a copied snippet, connects with a cipher list that names one legacy suite first; the server agrees, and the traffic for that session is protected by whatever the attacker picked rather than by what the operator chose. The credential and the result rows are exposed to the same offline analysis that suite was retired for.
 
-        - **Prevents client-driven downgrade:** A client cannot select the weakest mutually supported suite.
-        - **Limits legacy library impact:** Outdated client libraries cannot drag sessions onto obsolete suites.
+        Leaving the server in charge also makes the posture uniform. Every client converges on the same preferred suite regardless of the defaults its own library ships with, so a single review of the server list describes what is actually negotiated across the fleet.
+
+        Turning this off is only defensible when a specific client needs a suite the server would otherwise deprioritize, and even then narrowing the server list is the better fix.
       audit: |
         ### Audit via CLI
 
@@ -748,20 +743,19 @@ queries:
       postgresql.hba.rules.none(authMethod.downcase == "cert") || postgresql.conf.sslCaFile != empty
     docs:
       desc: |
-        This check ensures that `ssl_ca_file` names a certificate authority bundle whenever `pg_hba.conf` contains a rule that authenticates clients with the `cert` method. Certificate authentication is only meaningful when the server has a trust anchor to validate the presented client certificate against.
+        This check verifies that a certificate authority bundle is configured whenever clients are authenticated by certificate.
 
-        Without `ssl_ca_file`, PostgreSQL has nothing to verify a client certificate chain against, so rules that appear to enforce certificate authentication cannot do so. The check applies only to servers that actually use the `cert` method, so a password authenticated deployment is not asked to configure a trust anchor it has no use for.
+        `ssl_ca_file` in `postgresql.conf` names the trust anchor the server validates presented client certificates against. The check looks at `pg_hba.conf` first: if no rule uses the `cert` method, it passes, because a password-authenticated deployment has no use for the bundle. If a `cert` rule exists, the bundle must be set. A reload applies the new path.
 
         **Why this matters**
 
-        - **Makes certificate authentication real:** A trust anchor is what turns a presented certificate into a verified identity.
-        - **Controls who can issue identities:** Only certificates chaining to the configured authority are accepted.
-        - **Supports revocation:** A managed authority bundle gives you a place to distrust compromised client certificates.
+        Certificate authentication without a trust anchor is a rule that cannot do its job. The server has nothing to build a chain to, so the rule that appears on paper to be the strongest authentication in the file is the weakest thing in it, and nobody reviewing the configuration notices, because the method name reads correctly.
 
-        **Risk mitigation**
+        The consequence is that an attacker who can reach a matching address does not need a credential the operator issued. They generate their own key pair, sign a certificate naming the role they want, and present it. The rule matches, the identity is unverified, and they hold a session as that role with whatever privileges it carries.
 
-        - **Rejects untrusted certificates:** A self-issued client certificate cannot satisfy an authentication rule.
-        - **Prevents a false sense of assurance:** Certificate rules that could never validate anything are surfaced before they are relied upon.
+        The bundle is also where revocation lives. When a client key is lost, the authority is what lets you stop accepting the certificates it signed; without one there is nothing to revoke against and no way to cut off the holder.
+
+        Point the directive at the issuing authority for your client certificates only, not at the system-wide root store, or every certificate any public authority ever issued becomes acceptable to the server.
       audit: |
         ### Audit via CLI
 
@@ -892,20 +886,19 @@ queries:
       postgresql.conf.passwordEncryption.downcase == "scram-sha-256"
     docs:
       desc: |
-        This check ensures that `password_encryption` is explicitly set to `scram-sha-256`, which is the salted challenge response mechanism PostgreSQL uses to store and verify passwords. The legacy `md5` scheme salts only with the role name, so the stored verifier is effectively a password equivalent: an attacker who reads `pg_authid` can authenticate as that role without ever recovering the password.
+        This check verifies that new and changed passwords are stored as salted challenge-response verifiers rather than as legacy hashes.
 
-        This directive governs how new and changed passwords are stored, so it must be set before passwords are rotated. Existing `md5` verifiers are not converted automatically and remain usable until each role's password is set again.
+        `password_encryption` in `postgresql.conf` decides the format used when a password is set. The check requires `scram-sha-256`. A reload applies it, but only to passwords set afterwards; verifiers already stored are not converted.
 
         **Why this matters**
 
-        - **Stolen verifiers are not credentials:** A SCRAM verifier cannot be replayed against the server the way an MD5 hash can.
-        - **Per-password salting:** Random per-password salts defeat precomputed lookup tables across roles and servers.
-        - **Configurable work factor:** SCRAM applies iterated hashing, which raises the cost of offline guessing.
+        The legacy `md5` scheme salts the hash with the role name alone, so the value stored in `pg_authid` is not a hint about the password, it is a password equivalent. An attacker who reads that catalog, through a backup file, a replica they attached to, a `SELECT` as a role with the right attributes, or a stolen data directory, can authenticate as that role without ever recovering the password. The stored value goes straight into the protocol exchange.
 
-        **Risk mitigation**
+        Salting by role name also means the salt is predictable and shared. A table built once for the role name `postgres` applies to every PostgreSQL cluster in the world, so the attacker who dumps a catalog does not even need to crack anything unique.
 
-        - **Blocks pass-the-hash against the database:** Reading the system catalog no longer yields directly replayable credentials.
-        - **Slows offline cracking:** Iterated, individually salted hashes make bulk recovery from a catalog dump impractical.
+        A challenge-response verifier removes both properties. It cannot be replayed at the protocol level, its salt is random per password, and it is produced with iterated hashing, so bulk offline guessing against a catalog dump costs far more than it returns.
+
+        Set the directive first, then reset each role's password so its verifier is rewritten, and check the catalog afterwards for roles whose stored value is still in the old format. Those roles keep working, and keep the exposure, until their passwords are set again.
       audit: |
         ### Audit via CLI
 
@@ -1032,20 +1025,19 @@ queries:
       postgresql.hba.rules.none(authMethod.downcase == "trust")
     docs:
       desc: |
-        This check ensures that no host-based authentication rule uses the `trust` method. A `trust` rule accepts any connection matching it without asking for a credential of any kind, so anyone who can reach the server on a matching address becomes the requested role, including a superuser.
+        This check verifies that no host-based authentication rule accepts a connection without asking for a credential.
 
-        Installation scripts and container entrypoints commonly write a `trust` rule so the first connection can create roles before any password exists. That bootstrap rule frequently survives into production. The check also asserts that rules were parsed at all, so a missing or unreadable `pg_hba.conf` is reported rather than passing silently.
+        Each line in `pg_hba.conf` names a connection type, a database, a role, a client address, and a method. This check requires that rules were parsed at all, so an unreadable or missing file is reported instead of passing quietly, and that none of them uses the `trust` method.
 
         **Why this matters**
 
-        - **Authentication is mandatory:** Every connection must present a credential before acting as a role.
-        - **Superuser is reachable through matching rules:** A `trust` rule that matches the `postgres` role hands over full control of the cluster.
-        - **Local rules matter too:** A `trust` rule scoped to local sockets grants the database to any account on the host, including compromised service accounts.
+        A `trust` rule grants whatever role the client asks for, with no password, no certificate, and no operating system identity check. Anyone who matches the rule's address becomes that role on request. When the rule matches `postgres`, they own the cluster: they read and alter every table, create roles for later, and read files on the host through server-side functions available to a superuser.
 
-        **Risk mitigation**
+        The path in is short. An attacker with any route to the port, a compromised container on the same network, an application server they already hold, or an exposed address, connects and is inside. There is no failed login to alert on, because nothing failed.
 
-        - **Prevents unauthenticated takeover:** An attacker who reaches the port cannot become a superuser without a credential.
-        - **Contains host compromise:** A foothold in an unrelated service on the same host does not extend into the database.
+        Local rules are not safer. A `trust` rule scoped to the Unix socket hands the database to every account on the host, so a foothold in an unrelated service running there escalates into the database without another credential.
+
+        Installation scripts and container entrypoints write a `trust` rule so the first connection can create roles before a password exists, and that bootstrap line survives into production far more often than it is removed. Replace it with a challenge-response method for network rules and with operating system identity for local socket rules, then reload.
       audit: |
         ### Audit via CLI
 
@@ -1169,20 +1161,19 @@ queries:
       postgresql.hba.rules.none(authMethod.downcase == "password")
     docs:
       desc: |
-        This check ensures that no host-based authentication rule uses the `password` method, which sends the password across the connection in cleartext. The similarly named `scram-sha-256` method performs a challenge response exchange instead, so the password itself never crosses the wire.
+        This check verifies that no host-based authentication rule accepts a password sent in the clear.
 
-        The `password` method is dangerous even on a TLS protected server, because a rule that permits it will still be used by clients that negotiate a plaintext connection through a `host` rule. Removing the method entirely closes that path rather than depending on every client to request TLS.
+        The `password` method in `pg_hba.conf` has the client transmit the password itself to the server. The similarly named challenge-response method exchanges proofs instead, so the password never crosses the connection. The check requires that rules were parsed and that none of them selects the cleartext method.
 
         **Why this matters**
 
-        - **The password never transits:** A challenge response exchange gives an observer nothing to replay or reuse.
-        - **Independent of transport:** Removing the method protects the credential even when a session is established without TLS.
-        - **No credential in server memory:** SCRAM avoids handling the cleartext password on the server side.
+        A single captured packet is the whole credential. An attacker on the path, on a mirrored switch port, in a compromised load balancer, or on a router between two data centers, reads the password as it is sent and then connects as that role from anywhere the rules allow. Nothing about the intrusion looks anomalous afterwards, because they authenticate the way the application does.
 
-        **Risk mitigation**
+        The damage rarely stops at the database. Database passwords are reused in deployment scripts, in other environments of the same service, and sometimes by the human who chose them, so the captured value gets tried elsewhere immediately.
 
-        - **Defeats network sniffing:** A captured session yields no usable password.
-        - **Limits credential reuse damage:** A password shared with other systems is not exposed by a database connection.
+        Having TLS enabled is not a defense here. A rule that permits the cleartext method is still matched by a client that connects through a `host` rule without requesting encryption, and clients do that by accident whenever a connection string omits the setting. Removing the method closes the path outright rather than depending on every client to ask for protection.
+
+        Confirm that stored verifiers are already in the `scram-sha-256` format before changing the rules, then rewrite the method and reload. A role whose verifier is still in the legacy format cannot complete the stronger exchange and will be locked out until its password is set again.
       audit: |
         ### Audit via CLI
 
@@ -1289,20 +1280,19 @@ queries:
       postgresql.hba.rules.none(authMethod.downcase == "md5")
     docs:
       desc: |
-        This check ensures that no host-based authentication rule uses the legacy `md5` method. The MD5 scheme salts the stored verifier with the role name alone, so the value held in `pg_authid` is replayable: an attacker who reads it can authenticate as that role without recovering the password.
+        This check verifies that no host-based authentication rule still selects the legacy password exchange.
 
-        A rule set to `md5` also accepts SCRAM verifiers, which makes the rule appear harmless on a cluster that has already migrated its passwords. It still permits the weaker exchange for any role whose verifier remains in the legacy format, so the rule should be changed to `scram-sha-256` to close that path.
+        The `md5` method in `pg_hba.conf` authenticates against a verifier salted with the role name alone. The check requires that rules were parsed and that none of them names this method, so authentication happens through `scram-sha-256` instead.
 
         **Why this matters**
 
-        - **Verifier theft is not authentication:** SCRAM verifiers cannot be replayed against the server.
-        - **Per-password salting:** Role-name salting allows precomputation across servers that share role names such as `postgres`.
-        - **Completes the migration:** Changing the rule prevents new connections from negotiating the weaker exchange.
+        The value stored in `pg_authid` under the old scheme is replayable. It is not a hint about the password, it is what the protocol exchange consumes, so an attacker who reads the catalog through a stolen backup, a data directory copy, or a query run as a privileged role authenticates as that role immediately, without cracking anything.
 
-        **Risk mitigation**
+        Because the salt is the role name, the work is also reusable. Precomputed tables built once for a common name such as `postgres` apply to every cluster that uses it, so a dump from one environment shortens the attack on another.
 
-        - **Blocks pass-the-hash:** A catalog dump no longer yields directly usable credentials.
-        - **Removes precomputation advantage:** Attackers cannot reuse tables built for common role names.
+        A rule left at the old method looks harmless on a cluster that has already migrated its passwords, since that method also accepts the newer verifiers. It is still the weaker exchange whenever a role's stored value remains in the legacy format, and it keeps that path open indefinitely.
+
+        Sequence the change carefully. Set the storage format, reset the password of every role whose verifier is still legacy, and only then rewrite the rules and reload. A role that has not been reset cannot complete the stronger exchange, so changing the rules first locks it out. A companion check in this policy covers the storage format itself.
       audit: |
         ### Audit via CLI
 
@@ -1431,20 +1421,19 @@ queries:
       postgresql.hba.rules.none(address == "0.0.0.0/0" || address == "::/0" || address.downcase == "all")
     docs:
       desc: |
-        This check ensures that no host-based authentication rule matches every possible client address. A rule scoped to `0.0.0.0/0`, `::/0`, or `all` accepts connection attempts from any host that can route to the server, which turns the authentication method into the only remaining barrier.
+        This check verifies that every host-based authentication rule names the networks it serves rather than matching every client address.
 
-        Narrowing the client address is the most effective control in `pg_hba.conf` because it stops an attacker before any credential exchange begins. Rules should name the specific subnets that host the application tier, replication peers, or administrative jump hosts.
+        The address column of a rule in `pg_hba.conf` is the first thing the server evaluates. The check requires that rules were parsed and that none of them uses `0.0.0.0/0`, `::/0`, or `all`, each of which matches any host that can route to the server.
 
         **Why this matters**
 
-        - **Fewer sources can attempt authentication:** Hosts outside the named ranges are rejected before a credential is offered.
-        - **Layered with the network controls:** Address scoping in the database survives a firewall change that unexpectedly opens the port.
-        - **Documents expected topology:** Explicit ranges record which systems are supposed to connect.
+        A wildcard address turns the authentication method into the only barrier, and methods fail in ways addresses do not. A weak password, a credential committed to a repository, or a legacy method still permitted somewhere in the file is enough, and the attacker only needs to reach the port. With a scoped rule they never get to make the attempt: the connection is refused before any credential is offered, and the failure is recorded with their source address.
 
-        **Risk mitigation**
+        That difference matters most during password guessing. Credential stuffing runs against every role name it can find; scoping the rule means those attempts come from addresses that match nothing, so they are rejected at the rule and never touch a verifier.
 
-        - **Stops credential stuffing at the door:** Password guessing cannot begin from an address the rule does not match.
-        - **Limits exposure after a network mistake:** An accidentally public port does not become an accessible database.
+        Address scoping is also the control that survives a mistake elsewhere. Firewall rules, security groups, and load balancer listeners change on their own schedules, and a rule set that names the application subnets keeps an accidentally opened port from becoming an accessible database.
+
+        Name the subnets that host the application tier, the replication peers, and the administrative jump hosts, one rule per network, and remember that the first matching rule wins, so a broad rule placed above a narrow one makes the narrow one unreachable.
       audit: |
         ### Audit via CLI
 
@@ -1568,20 +1557,19 @@ queries:
       postgresql.hba.rules.where(address != "" && address.downcase != "samehost").none(type.downcase == "host" || type.downcase == "hostnossl")
     docs:
       desc: |
-        This check ensures that every rule carrying a remote client address uses the `hostssl` connection type. A `host` rule accepts both encrypted and unencrypted connections, so a client that simply omits TLS is still admitted. A `hostnossl` rule goes further and matches only unencrypted connections.
+        This check verifies that every rule carrying a remote client address demands an encrypted connection.
 
-        Enabling the `ssl` directive makes TLS available but does not make it mandatory. Requiring `hostssl` on remote rules is what actually forces encryption. Rules for local socket connections are excluded, because those never traverse a network and TLS does not apply to them.
+        `pg_hba.conf` distinguishes three network connection types. A `hostssl` rule matches only encrypted sessions, a `hostnossl` rule matches only unencrypted ones, and a `host` rule matches either. The check requires that rules were parsed and that no rule with a remote address uses the permissive or the plaintext type. Rules for the local socket are outside its scope, since those never cross a network.
 
         **Why this matters**
 
-        - **Encryption becomes mandatory:** A client cannot reach the database by declining TLS.
-        - **Closes the optional-TLS gap:** Turning `ssl` on protects only the clients that ask for it, while `hostssl` protects all of them.
-        - **Local access stays workable:** Unix socket rules continue to function without certificates.
+        Turning the `ssl` directive on makes encryption available; it does not make it mandatory. A `host` rule admits a client that never asked for TLS, and clients omit it constantly: a connection string copied without the setting, a driver whose default changed between releases, a retry path that falls back on handshake failure. Every one of those sessions carries its credential and its result rows in the clear, and neither end reports a problem.
 
-        **Risk mitigation**
+        An attacker uses that gap deliberately. Sitting on the path, they interfere with the TLS handshake until the client falls back to an unencrypted attempt, and because the rule accepts it the server completes the session. They then read the authentication exchange and the traffic, and reuse the credential from their own host.
 
-        - **Prevents accidental cleartext sessions:** A misconfigured client library cannot silently fall back to an unencrypted connection.
-        - **Removes a downgrade path:** An active attacker cannot strip TLS and have the server accept the session anyway.
+        A `hostnossl` rule is worse, because it accepts only unencrypted sessions and so guarantees the exposure for anything that matches it.
+
+        Verify that TLS is working before converting the rules, since an encrypted-only rule refuses every client the moment the certificate is missing or expired. Local socket rules continue to work unchanged and need no certificate.
       audit: |
         ### Audit via CLI
 
@@ -1702,20 +1690,19 @@ queries:
       postgresql.hba.rules.where(database.downcase == "replication").none(address == "0.0.0.0/0" || address == "::/0" || user.downcase == "all")
     docs:
       desc: |
-        This check ensures that rules granting access to the special `replication` database name a specific role and a specific client address. A replication connection streams the write-ahead log, which carries the contents of every table in the cluster, so a permissive replication rule is equivalent to granting a full copy of the database.
+        This check verifies that rules granting the special `replication` connection name a specific role and a specific client address.
 
-        Replication rules deserve tighter scoping than ordinary client rules because a single successful connection exfiltrates everything rather than only what a role is granted to read. Name the dedicated replication role and the exact addresses of the standby servers.
+        Replication rules live in the same file as ordinary client rules but are matched by their database column. The check fails when such a rule accepts any address or when its role column matches every role, and passes when the rule names one replication role and the addresses of the standby servers.
 
         **Why this matters**
 
-        - **Replication bypasses table privileges:** The log stream is not filtered by object level grants.
-        - **Standby addresses are known and stable:** There is no operational reason for a replication rule to accept arbitrary clients.
-        - **Dedicated role limits blast radius:** A purpose-built replication role cannot be reused for ordinary queries.
+        A replication connection streams the write-ahead log, and the log carries the contents of every table in the cluster. Object-level grants do not filter it, so a role that would be refused a `SELECT` on a table still receives every row of that table through the stream. One successful replication connection is a full copy of the database, taken continuously, from a code path that looks like normal operation.
 
-        **Risk mitigation**
+        An attacker who matches a permissive replication rule needs only a credential that the rule's role column accepts. They attach a standby of their own from anywhere that routes to the port, let it catch up, and then read the tables at leisure on hardware the operator does not control. Nothing in the primary's ordinary query logs shows the tables being read, because they are not being queried.
 
-        - **Prevents wholesale data exfiltration:** An attacker cannot attach as a standby and stream the cluster contents.
-        - **Blocks unauthorized standbys:** Only the named hosts can establish a replication session.
+        Standby addresses are known and stable, which is why there is no operational reason for a rule here to accept arbitrary clients.
+
+        Create a role that holds only the replication attribute, use it for nothing else, and write one rule per standby naming its address. Where standbys are provisioned dynamically, scope the rule to the subnet they are created in rather than opening it to everything.
       audit: |
         ### Audit via CLI
 
@@ -1845,20 +1832,19 @@ queries:
       postgresql.hba.rules.where(authMethod.downcase == "cert").all(options["clientcert"] == "verify-full")
     docs:
       desc: |
-        This check ensures that every rule using the `cert` authentication method also sets `clientcert=verify-full`. With `verify-ca`, PostgreSQL confirms only that the client certificate chains to a trusted authority. Any certificate that authority has ever issued then satisfies the rule, regardless of which identity it names.
+        This check verifies that certificate authentication ties each certificate to the specific role it may connect as.
 
-        The `verify-full` setting additionally requires that the certificate's common name match the PostgreSQL role the client is requesting. That binding is what turns a valid certificate into a specific, verified identity.
+        Rules in `pg_hba.conf` that use the `cert` method carry a `clientcert` option. This check requires `clientcert=verify-full` on every such rule. With `verify-ca` the server confirms only that the presented certificate chains to the configured authority; `verify-full` additionally requires the certificate's common name to match the role being requested.
 
         **Why this matters**
 
-        - **Certificates map to one identity:** A certificate issued for one service cannot be used to connect as another role.
-        - **Contains authority scope:** An internal authority that also issues certificates for other purposes cannot be used to reach any role.
-        - **Completes mutual authentication:** Both endpoints are identified rather than only the server.
+        Chain validation alone answers the wrong question. It establishes that the authority issued the certificate, not that the holder is the party the rule is about, so any certificate that authority has ever signed satisfies the rule regardless of the identity it names.
 
-        **Risk mitigation**
+        Internal authorities sign a great deal. The same one typically issues certificates for web servers, service meshes, monitoring agents, and developer laptops. An attacker who takes any one of those keys, from a host far less protected than the database, presents it and asks to connect as the role of their choosing. The chain validates, the rule matches, and they hold a session as a privileged role without ever touching a database credential.
 
-        - **Blocks cross-identity reuse:** A compromised service certificate cannot authenticate as a privileged role.
-        - **Limits the impact of broad authorities:** Certificates issued for unrelated systems are rejected.
+        Binding the common name closes that. A certificate issued for one service authenticates as that service only, so compromising a low-value host yields access to whatever that host already had and nothing more.
+
+        Confirm before changing the rules that each client certificate's common name matches the role that client connects as, or configure an identity map to translate between them. A mismatch is rejected, so a rollout that skips this step disconnects working clients.
       audit: |
         ### Audit via CLI
 
@@ -1958,20 +1944,19 @@ queries:
       postgresql.ident.mappings.none(pgUsername.downcase == "postgres")
     docs:
       desc: |
-        This check ensures that no `pg_ident.conf` mapping resolves an external identity onto the `postgres` superuser role. Identity maps translate an authenticated operating system account, Kerberos principal, or certificate common name into a PostgreSQL role, and they are consulted by the `ident`, `peer`, `gss`, and `cert` methods.
+        This check verifies that no external identity is mapped directly onto the cluster superuser.
 
-        A mapping that targets `postgres` grants cluster ownership to whoever controls the mapped external identity. Administrators should connect as a named role that holds only the privileges they need, and escalate deliberately, rather than being mapped straight onto the superuser.
+        `pg_ident.conf` translates an authenticated operating system account, Kerberos principal, or certificate common name into a PostgreSQL role, and it is consulted by the `ident`, `peer`, `gss`, and `cert` methods. The check fails when any mapping resolves to the `postgres` role.
 
         **Why this matters**
 
-        - **Named accountability:** Actions taken in the database are attributable to a specific role rather than a shared superuser.
-        - **Least privilege by default:** Routine work happens without cluster-wide authority.
-        - **External identity compromise is contained:** Losing control of a mapped account does not immediately mean losing the cluster.
+        Such a mapping makes control of the external identity equal to ownership of the cluster. Whoever holds that operating system account, that ticket, or that certificate connects as a superuser with no further credential, so the security of the database becomes the security of the weakest system that issues the identity.
 
-        **Risk mitigation**
+        For a local account mapping, that system is the host itself. An attacker who reaches any code execution as the mapped user, through a vulnerable service running under it, a writable script it executes from cron, or a stolen key in its home directory, is a superuser in the database on the next connection. From there they read every table, install a function that runs commands as the server account, and add a role of their own so they keep access after the original hole is closed.
 
-        - **Prevents silent privilege escalation:** A mapped operating system or certificate identity cannot become a superuser implicitly.
-        - **Limits lateral movement:** A compromised host account cannot take ownership of the database.
+        Superuser sessions are also unattributable. Several administrators mapped onto the same role produce log lines that name that role, so an investigation cannot tell which person or which process acted.
+
+        Map administrators onto named roles carrying only the privileges their work needs, and let escalation be a deliberate, logged step rather than the default state of every session.
       audit: |
         ### Audit via CLI
 
@@ -2102,20 +2087,19 @@ queries:
       postgresql.ident.mappings.none(systemUsername == /\.\*/ || systemUsername == /\.\+/)
     docs:
       desc: |
-        This check ensures that no `pg_ident.conf` mapping uses a regular expression that matches every external identity. A system username entry beginning with a slash is treated as a regular expression, so a pattern such as `/^(.*)$` matches any authenticated account and hands each of them the mapped PostgreSQL role.
+        This check verifies that identity mappings enumerate the external accounts they accept instead of matching all of them with a pattern.
 
-        Catch-all patterns are usually introduced to save writing one mapping per user, but they remove the boundary the map is supposed to enforce. Any identity the authentication method accepts becomes the mapped role, which turns a specific grant into a broad one.
+        A system username in `pg_ident.conf` that begins with a slash is treated as a regular expression, so an entry such as `/^(.*)$` matches every authenticated identity and grants each one the mapped PostgreSQL role. The check fails on patterns of that shape and passes when each mapping names a specific identity.
 
         **Why this matters**
 
-        - **Explicit mappings are reviewable:** A finite list shows exactly who can assume which role.
-        - **New accounts are not implicitly granted:** Creating an operating system account does not silently create database access.
-        - **Patterns can capture more than intended:** A broad expression matches identities that were never considered.
+        A catch-all removes the boundary the map exists to enforce. The authentication method establishes that the connecting party is who they claim to be; the map is supposed to decide which of those parties may act as which role. Match everything and the second decision disappears, so proving any identity at all is enough to hold the mapped role.
 
-        **Risk mitigation**
+        That converts account creation into database access. An attacker who can add a local account on the host, or who compromises a service account nobody associated with the database, connects and is granted the role. On a certificate-based deployment the same pattern accepts every certificate the trusted authority ever issued, including ones minted for unrelated systems.
 
-        - **Prevents unintended role assumption:** An unrelated account cannot connect as the mapped role.
-        - **Blocks escalation through account creation:** An attacker who can add a host account gains no database access from it.
+        Broad patterns also capture more than their author intended. A regular expression written to match a naming convention matches every future account that happens to fit it, so access is granted by a hostname convention or a username prefix rather than by a decision anyone made.
+
+        Write one mapping per identity so the file is a reviewable list of who may assume which role. Where a pattern is genuinely necessary, anchor it tightly to a prefix that only the intended accounts can hold, and revisit it whenever the account naming convention changes.
       audit: |
         ### Audit via CLI
 
@@ -2241,20 +2225,19 @@ queries:
       postgresql.conf.params["db_user_namespace"] == empty || postgresql.conf.params["db_user_namespace"].downcase == "off"
     docs:
       desc: |
-        This check ensures that `db_user_namespace` is left disabled. When enabled, PostgreSQL accepts per-database usernames written as `user@dbname`, and the client-supplied name is rewritten before authentication. The feature is off by default and the check treats an absent directive as compliant.
+        This check verifies that role names mean the same thing regardless of which database a client selects.
 
-        The rewriting behavior makes the effective role name depend on the database the client selected, so the same connection string can resolve to different roles. That indirection makes authentication rules and audit records harder to reason about, and the feature interacts poorly with SCRAM because clients must know whether to include the database suffix when computing their response.
+        `db_user_namespace` in `postgresql.conf` enables per-database usernames written as `user@dbname`. When it is on, the server strips the suffix and rewrites the client-supplied name before authentication runs. The feature is off by default, so the check treats an absent directive as compliant and fails only when it has been turned on.
 
         **Why this matters**
 
-        - **Role names stay unambiguous:** A username in a log line or an authentication rule means exactly one role.
-        - **Authentication rules remain predictable:** Rule matching does not shift based on the selected database.
-        - **Avoids a deprecated mechanism:** The feature exists for backward compatibility and is not recommended for new deployments.
+        The rewrite happens before rule matching, so the role a rule applies to depends on the database the client asked for. The same connection string resolves to different roles against different databases, which means reading the authentication file no longer tells you who can connect as what. An attacker probing the server manipulates one half of the pair to reach a name that a permissive rule matches, and the reviewer who wrote that rule never considered the combination.
 
-        **Risk mitigation**
+        Recorded usernames become ambiguous in the same way. A log line names the rewritten role, so during an investigation the identity in the record does not correspond to the name the client actually presented, and correlating database activity with application logs stops working exactly when it is needed.
 
-        - **Prevents rule bypass through name rewriting:** An attacker cannot influence which role a rule matches by changing the database.
-        - **Keeps audit trails reliable:** Recorded usernames correspond directly to roles during investigation.
+        The mechanism also interacts poorly with challenge-response authentication, because the client has to know whether to include the suffix when computing its response, and getting that wrong produces authentication failures that look like the wrong password rather than a configuration problem.
+
+        The feature exists for backward compatibility and is not recommended for new deployments. Confirm no role name depends on the suffixed form before turning it off, then set the directive and reload.
       audit: |
         ### Audit via CLI
 
@@ -2368,20 +2351,19 @@ queries:
       postgresql.conf.loggingCollector == true
     docs:
       desc: |
-        This check ensures that `logging_collector` is enabled so PostgreSQL captures server messages into log files it manages itself. Without the collector, messages go to the process standard error stream, where they depend entirely on how the service was started and are frequently discarded.
+        This check verifies that the server captures its own messages into log files it manages.
 
-        The collector is also a prerequisite for the log protection and rotation settings in this policy. Directives such as `log_file_mode`, `log_rotation_age`, and `log_filename` only take effect when the collector is running.
+        `logging_collector` in `postgresql.conf` starts a dedicated process that receives server messages and writes them to files. The check requires it to be on. The setting is read at startup, so it needs a restart rather than a reload.
 
         **Why this matters**
 
-        - **Durable records:** Messages are written to files that survive a client disconnect or a terminal closing.
-        - **Enables log protection:** File permissions on log output can only be controlled when PostgreSQL owns the files.
-        - **Supports rotation:** Predictable filenames and rotation keep log volume manageable without losing history.
+        Without the collector, messages go to the process standard error stream, and where they end up depends entirely on how the service was started. Under some unit files they land in the journal, under others in a file nobody rotates, and inside many container images they go to a stream that is discarded when the container is replaced. The result is that a cluster can be attacked repeatedly and produce no durable record of it.
 
-        **Risk mitigation**
+        That gap is the attacker's advantage rather than an inconvenience. Failed authentications, connections from unexpected addresses, and the statements that created a new superuser role all still happen; they leave nothing behind for anyone to find. An investigation that begins after the fact then has no way to establish when access started or what was touched.
 
-        - **Preserves incident evidence:** Authentication failures and errors remain available for investigation.
-        - **Prevents silent loss of audit data:** Messages are not discarded because no one captured the output stream.
+        The collector is also what makes the rest of the logging configuration real. `log_file_mode`, `log_rotation_age`, and `log_filename` only take effect when PostgreSQL owns the files, so log protection and rotation cannot be applied until the collector is running.
+
+        Where a container platform deliberately harvests the standard error stream into a durable, protected pipeline, that is a reasonable alternative; confirm that the collection actually persists and is access-controlled before treating it as one.
       audit: |
         ### Audit via CLI
 
@@ -2486,20 +2468,19 @@ queries:
       postgresql.conf.logDestination == /csvlog|jsonlog|syslog/
     docs:
       desc: |
-        This check ensures that `log_destination` includes `csvlog`, `jsonlog`, or `syslog` rather than relying on the default freeform `stderr` output. Structured formats emit one record per event with stable fields, and `syslog` forwards records to a collector off the host.
+        This check verifies that server messages are emitted in a form a log pipeline can parse or are forwarded off the host.
 
-        Freeform output is readable by a person but awkward for automated analysis, because message text and field boundaries vary by event type. Structured output lets a log pipeline parse authentication failures, connection records, and statement logs reliably.
+        `log_destination` in `postgresql.conf` selects the output format. The check requires the value to include `csvlog`, `jsonlog`, or `syslog` rather than only the default freeform `stderr` text. A reload applies the change.
 
         **Why this matters**
 
-        - **Reliable parsing:** Fixed fields let detection rules match events without fragile text matching.
-        - **Off-host retention:** Forwarding records to a collector preserves them when the host is lost or compromised.
-        - **Consistent correlation:** Structured fields align database events with records from other systems.
+        Freeform text is written for a person reading one line at a time. Message wording and field boundaries vary by event type and change between releases, so detection rules built on text matching miss events after an upgrade and match the wrong ones in the meantime. The events that matter most, a burst of failed authentications or a connection from an address that has never appeared before, are exactly the ones a fragile pattern drops.
 
-        **Risk mitigation**
+        Structured output removes the guesswork by emitting one record per event with stable fields, so a rule matches on the role, the client address, and the error code instead of on a sentence.
 
-        - **Resists local log tampering:** Records already forwarded cannot be edited by an attacker on the host.
-        - **Improves detection coverage:** Authentication anomalies are matched dependably rather than missed by text patterns.
+        Forwarding matters for a different reason. Logs that only exist on the database host are within reach of an attacker who reached that host. Clearing or editing them is a routine step once a foothold is established, and it works: the evidence of how they arrived is in the same file they can now write to. Records already sent to a collector are outside their control and survive the loss of the machine.
+
+        Choose the destination your pipeline actually consumes, and keep a local copy alongside the forwarded one so a collector outage does not leave a hole in the record.
       audit: |
         ### Audit via CLI
 
@@ -2606,20 +2587,19 @@ queries:
       postgresql.conf.logConnections == true
     docs:
       desc: |
-        This check ensures that `log_connections` is enabled so every successful connection attempt is recorded together with the authenticated role and the client address. PostgreSQL leaves this off by default, which means a cluster can be accessed repeatedly without producing any record of who connected.
+        This check verifies that every successful connection to the cluster is recorded.
 
-        Connection records are the foundation of database access monitoring. They establish which identities reached the server, from where, and when, and they provide the baseline that makes unusual access visible.
+        `log_connections` in `postgresql.conf` makes the server write a record for each session as it is established, naming the authenticated role, the database, and the client address. PostgreSQL leaves it off, so the check fails on the default. A reload applies it.
 
         **Why this matters**
 
-        - **Attribution:** Each session is tied to a role and a source address.
-        - **Baseline for anomaly detection:** Normal access patterns become measurable, so deviations stand out.
-        - **Investigation timeline:** Responders can establish when an identity first appeared.
+        With it off, a cluster can be reached again and again without leaving any trace of who arrived. An attacker who has obtained a credential, from a configuration file on a compromised application host, a repository, or a backup, connects with a normal client, does what they came for, and disconnects. Nothing distinguishes their session from the application's, because nothing recorded either one.
 
-        **Risk mitigation**
+        Connection records are what make the abnormal visible. A production database is contacted by a small, stable set of addresses; a session from a workstation subnet, from a container that should not talk to it, or at three in the morning stands out immediately against that baseline. Without the records there is no baseline and no deviation to notice.
 
-        - **Reveals credential misuse:** Access from an unexpected address or at an unusual time becomes visible.
-        - **Detects reconnaissance:** Repeated connection attempts across roles are recorded rather than invisible.
+        They also bound an incident. When a compromise is discovered later, the first question is when the attacker's access began and which roles they used, and connection records answer it directly. Without them, responders cannot distinguish a week of access from a month.
+
+        The volume is modest, one line per session, though an application that opens a connection per request rather than pooling will generate a great deal of it; fix the pooling rather than turn off the record.
       audit: |
         ### Audit via CLI
 
@@ -2723,20 +2703,19 @@ queries:
       postgresql.conf.logDisconnections == true
     docs:
       desc: |
-        This check ensures that `log_disconnections` is enabled so the end of each session is recorded along with its duration. Paired with connection records, this closes the session out and shows how long an identity held access to the database.
+        This check verifies that the end of each session is recorded along with how long it lasted.
 
-        Session duration is frequently the most informative signal in a database log. A connection that stays open far longer than the application's normal pattern, or one that ends immediately after connecting, both stand out only when the disconnect is recorded.
+        `log_disconnections` in `postgresql.conf` writes a record when a session closes, including its duration. It is off by default. Paired with the connection record, it closes the session out so the log shows both when an identity arrived and how long it held access. A reload applies it.
 
         **Why this matters**
 
-        - **Complete session records:** Every connection has a matching close with an elapsed time.
-        - **Duration as a signal:** Unusually long or short sessions become measurable.
-        - **Accurate concurrency history:** Reconstructing who held sessions at a given moment becomes possible.
+        Duration is one of the most informative signals a database log carries, and it exists only when the close is recorded. A pooled application connection lives for hours in a predictable pattern; a session that connects, runs a handful of statements, and vanishes in four seconds looks nothing like it, and neither does one that stays open for two days while rows are pulled out in small batches to stay under a rate alarm. Both are visible against the normal shape of the workload, and both are invisible when only the open is logged.
 
-        **Risk mitigation**
+        Without the close, responders also cannot say when access ended. They know an attacker connected at a point in time and have no way to bound what happened afterwards, which forces them to treat everything since as suspect and widens the scope of the incident far beyond what actually occurred.
 
-        - **Exposes long-lived unauthorized sessions:** A session held open for data collection is visible in the record.
-        - **Supports scope assessment:** Responders can bound how long an attacker had access.
+        Complete session records make concurrency reconstructable as well, so it is possible to establish which identities held sessions at the moment a table was altered or a role was created.
+
+        Enable it alongside the connection record; each is far less useful on its own than the pair is together.
       audit: |
         ### Audit via CLI
 
@@ -2840,20 +2819,19 @@ queries:
       postgresql.conf.logStatement.downcase == "ddl" || postgresql.conf.logStatement.downcase == "mod" || postgresql.conf.logStatement.downcase == "all"
     docs:
       desc: |
-        This check ensures that `log_statement` is set to `ddl`, `mod`, or `all` so schema changing statements are recorded. PostgreSQL defaults to `none`, which means statements that create roles, grant privileges, drop tables, or alter the schema leave no record of the statement text.
+        This check verifies that statements which change the schema or the privilege structure are recorded with their text.
 
-        The `ddl` setting captures data definition statements including `CREATE`, `ALTER`, `DROP`, and `GRANT`. The `mod` setting adds data modifying statements, and `all` records every statement at a substantially higher log volume. Choose the level that matches your retention capacity, but record at least data definition.
+        `log_statement` in `postgresql.conf` selects which statement classes are logged. PostgreSQL defaults to `none`. This check requires `ddl`, `mod`, or `all`. The `ddl` level captures data definition statements including `CREATE`, `ALTER`, `DROP`, and `GRANT`; `mod` adds data-modifying statements; `all` records everything at a substantially higher volume. A reload applies the change.
 
         **Why this matters**
 
-        - **Privilege changes are recorded:** `GRANT` and `CREATE ROLE` statements leave an auditable trail.
-        - **Schema tampering is visible:** Added functions, triggers, or dropped tables are attributable.
-        - **Change reconstruction:** Responders can determine exactly what an attacker altered.
+        At the default, an attacker who reaches the database can restructure it silently. They run `CREATE ROLE` with a password only they know and grant it membership in a privileged group, so they keep access after the credential they arrived with is rotated. They install a trigger or a function that re-creates that role whenever it is deleted. They drop a table or alter a constraint to hide what they took. None of it leaves a record of the statement text.
 
-        **Risk mitigation**
+        Privilege changes are the ones that matter most. A `GRANT` is a single short statement that permanently widens what an identity may do, and it is indistinguishable from legitimate administration unless the text and the time are in the log.
 
-        - **Detects persistence mechanisms:** A trigger or function installed to maintain access is logged when it is created.
-        - **Reveals privilege escalation:** A role granted membership in a privileged group is recorded.
+        The same records make recovery possible. After an incident, the difference between knowing exactly which objects were altered and having to compare the schema against a backup is the difference between an afternoon and a week.
+
+        Choose the level your retention can hold. Recording every statement on a busy cluster produces an enormous volume and often captures parameter values you would rather not store, so record at least data definition and go further only where the traffic justifies it.
       audit: |
         ### Audit via CLI
 
@@ -2963,20 +2941,19 @@ queries:
       postgresql.conf.params["log_line_prefix"] == /%d/
     docs:
       desc: |
-        This check ensures that `log_line_prefix` includes the timestamp with milliseconds as `%m`, the connecting role as `%u`, and the database as `%d`. Without these fields, log records describe what happened but not who did it or where, which makes them nearly unusable for investigation.
+        This check verifies that every log line identifies when it was written, which role produced it, and which database it concerns.
 
-        Every message the server writes carries this prefix, so it determines whether an error or a logged statement can be attributed to a session. Adding `%h` for the client host and `%p` for the process identifier makes correlation across records straightforward.
+        `log_line_prefix` in `postgresql.conf` is prepended to every message the server writes. The check requires the value to be set and to include the timestamp with milliseconds as `%m`, the connecting role as `%u`, and the database as `%d`. A reload applies the change.
 
         **Why this matters**
 
-        - **Attribution per record:** Each line identifies the role and database it belongs to.
-        - **Accurate ordering:** Millisecond timestamps allow events to be sequenced reliably.
-        - **Cross-record correlation:** Process identifiers tie together the statements of a single session.
+        Without those fields the log says what happened but not who did it. A line recording a dropped table, a failed authentication, or a permission error is an observation with no subject, so an investigation can establish that something occurred and can go no further. The events are present and useless at the same time, which is worse than an obvious gap because it looks like coverage.
 
-        **Risk mitigation**
+        Attribution is what turns a record into evidence. Repeated authentication failures against one role tell you a credential is being guessed only when the role is named; the same lines without it are indistinguishable from an application misconfiguration.
 
-        - **Makes logs usable during response:** Malicious activity can be attributed to an identity rather than merely observed.
-        - **Prevents anonymous errors:** Repeated authentication failures can be traced to a source.
+        Timestamp precision decides whether events can be ordered. Several statements within the same second are common on an active cluster, and second-granularity stamps leave their sequence ambiguous exactly when the sequence is the question, such as whether a privilege was granted before or after the statement that used it.
+
+        Add `%h` for the client host and `%p` for the process identifier as well. The process identifier is what ties the separate lines of one session together, and the client host is what lets a database event be lined up against records from the network and the application.
       audit: |
         ### Audit via CLI
 
@@ -3083,20 +3060,19 @@ queries:
       postgresql.conf.params["log_error_verbosity"] == empty || postgresql.conf.params["log_error_verbosity"].downcase != "terse"
     docs:
       desc: |
-        This check ensures that `log_error_verbosity` is not set to `terse`. The `terse` setting strips the detail, hint, and context fields from logged errors, leaving only the primary message. PostgreSQL defaults to `default`, and the check treats an absent directive as compliant.
+        This check verifies that logged errors keep the fields that explain them.
 
-        The suppressed fields carry the information that makes an error actionable, including which constraint was violated and the statement context in which the failure occurred. During an investigation, that context often distinguishes an application bug from an injection attempt.
+        `log_error_verbosity` in `postgresql.conf` controls how much of an error is written. The `terse` value strips the detail, hint, and context fields and leaves only the primary message. PostgreSQL uses `default`, so the check treats an absent directive as compliant and fails only on the reduced setting. A reload restores the detail.
 
         **Why this matters**
 
-        - **Errors stay diagnosable:** Detail and hint fields explain why a statement failed.
-        - **Context identifies the source:** The context field shows the function or statement that raised the error.
-        - **Better failure triage:** Recurring errors can be classified without reproducing them.
+        The stripped fields are the ones that identify what actually failed. The primary message says a syntax error occurred or a constraint was violated; the detail says which constraint and which values, and the context names the function and the statement that raised it. Without them a log of errors records that the database is unhappy without recording why, and every entry has to be reproduced before it means anything.
 
-        **Risk mitigation**
+        That gap costs most during an intrusion. Injection attempts against an application generate a characteristic run of errors, malformed literals, type mismatches, references to objects that do not exist, and the diagnostic fields are what distinguish that pattern from a bug in a deployment that went out the same afternoon. Reduced to a bare message, the two look identical, so the probing is filed as noise while it continues.
 
-        - **Preserves attack indicators:** Malformed statements characteristic of injection attempts retain their diagnostic detail.
-        - **Speeds investigation:** Responders do not have to reproduce a failure to learn what it was.
+        The same detail is what makes an error tractable at all after the fact, since the failing statement is often long gone and cannot be run again against the same data.
+
+        Leave the setting alone unless log volume genuinely demands it, and if it does, reduce the statement logging level rather than the error detail.
       audit: |
         ### Audit via CLI
 
@@ -3200,20 +3176,19 @@ queries:
       postgresql.conf.params["log_file_mode"] == empty || postgresql.conf.params["log_file_mode"] == /^0?600$/
     docs:
       desc: |
-        This check ensures that `log_file_mode` keeps PostgreSQL log files readable only by the account that owns the server. PostgreSQL defaults to `0600`, and the check treats an absent directive as compliant. It fails when the mode has been widened to allow group or world access.
+        This check verifies that log files the server writes are readable only by the account that runs it.
 
-        Log files hold the material that makes logging valuable and also makes it sensitive. With `log_statement` recording data definition statements, log files contain role names, granted privileges, and schema structure. With `log_line_prefix` populated they also record client addresses and database names.
+        `log_file_mode` in `postgresql.conf` sets the permission bits applied to each new log file. PostgreSQL uses `0600`, so the check treats an absent directive as compliant and fails when the mode has been widened to allow group or world access. A reload applies the mode to files created afterwards; files already on disk keep the mode they were created with.
 
         **Why this matters**
 
-        - **Logs are sensitive output:** Recorded statements and identities should not be world readable.
-        - **Limits reconnaissance:** An unprivileged local account cannot enumerate roles and schema from the logs.
-        - **Protects audit integrity:** Restricting access reduces the number of accounts able to read the audit trail.
+        Logs are valuable precisely because of what they contain, and that makes the files themselves sensitive. With `log_statement` recording data definition, they hold role names, group memberships, granted privileges, and the shape of the schema. With `log_line_prefix` populated they hold client addresses and database names, and error detail routinely includes column values from the statement that failed.
 
-        **Risk mitigation**
+        A world-readable log therefore hands a local attacker a map. An unprivileged account on the host, or a compromised unrelated service running there, reads which roles exist, which of them are privileged, which networks connect, and which tables are worth reaching, all without touching the database or producing a single failed login.
 
-        - **Blocks local information disclosure:** A compromised unrelated service on the host cannot read database logs.
-        - **Prevents credential leakage through logs:** Connection strings or statements that embed sensitive values stay protected.
+        Occasionally the logs give up more than a map. Statements that embed a password in a role definition, connection strings written into a function body, and application errors that echo parameter values all end up in the file verbatim.
+
+        Restrict access to the server account and to the log collection agent, and correct the permissions on files written before the change, since the directive does not go back and fix them.
       audit: |
         ### Audit via CLI
 
@@ -3338,20 +3313,19 @@ queries:
       postgresql.conf.sharedPreloadLibraries.any(_ == "pgaudit")
     docs:
       desc: |
-        This check ensures that `pgaudit` appears in `shared_preload_libraries` so the extension is loaded at server start. The built-in `log_statement` setting records statement text but not which objects a statement touched, and it cannot record read access at the object level.
+        This check verifies that object-level auditing is loaded into the server.
 
-        The pgaudit extension adds session and object level auditing, so reads of specific tables can be recorded and audit entries are emitted in a consistent, parseable format. Because the extension must be preloaded, it cannot be enabled with a reload and requires a restart.
+        The `pgaudit` extension has to be listed in `shared_preload_libraries` in `postgresql.conf` so it is loaded when the server starts. The check fails when it is absent from that list. Because the library is preloaded, adding it requires a restart rather than a reload, and the extension must also be created in each database it should audit.
 
         **Why this matters**
 
-        - **Read access is auditable:** `SELECT` against sensitive tables can be recorded, which `log_statement` cannot do.
-        - **Object level granularity:** Auditing can target specific tables rather than entire statement classes.
-        - **Consistent audit format:** Entries are structured for downstream analysis rather than freeform.
+        The built-in `log_statement` setting records statement text, but it cannot tell you which objects a statement touched, and it does not record reads at all at any level short of logging every statement on the server. Reads are what an attacker who is stealing data actually does. A credential that is used exactly as intended, running `SELECT` against tables it holds a grant on, produces nothing at all in a configuration that only logs schema changes.
 
-        **Risk mitigation**
+        Object-level auditing closes that. Reads of the specific tables that hold regulated or high-value data are recorded with the role, the object, and the statement, so bulk extraction stands out against the volume an application normally issues, and a query that walks a customer table row by row leaves a trail even though every individual statement was authorized.
 
-        - **Detects data exfiltration:** Bulk reads of sensitive tables leave an audit record.
-        - **Supports regulatory evidence:** Object level access records demonstrate who read protected data.
+        The entries are also emitted in a consistent, parseable shape rather than as freeform text, which is what makes alerting on them practical.
+
+        Scope the auditing to the objects that warrant it. Auditing everything on a busy cluster produces a volume nobody retains, and the records that matter get rotated away with the rest.
       audit: |
         ### Audit via CLI
 
@@ -3500,20 +3474,17 @@ queries:
       postgresql.conf.files.all(permissions.group_writeable == false && permissions.other_readable == false && permissions.other_writeable == false)
     docs:
       desc: |
-        This check ensures that `postgresql.conf` and every fragment it pulls in through `include`, `include_if_exists`, and `include_dir` are readable only by the server account. PostgreSQL does not enforce permissions on its own configuration files the way it does for TLS key material, so a widened mode goes unnoticed at start up.
+        This check verifies that the server's configuration files are not readable or writable by other accounts on the host.
 
-        Include fragments deserve the same protection as the main file. Configuration management tooling frequently writes drop-in files under a `conf.d` directory with default permissions, which leaves a fragment world readable even when the main file is correctly restricted. This check evaluates every contributing file rather than only the entry point.
+        It evaluates `postgresql.conf` together with every fragment pulled in by `include`, `include_if_exists`, and `include_dir`, and fails when any of them is group-writable or world-readable or world-writable. PostgreSQL does not enforce permissions on these files the way it does on TLS key material, so a widened mode produces no warning at startup.
 
         **Why this matters**
 
-        - **Configuration reveals architecture:** Listen addresses, data directory paths, and TLS material locations describe how to reach and attack the server.
-        - **Write access is server control:** An account able to modify a fragment can point the server at different authentication rules.
-        - **Fragments are easy to overlook:** Drop-in files inherit the permissions of whatever wrote them.
+        Read access is reconnaissance. The files record the addresses the server listens on, where the data directory lives, where the private key and certificate sit, which authentication and identity files are in use, and where logs are written. A local account that can read them knows exactly which file to target next, and whether a target is worth the effort, without generating a single connection attempt.
 
-        **Risk mitigation**
+        Write access is control of the database. An account that can edit a fragment points the server at an authentication file of its own on the next reload, and that file can grant unauthenticated superuser access. The change is a few characters in a file the attacker already had permission to write, and the reload may be triggered by ordinary configuration management rather than by them.
 
-        - **Blocks local reconnaissance:** An unprivileged account cannot read where keys and data live.
-        - **Prevents configuration tampering:** An attacker cannot weaken authentication by editing an included fragment.
+        Fragments are the part that gets missed. Configuration management tooling writes drop-in files under a `conf.d` directory with whatever default the module carries, so a fragment ends up world-readable while the main file is correctly locked down, which is why this check evaluates every contributing file rather than only the entry point.
       audit: |
         ### Audit via CLI
 
@@ -3639,20 +3610,19 @@ queries:
       postgresql.hba.file.permissions.other_writeable == false
     docs:
       desc: |
-        This check ensures that `pg_hba.conf` is readable only by the account that owns the server. This file is the complete authorization policy for the cluster: it records which roles may connect, from which networks, and with which authentication method.
+        This check verifies that the host-based authentication file is readable only by the account that runs the server.
 
-        Read access alone is valuable to an attacker, because the file shows exactly which network ranges are trusted and which roles use weaker authentication methods. Write access is equivalent to controlling the database, since a new rule can grant unauthenticated superuser access on the next reload.
+        `pg_hba.conf` is the cluster's complete access policy: which roles may connect, from which networks, over which connection types, and with which authentication method. The check fails when the file is group-writable, world-readable, or world-writable.
 
         **Why this matters**
 
-        - **The file is the access control policy:** Its contents describe every path into the cluster.
-        - **Write access defeats authentication:** An added rule can bypass every credential requirement.
-        - **Reveals the weakest path:** An attacker learns which roles and networks to target first.
+        Read access alone is a reconnaissance win. The file states which network ranges are trusted, which roles are reachable from where, and which rules still use a weaker method, so a local attacker learns the cheapest way in and pursues that one instead of guessing. It also tells them which rules will not match, so their attempts are confined to paths that could work and are less likely to trip a threshold.
 
-        **Risk mitigation**
+        Write access is equivalent to owning the database. One added line that grants unauthenticated access to the superuser role takes effect on the next reload, and reloads happen for unrelated reasons all the time: a certificate renewal, a configuration management run, a log rotation hook. The attacker does not have to trigger it themselves, and afterwards they connect as a superuser with no credential and no failed attempt in the log.
 
-        - **Prevents authentication bypass:** An attacker cannot insert a permissive rule.
-        - **Blocks targeted attacks:** Trusted ranges and weak methods are not disclosed to local accounts.
+        That path is also short. Any local foothold, a vulnerable service running under a group that shares access to the file, an over-permissive deployment account, or a backup directory that copied the file with default permissions, is enough.
+
+        Set ownership to the server account with access restricted to it, and resolve the path from the running server rather than assuming a distribution default, since the location is itself configurable.
       audit: |
         ### Audit via CLI
 
@@ -3763,20 +3733,17 @@ queries:
       postgresql.conf.params["local_preload_libraries"] == empty
     docs:
       desc: |
-        This check ensures that `local_preload_libraries` is unset. Unlike `shared_preload_libraries`, this directive can be set by an ordinary role on a per-session basis, and the libraries it names are loaded into the backend process at connection time.
+        This check verifies that the server does not carry a cluster-wide list of libraries to load into ordinary client backends.
 
-        Because it is settable without special privileges, the directive is a recognized route for loading code into the server. A server-wide value in `postgresql.conf` should be empty so that any library loaded into a backend is deliberate and traceable to the preload list an administrator controls.
+        `local_preload_libraries` in `postgresql.conf` names shared libraries loaded into a backend process when a session starts. Unlike `shared_preload_libraries`, it can also be set by an unprivileged role for its own session. The check requires the server-wide value to be empty. A reload applies the change.
 
         **Why this matters**
 
-        - **Loaded code runs with server privileges:** A library in a backend process has the access of the server account.
-        - **Unprivileged roles can set it:** The directive does not require superuser, so a server-wide default deserves scrutiny.
-        - **Deliberate extension loading:** Extensions belong in `shared_preload_libraries`, where they are visible and reviewed.
+        A library loaded into a backend runs inside the server process with the privileges of the account that owns the cluster. That is not the privileges of the connecting role, it is read and write access to the data directory, to the TLS private key, and to anything else that account can reach on the host, plus the ability to make network connections outward from the database host.
 
-        **Risk mitigation**
+        Because the setting does not require superuser, it is a recognized route for turning a foothold on the host into code execution inside the database. An attacker who can write a shared object into the plugin directory, through a deployment account, a writable path, or a package they persuaded an operator to install, gets it loaded on the next connection made by any role. A value already present in the server configuration makes that easier still, since it establishes the load path as normal and the addition of one more name attracts no attention.
 
-        - **Blocks a code loading path:** An attacker who can write to the plugin directory cannot rely on a preconfigured load.
-        - **Preserves an auditable extension list:** All loaded libraries remain visible in the administrator-controlled setting.
+        Keep the server-wide list empty so that any library loaded into a backend is deliberate. Extensions belong in the preload list an administrator controls, where they are visible, reviewed, and applied at startup rather than per session.
       audit: |
         ### Audit via CLI
 

--- a/content/mondoo-redis-security.mql.yaml
+++ b/content/mondoo-redis-security.mql.yaml
@@ -63,19 +63,20 @@ queries:
     mql: |
       redisdb.instance.tlsEnabled == true
     docs:
-      desc: |-
-        This check ensures that the server has a TLS listener enabled so that client connections can be encrypted in transit. Without TLS, the `AUTH` password and every command and result crosses the network in cleartext.
+      desc: |
+        This check verifies that the server has a TLS listener bound so clients can connect over an encrypted channel.
+
+        TLS is configured in `redis.conf` by setting a nonzero TLS port and pointing the server at a certificate, a private key, and a certificate authority file that only the Redis account can read. Operators normally disable the plaintext listener at the same time by setting the ordinary port to zero. The certificate files must be present before the listener can bind, so this is a restart rather than a runtime change, and a value set with `CONFIG SET` is lost unless `CONFIG REWRITE` persists it.
 
         **Why this matters**
 
-        - **Confidentiality in transit:** TLS protects credentials, command text, keys, and values from anyone able to observe the network path.
-        - **Integrity in transit:** It prevents tampering with commands and responses on the wire.
-        - **Compliance:** Many frameworks require encryption of sensitive data in transit for database traffic.
+        Without a TLS listener, the protocol runs in cleartext and Redis makes no attempt to hide anything. The password presented with `AUTH` is sent as an argument in the same plain form as every other command, so a single captured packet gives an attacker the credential outright, with no hash to crack and no exchange to replay.
 
-        **Risk mitigation**
+        Everything after that is equally readable. Keys, values, and the commands themselves cross the network in the clear, and Redis is usually holding exactly the material worth reading: session identifiers, cached user records, queued jobs, and rate-limit state. An attacker with a copy of the traffic collects live session tokens and replays them against the application without ever touching Redis again.
 
-        - **No cleartext credentials:** The password sent during `AUTH` is no longer exposed to a network eavesdropper.
-        - **Man-in-the-middle resistance:** Combined with certificate verification on the client, TLS prevents interception and impersonation.
+        A cleartext connection also lets an active attacker write. They can inject a command into an established session, so a stream they can reach is a stream they can modify.
+
+        Configure the clients to verify the server certificate as well. Encryption without verification stops a passive listener but not someone who terminates the connection themselves and passes the traffic through.
       audit: |-
         ### Audit via redis-cli
 
@@ -137,19 +138,20 @@ queries:
     mql: |
       redisdb.instance.users.where(enabled == true).all(nopass == false)
     docs:
-      desc: |-
-        This check ensures that no enabled access-control (ACL) user carries the `nopass` flag. A `nopass`, enabled user, especially the built-in `default` user, lets anyone who can reach the port authenticate as that user with whatever access its rules grant.
+      desc: |
+        This check verifies that every enabled access-control user has to present a password.
+
+        Access-control users are defined by `user` directives in `redis.conf` or in the external ACL file, and each carries flags describing its rules. The `nopass` flag means the user authenticates with anything at all. The check fails when any enabled user carries it, including the built-in `default` user, which is where it usually appears. A password set at runtime is not persisted unless `CONFIG REWRITE` writes the configuration back out.
 
         **Why this matters**
 
-        - **No anonymous access:** A `nopass` default user means possession of a network path is enough to run commands, defeating authentication entirely.
-        - **Blast radius:** A passwordless user with `~* +@all` hands full control of every key and administrative command to any client that connects.
-        - **Least privilege of authentication:** Every enabled identity should prove itself with a credential before it can issue commands.
+        An enabled user with that flag makes network reachability the only requirement. There is nothing to guess, nothing to steal, and no failed attempt for anyone to notice: a client opens a socket and is authenticated.
 
-        **Risk mitigation**
+        The `default` user is the one that matters, because a client that sends no credentials is treated as that user, and its shipped rule set is `~* +@all`, meaning every key and every command. So an attacker who reaches the port reads and rewrites the entire keyspace, flushes it, and reaches the administrative commands as well. They read the configuration to learn where the data files are written, use the server's own persistence commands to write a file of their choosing to a path they control, and turn a cache into code execution on the host.
 
-        - **Credential enforcement:** Requiring a password on every enabled user forces each client to authenticate.
-        - **Reduced exposure:** Combined with protected mode and tight bind rules, this prevents unauthenticated connections from the network.
+        Because the flag lives on the user rather than on the network, no firewall change repairs it. Any workload that can route to the port inherits full control.
+
+        Give every enabled user a password and remove the flag, or disable the users that are not needed. Combine that with protected mode and an explicit bind list so the server does not answer clients it was never meant to serve.
       audit: |-
         ### Audit via redis-cli
 
@@ -203,19 +205,20 @@ queries:
     mql: |
       redisdb.instance.protectedMode == true
     docs:
-      desc: |-
-        This check ensures that protected mode is turned on. Protected mode refuses connections from non-loopback clients when no password and no explicit `bind` address are configured, so turning it off on an exposed server removes a key safety net that guards an otherwise open instance.
+      desc: |
+        This check verifies that the server's last-resort guard against answering anonymous remote clients is left in place.
+
+        Protected mode is set in `redis.conf` and also with `CONFIG SET`, where a `CONFIG REWRITE` is needed to make the change survive a restart. When it is on and the server has neither a password nor an explicit `bind` list, connections from anything other than the loopback interface are refused with an explanatory error. It is on by default, and the check fails only when it has been turned off.
 
         **Why this matters**
 
-        - **Default safety net:** Protected mode is the guard that stops a freshly started, unconfigured server from answering remote clients with no credentials.
-        - **Defense in depth:** It backs up the authentication and bind controls, so a misconfiguration in one does not immediately expose the server.
-        - **Reduced attack surface:** With protected mode on, an accidentally exposed instance still rejects remote unauthenticated connections.
+        The guard exists because of what happened without it. Redis has no authentication until an operator configures some, and for years the default configuration answered every interface, which put tens of thousands of unauthenticated instances on the public internet. Automated campaigns swept them continuously, and reaching one meant reading the entire keyspace, so session tokens, cached credentials, and personal records were collected wholesale, and the same access was used to write attacker-controlled content into the data directory and take the host.
 
-        **Risk mitigation**
+        Protected mode is what stops a freshly started or half-configured server from repeating that. It catches exactly the combination that produces the incident, a server listening beyond loopback with no credential set, and refuses the remote client rather than serving it.
 
-        - **No accidental exposure:** A server bound to all interfaces without a password still refuses remote clients while protected mode is on.
-        - **Contained misconfiguration:** Turning it off should be a deliberate act paired with authentication and bind rules, not a silent default.
+        Turning it off removes the safety net at the moment it would have mattered, because it only ever engages when the other controls are missing. A server with a password and a narrow bind list is unaffected by it either way, so switching it off buys nothing and costs the one protection that covers a mistake in the other two.
+
+        Leave it on and rely on a password and an explicit bind list as the actual controls.
       audit: |-
         ### Audit via redis-cli
 


### PR DESCRIPTION
Rewrites `docs.desc` for all 44 checks across the five self-managed database policies.

| Bundle | Checks |
|---|---|
| `mondoo-postgresql-security` | 29 |
| `mondoo-mssql-security` | 4 |
| `mondoo-mongodb-security` | 4 |
| `mondoo-cassandra-security` | 4 |
| `mondoo-redis-security` | 3 |

## What changed

All five bundles carried the generated skeleton: a `**Why this matters**` section made of bulleted bold labels, followed by a `**Risk mitigation**` section that restated `docs.remediation`. The labels named the *category* of a concern without ever saying what happens, and the duplicated section added nothing the remediation did not already carry. Both are gone.

Each description now opens with what is verified, names the setting **where the reader administers it**, and says what an attacker concretely does without the control rather than gesturing at "unauthorized access".

Because these are five different engines with five different configuration mechanisms, the descriptions deliberately do not read as one template:

- **PostgreSQL** names the directive and the file it lives in, says whether a reload or a restart is required, and notes where `ALTER SYSTEM` writes `postgresql.auto.conf` and overrides the value the check reads. `pg_hba.conf` checks describe the rule columns; `pg_ident.conf` checks describe the mapping.
- **SQL Server** names the `sp_configure` option, the `show advanced options` prerequisite and the `RECONFIGURE` that makes a value running, or the Configuration Manager and Management Studio path where the setting is a server property.
- **MongoDB** names the `mongod.conf` key under `security:` or `net:` and the `mongod` restart.
- **Cassandra** treats the `authenticator` and the `authorizer` in `cassandra.yaml` as the separate classes they are, and notes the rolling restart.
- **Redis** names the `redis.conf` directive and the `CONFIG REWRITE` a runtime change needs to persist, and the `protected-mode` and `requirepass` descriptions say plainly why those settings exist.

Descriptions that turn on the difference between a local socket connection and a network one, or between an authenticated and an anonymous default, say so explicitly rather than treating it as incidental.

## Median word count

| Bundle | Before | After |
|---|---|---|
| PostgreSQL | 172 | 265 |
| SQL Server | 128 | 286 |
| MongoDB | 129 | 274 |
| Cassandra | 126 | 281 |
| Redis | 142 | 286 |
| **All 44** | **161** | **269** |

No policy version was bumped.

## Gates

Run per file, all five:

- `cnspec policy lint ./content/<policy>.mql.yaml` → `valid policy bundle(s)` for all five.
- `typos content/<policy>.mql.yaml` → silent for all five.
- `go test -count=1 ./internal/bundle/...` → `ok`.
- Structural diff against `origin/main` → `trees identical apart from docs.desc and policy version` for all five.
- Substance gate → **0 specifics lost** on every bundle: 0/29 PostgreSQL, 0/4 SQL Server, 0/4 MongoDB, 0/4 Cassandra, 0/3 Redis. Every backticked literal and numeric threshold in the old text survives into the new, so nothing was waived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)