### PR TITLE
📝 saas: rewrite check descriptions as prose

### DIFF
--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -72,19 +72,19 @@ queries:
       atlassian.admin.organization.policies.any(policyType == "ip-allowlist" && status == "enabled")
     docs:
       desc: |
-        This check ensures that the Atlassian organization has at least one IP allowlist policy enabled. Without an active IP allowlist, every Atlassian Cloud product is reachable from any address on the public internet, so a stolen credential or API token can be used from anywhere an attacker happens to be.
+        This check verifies that the Atlassian organization restricts product access to a list of approved source addresses.
+
+        An IP allowlist names the network ranges from which Atlassian Cloud products accept traffic, and it is evaluated before any credential is examined. You create one at admin.atlassian.com under **Security > IP allowlists**, name it, add the ranges of corporate offices, VPN exit nodes, and approved cloud egress points, then apply it to the products you want to protect. This check requires at least one allowlist on the organization whose status is enabled. Jira, Jira Service Management, Confluence, and Compass need a Premium plan for the feature, and Atlassian Analytics needs Enterprise.
 
         **Why this matters**
 
-        - **Network-layer enforcement:** An IP allowlist blocks unauthorized addresses before credentials are evaluated, removing the entire pool of internet-based attackers as a threat.
-        - **Stolen-credential containment:** Even when a password or token is exposed, the attacker cannot use it from outside an allowed network range.
-        - **Reduced attack surface:** Restricting access to known corporate networks and VPN ranges narrows the set of sources from which authentication attempts can succeed.
-        - **Audit-trail clarity:** Sign-ins originate from a predictable set of networks, which makes anomalous source addresses easier to spot in audit logs.
+        With no allowlist, every Atlassian Cloud product answers requests from any address on the public internet. An attacker who phishes an employee password or lifts an API token out of a CI job log signs in from their own machine, opens Jira, and reads the issue history of every project that account can see. Nothing about the request looks unusual, because there is no location the product considers wrong.
 
-        **Risk mitigation**
+        An allowlist removes the entire pool of internet-based attackers before authentication runs. A password-spray campaign against your organization never reaches the credential check, so the stolen password stays useless outside your networks and the token found in a public repository cannot be replayed from a hosting provider.
 
-        - **Define corporate ranges:** Maintain the allowlist with the IP ranges of corporate offices, VPN exit nodes, and approved cloud egress points.
-        - **Review regularly:** Audit the allowed ranges so deprecated office addresses or stale cloud egress IPs do not silently retain access.
+        Sign-ins also become predictable. When every successful authentication originates from a small set of known ranges, a source address outside them stands out in the audit log instead of blending into ordinary traffic.
+
+        Activation takes effect immediately and denies every source outside the listed ranges, so confirm your own egress address falls inside a range before you enable it, and list VPN exit ranges rather than individual home addresses. An organization with no stable egress, such as a fully remote workforce on residential connections, should reach the same goal through identity and device conditions instead.
       audit: |
         ### Audit via Atlassian Admin
 
@@ -147,19 +147,19 @@ queries:
       atlassian.admin.organization.domains.any(type == "verified")
     docs:
       desc: |
-        This check ensures that the Atlassian organization has claimed and verified at least one email domain. Without a verified domain, the organization cannot claim accounts at that domain as managed identities, so administrators have no way to enforce single sign-on, password policy, or session controls on users who sign up with that email domain.
+        This check verifies that the Atlassian organization has proven ownership of at least one email domain.
+
+        Domain verification is how Atlassian confirms that your organization controls an email namespace before it will let you assert policy over the accounts inside it. You add the domain at admin.atlassian.com under **Directory > Domains** and prove control with a DNS TXT record, an HTML file in the root folder of the domain's website, or a connected identity provider such as Google Workspace or Microsoft Entra ID. This check requires at least one domain whose claim status is verified.
 
         **Why this matters**
 
-        - **Managed-account enforcement:** Verified domain ownership is the prerequisite for converting individual Atlassian accounts at that domain into organization-managed accounts.
-        - **Identity proofing:** Domain verification proves the organization controls the email namespace before any policy is asserted over its users.
-        - **Policy applicability:** Sign-on, authentication, and session policies only apply to managed accounts, so unverified domains create blind spots.
-        - **Offboarding completeness:** Only managed accounts can be reliably deactivated when a person leaves the organization.
+        Verification is the gate on managed accounts, and managed accounts are the only ones your organization governs. Without a verified domain, single sign-on, password policy, session length, and account deactivation apply to nobody. Every employee holding an Atlassian account at your domain holds a personal account that happens to have your logo on it.
 
-        **Risk mitigation**
+        That gap is what an attacker uses. An unmanaged account signs in with an email address and password directly, bypassing whatever multi-factor requirement your identity provider enforces, so a password recovered from an unrelated breach is enough to read the Jira projects and Confluence spaces the person belongs to. When that person leaves the company, the organization has no button that turns their access off, so the account and its session keep working long after the badge is returned.
 
-        - **Verify every corporate domain:** Verify every email domain used by employees and contractors so each user can be claimed and managed centrally.
-        - **Reclaim shadow accounts:** After verification, claim existing unmanaged accounts at the domain so they fall under organization policy.
+        Verification also closes the offboarding gap in the other direction. Once the domain is claimed you can see every account at it, including accounts an employee created without telling anyone.
+
+        After the domain shows as verified, claim the accounts at it from the same page. Claiming is disruptive, because it converts existing personal accounts at the domain into managed accounts your organization governs and may be billed for, so review the account list and communicate the change before you proceed.
       audit: |
         ### Audit via Atlassian Admin
 
@@ -230,19 +230,19 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that every API token issued to an active managed Atlassian account has been used recently. API tokens grant the same access as the account that created them, do not require a second factor, and remain valid until explicitly revoked, so a token that has not been used in months is far more likely to be unaccounted for than legitimate.
+        This check verifies that every API token belonging to an active managed Atlassian account has been used recently.
+
+        API tokens authenticate REST calls with the full access of the account that created them. Atlassian records the last use of each one, and **Insights > API token activity** at admin.atlassian.com lists every token a managed account holds together with its creation date, expiry, and last-used date. This check compares that last-used timestamp against an inactivity threshold you set as a policy property in days, and fails a token that has never been used or has gone unused for longer than the threshold.
 
         **Why this matters**
 
-        - **Long-lived credentials:** Atlassian API tokens do not expire on their own, so a forgotten token can remain valid indefinitely.
-        - **No second factor:** API tokens bypass interactive multi-factor authentication, so a stolen token gives an attacker direct access.
-        - **Reduced detectability:** Tokens that are not actively used produce no audit-log noise, so unauthorized use is unlikely to be noticed.
-        - **Lateral movement:** A leaked token can be used from any source allowed by the organization's network policy without triggering sign-in alerts.
+        A token nobody has used in months is almost never a token somebody is carefully looking after. It is the one pasted into a shell script on a laptop that was replaced, committed to a repository before the team started scanning history, or left in the environment of a build agent that was decommissioned without anyone revoking its credentials.
 
-        **Risk mitigation**
+        An attacker who finds one gets the same reach as the person it belongs to, with none of the friction. The token is presented with basic authentication and is never challenged for a second factor, so multi-factor enrollment on the account does not slow the attacker down. They page through the Jira and Confluence REST APIs and pull every issue, comment, attachment, and page the owner can read. Because there is no interactive sign-in, none of it produces the sign-in event that an anomalous login would.
 
-        - **Revoke unused tokens:** Treat any token unused for the configured threshold as abandoned and revoke it.
-        - **Document active tokens:** Maintain a current inventory of API tokens with the system or person that owns each one so unowned tokens can be identified and removed.
+        Atlassian tokens do not expire on their own, so this state persists indefinitely until someone revokes the token.
+
+        Revocation is permanent and immediately breaks any integration still using the token, so contact the owner of any token whose purpose is unclear before revoking it, and issue a replacement only where there is a documented active use case.
       audit: |
         ### Audit via Atlassian Admin
 
@@ -320,19 +320,19 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that every active managed Atlassian account has signed in or otherwise transacted with the organization inside the configured inactivity threshold. Accounts that retain an active status but have not been used for months represent unused identities whose credentials may have been forgotten, shared, or compromised without anyone noticing.
+        This check verifies that every managed Atlassian account still marked active has actually been used recently.
+
+        Atlassian records a last active date for each managed account, and the CSV export from **Directory > Managed accounts** at admin.atlassian.com carries that date for every account in the organization. This check reads it for accounts of type Atlassian whose status is active, compares it against an inactivity threshold you set as a policy property in days, and fails any account that has been idle longer than the threshold or has no recorded activity at all.
 
         **Why this matters**
 
-        - **Account-takeover surface:** Dormant accounts retain their access, group memberships, and API tokens, so a successful credential theft has the same impact as on an active employee.
-        - **Offboarding gaps:** A dormant account often signals an incomplete offboarding where the leaver was never deactivated.
-        - **License waste and noise:** Inactive accounts inflate license counts and dilute the signal in audit reviews of who has access.
-        - **Compliance review fatigue:** A large backlog of unused accounts makes access reviews longer and reduces the chance that genuinely risky access is spotted.
+        Deactivating an account removes its access. Leaving it active and unused does not. A dormant account keeps its group memberships, its Jira project roles, its Confluence space permissions, and any API tokens it issued, so the access is exactly what it was on the person's last working day.
 
-        **Risk mitigation**
+        What is missing is the owner. Nobody signs in to the account, so nobody notices when someone else does. An attacker who lands the account's password from a credential-stuffing list gets no complaint from a real user about a strange login prompt, no report of a session appearing on an unfamiliar device, and no colleague wondering why that person is suddenly reading a project they left two years ago. They browse the same issues and pages the account always could, at whatever pace avoids attention.
 
-        - **Deactivate dormant accounts:** Deactivate or delete accounts that have not been used inside the threshold and have no documented business justification.
-        - **Tie offboarding to identity events:** Connect leaver workflows from HR or the IdP to managed-account deactivation so departures are reflected in Atlassian immediately.
+        Dormancy usually points at an offboarding that stopped halfway, where the identity provider entry was removed but the Atlassian account was never deactivated. It also inflates the license count and buries genuinely risky access in a long list of accounts nobody uses.
+
+        Some accounts legitimately transact rarely, such as a break-glass administrator or a seasonal contractor. Confirm with the owning team, then either deactivate the account or record the justification and schedule a follow-up review.
       audit: |
         ### Audit via Atlassian Admin
 
@@ -393,19 +393,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that no Jira project's permission scheme contains a grant whose holder is anyone, the holder type Atlassian uses to grant a permission to unauthenticated callers. An anyone grant means the named permission applies to every visitor, including users with no Atlassian account, so anything the permission allows is effectively public.
+        This check verifies that no Jira project grants a permission to unauthenticated visitors.
+
+        Every permission in a Jira permission scheme is granted to a holder, and Jira offers one holder type, anyone, that means exactly what it says: the permission applies to callers with no Atlassian account at all. You review the holders under **Settings > Issues > Permission schemes** in your Jira site. This check requires every grant in every project's scheme to name an authenticated holder instead, such as a user, group, project role, application role, assignee, reporter, or project lead.
 
         **Why this matters**
 
-        - **Unauthenticated exposure:** A grant to anyone bypasses login entirely, so an issue, comment, or attachment covered by that permission is readable or writable from the public internet.
-        - **Data leak vector:** Permissions such as Browse Projects or View Read-Only Workflow expose ticket content; permissions such as Create Issues expose write surface to the open web.
-        - **Audit-trail integrity:** Actions taken under an anonymous grant have no associated user identity, so audit logs cannot attribute who did what.
-        - **Compliance violation:** Most frameworks require that access to information assets be tied to an identified user.
+        A Browse Projects permission granted to anyone turns the project into a public archive. Someone who has your site URL and guesses a project key reads every issue in it without signing in, and issue trackers are where teams paste the things they would never put in a document: stack traces with internal hostnames, customer names attached to bug reports, screenshots of admin consoles, and the occasional token dropped into a comment while debugging. The attacker does not need to break anything, because nothing is asking who they are.
 
-        **Risk mitigation**
+        Grants that carry write access are worse still. Create Issues held by anyone hands the open internet a way to inject content into a workspace employees trust, which is a serviceable delivery route for a link that staff will open because it arrived in a familiar tool.
 
-        - **Replace anyone grants with named holders:** Re-grant the same permission to a specific group, project role, or application role that represents an authenticated audience.
-        - **Review permission schemes regularly:** Re-audit project permission schemes during access reviews so anonymous grants introduced for short-term use cases do not persist.
+        Anonymous actions also carry no identity, so the audit log records that something happened without recording who did it. After the fact you cannot tell which issues were read or by whom.
+
+        If content genuinely needs to be reachable without a login, expose it through a service desk portal that still identifies the requester, rather than opening a project permission to anyone.
       audit: |
         ### Audit via Jira Admin
 
@@ -464,20 +464,19 @@ queries:
       atlassian.confluence.spaces.none(anonymousAccess == true)
     docs:
       desc: |
-        This check ensures that no Confluence space is configured to allow access for anonymous, unauthenticated users. A space with anonymous access enabled publishes every page within it to the public internet, so any content that ends up there — internal documentation, runbooks, customer data, credentials — is readable by anyone who guesses or stumbles on the URL.
+        This check verifies that no Confluence space is readable without signing in.
+
+        Anonymous access is a per-space setting that grants permissions to visitors with no account. A space administrator finds it under **Space settings > Space access > Anonymous access**, and a Confluence administrator can additionally turn off the global setting that allows spaces to enable it at all. This check reads the per-space configuration, so the permissions granted to the anonymous principal must be cleared on each affected space even when the site-wide setting is already off.
 
         **Why this matters**
 
-        - **Direct public exposure:** Anonymous access turns a Confluence space into a public website, regardless of the sensitivity of the content authors have added to it.
-        - **Default-deny violation:** A space configured this way explicitly inverts the default-deny posture expected for internal collaboration tools.
-        - **Audit-trail gap:** Reads by anonymous viewers do not produce attributable audit log entries, so leaks cannot be traced to a specific person or session.
-        - **Search-engine indexing:** Public spaces are indexable by search engines, so once a page is exposed it may remain reachable from cached results long after the permission is corrected.
-        - **Compliance violation:** Most frameworks require that access to internal information be granted only to authenticated, authorized users.
+        A space with anonymous access is a public website, and the people writing in it do not know that. Confluence is where the runbook with the recovery procedure lives, where the architecture page names the internal hostnames, where onboarding docs walk a new hire through bootstrapping their credentials, and where a postmortem describes exactly how a control failed.
 
-        **Risk mitigation**
+        Reaching that content takes no attack. A page URL leaks in a support ticket, a partner email, or a search engine index, and the attacker follows it, then walks the space tree from there. They learn your internal topology and your escalation paths before touching anything you would recognize as an intrusion, and that reading is the reconnaissance phase of the intrusion that follows.
 
-        - **Disable anonymous access:** Remove the anonymous permission from every space and confirm no space-level permission entry references the anonymous principal.
-        - **Curate intentional public spaces:** If a space must be public, move it to a dedicated marketing or documentation site and treat it as published external content rather than internal collaboration.
+        Anonymous reads produce no attributable audit entry, so after the exposure is found you cannot say which pages were taken or when. Search engines compound this: once a page has been crawled it may stay reachable from cached results long after the permission is corrected.
+
+        If a space genuinely must be public, that is a publishing decision rather than a permission tweak. Move the content to a dedicated documentation site where it is reviewed as external material, and leave the internal instance closed.
       audit: |
         ### Audit via Confluence Admin
 
@@ -537,19 +536,19 @@ queries:
       atlassian.confluence.spaces.none(unlicensedAccess == true)
     docs:
       desc: |
-        This check ensures that no Confluence space is configured to allow access for unlicensed users such as Jira Service Management customers or other portal-only accounts. Unlicensed access widens the audience for the space beyond the licensed employees the access model is built around, so internal documentation can be read by external customers without the access being treated as external sharing.
+        This check verifies that no Confluence space is exposed to users who hold no Confluence license.
+
+        Unlicensed access is how Jira Service Management shows Confluence pages to portal customers through a linked knowledge base. It is configured per service project under **Project settings > Knowledge base**, where the **Who can view** option decides whether reading requires access to the linked space or is open to portal users without a Confluence license, and it can be turned off site-wide from the **JSM Access** tab in Confluence settings. This check requires no space to report unlicensed access.
 
         **Why this matters**
 
-        - **External audience leak:** Service desk customers and other unlicensed accounts are external to the organization, so granting them access to internal spaces is equivalent to publishing the content to those customers.
-        - **Boundary confusion:** Authors of internal documentation usually assume the audience is licensed employees, so they may post information that is inappropriate for an external audience.
-        - **Audit visibility loss:** Unlicensed-user reads are not always surfaced in standard access reviews because they are scoped through the portal, not regular space membership.
-        - **Compliance violation:** Many frameworks require that information access be restricted to authorized, identified personnel.
+        Portal customers are outside your organization, but this route does not look like external sharing to anyone involved. The person who wrote the escalation runbook assumed licensed colleagues were reading it. The service desk administrator who linked the knowledge base was trying to reduce ticket volume. Neither decision, on its own, reads as publishing internal documentation to customers.
 
