### PR TITLE
📝 content: rewrite Netlify and HCP check descriptions as prose

### DIFF
--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -66,19 +66,20 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that no HCP Vault cluster exposes an unrestricted public endpoint. A cluster may keep its public endpoint enabled only when an IP allowlist restricts which source addresses can reach it; a public endpoint with no allowlist puts the secrets engine on the open internet.
+      desc: |
+        This check verifies that an HCP Vault cluster is not reachable from the whole internet.
+
+        A cluster satisfies this in either of two ways. Its public endpoint can be off, leaving the cluster reachable only across the HashiCorp Virtual Network peered with your own infrastructure. Or the public endpoint can stay on while an IP allowlist names the CIDR ranges permitted to reach it. Both are edited in the HCP portal by opening Vault, selecting the cluster, and opening its networking configuration, and both appear on the `hcp_vault_cluster` Terraform resource as `public_endpoint` and an `ip_allowlist` block taking an `address` and a `description`. A cluster with a public endpoint and no allowlist fails.
 
         **Why this matters**
 
-        - **Reduced attack surface:** A publicly reachable Vault API is exposed to internet-wide scanning, credential-stuffing, and exploitation attempts around the clock.
-        - **Network-layer control:** An IP allowlist limits reachability to known operator and application networks, keeping everyone else from ever completing a connection.
-        - **Defense in depth:** Restricting the network path complements Vault's own authentication and policy controls rather than relying on them alone.
+        Vault holds the credentials for everything else, which makes an internet-facing Vault API a single address worth an attacker's sustained attention. The endpoint answers on a predictable hostname and returns a recognizable response, so it is found by scanning rather than by anyone disclosing where it is.
 
-        **Risk mitigation**
+        What follows is quiet and unlimited. An attacker works leaked tokens against the login endpoints for as long as they like, at whatever rate they choose, from anywhere. A token that turned up in a CI log, in an environment file committed to a repository, or in a developer's shell history is tried against the open endpoint the moment it is found, from an address that has no relationship to your infrastructure. Once one authenticates, the holder reads secrets and, depending on the policy attached to that token, mints fresh credentials for the databases and cloud accounts Vault brokers, which are then usable long after the original token is revoked.
 
-        - **Blast-radius containment:** Even with a leaked token, an attacker outside the allowlisted ranges cannot reach the cluster to use it.
-        - **Fewer exposure paths:** Disabling the public endpoint entirely, where a private path exists, removes the internet-facing surface completely.
+        An allowlist takes all of that away from anyone outside your ranges. The leaked token is still leaked, but it cannot be presented from where the attacker is standing.
+
+        An allowlist is not a replacement for Vault's own controls, since a compromised host inside an allowlisted range reaches the cluster as normally as any other client. Keep token lifetimes short and policies narrow, and pair this with the companion check in this policy that streams audit logs off the cluster, so that use of the endpoint leaves a record you still hold afterwards.
       audit: |-
         ### Audit via the HCP portal
 
@@ -187,19 +188,20 @@ queries:
           mondoo.com/filter-title: Terraform State
           mondoo.com/filter-icon: terraform
     docs:
-      desc: |-
-        This check ensures that every HCP Vault cluster streams its audit logs to an external destination. Audit logs record authentication events and every secret access, so exporting them off the cluster preserves the trail even if the cluster itself is tampered with or destroyed.
+      desc: |
+        This check verifies that an HCP Vault cluster streams its audit log to a destination outside the cluster.
+
+        Streaming is configured in the HCP portal by opening Vault, selecting the cluster, and opening its audit log configuration, and on the `hcp_vault_cluster` Terraform resource as an `audit_log_config` block. That block names one destination through its own set of arguments, so a CloudWatch destination is given as a region, a group name, a stream name, and credentials, while Datadog, Elasticsearch, Grafana, New Relic, Splunk, and a generic HTTP endpoint each take a different set. This check requires some destination to be configured.
 
         **Why this matters**
 