-        **Risk mitigation**
+        An attacker takes the shortest path in. Many service desks accept self-signup or accept any address at a partner domain, so obtaining a portal account is a form submission rather than a compromise. From there the linked space opens, and its pages give up internal escalation contacts, vendor account details, and writeups of known weaknesses that have not been fixed yet. That is targeting material for the social-engineering call that follows.
 
-        - **Disable unlicensed access:** Turn off the unlicensed-access permission on every internal space.
-        - **Use a dedicated customer space:** If unlicensed users genuinely need access to documentation, create a separate space whose content is reviewed and published as external collateral.
+        These reads scope through the portal rather than through space membership, so they do not surface in the usual access review of who belongs to a space. The exposure stays invisible to the review that was supposed to catch it.
+
+        Where portal customers genuinely need documentation, link a dedicated customer-facing space whose pages are written and reviewed as external collateral, instead of relaxing access on a space the internal teams treat as private.
       audit: |
         ### Audit via Confluence Admin
 

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -75,19 +75,19 @@ queries:
     mql: googleworkspace.users.all ( isEnforcedIn2Sv == true )
     docs:
       desc: |
-        This check ensures that 2-step verification is configured to be enforced for every user in the Google Workspace organization. Workspace does not require a second factor by default, so an account protected only by a password can be taken over with stolen credentials.
+        This check verifies that every user in the Google Workspace account is required to present a second factor, not merely permitted to.
+
+        Google splits this into two settings under **Security > Authentication > 2-step verification** in the Admin console at admin.google.com. Allowing users to turn on 2-step verification opens self-enrollment, and enforcement is what makes it mandatory. Enforcement is applied per organizational unit, so an account can look protected at the top level while a child unit that was never selected carries none of it. This check reads the enforcement state of each user and requires it on all of them.
 
         **Why this matters**
 
-        - **Account takeover prevention:** Even if passwords are stolen through phishing or breaches, attackers cannot access accounts without the second factor.
-        - **Credential stuffing defense:** Reused passwords from other compromised services cannot be used to sign in to Google Workspace.
-        - **Lateral movement prevention:** Compromised accounts cannot be used to reach shared documents, email, or connected services.
-        - **Compliance alignment:** SOC 2, ISO 27001, HIPAA, and other frameworks require or recommend multi-factor authentication for all users.
+        Self-enrollment protects the people who were already going to be careful. The accounts that stay password-only are the ones nobody chased, and those are the accounts an attacker finds first.
 
-        **Risk mitigation**
+        Getting the password is the easy half. It comes from a dump of an unrelated service where the employee reused it, or from a sign-in page rendered convincingly enough that they typed it in. With no second factor, that password is the whole authentication. The attacker signs in and Gmail hands over the mailbox: the password reset messages for every other service the person uses, the finance thread with the wire instructions, the contract attachments. Drive hands over whatever the account can open, including the shared drives the person was added to and forgot about. Nothing else has to be broken.
 
-        - **Business email compromise defense:** BEC attacks typically begin with account takeover, which a second factor helps prevent.
-        - **Consistent organization-wide protection:** Enforcing 2-step verification at the organizational level removes per-user gaps in authentication strength.
+        Enforcement across the entire organization removes the per-user gaps that make this predictable. It also removes the gap between a policy that exists on paper and the accounts it was never actually applied to.
+
+        Roll it out with a new user enrollment period so accounts created after the change can sign in once and enroll, and track coverage under **Reporting > Reports > User Reports > Security** before the enforcement date so nobody is stranded outside their account when it arrives.
       audit: |
         ### Audit via Admin Console
 
@@ -152,19 +152,19 @@ queries:
     mql: googleworkspace.report.users.where(isSuperAdmin == true).length <= 4
     docs:
       desc: |
-        This check ensures that the Google Workspace organization is configured to keep no more than four users with super admin permissions. Super admin accounts have unrestricted access to all organizational data and settings, so each one is a high-value target.
+        This check verifies that no more than four accounts hold the super admin role.
+
+        A super admin has unrestricted control of the Google Workspace account: every setting, every organizational unit, every user, and the ability to reset any password or read any mailbox by granting itself delegation. You list them in the Admin console under **Directory > Users** with the **Admin role** filter set to **Super Admin**. This check counts those accounts and requires four or fewer.
 
         **Why this matters**
 
-        - **Attack surface expansion:** Each super admin account adds another potential compromise vector for attackers.
-        - **Privilege accumulation:** Organizations often gather super admins over time without removing former ones.
-        - **Audit clarity:** A small set of super admins makes it easier to track who made security-sensitive changes.
-        - **Compliance alignment:** Security frameworks recommend minimizing the number of highly privileged accounts.
+        The role accumulates. Someone needed it for a migration in 2021, someone else was made a super admin because a delegated role could not do one specific task, and neither was reviewed afterwards. Each of those accounts is a complete path to the organization, held by a person who no longer thinks of themselves as an administrator and does not treat the account like one.
 
-        **Risk mitigation**
+        That is precisely what an attacker looks for. They do not target the security lead who uses a hardware key. They target the marketing manager who was granted super admin for a Drive cleanup two years ago and still signs in from a personal laptop. With that account they create a user of their own, grant it domain-wide delegation, and read every mailbox in the organization through the API without ever touching another password. Because the access is granted rather than stolen, revoking the original account does not remove it.
 
-        - **Reduced blast radius:** Fewer super admins limits the data, users, and settings exposed if one account is compromised.
-        - **Least privilege enforcement:** Delegated admin roles cover users who need limited administrative access without granting full control.
+        Capping the count is what makes the remaining accounts reviewable. Four accounts can be watched, given hardware keys, and checked against a named owner. Fifteen cannot.
+
+        Move each user beyond that set to a delegated role such as **User Management Admin** or **Help Desk Admin**, or build a custom role carrying only the privileges the person's actual work requires. Keep at least two, since a single super admin is its own failure and a companion check in this policy enforces the lower bound.
       audit: |
         ### Audit via Admin Console
 
@@ -223,19 +223,19 @@ queries:
     mql: googleworkspace.report.users.where(isSuperAdmin == true).length > 1
     docs:
       desc: |
-        This check ensures that the Google Workspace organization is configured to keep more than one user with super admin permissions. A single super admin creates a single point of failure for all administrative access.
+        This check verifies that more than one account holds the super admin role.
+
+        Super admin is the only role that can restore access to the Google Workspace account when the usual paths fail. It resets any password, changes the recovery details, reassigns roles, and unlocks accounts. You see who holds it in the Admin console under **Directory > Users** with the **Admin role** filter set to **Super Admin**. This check requires at least two such accounts.
 
         **Why this matters**
 
-        - **Single point of failure:** If the only super admin is unavailable, the organization cannot perform critical administrative tasks.
-        - **Account lockout risk:** If the single admin account is compromised or locked, there is no way to regain administrative access.
-        - **Emergency response:** Security incidents may require immediate administrative action that is impossible with an unavailable admin.
-        - **Business continuity:** Extended admin unavailability can disrupt onboarding, offboarding, and security operations.
+        With a single super admin, that person is the account. If they lose their second factor on a Friday, leave without a handover, are hit by the same phishing campaign as everyone else, or are on a long flight, nobody can act on the organization until they come back.
 
-        **Risk mitigation**
+        The security consequences arrive at the worst moment. During an active compromise, the response is to suspend the affected accounts, reset passwords, revoke the OAuth tokens the attacker is using, and force sign-out. Every one of those actions needs a super admin. If the account the attacker took is the sole super admin, they now hold the only key and can lock the legitimate owners out of their own organization while they work.
 
-        - **Resilient recovery:** Maintaining at least two trusted super admins avoids Google's lengthy recovery process for a sole locked admin.
-        - **Operational continuity:** A second admin keeps administrative access available when the primary admin is unreachable.
+        Google's recovery process for a locked-out sole super admin runs through a support and ownership verification path that takes days, and it requires evidence about the domain that somebody has to find while the incident continues.
+
+        Add a second trusted super admin, keep the number small since a companion check in this policy caps it, and require the backup account to enroll a hardware security key before you rely on it. Give the backup account its own credentials rather than sharing one login, so the audit log can still tell the two administrators apart.
       audit: |
         ### Audit via Admin Console
 
@@ -294,19 +294,19 @@ queries:
     mql: googleworkspace.report.users.all(isLessSecureAppsAccessAllowed == false)
     docs:
       desc: |
-        This check ensures that the Google Workspace organization is configured to block users from granting access to less secure apps that use legacy authentication without OAuth. Less secure apps bypass modern authentication controls and create a significant vulnerability.
+        This check verifies that no account is still marked as permitted to use less secure app access.
+
+        Less secure app access was the Google Workspace setting that let a client authenticate to Gmail, Calendar, or Contacts with a username and password alone, without OAuth. Google removed it from Workspace in 2024, and the **Less secure apps** page no longer appears in the Admin console, so sign-ins of that shape are already rejected. This check reads the per-user reporting data and flags any account still carrying the flag, which now means stale report data or a value set through the API before the feature was withdrawn.
 
         **Why this matters**
 
-        - **No OAuth protection:** These apps require storing raw passwords instead of using secure token-based authentication.
-        - **MFA bypass:** Less secure apps often cannot support a second factor, negating 2-step verification enforcement.
-        - **Credential exposure:** Passwords stored in less secure apps can be extracted if those apps or devices are compromised.
-        - **Limited visibility:** Legacy authentication methods provide less logging and monitoring capability.
+        The reason the control existed is worth keeping in view, because the underlying pattern has not gone away. A client that authenticates with a raw password has to store that password somewhere on the device, and it cannot present a second factor at all. An attacker who reaches the device reads the credential out of the mail client's configuration, and an attacker who has only the password uses it against a protocol that never asks for anything else, walking straight past the 2-step verification you enforced everywhere else.
 
-        **Risk mitigation**
+        Those sign-ins also log poorly. There is no app identity, no consent record, and nothing to revoke short of changing the password, so the access is hard to see while it is happening and hard to scope afterwards.
 
-        - **Closed attack vector:** Blocking less secure app access removes a path threat actors use specifically to bypass MFA requirements.
-        - **Modern authentication adoption:** Disabling the setting drives users toward applications that support OAuth.
+        The residual state this check reports carries no live risk on its own, since the authentication path is closed. Treat a finding as a prompt to look for what the flag was set for.
+
+        Review third-party access under **Security > Access and data control > API controls**, find any user or device still connecting over IMAP, POP, or SMTP with a password, move it to a client that supports OAuth, and have the owners remove app passwords they no longer need.
       audit: |
         ### Audit via Admin Console
 
@@ -365,19 +365,19 @@ queries:
     mql: googleworkspace.report.users.where(isSuperAdmin == true).all(numSecurityKeys >= 1)
     docs:
       desc: |
-        This check ensures that every super admin account is configured with at least one hardware security key registered for 2-step verification. Super admins control the entire organization and need the strongest available authentication.
+        This check verifies that every super admin has a hardware security key registered on their account.
+
+        A security key is a physical FIDO2 authenticator such as a YubiKey or a Google Titan key, registered from the user's own 2-Step Verification settings. In the Admin console you can then require it exclusively by putting the super admins in a dedicated organizational unit or group, opening **Security > Authentication > 2-step verification** with that unit selected, and choosing the security key only method. This check reads the number of registered keys on each super admin account and requires at least one.
 
         **Why this matters**
 
-        - **Phishing immunity:** Hardware security keys are resistant to phishing because they verify the legitimate site origin.
-        - **SIM swapping protection:** Unlike SMS, security keys cannot be compromised through carrier social engineering.
-        - **Strong cryptographic verification:** Modern keys use FIDO2 and WebAuthn protocols that prevent credential interception.
-        - **Compliance alignment:** Many security frameworks recommend hardware tokens for privileged account protection.
+        Every other second factor can be relayed. A phishing kit acting as a proxy shows the user a convincing sign-in page, forwards the credentials to Google in real time, prompts for the code from their authenticator app or the push approval on their phone, and passes that through too. The user sees a successful login. The attacker has a session cookie for a super admin account, which is unrestricted control of the organization.
 
-        **Risk mitigation**
+        A security key does not participate in that. It signs a challenge bound to the origin the browser is actually talking to, so a key registered for the real Google sign-in page produces nothing a proxy on a lookalike domain can use. The attack fails at the step it was built to defeat, and it fails silently from the attacker's side.
 
-        - **Hardened high-value targets:** Requiring keys for super admins removes the weakest second-factor methods from the accounts attackers prioritize.
-        - **Standardized strong factor:** FIDO2-compliant keys such as YubiKey or Google Titan provide consistent protection across all super admin accounts.
+        Keys also close the SMS path outright, since there is no code to intercept and no phone number to have transferred at a carrier's front desk.
+
+        Register at least two keys per administrator so a lost key does not lock the account, and confirm every super admin has registered before restricting the allowed method, because an administrator without a key is locked out the moment the restriction takes effect.
       audit: |
         ### Audit via Admin Console
 
@@ -444,19 +444,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that no third-party connected application is configured with full access to Gmail or Google Drive. Scopes such as `https://mail.google.com/` and `https://www.googleapis.com/auth/drive` allow an application to read, write, and delete all emails or files.
+        This check verifies that no third-party application holds unrestricted access to Gmail or Drive.
+
+        OAuth scopes decide what a connected app can do, and two of them are effectively total. `https://mail.google.com/` grants full control of a user's mailbox, and `https://www.googleapis.com/auth/drive` grants the same over their files. You review what each app has been granted in the Admin console under **Security > Access and data control > API controls**, in **Manage Third-Party App Access**. This check requires no connected app to hold either scope.
 
         **Why this matters**
 
-        - **Data exfiltration:** Applications with full access can read and export all email messages or files from users' accounts.
-        - **Email manipulation:** Full Gmail access lets applications send, delete, or modify messages on behalf of users.
-        - **Untrusted developers:** Connected apps may be built by untrusted parties and used for data harvesting.
-        - **Persistent access:** OAuth tokens keep access alive even after a user changes their password.
+        An app with those scopes reads, writes, and deletes everything the user can, and it does so through the API rather than through a browser session, at whatever rate it likes. If the vendor is compromised, or the app was built to harvest data in the first place, the outcome is a bulk copy of the mailboxes and drives of everyone who consented, which is a breach of your data caused by an organization you do not control and may not be able to audit.
 
-        **Risk mitigation**
+        Full Gmail access carries a second capability that is easy to miss: the app can send as the user and delete what it sends. That is a complete business email compromise toolkit granted through a consent screen instead of a stolen password.
 
-        - **Supply chain containment:** Revoking broad scopes limits how a compromised third-party application can reach organizational data.
-        - **Least privilege enforcement:** Granting only the scopes an application needs reduces the data exposed by any single integration.
+        The access also outlives the credential. An OAuth token remains valid after the user changes their password and after they enroll a second factor, so the usual response to a compromised account does not touch it.
+
+        Coordinate with the owners of each affected integration before you act, since removing access stops the app working until it is reauthorized with narrower scopes. Set the app to blocked or limited, then revoke the tokens users already issued, and reauthorize the ones you still need with the narrowest scope that does the job.
       audit: |
         ### Audit via Admin Console
 
@@ -524,19 +524,19 @@ queries:
       googleworkspace.domains.all(verified == true)
     docs:
       desc: |
-        This check ensures that every domain registered in the Google Workspace organization is verified. An unverified domain indicates that DNS ownership was never confirmed, which points to misconfiguration or domain spoofing risk.
+        This check verifies that every domain registered in the Google Workspace account has completed ownership verification.
+
+        Adding a domain in the Admin console under **Account > Domains > Manage domains** does not by itself prove you control it. Verification does, by requiring a DNS TXT or CNAME record that only somebody with access to the zone can publish. This check requires every listed domain to show as verified rather than pending or failed.
 
         **Why this matters**
 
-        - **Domain spoofing:** Unverified domains could be used to send email that appears to come from the organization.
-        - **Incomplete setup:** An unverified domain means DNS verification was not completed, so email routing and other services may not be configured correctly.
-        - **Email deliverability:** SPF, DKIM, and DMARC require verified domain ownership to function correctly.
-        - **Organizational trust:** Users and external parties may receive mail from unverified domains, creating confusion about message authenticity.
+        An unverified domain is a claim without evidence, and it usually means one of two things. Either the setup was abandoned partway, in which case mail routing and the rest of the domain's configuration are in an unknown state, or the domain does not belong to you in the way somebody assumed when they typed it in.
 
-        **Risk mitigation**
+        Both matter for email authentication, which is the practical exposure. SPF, DKIM, and DMARC all rest on records published in the domain's own DNS zone, and none of them can be established for a domain whose zone you have not demonstrated control of. Until that is fixed, receiving mail servers have no published policy telling them which senders are legitimate, so an attacker sends mail that appears to come from an address at your domain and it arrives with nothing to fail. That is the delivery mechanism for the invoice-redirection message to your customer and the credential-harvesting message to your own staff, both carrying your name.
 
-        - **Compliance alignment:** Verifying all business domains satisfies frameworks that require organizations to control every domain used for communication.
-        - **Reduced unused surface:** Removing domains that are no longer needed eliminates unverified entries that serve no purpose.
+        Unverified entries also clutter the domain list, which makes it harder to notice a domain that should not be there at all.
+
+        Complete verification for every domain your organization actually uses, then publish the authentication records for each one. Remove domains you no longer need rather than leaving them unverified, since an entry that serves no purpose still appears in the account's configuration.
       audit: |
         ### Audit via Admin Console
 
@@ -599,19 +599,19 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that no user calendar is configured for public sharing. A calendar ACL rule with a scope type of `default` and a role other than `none` makes the calendar accessible to anyone on the internet.
+        This check verifies that no calendar is readable by anyone on the internet.
+
+        A Google Calendar access rule with a scope type of `default` means the public, and any role on that rule other than `none` grants the public something. The organization-wide setting sits in the Admin console under **Apps > Google Workspace > Calendar > Sharing settings**, where the most restrictive external option shows free and busy information only. This check reads the access rules on the calendars themselves, so a calendar a user already made public keeps its rule until it is removed individually.
 
         **Why this matters**
 
-        - **Meeting intelligence:** Public calendars reveal participants, topics, and schedules that can be used for social engineering.
-        - **Organizational exposure:** Calendar data exposes reporting structures, team composition, and internal processes.
-        - **Travel schedules:** Executive calendars may reveal travel plans, creating physical security risks.
-        - **Business intelligence leakage:** Competitors can monitor public calendars to learn about upcoming projects, partnerships, and strategic initiatives.
+        A calendar is an organizational chart with timestamps. Attendee lists reveal who reports to whom and which teams are working together. Meeting titles name the acquisition, the customer escalation, the incident bridge, and the vendor being evaluated. Recurring one-to-ones identify a person's manager, and a gap in the pattern identifies when they are away.
 
-        **Risk mitigation**
+        That is source material for a targeted attack rather than an abstract privacy concern. Knowing that the finance lead meets the CFO every Tuesday, and that the CFO is travelling on Thursday, is what makes the Thursday payment request from a spoofed address plausible. Knowing an incident bridge is running right now is what makes a message impersonating the responder land.
 
-        - **Privacy protection:** Restricting sharing keeps employee schedules and personal appointments from being inadvertently exposed.
-        - **Scoped access:** Sharing calendars only with specific internal users or groups removes anonymous public visibility.
+        Executive travel raises the stakes further, since a public calendar with locations tells anyone reading it where a named individual will be and when.
+
+        Note that free and busy visibility still makes a calendar publicly readable in the sense this check reads, so removing the public access rule on each affected calendar is the step that resolves it. Restrict the organization setting first so new calendars do not repeat the pattern, then have each affected user clear the public access on their own calendar and share with named people or groups instead.
       audit: |
         ### Audit via Admin Console
 
@@ -682,19 +682,19 @@ queries:
     mql: googleworkspace.users.none(ipWhitelisted == true)
     docs:
       desc: |
-        This check ensures that no user in the Google Workspace organization has the deprecated IP whitelisting setting enabled. The `ipWhitelisted` flag is a legacy setting that exempts users from IP-based access controls and weakens the organization's security posture.
+        This check verifies that no account carries the deprecated per-user IP exemption.
+
+        The `ipWhitelisted` flag is a legacy property on a Google Workspace user that exempts that account from network-based access enforcement. The Admin console does not display it anywhere, so it can neither be found nor cleared from the interface; both jobs run through the Admin SDK Directory API. This check reads the flag on every user and requires it to be false throughout.
 
         **Why this matters**
 
-        - **Security bypass:** IP-whitelisted users can skip network-based access restrictions such as context-aware access policies.
-        - **Deprecated control:** Google has deprecated this setting in favor of context-aware access, which provides more granular and secure controls.
-        - **Inconsistent enforcement:** Exempted users are not subject to the same access policies as everyone else, creating gaps in security coverage.
-        - **Audit blind spots:** Exempted users may access resources from untrusted networks without triggering security alerts.
+        An exemption nobody can see is worse than a missing control, because the organization believes the control is uniform. The access policy on the dashboard says one thing, and a handful of accounts quietly do not obey it.
 
-        **Risk mitigation**
+        Those accounts are the ones an attacker wants. Whatever network conditions your other controls place on a sign-in, an exempt account is not evaluated against them, so a stolen password works from a residential connection in another country exactly as it would from a corporate office. The sign-in does not trip the location rule that was supposed to catch it, and there is no console page an administrator can open to discover why.
 
-        - **Compliance alignment:** Removing the exemption satisfies frameworks that require uniform access policy enforcement.
-        - **Modern access controls:** Migrating affected users to context-aware access policies restores consistent, granular enforcement.
+        The flag survives ordinary hygiene. Password resets, role changes, and organizational unit moves do not clear it, so an exemption granted for a contractor's connectivity problem in 2019 is still exempting whoever holds that account today.
+
+        Clear the flag on each affected account through the Directory API. If the account genuinely needed a network exemption, configure context-aware access policies instead, which express the same intent as a reviewable policy that names the device and network conditions rather than as an invisible per-user override.
       audit: |
         ### Audit via Admin Console
 
@@ -762,19 +762,19 @@ queries:
     mql: googleworkspace.users.where(isAdmin == true).none(isGuestUser == true)
     docs:
       desc: |
-        This check ensures that no guest user account is granted administrative privileges in the Google Workspace organization. Guest accounts are not subject to the same identity vetting and lifecycle management as full organizational accounts, so granting them admin rights is a significant risk.
+        This check verifies that no administrative role is held by a guest account.
+
+        A guest in Google Workspace is an identity that exists in the directory without being a full member of the organization, typically created for an external collaborator. Full accounts are governed by the organizational unit they sit in, which is what applies your authentication requirements, session policy, and offboarding. This check takes every account with an admin role, visible under **Directory > Users** in the Admin console, and requires none of them to be a guest.
 
         **Why this matters**
 
-        - **Reduced accountability:** Guest accounts may not follow the same identity verification and lifecycle management as regular organizational accounts.
-        - **Weaker authentication:** Guest users may not be subject to the same authentication policies, MFA requirements, or conditional access controls as full members.
-        - **Audit trail gaps:** Actions performed by guest admin accounts can be harder to attribute to a specific individual during incident investigations.
-        - **Privilege escalation risk:** Guest accounts with admin rights can modify security settings, access sensitive data, and manage other user accounts.
+        An administrative role assumes an identity your organization vetted, provisioned, and can retire. A guest account satisfies none of those assumptions. It was created because somebody outside needed access to something, its lifecycle belongs to whoever set it up rather than to your joiner and leaver process, and it is not covered by the policies you scope to organizational units.
 
-        **Risk mitigation**
+        That combination is the attack. The guest identity sits outside your 2-step verification enforcement and your context-aware access rules, so it is the softest credential in the directory, and it holds a role that can change other people's settings, reset passwords, and read data across the organization. An attacker who takes it does not need to escalate, because the escalation was already granted.
 
-        - **Compliance alignment:** Limiting admin rights to vetted organizational members satisfies frameworks that restrict privileged access to identified individuals.
-        - **Controlled administration:** Requiring administrators to use full organizational accounts brings their access under standard authentication and lifecycle controls.
+        The account is also durable in the wrong way. When the collaboration ends, the contractor's engagement closes and their own employer offboards them, but the guest account in your directory keeps its role, since no process on either side owns it.
+
+        If the person genuinely needs administrative access, create a full organizational account for them so the access inherits your authentication and lifecycle controls, and assign the narrowest delegated role that covers the work rather than reusing the guest identity.
       audit: |
         ### Audit via Admin Console
 
@@ -833,19 +833,19 @@ queries:
     mql: googleworkspace.users.where(isAdmin == true).all(isEnrolledIn2Sv == true)
     docs:
       desc: |
-        This check ensures that every administrator account has completed 2-step verification enrollment, not merely that enforcement is turned on at the organizational level. Enforcement sets the policy, but an admin in a grace period or mid-setup may still be protected only by a password.
+        This check verifies that every administrator has actually finished enrolling in 2-step verification, not merely that the policy requires it.
+
+        Enforcement and enrollment are separate states in Google Workspace. Turning enforcement on under **Security > Authentication > 2-step verification** sets the requirement, while enrollment is the user registering a factor. Google offers an enrollment grace period for new accounts, and an account inside that window signs in with a password alone despite the policy. This check reads the enrollment status of each account holding an admin role and requires it to be complete.
 
         **Why this matters**
 
-        - **Grace period exposure:** When 2-step verification enforcement is first enabled, admins often get a grace period to enroll, during which their accounts rely on passwords alone.
-        - **Incomplete rollout:** Newly created admin accounts may not have completed enrollment even when enforcement is active.
-        - **High-value targets:** Admin accounts are priority targets, so any window without an active second factor is a window of vulnerability.
-        - **Compliance gap:** Security frameworks require MFA to be actively in use, not just configured as a policy.
+        A policy that has not taken effect on an account provides that account no protection, and the dashboard does not distinguish the two. An organization can report full enforcement while several administrators are still password-only, and the gap sits exactly where it matters most.
 
-        **Risk mitigation**
+        New administrator accounts are the common case. One is created for a person joining the platform team, the enrollment period gives them a week to register a factor, and during that week the account already holds the role. If the account's initial password was delivered over a channel that leaked, or matches a pattern an attacker guesses, the second factor that would have stopped the sign-in has not been registered yet.
 
-        - **Closed takeover window:** Confirming completed enrollment removes the exposure that lets an admin account fall to a password-only attack.
-        - **Verified second factor:** Checking enrollment status, not just policy, ensures every admin is actively using a second factor.
+        An attacker with the password of an unenrolled administrator gets in, and the first thing they do is register a factor of their own, which converts a temporary window into durable access that now looks compliant.
+
+        Verify enrollment rather than policy. Reduce or remove the grace period so new admin accounts cannot linger unenrolled, contact anyone still outstanding, and consider withholding the role until enrollment is complete so the privilege and the second factor arrive together.
       audit: |
         ### Audit via Admin Console
 
@@ -906,19 +906,19 @@ queries:
     mql: googleworkspace.users.where(isAdmin == true).none(changePasswordAtNextLogin == true)
     docs:
       desc: |
-        This check ensures that no administrator account has the change password at next login flag set, which indicates a forced password change that has not yet been completed. A pending reset leaves the account in an unresolved security state.
+        This check verifies that no administrator account is sitting on a password change that was demanded and never completed.
+
+        When an administrator forces a reset on an account, Google flags it to change its password at next sign-in and leaves the current password working until that sign-in happens. The Admin console does not display the pending state, so it is read through the Admin SDK Directory API. This check requires no account holding an admin role to carry the flag.
 
         **Why this matters**
 
-        - **Compromised credential exposure:** A forced password change is often triggered because the current password may be compromised, and the account stays at risk until the change is completed.
-        - **Stale resets:** Reset flags that persist for a long time indicate that the administrator is not actively using or monitoring the account.
-        - **Account takeover window:** An attacker who knows the current password can sign in before the legitimate admin completes the change.
-        - **Incident response gap:** Admin accounts with pending resets may not be immediately usable for emergency response actions.
+        The flag is usually set for a reason, and the most common reason is a suspicion that the current password is known to somebody else. Until the account signs in, that suspect password is still valid. An attacker who already has it does not care that a change is pending; they authenticate with the old credential, and if they get there before the legitimate administrator does, they complete the change themselves and set a password only they know. The forced reset then becomes the mechanism by which the real owner loses the account.
 
-        **Risk mitigation**
+        A flag that stays pending for weeks says something else as well: nobody is signing in to that account. An administrator account that goes unused for that long is one that no one is watching, which is the profile of an account that was created for a project, granted a role, and never retired.
 
-        - **Prompt remediation:** Completing pending resets quickly satisfies frameworks that require credential changes to be finished without delay.
-        - **Account hygiene:** Investigating long-pending resets surfaces stale or abandoned admin accounts that should be removed or suspended.
+        There is also an availability edge. An account in this state cannot be used cleanly for emergency response, which matters when the accounts that hold administrative roles are the ones the response depends on.
+
+        Have each affected administrator complete the change immediately, remove the role or suspend the account if it is no longer needed, and look into why the reset was triggered by reviewing the sign-in events under **Reporting > Audit and investigation** for signs the account was already compromised.
       audit: |
         ### Audit via Admin Console
 

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -118,20 +118,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that Microsoft Entra ID Protection is configured to detect and respond to risky sign-in events in real time and offline. By default, no sign-in risk Conditional Access policy is created, leaving the tenant dependent on after-the-fact log review to spot suspicious authentication activity.
+        This check verifies that the tenant acts automatically on sign-ins Microsoft Entra ID Protection scores as risky.
+
+        Entra ID Protection scores each authentication attempt using signals such as an anonymized IP address, impossible travel between two locations, a device previously linked to malware, and sign-in properties unfamiliar for that account. The score does nothing on its own. Turning it into enforcement takes a Conditional Access policy, created in the Microsoft Entra admin center under **Protection > Conditional Access > Policies**, with **Conditions > Sign-in risk** set to the high and medium levels and **Grant** requiring multifactor authentication. This check requires such a policy to exist and to be on rather than in report-only or off state. Where the tenant is provisioned as code, the same policy appears as a conditional access policy resource in the Terraform or Bicep definition.
 
         **Why this matters**
 
-        - **Real-time threat response:** Sign-in risk policies trigger MFA or block access the moment a suspicious pattern is detected, stopping attackers before they establish a session.
-        - **Coverage of novel attack vectors:** Risk signals include anonymous IP addresses, atypical travel, malware-linked IPs, and unfamiliar sign-in properties, providing protection beyond simple password checks.
-        - **Reduced dwell time:** Automated policy enforcement closes the window between credential compromise and unauthorized access far faster than manual investigation.
-        - **Defense in depth:** Layering risk-based access controls on top of MFA means that even a successfully phished second factor is not enough to complete a high-risk sign-in.
+        Without the policy the risk signal becomes a report somebody reads the next morning. The attacker who triggered it has been inside for hours.
 
-        **Risk mitigation**
+        The sequence is routine. A password recovered from an unrelated breach is replayed from a hosting provider through an anonymizing proxy, minutes after the real employee signed in from their office. Entra rates the attempt high risk and issues the session anyway, because nothing was configured to stop it. The attacker opens Outlook on the web, searches the mailbox for the word invoice, sets a mailbox rule that files their own messages away from the owner's view, and starts a conversation with the finance team.
 
-        - **Account takeover:** Requiring MFA or blocking access on medium and high sign-in risk stops stolen credentials from granting immediate entry.
-        - **Lateral movement:** Blocking suspicious sign-ins prevents attackers from pivoting across services and escalating privileges once inside the tenant.
-        - **Data exfiltration:** Cutting off a session at the sign-in stage limits the attacker's ability to reach sensitive data, even when credentials are already compromised.
+        With the policy in place, that same attempt has to satisfy a multifactor prompt on a device the attacker does not hold, so it fails at the point of sign-in rather than at the point of discovery.
+
+        Exclude at least one emergency access account from the policy before you enable it, and consider running it in report-only mode first to see who would have been challenged, but understand that report-only mode enforces nothing.
       audit: |
         ### Audit via Console
 
@@ -331,20 +330,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that Microsoft Entra ID Protection is configured with a Conditional Access policy that acts automatically when user risk reaches a high level. By default, no user-risk policy is created, so accounts flagged as likely compromised continue to operate without interruption unless an administrator manually investigates the alert.
+        This check verifies that the tenant acts automatically when Microsoft Entra ID Protection concludes an identity itself is compromised.
+
+        User risk is a judgment about the account rather than about one sign-in. It rises when Microsoft finds the account's credentials in a leaked credential dump, when Microsoft threat intelligence links the identity to known attacker activity, or when a pattern of behavior over time indicates compromise. Acting on it requires a Conditional Access policy, created in the Microsoft Entra admin center under **Protection > Conditional Access > Policies**, with **Conditions > User risk** set to high and **Grant** requiring both multifactor authentication and a password change. This check requires such a policy to exist and be enabled. Provisioned as code, it is the same conditional access policy resource with a user risk condition.
 
         **Why this matters**
 