-        - **Attributable access:** Vault audit logs tie every request to an identity, token, and path, which is essential for investigating misuse of secrets.
-        - **Tamper resistance:** Streaming logs to an external destination keeps a copy beyond the reach of anyone who compromises the cluster.
-        - **Compliance evidence:** Audit frameworks require retained, reviewable access logs for systems that broker sensitive credentials.
+        The Vault audit log is the only record of which token read which secret at what time, which makes it the record an attacker most wants gone. Someone who reaches the cluster with enough privilege can disable an audit device or stop the export, and from that moment their reads leave nothing behind. Streaming continuously into a different trust boundary means the entries written before that point are already elsewhere and beyond reach, so the attempt to cover the tracks shows up as a gap in a record you still hold rather than as an absence of evidence.
 
-        **Risk mitigation**
+        The record also decides how large an incident turns out to be. When a token is found to have leaked, the audit log answers which paths it actually read, and that answer is the difference between rotating a handful of secrets and rotating every credential the token's policy allowed. With no exported log the safe assumption is the second, which for a Vault cluster means rotating the database and cloud credentials of everything downstream of it.
 
-        - **Faster incident response:** An off-cluster record of authentication and secret access narrows the source and timeline of suspicious activity.
-        - **Detection coverage:** Exported logs can feed a SIEM to alert on anomalous secret reads, failed authentication bursts, and off-hours access.
+        Exported entries are what detection runs on as well. A collector holding them can alert on a burst of failed logins, on a token reading paths it has never touched before, and on secret access outside working hours, none of which is visible from inside the cluster alone.
+
+        Send the stream somewhere the Vault operators do not administer, because a destination reached with the same credentials and controlled by the same people as the cluster inherits the cluster's compromise along with its logs.
       audit: |-
         ### Audit via the HCP portal
 

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -60,19 +60,20 @@ queries:
       # than guessing how the positive case is spelled.
       netlify.accounts.all(enforceMfa != "not_enforced")
     docs:
-      desc: |-
-        This check ensures that every Netlify team account enforces multi-factor authentication for its members. When MFA is enforced at the team level, a stolen or guessed password alone cannot sign in, because a second factor is always demanded. Note that MFA enforcement is a Netlify paid-team capability.
+      desc: |
+        This check verifies that every Netlify team requires its members to sign in with a second factor.
+
+        The setting is found in the Netlify UI by opening Team settings and then the Security section, where it appears as Enforce multi-factor authentication. Turning it on requires each member to enroll a second factor before they can continue working in the team. The team record reports the state as `enforceMfa`, whose only documented negative value is `not_enforced`, and this check requires the team to be in any other state. Enforcement is a paid-team capability, so a team on the free plan cannot satisfy this check without an upgrade.
 
         **Why this matters**
 
-        - **Credential theft resistance:** Passwords are phished, reused, and leaked constantly; a mandatory second factor stops a valid password from being enough to log in.
-        - **Team-wide coverage:** Enforcing MFA at the team level closes the gap left when it is only encouraged, so no member can opt out.
-        - **Privileged-account protection:** Netlify team members can deploy sites, change domains, and manage build settings, so their accounts are high-value targets that warrant strong authentication.
+        A Netlify team member controls what visitors receive from every site the team publishes. An attacker who signs in as one deploys a build of their choosing, and that build then runs in each visitor's browser: a script that reads session cookies from the site's own origin, a checkout page that posts card numbers to an endpoint the attacker controls, a redirect that quietly sends traffic elsewhere. Because the deploy travels through Netlify's normal pipeline and is served on the site's real domain under a valid certificate, nothing a visitor can see distinguishes it from a legitimate release.
 
-        **Risk mitigation**
+        The same account reaches the team's environment variables, which typically hold the API keys and database credentials the site's functions use at runtime, and the domain settings, where control of DNS is enough to take delivery of certificate validation for the domain itself.
 
-        - **Account-takeover containment:** Even after a password compromise, an attacker without the second factor cannot access the team.
-        - **Consistent enforcement:** A single team setting guarantees the control applies to current and future members alike.
+        A password alone protects none of that, and passwords are lost in bulk rather than one at a time. They are reused on sites that later get breached, entered on phishing pages that copy the Netlify sign-in screen, and pulled straight out of browsers by infostealer malware.
+
+        Enforce at the team level rather than asking members to enroll on their own, because the team setting covers people who join later and removes the choice from members who would otherwise skip it. Confirm that existing members have enrolled afterwards, since an account still lacking a factor is exactly the one worth attacking.
       audit: |-
         ### Audit via the Netlify UI
 