-        - **Automated remediation:** A user-risk policy forces a password change or blocks access the moment Entra ID Protection classifies an account as high risk, reducing attacker dwell time.
-        - **Coverage of credential leak signals:** User risk aggregates intelligence from leaked credential databases, anomalous behavior patterns, and dark-web feeds, detecting compromise that password-based controls alone would miss.
-        - **Privileged account protection:** Compromised accounts with elevated permissions can cause outsized damage; automatic risk-based blocking limits the blast radius before manual review completes.
-        - **Reduced incident response burden:** Automated policy enforcement reduces the volume of manual remediation tasks that security teams must handle after a credential compromise event.
+        A high user risk score means Microsoft has concrete evidence the password is in somebody else's hands. Without a policy, that evidence produces a dashboard entry and nothing else, and the compromised credential keeps working until an analyst notices and acts manually. In practice that window is measured in days, and often nobody looks at all.
 
-        **Risk mitigation**
+        The attacker does not wait. The leaked password that raised the score is the one they are already using, and the account continues serving mail, Teams history, and SharePoint content to them throughout.
 
-        - **Credential compromise:** Requiring a password change on high user risk invalidates stolen credentials and forces re-authentication with a fresh secret before the attacker can act.
-        - **Lateral movement:** Blocking high-risk accounts prevents attackers from pivoting to other services and escalating privileges within the tenant.
-        - **Data exfiltration:** Cutting access at the identity layer stops an attacker from reaching sensitive data even when they already hold valid credentials.
+        A user risk policy closes that gap without a human in the loop. The account is forced through a password change backed by a second factor at its next authentication, which invalidates the credential the attacker holds and requires them to defeat a factor they do not have to regain anything.
+
+        Exclude an emergency access account so a false positive on the wrong identity cannot lock every administrator out of the tenant, and pair this with a sign-in risk policy, since the two cover different signals and a companion check in this policy tracks the other one.
       audit: |
         ### Audit via Console
 
@@ -544,19 +542,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that a Conditional Access policy is in place to block legacy authentication client types, including Exchange ActiveSync clients and other legacy protocols such as POP and IMAP. By default, Microsoft 365 tenants permit these older protocols, which cannot enforce multifactor authentication and are routinely targeted in credential-stuffing and password-spray campaigns.
+        This check verifies that authentication protocols incapable of multifactor authentication are blocked outright.
+
+        Legacy authentication covers Exchange ActiveSync and the older mail clients grouped as other clients, which includes POP, IMAP, and SMTP AUTH. Microsoft 365 accepts these protocols by default, and they predate modern authentication and cannot present an interactive second factor, so a sign-in over them completes on a password alone regardless of what the tenant requires elsewhere. You block them with a Conditional Access policy in the Microsoft Entra admin center under **Protection > Conditional Access > Policies**, setting **Conditions > Client apps** to those legacy client types and **Grant** to block access. This check requires such a policy to be enabled rather than report-only or off. In infrastructure code it is the same conditional access policy resource with a blocking grant control.
 
         **Why this matters**
 
-        - **MFA bypass prevention:** Legacy authentication protocols bypass Conditional Access MFA requirements entirely, meaning an attacker with a valid password can authenticate without a second factor.
-        - **Reduced credential-stuffing exposure:** Blocking these protocols eliminates the most common automated attack surface used to test large volumes of stolen credentials against Exchange and other Microsoft services.
-        - **Smaller attack surface:** Disabling client app types that the organization does not need removes an entire class of authentication pathways that cannot be made more secure without replacing the protocol.
-        - **Enforcement consistency:** A Conditional Access block policy applies uniformly across all users, preventing individual exemptions that could leave gaps in coverage.
+        Legacy endpoints are where password spraying goes, precisely because they answer with a yes or a no and nothing else. An attacker takes a list of your employees' addresses, which is largely derivable from your website and public profiles, tries one common seasonal password against all of them, and waits before the next attempt so no single account locks out. Every hit is a working session, and the multifactor policy the tenant is proud of never enters the conversation.
 
-        **Risk mitigation**
+        The mailbox is the objective and it is reached directly. The attacker synchronizes mail over IMAP, which is quiet, produces no browser session, and copies the entire mailbox at once rather than page by page.
 
-        - **Account compromise:** Attackers lose the ability to authenticate to Exchange ActiveSync and IMAP endpoints using stolen passwords alone, since those endpoints can no longer complete a sign-in.
-        - **Compliance posture:** Blocking legacy authentication satisfies explicit requirements in frameworks that mandate strong authentication, closing the gap created by MFA-incapable protocols.
+        Blocking the client types removes the whole class of attack rather than raising its cost, because there is no supported way to add a second factor to these protocols.
+
+        Exclude an emergency access account, and inventory what still uses these protocols before you enable the policy, since multifunction printers, scan-to-email devices, and older line-of-business applications commonly authenticate this way and will stop working.
       audit: |
         ### Audit via Console
 
@@ -739,19 +737,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that a Conditional Access policy is in place requiring multifactor authentication for all users assigned to privileged directory roles in the Microsoft 365 tenant. By default, no such policy is created, leaving administrative accounts protected only by a password and making them prime targets for credential-based attacks.
+        This check verifies that holding a privileged directory role requires a second factor at sign-in.
+
+        Microsoft 365 creates no such requirement on its own. It is a Conditional Access policy, built in the Microsoft Entra admin center under **Protection > Conditional Access > Policies**, with the **Users** assignment targeting directory roles rather than individuals and **Grant** set to require multifactor authentication. Scoping by role rather than by name is the important part, because the policy then covers whoever holds the role next. This check requires an enabled policy of that shape. Provisioned as code, it is a conditional access policy resource whose user condition names the administrative role template identifiers.
 
         **Why this matters**
 
-        - **Privileged account protection:** Administrative roles carry permissions that can modify tenant configuration, access all user data, and grant additional privileges, so a single compromised admin account can lead to full tenant takeover.
-        - **Phishing resistance:** MFA forces an attacker who has stolen an admin password to also defeat a second factor, significantly raising the cost of a successful attack.
-        - **Blast radius reduction:** Even when credentials are phished, MFA prevents the attacker from completing the sign-in and stops the compromise from escalating beyond the initial credential theft.
-        - **Regulatory alignment:** MFA for privileged users is an explicit requirement in multiple security frameworks, and a Conditional Access policy provides auditable proof of enforcement.
+        An administrative account is not a bigger version of a user account, it is a different object. A Global Administrator can read any mailbox by granting itself access, reset any password, add a federated identity provider that mints tokens for any user, and register an application with permissions over the whole tenant. Compromise of one is compromise of everything, and there is no containment step afterwards.
 
-        **Risk mitigation**
+        Attackers know which accounts these are, because directory role membership is readable by anyone signed in to the tenant. The path is a targeted phishing message to an administrator, a password, and nothing else in the way. Once inside they create a second privileged identity of their own so that resetting the original password changes nothing.
 
-        - **Credential compromise:** Requiring a second factor for every administrative sign-in means that stolen passwords alone cannot be used to access the tenant's highest-privilege accounts.
-        - **Insider threat containment:** MFA creates an additional verification step that limits the window during which a disgruntled or inattentive administrator can perform unauthorized actions with a shared or reused credential.
+        Requiring a second factor means the stolen password stops being sufficient. The attacker has to defeat a device or a key in the administrator's possession, which is a materially harder problem than sending a convincing email.
+
+        Cover the roles that can grant privilege or read data rather than only Global Administrator, exclude at least one emergency access account so a failed rollout cannot lock every administrator out, and start in report-only mode long enough to confirm in the sign-in logs that nobody legitimate would be blocked.
       audit: |
         ### Audit via Console
 
@@ -996,19 +994,19 @@ queries:
           mondoo.com/filter-icon: bicep
     docs:
       desc: |
-        This check ensures that a Conditional Access policy is in place requiring multifactor authentication for every user in the Microsoft 365 tenant, not just administrators. By default, no tenant-wide MFA policy exists, so non-privileged user accounts are protected only by a password and are frequently targeted in credential-stuffing and phishing campaigns.
+        This check verifies that every account in the tenant, not only the administrators, must present a second factor.
+
+        The control is a Conditional Access policy created in the Microsoft Entra admin center under **Protection > Conditional Access > Policies**, with the **Users** assignment set to all users and **Grant** set to require multifactor authentication. A Microsoft 365 tenant with no such policy leaves ordinary accounts protected by a password alone. This check requires the policy to exist and be enabled. Declared as code, it is a conditional access policy resource including all users with a multifactor grant control.
 
         **Why this matters**
 
-        - **Broad attack surface reduction:** Non-administrative accounts far outnumber privileged accounts, and compromising any of them provides an attacker with initial access and data exposure even without elevated privileges.
-        - **Phishing resistance at scale:** Requiring a second factor for all users means that a successful phishing campaign that harvests passwords still cannot result in account access.
-        - **Data protection:** Even accounts with limited permissions can access sensitive files, emails, and collaboration content; MFA closes the gap between credential theft and data exfiltration.
-        - **Uniform policy enforcement:** A single Conditional Access policy covering all users eliminates ad-hoc exceptions and ensures consistent authentication requirements across the tenant.
+        Administrators are a handful of accounts that people watch. Everyone else is thousands of accounts that nobody watches, and an attacker only has to succeed against one of them.
 
-        **Risk mitigation**
+        The value in an ordinary mailbox is routinely underestimated. It holds the password reset messages for every other system the person uses, the customer contracts they negotiated, the spreadsheets finance sends around, and the internal threads that make a follow-up message from that person entirely believable. Taking one non-privileged account gives an attacker a trusted identity inside the organization, which is the ideal position from which to phish the accounts that do have privilege. Business email compromise almost always starts here rather than at the top.
 
-        - **Credential-stuffing attacks:** Blocking sign-ins that lack a second factor prevents automated tools from using lists of breached passwords to access any account in the tenant.
-        - **Lateral movement:** An attacker who compromises a low-privilege account cannot easily pivot to additional accounts or services because each authentication attempt requires a fresh MFA approval.
+        A password reaches the attacker through reuse or a convincing sign-in page, and with no second factor that is the end of the story. With one, the harvested password is worth nothing on its own.
+
+        Enforcing tenant-wide blocks sign-in for anyone who has not registered a method, so confirm registration coverage and communicate the change before turning the policy on, exclude at least one emergency access account, and use report-only mode first to find the service accounts and shared mailboxes that will need a different approach.
       audit: |
         ### Audit via Console
 
@@ -1174,19 +1172,17 @@ queries:
       microsoft.policies.identitySecurityDefaultsEnforcementPolicy.isEnabled == false
     docs:
       desc: |
-        This check ensures that Microsoft Entra ID Security Defaults are disabled, allowing the organization to enforce access controls through custom Conditional Access policies instead. Security Defaults are enabled by default in new tenants and provide a baseline level of protection, but they prevent organizations from configuring the more granular, risk-based, and role-scoped policies required by mature security programs.
+        This check verifies that the tenant has moved off the Microsoft-managed baseline and onto its own explicit access policies.
+
+        Security defaults is a single on or off switch in the Microsoft Entra admin center under **Identity > Overview > Properties > Manage security defaults**. It applies a fixed set of protections to everybody and cannot be scoped, tuned, or excepted. Critically, it is mutually exclusive with Conditional Access: while security defaults is on, the tenant cannot use Conditional Access policies at all. This check requires it to be disabled, which is what makes the policies the rest of this bundle looks for possible.
 
         **Why this matters**
 
-        - **Policy granularity:** Security Defaults apply a single fixed set of controls across the entire tenant and cannot be scoped by user, group, application, or risk level, making them unsuitable for organizations with differentiated access requirements.
-        - **Legacy authentication blocking:** Security Defaults block some legacy protocols, but a custom Conditional Access policy provides explicit, auditable enforcement with per-client-app-type granularity that satisfies compliance evidence requirements.
-        - **Risk-based access control:** Custom Conditional Access policies can integrate Entra ID Protection sign-in risk and user risk signals, which Security Defaults do not support.
-        - **Break-glass account support:** Custom policies allow explicit exclusions for emergency access accounts, whereas Security Defaults offer no such override mechanism.
+        The gap security defaults leaves is not weak protection, it is inflexibility that forces bad choices. It has no exclusion mechanism, so there is no way to keep an emergency access account outside the multifactor requirement, and a tenant that loses access to its authentication methods has no way back in. It cannot condition access on sign-in risk or user risk, so the Entra ID Protection signals that identify a compromised credential cannot be acted on automatically. It cannot distinguish an administrator from a contractor, or a managed device from an unmanaged one.
 
-        **Risk mitigation**
+        The result in practice is that organizations needing any of that turn security defaults off and then do not replace it, leaving a window with neither the baseline nor its successor. That window is where an attacker with a phished password walks in unchallenged.
 
-        - **Configuration drift:** Replacing Security Defaults with explicit Conditional Access policies makes the organization's authentication requirements visible, versioned, and auditable rather than relying on an opaque Microsoft-managed baseline.
-        - **Compliance gap:** Several frameworks require evidence of specific, documented authentication controls; a named Conditional Access policy provides that evidence in a way that a vendor-managed default cannot.
+        Disabling this is only correct as part of a migration, not on its own. Do not turn it off until the Conditional Access policies that replace it are built and enabled, including a tenant-wide multifactor requirement and a policy blocking legacy authentication, which companion checks in this policy verify. A small tenant without the licensing for Conditional Access is better served by leaving security defaults on and accepting this finding than by disabling it and enforcing nothing.
       audit: |
         ### Audit via Console
 
@@ -1268,20 +1264,19 @@ queries:
       microsoft.roles.where(displayName == "Global Administrator").all(assignments.length.inRange(2,4))
     docs:
       desc: |
-        This check ensures that the Global Administrator role is assigned to between two and four accounts. By default Microsoft 365 imposes no upper or lower bound on Global Administrator assignments, so tenants frequently end up either with a single point of failure or with an excessively large group of unrestricted privileged accounts.
+        This check verifies that the Global Administrator role is held by a small named group, between two and four accounts.
+
+        Global Administrator is the unrestricted role in Microsoft 365. Microsoft imposes no upper or lower bound on how many accounts hold it, so the count drifts in both directions. You review the assignments in the Microsoft Entra admin center under **Identity > Roles & admins > Roles**, and change them there or from the Microsoft 365 admin center under **Users > Active Users** using **Manage roles**. This check requires the number of assignments to fall between two and four.
 
         **Why this matters**
 
-        - **Redundancy:** At least two Global Administrators ensure that critical administrative tasks can continue if one account is unavailable, locked, or compromised.
-        - **Blast-radius control:** Capping assignments at four limits how many accounts can perform tenant-wide destructive actions, reducing the damage a compromised credential can cause.
-        - **Auditability:** A small, bounded set of privileged accounts is easier to monitor, review, and audit than an unbounded list.
-        - **Separation from operational accounts:** Keeping the count low encourages administrators to use role-specific, least-privilege roles for everyday tasks instead of relying on Global Administrator for convenience.
+        Every Global Administrator is a complete path to the tenant, and an attacker needs only the weakest one. Where the role has been handed out for convenience, the weakest is usually someone who does not think of themselves as an administrator: the person granted it years ago to install one application, who signs in from a personal device and has never been the subject of a security conversation.
 
-        **Risk mitigation**
+        What that access yields is total. Read any mailbox through granted access, reset any password, add an identity provider that issues tokens for any user, consent an application to tenant-wide permissions. The attacker's first move is usually to establish a second privileged identity of their own, so that discovering and resetting the original account does not evict them.
 
-        - **Credential compromise:** Fewer Global Administrator accounts reduce the number of high-value targets an attacker can pursue through phishing or credential stuffing.
-        - **Insider threat:** Limiting the role to a small named set of individuals makes unauthorized privilege escalation more visible during periodic access reviews.
-        - **Availability:** Requiring at least two assignments prevents a single account lockout or departure from blocking emergency administrative access to the tenant.
+        The lower bound guards a different failure. A single Global Administrator means one lockout, one departure, or one compromise leaves nobody able to suspend accounts, revoke tokens, or run an investigation during the incident that just started.
+
+        Move day-to-day work to least-privilege roles such as Exchange Administrator or User Administrator rather than leaving people at the top, and pair the small standing group with just-in-time activation, which a companion check in this policy verifies.
       audit: |
         ### Audit via Console
 
@@ -1414,18 +1409,19 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where(platformType == "android").all(settings.storageRequireDeviceEncryption == true)
     docs:
       desc: |
-        This check ensures that Android device configuration profiles in Microsoft Intune are configured to require storage encryption. By default Intune does not enforce device encryption in newly created Android profiles, so organizations must explicitly set `storageRequireDeviceEncryption` to require it.
+        This check verifies that managed Android devices are required to encrypt their storage.
+
+        The requirement is expressed in a device configuration profile in the Microsoft Intune admin center under **Devices > Configuration**, where a device restrictions profile for the Android platform carries the `storageRequireDeviceEncryption` setting. Intune does not turn it on in a newly created profile, so it has to be set deliberately and the profile assigned to the device groups that need it. This check requires every Android device configuration profile to require storage encryption.
 
         **Why this matters**
 
-        - **Data protection at rest:** Encryption renders the data stored on a device unreadable without the correct decryption key, protecting it if the device is lost or stolen.
-        - **Breach containment:** An encrypted device limits an attacker's ability to extract sensitive corporate data even after gaining physical access.
-        - **Compliance readiness:** Many regulatory frameworks require encryption of data on mobile endpoints, and an explicit Intune policy provides auditable evidence of enforcement.
+        A managed phone holds a working copy of corporate data rather than a link to it. Cached mail going back weeks, attachments opened in Outlook, files synced from OneDrive and SharePoint, Teams message history, and the tokens that authenticate all of it without asking for a password again.
 
-        **Risk mitigation**
+        Unencrypted, that copy survives the lock screen. A phone left in a taxi or lifted at a conference is not attacked through its interface; the storage is read directly, either by attaching the device to a computer in a diagnostic mode or by removing the flash storage entirely. The lock screen never participates. The attacker gets the mailbox contents and, more usefully, the refresh tokens, which let them continue authenticating as that user from their own machine until the tokens are revoked, long after the phone is written off as lost.
 
-        - **Lost or stolen devices:** Without encryption a lost Android device exposes all locally cached email, files, and credentials to anyone who finds it.
-        - **Unauthorized physical access:** Encryption prevents data extraction through direct device access methods such as connecting to a computer or removing storage media.
+        Encryption ties the data to a key the lock credential releases, so the same physical access yields nothing readable.
+
+        Android Enterprise work profile and fully managed enrollments enforce storage encryption on their own, so provisioning through Android Enterprise satisfies the requirement without a separate setting. The legacy Android device administrator path is deprecated and winding down in Intune, so treat any remaining profiles there as a migration task rather than a place to add new configuration.
       audit: |
         ### Audit via Console
 
@@ -1536,18 +1532,19 @@ queries:
       microsoft.devicemanagement.deviceConfigurations.where(platformType == "androidWorkProfile").all(settings.passwordMinimumLength >= 8)
     docs:
       desc: |
-        This check ensures that Microsoft Intune device configuration profiles are configured to require a minimum password or passcode length of at least eight characters across all managed device platforms. By default Intune does not enforce a minimum length in newly created profiles, leaving it up to the device default or the user's choice.
+        This check verifies that managed devices require a device password or passcode of at least 8 characters.
+
+        The requirement is set per platform in a device restrictions profile in the Microsoft Intune admin center under **Devices > Configuration**, in the password section. This check reads the configured minimum for Windows 10 and later, macOS, iOS, Android, and Android Enterprise work profile devices, and requires every profile to enforce at least 8. On iOS and iPadOS the field is named minimum passcode length rather than password length. Intune leaves the value unset in a new profile, which means the device default or whatever the user chooses.
 
         **Why this matters**
 
-        - **Brute-force resistance:** Longer passwords expand the search space an attacker must exhaust, making automated guessing attacks substantially more expensive.
-        - **Alignment with security standards:** NIST SP 800-63B recommends a minimum of eight characters for memorized secrets, and enforcing this through MDM policy provides consistent coverage across Windows, macOS, iOS, and Android devices.
-        - **Consistent enforcement:** Centrally managed password-length requirements through Intune remove reliance on users to choose adequately long passwords on their own.
+        The device credential is the only thing between someone holding the hardware and the data on it, because it is also what releases the storage encryption key. A four-digit PIN gives ten thousand possibilities, which is not a search space, it is a short wait. Somebody who takes the phone from a hotel room can exhaust it, and shoulder-surfing or a smudge pattern narrows it further before they start.
 
-        **Risk mitigation**
+        What is behind the credential is the whole point. Cached mail and attachments, files synced from OneDrive and SharePoint, Teams history, saved credentials in the browser, and the refresh tokens that let the attacker keep authenticating as that user from their own equipment after the device itself is wiped and forgotten.
 
-        - **Unauthorized device access:** A minimum eight-character password significantly reduces the likelihood of a successful brute-force or opportunistic login on a lost or unattended device.
-        - **Credential reuse:** Requiring a meaningful minimum length discourages the use of trivially guessable PINs or short passwords that users might reuse across personal and corporate accounts.
+        Eight characters is a floor rather than a target. It is the length below which offline and opportunistic guessing stops being meaningfully constrained, and it is the length recommended by current federal password guidance for memorized secrets.
+
+        Set the value on every platform your organization manages rather than only the dominant one, since an unset profile leaves the choice to the user, and pair the length requirement with storage encryption, which a companion check in this policy verifies for Android.
       audit: |
         ### Audit via Console
 
@@ -1683,19 +1680,19 @@ queries:
       microsoft.domains.all(passwordValidityPeriodInDays == 2147483647)
     docs:
       desc: |
-        This check ensures that all Microsoft 365 domains are configured so that user passwords never expire, reflected by a `passwordValidityPeriodInDays` value of `2147483647`. By default Microsoft 365 sets passwords to expire after 90 days, a practice that modern security research has shown to weaken rather than strengthen credential hygiene.
+        This check verifies that user passwords are not forced to rotate on a schedule.
+
+        The setting lives in the Microsoft 365 admin center under **Settings > Org settings > Security & privacy > Password expiration policy**, where selecting the never expire option is what this check requires. Microsoft records it per domain as a `passwordValidityPeriodInDays` value of `2147483647`, the sentinel meaning no expiry. Tenants that have not changed it may still carry the older default of 90 days.
 
         **Why this matters**
 
-        - **Eliminates predictable rotation patterns:** Users forced to change passwords on a fixed schedule frequently make minor, predictable modifications to their existing passwords, which attackers exploit using password-spraying techniques that account for common incremental changes.
-        - **Encourages strong initial choices:** When users know a password is permanent, they are more motivated to choose a long, unique, randomly generated credential and store it in a password manager rather than selecting something easily memorable and therefore guessable.
-        - **Aligns with current NIST guidance:** NIST SP 800-63B explicitly recommends against periodic password rotation except after a confirmed compromise, and Microsoft's own security baselines reflect this shift.
-        - **Complements MFA:** Organizations that enforce multi-factor authentication gain a second layer of protection that makes the age of a password largely irrelevant to its security, making forced rotation an unnecessary burden.
+        Forced rotation degrades the passwords it is meant to refresh. People do not generate a new secret every quarter; they increment the one they have. Autumn2024! becomes Winter2025!, and the pattern is so consistent that password-spray tooling derives the next season's guesses directly from a leaked earlier password. An attacker holding one historical credential for your organization can often produce the current one without guessing blindly.
 
-        **Risk mitigation**
+        Rotation also pushes users away from the practices that actually help. A password that must be memorized and retyped every ninety days will not be a long random string from a password manager; it will be short, meaningful, and reused. And because staff are trained to expect periodic reset prompts, a phishing message that presents one is unremarkable.
 
-        - **Phishing and credential stuffing:** Removing rotation pressure leads users to adopt longer, unique passwords that are far harder to guess or reuse across breached credential databases.
-        - **Help-desk and user friction:** Eliminating expiration-driven password resets reduces support load and the social-engineering opportunities that arise when users are trained to expect reset prompts.
+        Removing expiry only helps if the password is not the sole defense. Current guidance from the national standards bodies and from Microsoft's own baselines is to drop scheduled rotation and rely on strong unique credentials, a second factor, and a reset triggered by evidence of compromise instead of by the calendar.
+
+        Confirm multifactor authentication is enforced for all users, which a companion check in this policy verifies, and turn on Microsoft Entra Password Protection to block weak and previously breached passwords before you remove expiry. Without those, a compromised password stays valid indefinitely.
       audit: |
         ### Audit via Console
 
@@ -1787,18 +1784,19 @@ queries:
       microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).spf != empty)
     docs:
       desc: |
-        This check ensures that every Exchange Online domain has a published SPF (Sender Policy Framework) TXT record that explicitly authorizes Microsoft's mail servers. By default no SPF record is created automatically when a domain is added to Microsoft 365; it must be published manually at the DNS provider.
+        This check verifies that every custom domain in the tenant publishes an SPF record naming the servers allowed to send as it.
+
+        Sender Policy Framework is a TXT record in the domain's own DNS zone listing authorized sending sources. For a domain that sends only through Exchange Online the record is `v=spf1 include:spf.protection.outlook.com -all`, and other sending systems are added as further include terms. Adding a domain to Microsoft 365 does not create it; it has to be published at your DNS provider. This check requires an SPF record on every verified domain other than the tenant's own onmicrosoft.com domain.
 
         **Why this matters**
 
-        - **Anti-spoofing protection:** SPF lets receiving mail servers confirm that inbound messages claiming to be from your domain actually originate from a server you have authorized, blocking the most common form of sender impersonation.
-        - **Phishing defense:** Without an SPF record, attackers can send email that appears to come from your domain's address with no technical barrier, making your brand a convenient cover for phishing campaigns targeting your customers, partners, or employees.
-        - **Deliverability and reputation:** Receiving servers and spam filters use SPF pass or fail results as a strong signal when deciding whether to deliver, quarantine, or reject email, so a missing record can cause legitimate outbound mail to be flagged as suspicious.
+        Without a published record, receiving mail servers have no way to distinguish a message your organization sent from one an attacker composed on a rented server. There is no vulnerability to exploit here. Sending mail claiming to be from your domain is a matter of setting a header field, and the only thing that ever objected was a policy you never published.
 
-        **Risk mitigation**
+        That is the delivery mechanism for the two most costly email attacks. A message that appears to come from your finance team reaches your customer with new bank details for an outstanding invoice. A message that appears to come from your IT team reaches your own staff with a link to a credential-harvesting page. Both arrive with your domain in the sender field, which is the entire reason they work.
 
-        - **Domain impersonation:** A valid SPF record with a hard-fail policy (`-all`) causes receiving servers to reject messages sent from unauthorized sources, directly preventing spoofed email from reaching recipients.
-        - **Cascading email-authentication failures:** SPF is a prerequisite for effective DMARC enforcement; without a passing SPF result, DMARC cannot reliably align and reject spoofed messages, undermining the entire email authentication chain.
+        The record also carries a policy on failure. The `-all` terminator tells receivers to reject mail from sources you did not authorize, where a softer terminator asks them to accept it and make a note.
+
+        Enumerate every system that sends on your behalf before publishing, including marketing platforms, ticketing systems, and application servers, since a record that omits one will cause legitimate mail to be rejected. SPF is also a prerequisite for DMARC enforcement, which a companion check in this policy verifies.
       audit: |
         Verify that every Exchange domain publishes an SPF record by querying its DNS TXT records:
 
@@ -1935,18 +1933,19 @@ queries:
     mql: microsoft.policies.authorizationPolicy.defaultUserRolePermissions.allowedToCreateApps == false
     docs:
       desc: |
-        This check ensures that non-administrator users are blocked from registering third-party applications in Microsoft Entra ID by verifying that the tenant authorization policy sets `allowedToCreateApps` to `false`. By default Microsoft Entra allows any user to register applications, meaning any account in the tenant can grant an external application access to Microsoft 365 data without administrator review or approval.
+        This check verifies that ordinary users cannot register applications in the tenant directory.
+
+        Application registration is governed by the tenant authorization policy, exposed in the Microsoft Entra admin center under **Identity > Users > User settings** as the users can register applications option. Microsoft ships it enabled, so any account in the tenant can create an application identity that reaches Microsoft 365 data. This check requires the setting to be off, recorded on the default user role as `allowedToCreateApps` set to `false`.
 
         **Why this matters**
 
-        - **Supply-chain risk reduction:** Restricting app registration to administrators ensures that every OAuth application connected to the tenant has been reviewed and approved, eliminating the risk of users silently connecting malicious or unvetted third-party tools.
-        - **Data exfiltration prevention:** Third-party applications registered by end users can request broad Microsoft Graph permissions, including access to email, files, and calendar data, without visibility to the security team.
-        - **Attack-surface control:** Each registered application is a potential attack vector; limiting who can create them reduces the number of OAuth tokens in circulation and the scope of any single compromised application.
+        An application registration is a first-class identity in your directory. It can hold its own credentials, be granted Microsoft Graph permissions, and authenticate without a user present, which is exactly the profile of a persistent backdoor. When any of thousands of accounts can create one, the security team has no list of what exists and no review step before something appears.
 
-        **Risk mitigation**
+        For an attacker who has compromised a single ordinary mailbox, this is the step that converts a temporary session into permanent access. They register an application, add a client secret they control, grant it what they can, and from then on authenticate as that application rather than as the user. Resetting the compromised user's password, revoking their sessions, and enforcing a second factor on their account changes nothing, because the attacker no longer needs the account.
 
-        - **OAuth phishing:** Attackers commonly use consent-phishing campaigns that trick users into granting a malicious application persistent access to their mailbox or OneDrive; removing the ability to register apps blocks this technique at its source.
-        - **Unmanaged shadow integrations:** Without enforcement, users can connect personal productivity tools or automation scripts that process corporate data outside the organization's data-governance and DLP policies.
+        The everyday version is quieter and just as damaging. Staff connect productivity tools, automation platforms, and scripts that read mail and files, and corporate data starts flowing to services that were never assessed and are not covered by your data governance or retention obligations.
+
+        Restricting registration to administrators means every application identity in the tenant has been through a review. Pair it with an approval path so people who legitimately need an integration have somewhere to ask, rather than routing around the control.
       audit: |
         ### Audit via Console
 
@@ -2030,20 +2029,19 @@ queries:
       ms365.exchangeonline.dkimSigningConfigs.all(enabled == true)
     docs:
       desc: |
-        This check ensures that Exchange Online is configured to enable DKIM signing for every domain. By default, Microsoft 365 provides a base-level DKIM signature, but custom per-domain signing is not enabled automatically; enabling it adds a cryptographic signature that receiving servers use to verify that a message originated from an authorized source and was not altered in transit.
+        This check verifies that Exchange Online cryptographically signs outbound mail for every domain in the tenant.
+
+        DomainKeys Identified Mail attaches a signature to each outgoing message, computed over the headers and body with a private key whose public half is published in the domain's DNS as two selector records. Receiving servers verify it and learn both that the message came from an authorized sender for that domain and that it was not modified in transit. Microsoft 365 signs with a shared default key, but per-domain signing must be turned on for each custom domain, in the Microsoft Defender portal under **Email & collaboration > Policies & rules > Threat policies > Email authentication settings** on the DKIM tab. This check requires signing to be enabled for every domain.
 
         **Why this matters**
 
-        - **Email authentication:** DKIM allows receiving mail servers to verify that outbound messages genuinely originated from your domain and were not tampered with.
-        - **Spoofing deterrence:** Domains with DKIM signatures are significantly harder for attackers to impersonate because forged messages fail cryptographic verification.
-        - **Deliverability protection:** Major mail providers factor DKIM pass/fail into spam scoring, so unsigned domains are more likely to have legitimate mail rejected or quarantined.
-        - **DMARC readiness:** DKIM alignment is a prerequisite for a complete DMARC policy, which provides the strongest email authentication posture available.
-        - **Brand reputation:** Consistent DKIM signing signals to the broader email ecosystem that your domain is well-administered, reducing the likelihood of being blocklisted.
+        A forged message can copy your sender address, your formatting, and your signature block, but it cannot produce a valid signature without your private key. That is the difference between a spoof that arrives looking like you and one that arrives failing verification.
 
-        **Risk mitigation**
+        The attacks this blocks are the expensive ones. An invoice with altered bank details sent to your customers under your name. A message to your own staff, apparently from a director, asking for gift cards or a password. Both depend entirely on the recipient's mail server having no cryptographic reason to doubt the sender.
 
-        - **Prevents domain impersonation:** A valid DKIM signature makes it computationally infeasible for an attacker to craft a message that passes authentication as your domain.
-        - **Reduces business email compromise exposure:** Attackers who rely on spoofed sender addresses lose their primary delivery mechanism when DKIM is enforced across all domains.
+        Signing also protects the message in flight, since any modification to the signed content invalidates the signature rather than passing silently.
+
+        Enabling DKIM fails until the two selector records returned by the tenant are published in the domain's DNS zone, so publish them, allow propagation, then enable. On its own DKIM tells receivers a message verified; the instruction to reject one that did not comes from DMARC, which a companion check in this policy verifies.
       audit: |
         ### Audit via Console
 
@@ -2125,20 +2123,21 @@ queries:
       ms365.exchangeonline.safeLinksPolicies.length > 0
     docs:
       desc: |
-        This check ensures that Microsoft Defender for Office 365 is configured with at least one Safe Links policy. By default, no custom Safe Links policies exist in a new tenant; without them, URLs in email and Office documents are delivered to users without real-time scanning or rewriting.
+        This check verifies that URLs in mail and documents are checked at the moment a user clicks them.
+
+        Safe Links is the Microsoft Defender for Office 365 feature that rewrites links so they resolve through Microsoft's checking service, evaluating the destination when the click happens rather than when the message arrived. Policies are created in the Microsoft Defender portal under **Email & collaboration > Policies & rules > Threat policies > Safe Links**. A new tenant has none, so links reach users unexamined. This check requires at least one Safe Links policy to be configured.
 
         **Why this matters**
 