@@ -118,19 +119,20 @@ queries:
     mql: |
       netlify.sites.all(forceSsl == true)
     docs:
-      desc: |-
-        This check ensures that every Netlify site forces HTTPS. When forced HTTPS is enabled, HTTP requests are redirected to HTTPS and visitors never exchange data with the site over an unencrypted connection, keeping page content and form submissions confidential in transit.
+      desc: |
+        This check verifies that every Netlify site redirects HTTP requests to HTTPS.
+
+        The setting is found in the Netlify UI by opening a site, then Site configuration, then Domain management, then HTTPS, where it appears as Force HTTPS. The sites API exposes the same state as `force_ssl`. A provisioned certificate has to be in place before the redirect can be turned on. This check requires the redirect to be in effect for each site the team publishes.
 
         **Why this matters**
 
-        - **Eavesdropping resistance:** Traffic sent over plain HTTP can be read and modified by anyone on the network path; forcing HTTPS encrypts it end to end.
-        - **Tamper protection:** HTTPS prevents on-path injection of malicious scripts or ads into pages served to visitors.
-        - **Consistent posture:** Forcing the redirect closes the window where a visitor first lands on the insecure HTTP version of a page.
+        Without the redirect, the site answers on plain HTTP as well as HTTPS, and the plain answer is the one many visitors get. A hostname typed into the address bar, an old bookmark, a link in a mail client that strips the scheme, and every place a bare domain appears in print or conversation all resolve to HTTP first.
 
-        **Risk mitigation**
+        That first request is what an attacker on the network path takes. On a shared network, a public hotspot, a hotel connection, a home router someone else already owns, they answer it themselves and return a modified copy of the page. The visitor's browser has nothing to object to, because an unencrypted response carries no certificate to fail. The modified copy can include a script that reads whatever the visitor types, so a login form on the site sends credentials to the attacker instead of to the origin, and a payment form sends card details the same way.
 
-        - **Credential and data confidentiality:** Login forms and other submitted data are protected from interception in transit.
-        - **Trust and integrity:** Visitors always receive the authenticated, encrypted version of the site rather than a downgraded one.
+        Passive reading is available on the same terms even when nothing is changed. Everything the visitor submits over HTTP, including session cookies that were not marked secure, is readable by everyone between them and the site, and a stolen session cookie needs no password at all.
+
+        Turning on the redirect closes the plain path for requests that reach Netlify. Pair it with a Strict-Transport-Security response header, set through the site's headers configuration, so that a returning browser goes straight to HTTPS and never sends the first insecure request that the redirect exists to catch.
       audit: |-
         ### Audit via the Netlify UI
 


### PR DESCRIPTION
Rewrites `docs.desc` for all four checks across `mondoo-netlify-security` and `mondoo-hcp-security`.

All four carried the full generated skeleton: a bulleted `**Why this matters**` list of bold category labels followed by a `**Risk mitigation**` section that restated `docs.remediation`. Both are gone. Each description now opens by naming what is verified, says where the reader administers the setting in the product's own UI or portal and what the API or Terraform resource calls it, then explains in prose what an attacker concretely does without the control and what to pair the check with.

The two products share nothing, so the descriptions do not either. The Netlify pair is written around what control of a team account or an unencrypted first request does to site visitors, and it keeps the note that MFA enforcement is a paid-team capability. The HCP pair is written around a Vault cluster as the holder of everything else's credentials, naming the `hcp_vault_cluster` arguments and the audit destinations the `audit_log_config` block accepts.

Median description length per bundle, before and after:

| Bundle | Checks | Before | After |
|---|---|---|---|
| netlify | 2 | 154.0 | 341.0 |
| hcp | 2 | 153.0 | 362.5 |

Gates run:

- `cnspec policy lint`: valid policy bundle(s) for both files
- `typos`: silent on both files
- `go test -count=1 ./internal/bundle/...`: ok
- structural diff against `origin/main`: trees identical apart from docs.desc and policy version, for both files
- substance gate: 0 specifics lost, 0 of 4 checks affected

No policy version bump, matching the sibling PRs in this campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