-        - **Time-of-click scanning:** Safe Links checks URLs at the moment a user clicks, catching links that were benign at delivery but became malicious after the email arrived.
-        - **Zero-day URL protection:** Behavioral analysis at click time identifies newly discovered malicious URLs that have not yet been added to static blocklists.
-        - **Internal email coverage:** Safe Links can be applied to messages sent within the organization, not only to inbound external mail.
-        - **Threat visibility:** Click tracking and reporting surface targeted users and recurring attack patterns that would otherwise go undetected.
-        - **Office application protection:** When configured to cover Office apps, Safe Links extends coverage beyond email to links embedded in Word, Excel, and PowerPoint files.
+        Filtering at delivery is a snapshot, and attackers have built their delivery around that fact. The link in the message points at a page that is empty, or at a legitimate file-sharing service, or at a redirect that has not yet been pointed anywhere. The message passes inspection cleanly and lands in the inbox. Hours later, once the mail has been scanned and forgotten, the destination is switched to the credential-harvesting page, and every user who clicks from that point on reaches it.
 
-        **Risk mitigation**
+        Checking at click time is what defeats that, because the evaluation happens against what the URL resolves to now rather than what it resolved to at delivery.
 
-        - **Blocks post-delivery link activation:** Attackers who send benign-looking URLs that redirect to malicious content after delivery are stopped at click time rather than after compromise.
-        - **Reduces successful phishing outcomes:** Removing direct access to malicious URLs interrupts the initial access phase of phishing campaigns that rely on user clicks.
+        Coverage matters beyond inbound mail. Internal messages carry links too, and a compromised colleague's account is the most effective phishing sender in the organization. Safe Links can be applied to internal mail, to Teams, and to links embedded in Word, Excel, and PowerPoint files.
+
+        Click telemetry is the other benefit. The reports show which users are being targeted repeatedly and which campaigns are landing, which is the information that makes awareness work specific instead of generic.
+
+        Configure the policy to cover all users, apply it to internal mail as well as inbound, and disable click-through on a blocked page so a determined user cannot override the verdict.
       audit: |
         ### Audit via Console
 
@@ -2227,20 +2226,19 @@ queries:
       ms365.exchangeonline.safeAttachmentPolicies.length > 0
     docs:
       desc: |
-        This check ensures that Microsoft Defender for Office 365 is configured with at least one Safe Attachments policy. By default, a new tenant has no custom Safe Attachments policies; without them, email attachments are delivered based on traditional antivirus signatures alone, with no sandboxed behavioral analysis.
+        This check verifies that email attachments are detonated in a sandbox before they reach a mailbox.
+
+        Safe Attachments is the Microsoft Defender for Office 365 feature that opens each attachment in an isolated virtual environment and watches what it does, rather than comparing it against known signatures. Policies are created in the Microsoft Defender portal under **Email & collaboration > Policies & rules > Threat policies > Safe Attachments**, where the unknown malware response decides whether a suspicious file is blocked or the message body is delivered while scanning continues. A new tenant has none. This check requires at least one Safe Attachments policy to be configured.
 
         **Why this matters**
 
-        - **Sandbox detonation:** Safe Attachments opens attachments in an isolated virtual environment and observes their behavior, detecting threats that have no known signature.
-        - **Ransomware prevention:** Blocking malicious attachments before they reach the endpoint interrupts ransomware delivery before any files are encrypted.
-        - **Novel malware coverage:** Behavioral detonation catches newly crafted malware variants that evade signature-based detection engines.
-        - **SharePoint and OneDrive scanning:** When enabled for collaboration workloads, Safe Attachments also scans files uploaded to SharePoint and OneDrive, not only email.
-        - **Dynamic delivery:** Safe Attachments can release the message body immediately while the attachment is scanned, minimizing user impact without sacrificing protection.
+        Signature matching only recognizes malware somebody has already seen and catalogued. The payload aimed at your organization is usually not that. It is a document generated for this campaign, or an off-the-shelf loader repacked so its bytes match nothing on file, delivered inside an archive or a document that looks like an invoice, a resume, or a shipping notice.
 
-        **Risk mitigation**
+        Behavioral detonation asks a different question. The file is opened in a disposable environment and observed: whether it spawns a scripting host, reaches out to a server on the internet, writes itself into a startup location, or begins encrypting the sample files around it. Those behaviors identify a payload that has never been catalogued, which is the whole population that matters.
 
-        - **Stops weaponized documents:** Malicious Office files, PDFs, and archives that carry exploit payloads are quarantined or blocked before reaching user mailboxes.
-        - **Limits dwell time:** Catching malware at the email gateway prevents the initial foothold that attackers need to establish persistence and move laterally.
+        Stopping it at the mail layer is stopping it before the foothold exists. Once the file runs on a workstation the attacker has code execution inside the network, and everything after that is response rather than prevention.
+
+        Extending the policy to SharePoint, OneDrive, and Teams covers files that arrive by upload rather than by mail, which is where the same payload goes when mail is filtered. Choose dynamic delivery if the scanning delay is disruptive, since it releases the message body immediately and attaches the file once it clears.
       audit: |
         ### Audit via Console
 
@@ -2330,20 +2328,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that Microsoft Defender for Office 365 has an enabled anti-phishing policy with spoof intelligence, mailbox intelligence, and mailbox intelligence protection turned on. Without these protections, inbound mail receives only basic anti-spoofing checks and lacks impersonation protection for high-value users and trusted domains.
+        This check verifies that impersonation protection is enabled and actually configured to act.
+
+        An anti-phishing policy in Microsoft Defender for Office 365 carries several distinct protections, and this check requires an enabled policy with three of them on: spoof intelligence, which analyzes sending infrastructure to identify mail falsely claiming a legitimate domain; mailbox intelligence, which learns each user's normal correspondents; and mailbox intelligence protection, which is what allows action to be taken on the result. You configure them in the Microsoft Defender portal under **Email & collaboration > Policies & rules > Threat policies > Anti-phishing**.
 
         **Why this matters**
 
-        - **Impersonation detection:** Anti-phishing policies identify messages that impersonate specific protected users or domains, such as executives and trusted partner organizations.
-        - **Spoof intelligence:** Built-in spoof intelligence analyzes sending infrastructure to flag messages that falsely claim to originate from legitimate domains.
-        - **Mailbox intelligence:** Machine learning models communication patterns for each user and flags messages from senders that deviate from established behavior.
-        - **Business email compromise protection:** Impersonation protection targets the executive and financial-staff accounts most frequently used in BEC fraud campaigns.
-        - **First-contact safety tips:** Users are warned when they receive email from an address they have never interacted with, reducing the chance of acting on a spoofed message.
+        The messages that cause the largest losses carry no attachment and no link. They are short, plausible, and impersonate somebody the recipient knows. A note from the chief executive's display name asking for an urgent transfer. A message from a supplier's finance contact, on a domain one character different from theirs, attaching updated bank details. Nothing in the message is technically malicious, so content filtering has nothing to catch.
 
-        **Risk mitigation**
+        What identifies these is relationship context. Mailbox intelligence knows this user has never corresponded with this sender, and that the display name matches an internal executive while the address does not. Spoof intelligence knows the sending infrastructure has no relationship with the domain being claimed. Together they flag a message that reads perfectly.
 
-        - **Disrupts BEC attack chains:** Quarantining impersonation attempts before they reach inboxes removes the social-engineering messages that initiate wire-transfer fraud and credential theft.
-        - **Reduces spear-phishing success rates:** Targeted phishing campaigns that rely on domain or user impersonation are surfaced and blocked before users can act on them.
+        Turning the detection on without setting the action is the common failure. The mailbox intelligence protection action defaults to taking no action, which produces the same outcome as leaving the protection off, so set it explicitly to quarantine or an equivalent disposition.
+
+        Name the executives, finance staff, and frequently impersonated partner domains explicitly in the impersonation protection lists, since those are the identities attackers actually borrow, and enable first-contact safety tips so users see a warning when a sender is new to them.
       audit: |
         ### Audit via Console
 
@@ -2436,20 +2433,19 @@ queries:
       ms365.sharepointonline.tenantConfiguration.sharingCapability != "ExternalUserAndGuestSharing"
     docs:
       desc: |
-        This check ensures that SharePoint Online is configured to restrict external sharing to a level more restrictive than the most permissive default. The most permissive setting, ExternalUserAndGuestSharing, allows any user to generate anonymous "Anyone" links that grant access to files and folders without requiring the recipient to authenticate, which means there is no record of who accessed the content.
+        This check verifies that SharePoint and OneDrive do not permit anonymous sharing links.
+
+        External sharing is set organization-wide in the SharePoint admin center under **Policies > Sharing**. The most permissive level, recorded as ExternalUserAndGuestSharing and shown in the console as anyone, allows users to generate links that grant access to a file or folder without the recipient signing in. This check requires the tenant to sit at a more restrictive level, such as new and existing guests, existing guests only, or organization members only.
 
         **Why this matters**
 
-        - **Uncontrolled data distribution:** Anonymous sharing links allow recipients to forward access to any third party, removing all organizational control over who views or downloads the content.
-        - **Data exfiltration pathway:** Any internal user who can create an Anyone link can silently exfiltrate documents to external parties without leaving an identity trail.
-        - **Guest account sprawl:** Permissive sharing settings generate large numbers of unmanaged guest accounts that may retain access to content long after a collaboration ends.
-        - **Compliance risk:** Most regulatory frameworks require demonstrable controls over access to sensitive data, and unauthenticated sharing links make access-control attestation impossible.
-        - **Audit gap:** Without authentication requirements, access logs show a link was clicked but cannot attribute the access to a specific identity.
+        An anyone link is a bearer credential in the form of a URL. Whoever holds it has the file, and possession is the entire authorization test. The recipient forwards it to a colleague, who forwards it to a personal address, and it comes to rest in a mailbox at another company or in a message thread that later gets exposed. Every copy still works, and nobody in your organization is aware any of it happened.
 
-        **Risk mitigation**
+        For an attacker who has taken one ordinary account, this is the exfiltration route that requires no tooling. They generate anyone links for the document libraries the account can reach and retrieve the content later from an entirely unauthenticated session, which never touches your tenant as that user again.
 
-        - **Enforces identity-based access:** Restricting sharing to authenticated guests ensures every access event is tied to a verifiable identity that can be reviewed and revoked.
-        - **Limits insider-driven exfiltration:** Requiring guest authentication and scoping sharing to existing or approved guests closes the anonymous link pathway most commonly exploited by malicious insiders.
+        The access logs cannot help afterwards. They record that a link was used, not who used it, so an investigation can establish that a document left and not where it went or how widely.
+
+        Restricting to authenticated guests keeps external collaboration working while tying every access to an identity you can enumerate, review, and revoke. New and existing guests is the usual balance point for organizations that genuinely need to share outside, and per-site overrides can tighten specific libraries further.
       audit: |
         ### Audit via Console
 
@@ -2532,20 +2528,19 @@ queries:
       ms365.exchangeonline.transportRules.any(state == "Enabled" && routeMessageOutboundRequireTls == true)
     docs:
       desc: |
-        This check ensures that Exchange Online is configured with at least one enabled transport rule that requires TLS encryption for outbound email. Exchange Online attempts TLS opportunistically by default but does not enforce it; without an explicit transport rule, messages can fall back to unencrypted SMTP delivery when the receiving server does not advertise TLS support.
+        This check verifies that outbound mail leaving the organization is required to travel over an encrypted connection.
+
+        Exchange Online negotiates TLS opportunistically by default, which means it uses encryption when the receiving server offers it and delivers in plain text when it does not. Making it mandatory takes a mail flow rule, created in the Exchange admin center under **Mail flow > Rules**, applying to recipients outside the organization with the action set to require TLS encryption. This check requires at least one enabled transport rule that enforces outbound TLS.
 
         **Why this matters**
 
-        - **Encryption in transit:** A transport rule that mandates TLS prevents Exchange from delivering messages over an unencrypted SMTP connection, regardless of the receiving server's configuration.
-        - **Data confidentiality:** Email content and attachments transmitted without encryption can be captured and read by anyone with access to network traffic along the delivery path.
-        - **Protection against downgrade attacks:** Without enforcement, an attacker who can manipulate DNS or SMTP negotiation can strip TLS and force plaintext delivery; a transport rule blocks the fallback.
-        - **Sensitive-message coverage:** Notifications containing credentials, financial data, or personal information are protected from interception when TLS is required at the mail-flow layer.
-        - **Auditability:** Transport rules provide a documented, enforceable control that can be cited in security assessments and compliance reviews as evidence of encryption-in-transit requirements.
+        Opportunistic encryption is decided by the other end, and the other end can be influenced. An attacker positioned on the path, or one able to manipulate DNS or the SMTP negotiation, strips the offer of encryption from the exchange. Exchange Online, doing exactly what it was configured to do, falls back to plain text and delivers the message unencrypted. Nothing about that looks like an incident, because from the sender's side it is a normal delivery.
 
-        **Risk mitigation**
+        The content is then readable to anyone who can observe the traffic between the two mail systems. That is contract drafts, personal data sent to a processor, invoices, and the password reset and account notification messages that flow out to staff and customers.
 
-        - **Prevents opportunistic downgrade:** Enforcing TLS at the transport-rule level removes the possibility of a receiving server negotiating an unencrypted session, closing the most common path to plaintext email interception.
-        - **Reduces man-in-the-middle exposure:** Requiring a verified TLS session before message delivery makes passive eavesdropping and active session hijacking computationally impractical for on-path attackers.
+        Requiring TLS removes the fallback. When a receiving server cannot negotiate an encrypted session the message is not delivered at all, which converts a silent confidentiality failure into a visible delivery failure somebody can act on.
+
+        That trade is real and needs planning. Once the rule is active, mail to any partner whose server cannot negotiate TLS bounces and the sender receives a non-delivery report. Scope the rule to specific sensitive senders or named recipient domains first, watch the non-delivery reports for a period, and widen it only once you know which correspondents would break.
       audit: |
         ### Audit via Console
 
@@ -2627,21 +2622,19 @@ queries:
       ms365.exchangeonline.unifiedAuditLogIngestionEnabled == true
     docs:
       desc: |
-        This check ensures that unified audit logging is enabled for the Microsoft 365 tenant. The unified audit log records user and administrator activity across Exchange Online, SharePoint Online, OneDrive, Microsoft Entra ID, Teams, and other workloads in a single searchable log.
+        This check verifies that the tenant records user and administrator activity in the unified audit log.
+
+        The unified audit log collects activity from across Microsoft 365, covering Exchange Online, SharePoint Online, OneDrive, Microsoft Entra ID, Teams, and the other workloads into one searchable record. It is controlled from the Microsoft Purview portal under **Audit**, where a banner offers to start recording if it is off. This check requires audit log ingestion to be enabled for the tenant.
 
         **Why this matters**
 
-        Without the unified audit log, the tenant produces no centralized record of who did what:
+        With the log off, the tenant is not merely under-monitored, it is unrecorded. The actions that define a compromise leave nothing behind: the mailbox rule that forwards mail to an attacker, the sudden download of an entire document library, the role assignment that made a new account a Global Administrator, the consent granted to an application nobody recognizes. None of it can be queried, because none of it was written down.
 
-          - **No incident detection:** Suspicious activity such as mass downloads, mailbox rule creation, or privilege changes goes unrecorded and unnoticed.
-          - **No forensic trail:** After a breach, responders cannot reconstruct attacker actions, identify compromised accounts, or scope data access.
-          - **No insider-threat visibility:** Data exfiltration and policy violations by internal users leave no evidence.
-          - **Compliance exposure:** Most regulatory frameworks require audit trails for access to sensitive data, so a disabled log is a direct finding.
+        The consequence lands during the incident. An attacker's access is discovered by some other means, and the response has to answer which accounts were used, what was read, whether data left the organization, and when it started. Those questions have no answers without the log, so the organization cannot scope the breach, cannot tell affected customers what was accessed, and cannot know whether the eviction was complete.
 
-        **Risk mitigation**
+        Deliberate insider activity disappears the same way, since a person copying files or reading colleagues' mailboxes leaves no trace to review.
 
-        - **Detection:** Enabling the log lets security tooling and analysts surface anomalous behavior in near real time.
-        - **Accountability:** A complete activity record deters misuse and supports investigations.
+        Enabling it is a single change, and the log starts from that moment rather than backfilling, so turning it on today does nothing for what happened yesterday. Allow up to 60 minutes for the change to take effect across all workloads, and pair the log with retention and alerting appropriate to your licensing, since a record nobody queries is only useful after the fact.
       audit: |
         ### Audit via Console
 
@@ -2716,21 +2709,21 @@ queries:
       ms365.exchangeonline.remoteDomains.all(autoForwardEnabled == false)
     docs:
       desc: |
-        This check ensures that automatic forwarding of email to external recipients is blocked, both through the outbound spam filter policy and the default remote domain configuration. By default Microsoft 365 permits automatic forwarding, which lets mailbox rules silently relay mail outside the organization.
+        This check verifies that mailbox rules cannot silently relay mail out of the organization.
+
+        Microsoft 365 permits automatic forwarding out of the box, and two settings govern it that both have to be closed. The outbound spam filter policies in the Microsoft Defender portal under **Email & collaboration > Policies & rules > Threat policies > Anti-spam** carry an automatic forwarding control that must be set to off, and each entry under **Mail flow > Remote domains** in the Exchange admin center carries an allow automatic forwarding option that must be cleared. This check requires forwarding to be off across the outbound spam policies and disabled on the remote domains.
 
         **Why this matters**
 
-        Attacker-created forwarding rules are one of the most common business email compromise techniques:
+        Creating a forwarding rule is the first thing an attacker does with a mailbox they have taken, and it is close to the last thing anybody notices. The rule copies every incoming message to an address they control, so they no longer need to sign in. Whatever detection you have on anomalous authentication stops firing, because there are no more authentications.
 
-          - **Silent data exfiltration:** A compromised mailbox can forward every incoming message to an attacker-controlled address with no further interaction.
-          - **Persistence after remediation:** A forwarding rule survives password resets and keeps leaking mail until the rule itself is found and removed.
-          - **Invoice and payroll fraud:** Forwarded threads give attackers the context to insert fraudulent payment instructions.
-          - **Exposure of secrets:** Password resets, MFA codes, and account notifications are forwarded along with everything else.
+        What flows out is everything the person receives from that day forward: the contract negotiation, the payroll file, the password reset links and one-time codes for every other system they use, and the internal threads that supply the tone and detail for a convincing fraudulent payment request later.
 
-        **Risk mitigation**
+        The rule also outlives the response. A password reset evicts the attacker's session and leaves the forwarding rule in place, quietly exfiltrating mail until somebody inspects the mailbox rules specifically, which is not part of most incident checklists.
 
-        - **Containment:** Blocking forwarding at the tenant level neutralizes attacker forwarding rules even before the compromised account is identified.
-        - **Controlled exceptions:** Legitimate forwarding can still be allowed through scoped policies for specific users or domains.
+        Blocking at the tenant level neutralizes rules that already exist as well as ones created later, without needing to find the compromised mailbox first.
+
+        Some remote domain entries exist specifically to permit forwarding to a trusted partner, so review each with its owners before saving. Where a narrow exception is genuinely needed, scope a dedicated outbound spam policy to those users instead of leaving a forwarding-enabled remote domain open to everyone.
       audit: |
         ### Audit via Console
 
@@ -2816,21 +2809,19 @@ queries:
       microsoft.policies.authorizationPolicy.defaultUserRolePermissions.permissionGrantPoliciesAssigned == empty
     docs:
       desc: |
-        This check ensures that non-administrative users cannot grant consent for applications to access organizational data on their behalf. When user consent is restricted, the default user role has no permission grant policy assigned, and application access must be approved by an administrator.
+        This check verifies that users cannot grant an application access to organizational data on their own authority.
+
+        Consent settings live in the Microsoft Entra admin center under **Identity > Applications > Enterprise applications > Consent and permissions > User consent settings**. Choosing not to allow user consent removes the permission grant policies from the default user role, which is the state this check requires, and routes every request for application access to an administrator instead.
 
         **Why this matters**
 
-        Illicit consent grants, also called consent phishing, let an attacker bypass passwords and MFA entirely:
+        Consent phishing bypasses passwords and multifactor authentication entirely, because it never attacks either one. The user receives a link to a genuine Microsoft consent page for an application the attacker registered, often named to look like an internal tool or a familiar service. The page is real, the sign-in is real, and the second factor prompt is satisfied by the user themselves. All they are asked to do is approve access, and one click hands the attacker an OAuth token for their mailbox, their OneDrive files, and their Teams conversations.
 
-          - **Token-based account takeover:** A user who consents to a malicious app hands the attacker a long-lived OAuth token for their mailbox, files, and Teams data.
-          - **MFA bypass:** OAuth tokens are honored without re-prompting for MFA, so the attacker keeps access even after a password reset.
-          - **Tenant-wide reach:** A single consenting user can expose data far beyond their own account if the app requests broad Graph scopes.
-          - **Low visibility:** Consent grants do not trigger the alerts a new sign-in would, so malicious apps can persist undetected.
+        The token is the point. It is honored without re-prompting for a second factor, and it survives a password reset, so the standard response to a compromised account leaves the attacker's access untouched. They read mail through the Graph API at their own pace, with no sign-in events to notice.
 
-        **Risk mitigation**
+        The blast radius is not limited to the person who clicked. An application requesting broad permissions reaches data far beyond that user's own mailbox, and a single approval can expose the wider tenant.
 
-        - **Administrative gate:** Requiring admin approval ensures every third-party app is reviewed before it can read organizational data.
-        - **Reduced attack surface:** Removing self-service consent eliminates the most common path for OAuth-based phishing.
+        Requiring administrator approval puts a review in front of every application that wants organizational data. Configure the admin consent workflow at the same time so users have a documented way to request the applications they genuinely need, which keeps the control from being routed around.
       audit: |
         ### Audit via Console
 
@@ -2906,21 +2897,19 @@ queries:
       microsoft.identityAndAccess.roleEligibilityScheduleInstances != empty
     docs:
       desc: |
-        This check ensures that Microsoft Entra Privileged Identity Management (PIM) is used to govern privileged roles, indicated by the presence of eligible role assignments. PIM grants administrative access just-in-time: a user is eligible for a role and must activate it for a limited window rather than holding it permanently.
+        This check verifies that privileged roles are held as activatable eligibility rather than as permanent standing access.
+
+        Microsoft Entra Privileged Identity Management changes the shape of an administrative assignment. Instead of holding a role continuously, a user is made eligible for it and must activate it for a bounded window, optionally passing a multifactor prompt, supplying a justification, and waiting for approval. You configure this in the Microsoft Entra admin center under **Identity governance > Privileged Identity Management > Microsoft Entra roles**, adding assignments with the type set to eligible and setting the activation requirements per role. This check requires at least one eligible role assignment to exist in the tenant. The feature needs Microsoft Entra ID P2 or Microsoft Entra ID Governance licensing.
 
         **Why this matters**
 
-        Permanent, always-active admin assignments leave high-value access standing around the clock:
+        A permanent Global Administrator assignment is privilege that is live at three in the morning on a Sunday, whether or not the person is working. An attacker who takes that account inherits the role at the moment of sign-in, with no further step, and the tenant sees an ordinary authentication rather than a privilege event.
 
-          - **Always-on attack surface:** A compromised account with a permanent Global Administrator assignment gives an attacker full tenant control at any moment, with no activation step to detect.
-          - **No activation trail:** Standing assignments produce no just-in-time activation events, removing a key signal for spotting misuse.
-          - **Privilege sprawl:** Without periodic activation and review, stale admin rights accumulate on accounts that no longer need them.
-          - **Broader blast radius:** Every permanently privileged account is an independent path to tenant takeover.
+        Eligibility removes that. The stolen session lands on an account with no administrative rights until it activates the role, and activation is where the defenses sit: a multifactor prompt on a device the attacker does not have, a written justification, an approval request that reaches a human, and a log entry that stands out precisely because activations are rare.
 
-        **Risk mitigation**
+        Standing assignments also accumulate silently. Nothing forces a review, so rights granted for one project remain years later on people who no longer need them, each one an independent path to the tenant.
 
-        - **Just-in-time access:** Eligible assignments mean privileges exist only during an approved, time-bound activation window.
-        - **Approval and review:** PIM can require justification, approval, and MFA on activation, and supports recurring access reviews.
+        Keep at least one emergency access account with a standing assignment so a failure in the activation path cannot lock everyone out, make the eligibility itself time-bound and reviewed rather than permanent, and set an activation maximum duration so each activation expires on its own.
       audit: |
         ### Audit via Console
 
@@ -3013,21 +3002,19 @@ queries:
       microsoft.domains.where(isVerified == true && id != /\.onmicrosoft\.com$/).all(dns(id).dmarc.policy == /quarantine|reject/)
     docs:
       desc: |
-        This check ensures that every verified custom domain publishes a DMARC record with an enforcing policy of `quarantine` or `reject`. DMARC (Domain-based Message Authentication, Reporting, and Conformance) tells receiving mail servers what to do with messages that fail SPF and DKIM alignment.
+        This check verifies that every custom domain publishes a DMARC record that tells receivers to act on authentication failures.
+
+        DMARC is a TXT record at the `_dmarc` host of the domain. It ties the SPF and DKIM results to the address the recipient actually sees, and states what to do when neither aligns. The policy value is what matters: `p=none` observes and reports, while `quarantine` and `reject` are enforcement. This check requires every verified custom domain to publish a record and to set the policy to `quarantine` or `reject`.
 
         **Why this matters**
 
-        SPF and DKIM alone do not stop spoofed mail. DMARC is the enforcement layer:
+        SPF and DKIM answer whether a message authenticated. Neither instructs the receiving server to do anything about a message that did not, and neither one is checked against the visible From address on its own. DMARC supplies both the alignment requirement and the instruction, which is why a domain with SPF and DKIM but no enforcing DMARC policy is still spoofable in practice.
 
-          - **Domain spoofing:** Without an enforcing DMARC policy, attackers can send mail that appears to come from your domain, since receivers have no instruction to reject failures.
-          - **Business email compromise:** Spoofed executive or finance messages drive fraudulent wire transfers and credential theft.
-          - **Brand and deliverability damage:** Spoofing campaigns harm domain reputation and can cause legitimate mail to be filtered.
-          - **No visibility:** A `p=none` policy or a missing record leaves the organization blind to who is sending mail as its domain.
+        The attack that exploits the gap is targeted at people who trust your name. A message with your domain in the sender field asks your customer's accounts payable team to update the bank details on file, or asks your own staff to review a document behind a sign-in page. Receiving servers see a failure, find no policy telling them to reject, and deliver it to the inbox.
 
-        **Risk mitigation**
+        A missing or observing-only record also leaves you blind. Aggregate reports show who is sending as your domain, and without them you learn about a spoofing campaign when a customer calls about a payment they already made.
 
-        - **Enforced rejection:** A `quarantine` or `reject` policy instructs receivers to drop or isolate unauthenticated mail claiming to be from your domain.
-        - **Reporting:** DMARC aggregate reports reveal spoofing attempts and misconfigured legitimate senders.
+        Move in stages. Publish with `quarantine` and a reporting address, read the aggregate reports until every legitimate sender aligns, and only then move to `reject`, since going straight to enforcement will silently drop mail from a system nobody remembered.
       audit: |
         Verify that every verified custom domain publishes an enforcing DMARC record by querying the `_dmarc` TXT record:
 

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -71,19 +71,19 @@ queries:
       slack.users.admins.length < 5 && slack.users.admins.length > 1
     docs:
       desc: |
-        This check ensures that the Slack workspace is configured to keep the number of administrator accounts between 2 and 4. Slack does not cap how many members can hold the admin or owner role, so workspaces tend to accumulate privileged accounts over time.
+        This check verifies that the privileged group in the Slack workspace stays small without shrinking to a single person, between 2 and 4 accounts.
+
+        Slack account types are set from **Tools & settings > Manage members**, where filtering the member list by account type shows the Workspace Admins and Workspace Owners. Slack applies no upper or lower bound of its own, so the count drifts as people are promoted for a project and never moved back. This check counts the accounts holding those roles and requires the total to land between 2 and 4.
 
         **Why this matters**
 
-        - **Operational resilience:** Keeping at least two administrators avoids a single point of failure if one person is unavailable or leaves the organization.
-        - **Reduced attack surface:** Each admin account is a high-value target, so a small privileged group means fewer accounts an attacker can compromise.
-        - **Accountability:** A limited set of administrators keeps it clear who can make security-sensitive changes and simplifies audit reviews.
-        - **Shared responsibility:** Multiple administrators allow workload to be shared while keeping the privileged group small and reviewable.
+        A workspace admin adds and removes members, installs and approves apps, invites guests, changes the workspace security settings, and on the plans that support it requests an export of workspace data. Every one of those accounts is therefore a full path to the workspace, and an attacker only needs the weakest of them. With a dozen admins there are a dozen people to phish, and the one who reused a password on a breached site decides the outcome for everyone.
 
-        **Risk mitigation**
+        What the attacker does next is the reason the count matters. Holding an admin account they turn off the workspace two-factor requirement, invite a single-channel guest they control, and install an app with broad scopes whose token keeps working after the compromised password is reset. Cutting the group to a handful of named people does not stop that, but it shrinks the target set to accounts you can watch closely.
 
-        - **Privilege creep prevention:** Regularly reviewing whether each admin account is still needed stops former or inactive admins from retaining access.
-        - **Containment:** A small admin group limits the blast radius if a privileged credential is phished or stolen.
+        One admin is a different failure. When that account is locked out or the person leaves, nobody can remove a compromised member, revoke a rogue app, or pull an export during an incident, and Slack's recovery path for a sole owner is measured in days.
+
+        On Enterprise Grid, org owners and org admins are managed separately from workspace roles, so review the org-level assignments alongside this count.
       audit: |
         ### Audit via Admin Settings
 
@@ -145,20 +145,19 @@ queries:
       slack.users.admins.all(has2FA == true && twoFactorType == "app")
     docs:
       desc: |
-        This check ensures that every Slack administrator account is configured to use app-based two-factor authentication rather than SMS verification. Slack supports both SMS and authenticator-app second factors, and SMS remains an option unless administrators deliberately choose the stronger method.
+        This check verifies that every Slack administrator's second factor is an authentication app rather than a text message.
+
+        Slack accepts both SMS codes and authenticator apps as a second factor for email sign-in, and SMS stays available to members unless an owner removes it. A workspace owner restricts the method under **Admin > Workspace settings > Security**, where **Two-factor authentication for email sign-in** offers an authenticator apps only option. This check requires every admin and owner to have two-factor authentication enabled with the method recorded as an authentication app.
 
         **Why this matters**
 
-        - **SIM swap resistance:** Authenticator apps cannot be intercepted by attackers who convince a carrier to transfer a phone number to a device they control.
-        - **Protection from network attacks:** App-based codes are not exposed to known weaknesses in the cellular signaling network that allow SMS interception.
-        - **Social engineering resistance:** Codes generated on a device cannot be redirected by tricking carrier support staff.
-        - **Privileged account protection:** Administrators can disable security controls, export data, and add users, so their accounts warrant the strongest available factor.
-        - **Compliance alignment:** Many frameworks recommend or require phishing-resistant authentication for privileged accounts.
+        SMS is a second factor delivered by a third party you do not control. An attacker who already has an administrator's password calls the carrier, passes a knowledge check built from information that is largely public, and has the number ported to a device they hold. The next code Slack sends arrives on their phone. There is no malware, no phishing page after the first one, and nothing on the workspace side that looks different from a normal sign-in.
 
-        **Risk mitigation**
+        The same number is also reachable without touching the carrier's front desk, because the signaling network that routes messages between operators has long-standing weaknesses that allow interception outright.
 
-        - **Account takeover prevention:** Removing SMS as an option closes the most common path used to bypass two-factor authentication on high-value accounts.
-        - **Consistent enforcement:** Standardizing administrators on authenticator apps ensures no privileged account silently falls back to a weaker factor.
+        An administrator is worth that effort. Once signed in, the attacker turns off the workspace two-factor requirement, invites a guest account they control into private channels, installs an app whose OAuth token survives the eventual password reset, and reads the conversation history in which teams paste credentials, customer records, and incident detail.
+
+        Restricting the method at the workspace level does not convert accounts that are already enrolled with SMS, so pair the setting with a pass over the current administrators. The 2FA column in **Manage members** is not shown on every plan and may be absent on Enterprise Grid, in which case identify affected administrators through the Slack API instead.
       audit: |
         ### Audit via Admin Settings
 
@@ -224,20 +223,19 @@ queries:
       slack.users.members.where(deleted == false).all( has2FA == true || enterpriseUser != empty || id == "USLACKBOT" )
     docs:
       desc: |
-        This check ensures that every active Slack user is configured with two-factor authentication enabled on their account. Slack leaves two-factor authentication optional for individual members unless an owner enforces it at the workspace or organization level.
+        This check verifies that every active member of the Slack workspace has a second factor on their account.
+
+        Slack leaves two-factor authentication to individual members unless an owner requires it. The requirement lives under **Admin > Workspace settings > Security**, where **Two-factor authentication for email sign-in** carries a **Require members to have 2FA set up** option. This check reads the enrollment state of each member who has not been deactivated, and treats members who reach Slack through Enterprise Grid single sign-on as covered by the identity provider instead.
 
         **Why this matters**
 
-        - **Credential stuffing resistance:** Passwords leaked from other services cannot be reused to access Slack when a second factor is required.
-        - **Phishing protection:** Even if a user enters credentials on a fake login page, an attacker cannot complete sign-in without the second factor.
-        - **Lateral movement containment:** A compromised account cannot easily be used to reach sensitive channels or impersonate employees when two-factor authentication blocks the login.
-        - **Data exfiltration prevention:** Blocking unauthorized sign-ins prevents attackers from searching and exporting confidential conversations and files.
-        - **Compliance alignment:** SOC 2, ISO 27001, and other frameworks require or recommend multi-factor authentication.
+        Slack is where an organization's least guarded material accumulates. Deployment credentials pasted for a colleague, customer names discussed in support threads, unannounced product plans, the salary conversation somebody had in a direct message. All of it is searchable, and a single password is the only thing standing in front of it.
 
-        **Risk mitigation**
+        That password is rarely secret for long. It appears in a credential dump from an unrelated service the employee used with the same password, or it is typed into a page that looks like the Slack sign-in and is not. Without a second factor, the attacker's next step is to sign in as that person and search. They read history that predates the account they took, download the files attached to it, and message colleagues from a name those colleagues trust, which is how the second and third accounts fall.
 
-        - **Workspace-wide enforcement:** Requiring two-factor authentication at the workspace or organization level protects every member instead of only those who opt in.
-        - **Reduced account takeover risk:** A mandatory second factor closes the most common path attackers use to convert a stolen password into account access.
+        Requiring the factor for everyone rather than for the security-minded few is the whole point, because an attacker picks the account that opted out.
+
+        Members who do not enroll within 24 hours of the setting being saved are signed out until they complete enrollment, so announce the change first. If your workspace signs in through single sign-on, the setting still matters for the owners and admins who can sign in with an email address and password and bypass it.
       audit: |
         ### Audit via Admin Settings
 
@@ -310,20 +308,19 @@ queries:
       slack.conversations.where(isExtShared && isChannel ).all(name == props.mondooSlackSecurityExternalChannelName )
     docs:
       desc: |
-        This check ensures that every externally shared Slack channel is named with a consistent pattern that identifies it as external, such as a prefix of "ext-" or "external-". Slack does not enforce naming conventions for shared channels, so externally shared channels can otherwise look identical to internal ones.
+        This check verifies that Slack channels shared outside the organization are named so that everyone in them can tell.
+
+        A Slack Connect channel looks exactly like an internal one. The sidebar entry, the message composer, and the channel header are the same, and the only difference is a small badge and a member list that people do not read before typing. Slack does not enforce a naming convention, so this check compares the name of every externally shared channel against a pattern you set as a policy property. The supplied default accepts an `ext-`, `extern-`, or `ex-` prefix, with a hyphen or an underscore, and you can replace it with whatever convention your workspace already uses.
 
         **Why this matters**
 
-        - **Context awareness:** A clear naming pattern lets users immediately recognize when they are communicating with parties outside the organization.
-        - **Leakage prevention:** Without distinct naming, employees may share confidential information in a channel they assume is internal.
-        - **Audit efficiency:** Consistent naming makes it straightforward to locate and review every external communication channel.
-        - **Access control reviews:** Security teams can quickly identify external channels during periodic access reviews.
-        - **Automated monitoring:** A predictable naming convention supports automated alerting on external channel activity.
+        The failure here is a person, not a system. An engineer is asked for the staging credentials, finds the channel where the conversation was happening, and pastes them. A support lead drops the full customer export into a thread to move a discussion along. Neither of them checked the member list, because in every other channel that day they did not need to. The vendor, contractor, or customer on the other side of the Slack Connect link now has the material, and nothing was breached to get it.
 
-        **Risk mitigation**
+        A visible marker in the channel name is what interrupts that. It arrives before the message is typed, in the one place the person is already looking.
 
-        - **Accidental disclosure prevention:** Visible external markers reduce the chance that sensitive information is posted to an outside audience by mistake.
-        - **Governance enforcement:** A documented naming standard gives administrators a reliable basis for monitoring and enforcing external sharing policy.
+        Consistent naming also makes external exposure reviewable. Security can enumerate every channel that reaches outside the organization from the channel list, rather than opening each one to inspect its membership, and monitoring can alert on activity in those channels as a class.
+
+        Naming is a prompt rather than a control, so pair it with the sharing approvals your plan offers, and communicate the convention to channel creators so new external channels follow it from the start.
       audit: |
         ### Audit via Admin Settings
 
@@ -392,20 +389,19 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that the Slack workspace is configured with at least one channel that is exclusively internal and not shared with external users, other organizations, or other workspaces. A workspace whose channels are all shared in some way leaves no guaranteed space for confidential internal communication.
+        This check verifies that the workspace still has at least one channel that is not shared with anybody outside it.
+
+        Slack channels can be shared with another workspace in the same organization, shared across an Enterprise Grid org, or shared with an external organization through Slack Connect, and a channel can also sit pending an external share that has been offered and not yet accepted. This check looks at the channel list in **Tools & settings > Manage channels** and requires at least one channel where none of those four conditions applies.
 
         **Why this matters**
 
-        - **Confidential discussion space:** Sensitive topics such as personnel matters, strategy, and security incidents need a channel with no external access.
-        - **Configuration signal:** A workspace with no internal channels can indicate improper setup or misuse.
-        - **Compliance boundaries:** Some communications must remain within organizational boundaries to satisfy regulatory requirements.
-        - **Incident response:** Security incidents should be coordinated where external parties cannot observe them.
-        - **Employee-only topics:** Onboarding and HR discussions require a channel guaranteed to exclude contractors and external partners.
+        Some conversations have to happen where no outside party is present. A security incident is the clearest case: the response has to be coordinated somewhere the attacker's likely entry point, which is often a connected vendor, cannot observe. Personnel discussions, unannounced organizational changes, and legal matters have the same requirement for different reasons.
 
-        **Risk mitigation**
+        A workspace in which every channel is shared in some form leaves no such room. The practical result is that those conversations still happen, but in a channel that carries an audience nobody enumerated, or in a scatter of direct messages that no one can review afterwards. When the incident is the vendor you share a channel with, coordinating in front of them is worse than the inconvenience of finding somewhere else.
 
-        - **Information leakage prevention:** A dedicated internal channel gives employees a safe place to discuss sensitive matters without external exposure.
-        - **Clear scoping:** Maintaining and communicating the purpose of an internal-only channel reduces the chance that confidential conversations happen in shared channels.
+        Failing this check is also a signal about how the workspace is being used. A workspace with no internal channel at all is usually one that was created for a single external collaboration and then quietly adopted for internal work, which means the sharing model nobody chose is now the default for everything.
+
+        A workspace that genuinely exists only to host an external collaboration is a legitimate exception, provided the internal side of that work lives in a different workspace.
       audit: |
         ### Audit via Admin Settings
 
@@ -479,20 +475,19 @@ queries:
         )
     docs:
       desc: |
-        This check ensures that internal-only Slack channels are kept free of external members such as guest users, single-channel guests, and strangers from connected organizations. Channels that are not externally shared can still pick up restricted or guest accounts as members, which undermines their internal status.
+        This check verifies that at least one unshared Slack channel also has no guest or external accounts in its membership.
+
+        A channel that has never been shared through Slack Connect can still carry outside people, because guests are invited individually. Slack distinguishes multi-channel guests, single-channel guests, and users who belong to a connected organization, and all three can appear in the member list of a channel the team thinks of as internal. This check takes the channels that are not shared, org-shared, externally shared, or pending an external share, and requires at least one of them whose members are all full members of your workspace.
 
         **Why this matters**
 
-        - **Guest access control:** Guest accounts can be added to channels meant for employees only if membership is not reviewed.
-        - **Stranger detection:** Users from connected organizations can appear in channels through Slack Connect features.
-        - **Single-channel guest scope:** Limited-access guests may end up in channels beyond their intended scope.
-        - **Leakage prevention:** External members in a channel believed to be internal can read confidential discussions and files.
-        - **Accurate trust assumptions:** Verified membership prevents employees from sharing sensitive information under a false belief that the channel is internal-only.
+        The channel-level sharing flag is the thing people check, and it is not the whole answer. A contractor is added to one channel for a project in March, the project ends in May, and nobody removes them. The channel keeps its internal appearance and its internal habits, so the incident retrospective, the customer escalation, and the credentials pasted during a late deploy all land in front of an account that belongs to a company you no longer work with.
 
-        **Risk mitigation**
+        That account is also outside your control in the way that matters after a breach. You do not manage its password, its second factor, or its offboarding, so when the contractor's own employer is compromised, the attacker inherits a seat in your internal channel and reads the history from the day the guest was added.
 
-        - **Membership audits:** Regularly reviewing internal channel membership ensures only authorized employees remain and external users are removed promptly.
-        - **Confidentiality assurance:** Keeping guest and restricted accounts out of internal channels preserves a reliable space for sensitive communication.
+        Reading history is the whole prize. Slack keeps the scrollback, so a guest added yesterday can search everything the channel said last year.
+
+        Review the member list of each channel meant to be internal and remove the guest, single-channel guest, and external accounts you find. If none of your unshared channels is clean, create one and invite only full members.
       audit: |
         ### Audit via Admin Settings
 
@@ -558,20 +553,19 @@ queries:
     mql: slack.conversations.where(isChannel == true && isExtShared == false).all( members.where(isBot == false && id != "USLACKBOT").all(profile['email'] == props.mondooSlackSecurityAllowListedDomains) )
     docs:
       desc: |
-        This check ensures that every member of an internal, non-externally-shared Slack channel has an email address from one of your organization's approved domains. Slack channel membership can include accounts with unexpected email domains unless membership is verified against an allowlist.
+        This check verifies that everyone in an internal Slack channel signs in with an email address at a domain you recognize.
+
+        Every Slack account carries the email address it was registered with, visible on the member profile and in the channel member list. This check reads that address for each human member of every channel that is not externally shared, and matches it against a pattern you set as a policy property. The supplied default accepts addresses ending in one of two example corporate domains, and you replace it with the domains your organization actually uses.
 
         **Why this matters**
 
-        - **Unauthorized access detection:** An email address from a domain that is not approved can indicate an account added incorrectly or maliciously.
-        - **Former employee identification:** Personal email accounts or previous employer domains point to users who should no longer have access.
-        - **Third-party scope control:** Vendor or partner accounts in internal channels can reach information beyond their engagement scope.
-        - **Data governance:** Regulations often require that certain data be accessible only to employees with corporate identities.
-        - **Offboarding verification:** Domain allowlisting surfaces users who should have been removed when they left the organization.
+        An unexpected domain is the artifact a mistake leaves behind. It is the invitation typed to a personal address instead of a work one, the account a departing employee kept by changing their email before their last day, the vendor added during an integration that finished a year ago, and occasionally the address an attacker registered at a domain that reads like yours at a glance.
 
-        **Risk mitigation**
+        Each of those accounts sits in the channel with full read access to its history, and Slack history is long. The former employee follows the roadmap discussion at their new employer. The vendor account, still authenticating with a password their own security team no longer tracks, becomes an attacker's foothold in your internal conversation the moment that vendor is breached. Neither shows up as an external share, because neither one is.
 
-        - **Membership reviews:** Configuring the allowed domain list to match your corporate domains and reviewing internal channel membership catches accounts that do not belong.
-        - **Identity enforcement:** Limiting internal channels to approved domains keeps confidential communication scoped to verified organizational identities.
+        Matching membership against your domains turns that into something you can find. It surfaces the accounts that do not belong to your identity lifecycle at all, which are exactly the ones no offboarding process will ever remove.
+
+        Investigate how each unrecognized account was added before removing it, since the answer often points at an invitation path that will admit the next one, and deactivate accounts that do not belong to your organization rather than only removing them from the channel.
       audit: |
         ### Audit via Admin Settings
 
@@ -639,20 +633,19 @@ queries:
         .all(isEmailConfirmed == true)
     docs:
       desc: |
-        This check ensures that every active Slack member, excluding bots, deactivated accounts, and pending invites, has a confirmed email address. An unconfirmed email address means Slack has not verified that the account holder actually controls the email it was registered with, which breaks an assumption that downstream security controls depend on.
+        This check verifies that every active human member of the workspace has confirmed the email address their Slack account was registered with.
+
+        Slack sends a confirmation link when an address is added or changed, and until the recipient follows it the account exists with an address nobody has proven control of. This check reads the confirmation state of each member, skipping deactivated accounts, pending invitations, and the various bot identities, and requires the remainder to be confirmed. Members can request a new confirmation link from their Slack account settings, and the workspace sign-in options decide whether new accounts can be created this way at all.
 
         **Why this matters**
 
-        - **Account takeover resistance:** Attackers can register accounts with look-alike domains and never prove ownership before participating in channels and direct messages.
-        - **Identity spoofing prevention:** Unconfirmed accounts can impersonate employees, partners, or executives in phishing and social engineering without being caught by email domain controls.
-        - **Recovery flow integrity:** When an email was never verified, a password reset link may be delivered to an address the real user cannot access, enabling a silent hijack.
-        - **Trustworthy allowlists:** Domain-based allowlisting assumes the email is real, so an unconfirmed address means the allowlist is protecting a string rather than a verified identity.
-        - **Audit trail reliability:** Messages, file uploads, and channel joins attributed to an unconfirmed user cannot be reliably traced back to a person.
+        An unconfirmed address breaks the assumption every other control in the workspace rests on. Domain allowlisting checks a string that was never verified, so an attacker who registers with an address at a domain that reads like yours passes the allowlist while controlling no mailbox at it. From inside the workspace they post as a plausible colleague, ask for a credential in a direct message, and get it, because the name in the sidebar is the whole authentication most people apply to an internal message.
 
-        **Risk mitigation**
+        Account recovery is the second problem. A password reset for an unconfirmed account sends its link to an address that may belong to someone else entirely, which turns the recovery flow into a takeover path that leaves no failed sign-in behind.
 
-        - **Verified membership:** Requiring every flagged user to confirm their email address, or deactivating accounts that cannot be verified, ensures each account maps to a real person.
-        - **Stronger onboarding:** Requiring SSO or a verified corporate domain at sign-up prevents new accounts from being created with unverified addresses.
+        The audit trail degrades in the same way. Messages, uploads, and channel joins are attributed to an account that maps to no verified person, so an investigation cannot say who was actually there.
+
+        Have legitimate users complete the confirmation flow, deactivate accounts you cannot attribute to a known person, and require single sign-on or a verified corporate domain at sign-up so new accounts cannot be created with unverified addresses.
       audit: |
         ### Audit via Admin Settings
 


### PR DESCRIPTION
Rewrites `docs.desc` for all 50 checks across the four collaboration SaaS bundles:

| Bundle | Checks | Median words before | after |
|---|---:|---:|---:|
| `mondoo-m365-security` | 23 | 217 | 307 |
| `mondoo-google-workspace-security` | 12 | 144 | 304 |
| `mondoo-slack-security` | 8 | 178 | 309 |
| `mondoo-atlassian-security` | 7 | 194 | 303 |

## What changed

All four bundles carried the full generated skeleton: bulleted bold labels under `**Why this matters**` plus a `**Risk mitigation**` section that restated `docs.remediation`. Both are gone.

Each description now leads with the capability being verified rather than the field name, names the console and the path where the reader actually administers the setting, and says in prose what an attacker concretely reads and how they got there. The bold labels are turned into the sentences they were standing in for.

Because these are four different vendors, the admin surfaces are named per product rather than generically:

- **Microsoft 365** points at the right console for each control: Microsoft Entra admin center for Conditional Access, roles, and consent; Microsoft 365 admin center for password expiry and Global Administrator assignment; Microsoft Defender portal for Safe Links, Safe Attachments, anti-phishing, DKIM, and outbound forwarding; Exchange admin center for transport rules and remote domains; Intune admin center for device profiles; SharePoint admin center for external sharing; Microsoft Purview for the unified audit log. Graph PowerShell is named where it is the practical path.
- **Google Workspace** points at the Admin console at admin.google.com, and calls out organizational unit scoping where it is load-bearing, which it is for 2-step verification enforcement and for the security-key requirement on super admins.
- **Slack** distinguishes workspace settings from Enterprise Grid org settings, and notes where a control or a console column is absent on some plans.
- **Atlassian** separates organization settings at admin.atlassian.com from per-product settings inside Jira and Confluence, including the Jira Service Management knowledge base link that drives unlicensed Confluence access.

No policy version bumps. No field other than `docs.desc` is touched.

## Gates

Run against all four files:

| Gate | Result |
|---|---|
| `cnspec policy lint` | `valid policy bundle(s)`, all four |
| `typos` | silent |
| `go test -count=1 ./internal/bundle/...` | ok |
| structural diff | `trees identical apart from docs.desc and policy version`, all four |
| substance gate | 4 losses across 50 checks |

The 4 substance losses are all on the deliberate exception list, and no backticked literal was lost in any bundle:

- `800` twice in `mondoo-m365-security`, from the `NIST SP 800-63B` citation in the password-expiry and mobile-password-length checks. Framework and guidance citations do not belong in prose; the fact survives as "current federal password guidance".
- `27001` once each in `mondoo-google-workspace-security` and `mondoo-slack-security`, from an `ISO 27001` citation in a compliance sentence. The `compliance/*` tags already carry that mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)