### PR TITLE
📝 content: rewrite check descriptions as prose

### DIFF
--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -6823,13 +6823,17 @@ queries:
         - url: https://man.freebsd.org/cgi/man.cgi?query=ntpd&sektion=8
           title: FreeBSD ntpd(8)
       desc: |
-        This check verifies that a time synchronization daemon is enabled and running. FreeBSD ships `ntpd` in the base system, but it is not enabled by default; OpenNTPD and chrony are available as alternatives from packages.
+        This check verifies that a time synchronization daemon is enabled and running. FreeBSD ships `ntpd` in the base system but leaves it disabled, and OpenNTPD and chrony are available from packages as alternatives. Any of the three satisfies the check, and each is turned on with its own `_enable` variable in `/etc/rc.conf`.
 
         **Why this matters**
 
-        - **Log and forensic correlation:** Accurate clocks let events from multiple hosts be lined up on a single timeline. Skewed clocks make it impossible to reconstruct the true order of events during an incident investigation.
-        - **Kerberos and certificate validity:** Kerberos authentication rejects tickets when clocks drift beyond a few minutes, and TLS certificate `notBefore`/`notAfter` checks depend on a correct system time. A drifting clock breaks authentication and can cause valid certificates to be rejected or expired ones to be accepted.
-        - **Audit-trail integrity:** Time stamps on audit and system logs are only trustworthy when the clock is synchronized to an authoritative source, which is a prerequisite for many compliance regimes.
+        Every log line and audit record on the host is stamped with the local clock, and a host whose clock has drifted cannot be placed on the same timeline as the firewall, the authentication server, or the other machines in an investigation. The events are all present and their order is wrong, which is worse than missing data because it leads to the wrong conclusion about what happened first.
+
+        Authentication depends on the clock directly. Kerberos rejects tickets outside a tolerance of a few minutes, so a drifting host loses domain authentication. TLS is the more dangerous case, because certificate validity is evaluated against local time through the `notBefore` and `notAfter` fields: a clock set behind real time accepts certificates that have expired or been revoked and replaced, and one set ahead rejects certificates that are perfectly valid.
+
+        An attacker with root can move the clock deliberately for the same reason, to shift the timestamps on the records of what they did, or to push a session or token outside the window in which it would have been questioned.
+
+        Point the daemon at time sources the organization controls or explicitly trusts, and configure more than one so that a single unreachable server does not leave the clock unattended.
       audit: |
         To verify that a time synchronization daemon is active, run the following commands:
 
@@ -6919,19 +6923,17 @@ queries:
         - url: https://man.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5
           title: FreeBSD pkg.conf(5)
       desc: |
-        This check verifies that the base FreeBSD pkg repository enforces fingerprint-based signature verification, so that tampered or man-in-the-middle-modified packages are rejected at install time. The default `/etc/pkg/FreeBSD.conf` sets `signature_type: "fingerprints"`; downgrading it to `"none"` disables verification entirely.
+        This check verifies that every configured pkg repository requires a signature before anything is installed from it.
+
+        The base repository is configured in `/etc/pkg/FreeBSD.conf`, which ships with `signature_type: "fingerprints"` and validates packages against the trusted keys in `/usr/share/keys/pkg`. Downgrading that to `signature_type: "none"`, or removing the file, disables verification and fails the check. The check also reads the custom repository definitions in `/usr/local/etc/pkg/repos/*.conf`, and any of those defining a repository with a `url` must declare an enforcing `signature_type` of its own. Both `fingerprints` and `pubkey` are accepted, the latter validating against a configured public key. An omitted `signature_type` means no verification, so a repository declaring none fails exactly as one setting `"none"` does, while a file that only disables a repository and sets no `url` need not declare one. `pkg -vv` reports the effective setting for every repository.
 
         **Why this matters**
 
-        - **Supply-chain integrity:** Packages are downloaded from a network mirror. Without signature verification, an attacker who controls a mirror or sits on the network path can substitute a malicious package that runs with root privileges during installation.
-        - **Tamper detection:** Fingerprint verification checks each package against trusted signing keys, so any modification to the package contents in transit or at rest on the mirror causes the install to fail rather than silently proceed.
-        - **Trusted provenance:** Enforcing signatures guarantees that installed software originates from the official FreeBSD signing infrastructure rather than an unverified source.
+        Package installation runs as root, and post-install scripts execute before anything on the host inspects what arrived. Signature verification is the only step that establishes the package came from the FreeBSD signing infrastructure rather than from whoever answered the request.
 
-        **Scope**
+        Without it, an attacker who controls a mirror or sits on the network path between the host and the repository substitutes a package with the same name and a higher version. The next `pkg upgrade` installs it and its script runs as root. No exploit is involved, and the operation reports success.
 
-        This check inspects the base repository configuration in `/etc/pkg/FreeBSD.conf` **and** any custom repository definitions under `/usr/local/etc/pkg/repos/*.conf`. It fails if `/etc/pkg/FreeBSD.conf` is missing or no longer enforces `signature_type: "fingerprints"` for the official repository. For custom repositories, every `.conf` file that defines a repository with a `url` must positively declare an enforcing `signature_type`.
-
-        FreeBSD's `pkg` supports two verification mechanisms that both enforce signatures. The `fingerprints` type is the official repository's default and validates packages against the trusted keys in `/usr/share/keys/pkg`, while `pubkey` validates against a configured public key. A custom repository using either type is accepted. Because an omitted `signature_type` defaults to no verification, a repository that declares no type at all fails this check just as one setting `signature_type: "none"` does. Configuration files that only disable a repository and set no `url` need not declare a signature type. The audit step shows how to confirm the effective setting across all configured repositories with `pkg -vv`.
+        Verification also catches the ordinary case of a corrupted or partially replaced file on a mirror, which fails the check in the same way a deliberately modified package does.
       audit: |
         To verify that signature verification is enabled for the base repository, inspect its configuration:
 

--- a/content/mondoo-linux-operational-policy.mql.yaml
+++ b/content/mondoo-linux-operational-policy.mql.yaml
@@ -39,16 +39,19 @@ queries:
       mount.list.where(fstype != "tmpfs" && fstype != "devtmpfs" && fstype != "squashfs" && fstype != "iso9660" && device != "udev" && device != /^\/dev\/loop/).where(size > 0).all(used * 100 / size < 80)
     docs:
       desc: |
-        This check verifies that every mounted persistent filesystem is using less than 80 percent of its capacity. Pseudo-filesystems such as `tmpfs`, `devtmpfs`, and loopback mounts are excluded.
+        This check verifies that every persistent filesystem on the host is below 80 percent used.
+
+        The check reads the mount table, computes used space as a proportion of size for each entry, and requires the result to stay under 80 percent. Pseudo-filesystems and read-only images are excluded, so `tmpfs`, `devtmpfs`, `squashfs`, `iso9660`, `udev`, and loopback devices do not count against the host. The threshold is a warning level rather than a failure point: a filesystem at 80 percent is working normally and is flagged because the remaining margin has grown thin.
 
         **Why this matters**
 
-        A filesystem that fills up causes write failures that cascade into application crashes, dropped data, and emergency outages. Catching high usage early gives operations teams time to act before a disk reaches capacity.
+        A full filesystem does not degrade gracefully. Writes return an error, and most software handles that error badly. A database refuses transactions or shuts down to protect its files, a log writer drops records without saying so, a package manager aborts partway through an upgrade leaving half-configured packages, and a service that writes its state file at shutdown fails to and comes back with an inconsistent one. The failures arrive at once and are not obviously related to each other, which is what makes the incident take longer to diagnose than it should.
 
-        - **Prevents data loss:** Free space ensures new data and logs can be written without failure.
-        - **Maintains performance:** A filesystem that is not near capacity avoids the slowdowns caused by fragmentation and constrained allocation.
-        - **Supports capacity planning:** Tracking usage trends surfaces growth before it becomes an outage.
-        - **Keeps services available:** Headroom on system and log volumes keeps critical daemons running.
+        The root filesystem filling is the worst version. With no space on `/`, the mechanisms used to recover need space themselves: shells cannot write history, the journal cannot record what happened, and package operations to clean up cannot run. On some configurations even logging in fails.
+
+        Twenty percent of headroom is what turns that into a ticket instead. The gap between crossing the threshold and running out is the time available to find what grew, and where growth is usually logs or an accumulating cache, that is a routine cleanup rather than an outage.
+
+        Treat a failing filesystem as a capacity question and not only as a cleanup. Deleting files buys time, and if usage returns to the threshold within a few weeks, the volume is undersized or something is retaining data it should be rotating.
       audit: |
         Run this command to inspect filesystem usage:
 
@@ -161,16 +164,19 @@ queries:
       command("LC_ALL=C free | awk '/^Mem:/ {print $3/$2 * 100.0}'").stdout.trim < 80.0
     docs:
       desc: |
-        This check verifies that the system is using less than 80 percent of its total physical memory.
+        This check verifies that the host is using less than 80 percent of its physical memory.
+
+        The check reads the totals the kernel reports and compares used memory against the total as a percentage. Memory the kernel holds as page cache and reclaimable buffers is not counted as used, so the figure reflects what processes have actually committed rather than everything that is occupied. A host at 80 percent is not failing; it is running with a margin thin enough that the next allocation spike has nowhere to come from.
 
         **Why this matters**
 
-        When a host exhausts physical memory it falls back to slower swap or triggers the out-of-memory killer, both of which degrade or interrupt service. Watching memory headroom surfaces pressure before it causes an outage.
+        Unlike disk space, memory pressure does not announce itself. Long before anything fails, the kernel starts reclaiming. Page cache is dropped, so file reads that were served from memory go back to the disk, and anonymous pages are pushed out to swap, where every subsequent access costs a disk round trip. Throughput falls and latency turns erratic while every service still reports itself as healthy, which is why the symptom usually arrives as unexplained slowness rather than as a memory alert.
 
-        - **Maintains performance:** Free memory keeps the system from thrashing on slow swap-backed virtual memory.
-        - **Avoids crashes:** Headroom prevents the kernel out-of-memory killer from terminating critical processes.
-        - **Surfaces memory leaks:** Rising utilization over time reveals processes that fail to release memory.
-        - **Informs resource allocation:** Knowing which workloads consume memory guides right-sizing decisions.
+        When the margin is gone entirely, the kernel's out-of-memory killer picks a process and terminates it. Its choice is driven by memory footprint, so it usually selects the largest process on the host, which on a single-purpose machine is the service the machine exists to run. The process disappears without a graceful shutdown, and unless the journal is being read the only record is a kernel message nothing was watching for.
+
+        Sustained high utilization is also the visible form of a leak. A process whose usage climbs steadily and never falls back will reach the limit eventually, and the only open question is whether that happens during working hours or overnight.
+
+        Read a failing result as a question about the workload rather than only about the host. Identify which processes hold the memory and whether the growth is steady, and decide from that between restarting a leaking service, bounding it with a memory limit in its unit file, moving work elsewhere, or adding RAM.
       audit: |
         Run this command to inspect memory utilization:
 

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -233,19 +233,19 @@ queries:
       package("aide").installed
     docs:
       desc: |
-        This check verifies that the Advanced Intrusion Detection Environment (AIDE) is installed on a Linux system. AIDE functions as a file integrity checker that helps detect unauthorized changes to critical system files and configurations.
+        This check verifies that the Advanced Intrusion Detection Environment is installed, by confirming the `aide` package is present.
+
+        AIDE is a host-based file integrity checker. It records a cryptographic hash, along with size, ownership, permissions, and timestamps, for each file an administrator lists in its configuration, and stores that snapshot in a local database. A later run compares the live filesystem against the database and reports every file that changed. The package is `aide` on yum, dnf, apt-get, and zypper based distributions alike. This check looks only for its presence; a companion check in this policy confirms that the comparison actually runs on a schedule.
 
         **Why this matters**
 
-        AIDE creates a database of cryptographic checksums for important system files and directories. Once initialized, AIDE can be used to scan the system and compare the current state of files against the known-good baseline. This process helps detect file tampering, rootkit installation, or configuration drift that may indicate a security breach.
+        An attacker who reaches root on a host wants to stay. The usual mechanisms are all writes to files: a replaced `sshd` or `login` binary that records passwords, a new setuid executable in a system directory, an added line in a cron file or a systemd unit, a modified shared library loaded by every process. None of these produce an alert on their own. The system keeps running normally, which is exactly the point.
 
-        Without a host-based file integrity monitoring (FIM) solution like AIDE, administrators may not be aware of changes to critical files made by malicious actors or unintended actions by privileged users. This lack of visibility undermines incident response, auditability, and system trustworthiness.
+        File integrity monitoring is what turns those writes into events. When the hash of `/usr/sbin/sshd` no longer matches the baseline and no package transaction explains it, the host has been modified by something outside the software supply chain, and that is worth investigating regardless of what the change was.
 
-        Installing AIDE contributes to the overall integrity assurance of a Linux system and supports compliance with standards such as:
-          - PCI-DSS Requirement 11.5
-          - NIST 800-53 (SI-7: Software, Firmware, and Information Integrity)
+        Detection also matters after the fact. When an incident is being reconstructed, the integrity database is often the only record of which files an intruder touched, and therefore of how far the compromise reached and which hosts need rebuilding rather than cleaning.
 
-        Ensuring AIDE is installed lays the foundation for host-based file integrity monitoring, which is a critical part of a defense-in-depth strategy for detecting intrusions and preserving system integrity.
+        Installing the package is the first half of the control and does nothing on its own. Initialize the database on a known-good system, keep a copy of it somewhere the host cannot write, and schedule the comparison.
       audit: |
         Run this command to confirm the AIDE package is installed:
 
@@ -367,18 +367,19 @@ queries:
       systemd.timer('aidecheck').enabled
     docs:
       desc: |
-        This check verifies that AIDE (Advanced Intrusion Detection Environment) integrity scans are scheduled to run regularly. It passes when daily runs are enabled through `CRON_DAILY_RUN=yes` in `/etc/default/aide`, when the root crontab contains an `aide --check` entry, or when the `aidecheck` systemd timer is enabled.
+        This check verifies that AIDE integrity comparisons run on a schedule rather than only when someone remembers to start one.
+
+        Any of three arrangements satisfies it: `CRON_DAILY_RUN=yes` in `/etc/default/aide`, a root crontab entry that runs `aide --check`, or an enabled `aidecheck` systemd timer. Distributions differ in which they ship, so any one of them is accepted.
 
         **Why this matters**
 
-        Installing AIDE alone is not sufficient to protect a system from unauthorized changes. To be effective, AIDE must run on a schedule so the current system state is routinely compared against its known-good baseline. Regular execution of these checks helps detect file tampering, unauthorized modifications, and early signs of compromise, especially in sensitive directories like /etc, /bin, and /sbin.
+        An integrity database that is never compared against is a file taking up disk space. The control does nothing until something reads the live filesystem, hashes it, and reports the differences, and the interval between those comparisons is the window in which a modified binary goes unnoticed.
 
-        If AIDE is not executed on a regular basis:
-          - Integrity violations may go undetected, exposing the system to persistent threats such as rootkits or malware.
-          - Audit logs and incident response efforts may be incomplete due to a lack of timely data.
-          - Organizations may fail to meet compliance requirements that mandate proactive monitoring of system integrity.
+        That window is where attackers operate. A backdoored `sshd`, a new setuid binary under `/bin` or `/sbin`, a modified init script in `/etc`, or a replaced shared library all keep working indefinitely, and each additional day of silence is a day of collected credentials, a day of lateral movement, and a day of log rotation carrying away the evidence that would have explained the change. Running the comparison daily bounds that window to hours.
 
-        Scheduling recurring AIDE checks turns the integrity baseline into an active detection control that surfaces file tampering shortly after it happens instead of leaving it unnoticed.
+        A schedule also changes the character of the signal. Manual runs happen after someone already suspects a problem, which means the baseline has usually drifted so far through ordinary patching that the report is unreadable. A daily run produces a short list of changes against yesterday, most of which map to a package transaction, and the handful that do not are the ones worth reading.
+
+        Send the output somewhere a person or a pipeline actually reads. A scheduled comparison whose report goes to an unread local mailbox restores the original problem in a less obvious form.
       audit: |
         Run these commands to confirm a periodic AIDE check is scheduled:
 
@@ -3263,18 +3264,19 @@ queries:
       nfs.exports.all(noRootSquash == false)
     docs:
       desc: |
-        This check verifies that no NFS export uses the `no_root_squash` option. With root squashing enabled, which is the default, the root user on a client is mapped to the unprivileged `nfsnobody` account when accessing the export. The `no_root_squash` option turns that protection off and lets a remote root user act as root on the exported files.
+        This check verifies that no NFS export turns off root squashing.
+
+        With root squashing in effect, which is the server default, requests arriving with user ID 0 are remapped to an unprivileged account such as `nfsnobody` before the server touches the filesystem. The `no_root_squash` option in `/etc/exports`, or in a file under `/etc/exports.d/`, removes that remapping and lets a client's root account act as root on the exported files. The check reads the active export table and requires the option to be absent everywhere.
 
         **Why this matters**
 
-        NFS authenticates clients by network address and trusts the user and group IDs they present. When `no_root_squash` is set, a user with root on any permitted client, or anyone able to impersonate one, gains root-equivalent control over the exported data.
+        NFS authenticates the client machine by network address and then trusts whatever user and group IDs that machine puts in each request. The server does not verify that the client's user ID 0 corresponds to anyone in particular; it accepts the number.
 
-        With root squashing disabled, an attacker can:
-          - Create setuid-root binaries inside the export and execute them to escalate privileges.
-          - Read, modify, or delete any file in the export regardless of its ownership.
-          - Overwrite ownership and permissions to establish persistence.
+        That is workable while every access is squashed, because the worst a hostile client can claim is an unprivileged identity. With `no_root_squash`, anyone with root on a permitted client, and anyone who can impersonate one, owns the export. The concrete step is short: mount the share, write a shell binary into it, set it setuid root, then execute it on the server or on any other host that mounts the same export and escalate there. Nothing about the attack requires a vulnerability in NFS.
 
-        Leaving root squashing enabled keeps remote root access mapped to an unprivileged account and preserves the principle of least privilege for networked file systems.
+        The same access reads every file in the export regardless of ownership, which is how credentials, keys, and databases stored on a shared volume leave the network, and it rewrites ownership and permissions to leave a way back in.
+
+        Where a client genuinely needs privileged access to an export, such as a backup host, express that with explicit `anonuid` and `anongid` mappings and restrict the export to that one address, rather than disabling squashing for every client the export permits.
       audit: |
         Run this command to review the active export options:
 
@@ -7013,20 +7015,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that kernel auditing is active from the earliest stage of boot, before the `auditd` daemon itself starts.
+        This check verifies that the kernel begins auditing at boot, before the `auditd` daemon has started.
 
-        The check reads the boot loader configuration under `/boot`, and on systems that use it the kernel parameters in `/etc/secboot/config.json`, for the `audit=1` kernel command line parameter.
+        The kernel queues audit events from very early in boot, but only if it is told to. The check reads the boot loader configuration under `/boot`, and on systems that store kernel parameters in `/etc/secboot/config.json` it reads that instead, looking for `audit=1` on the active kernel command line. Setting it means adding the parameter to `GRUB_CMDLINE_LINUX` and regenerating the boot loader configuration, and it takes effect on the next boot.
 
         **Why this matters**
 
-        By default, some processes may start before auditd is initialized, especially during early boot. Without early auditing enabled, actions taken by these processes can go unrecorded, creating a blind spot in audit logs and weakening the system's ability to track critical events.
+        Between the kernel handing control to the init system and `auditd` opening its socket, the host runs a considerable amount of code: the init system itself, mount and udev work, early kernel module loads, and any unit ordered ahead of the audit daemon. Without `audit=1`, none of it is auditable, because the kernel discards audit events instead of holding them until a daemon is listening.
 
-        If the audit=1 kernel parameter is not set:
-          - Early-boot processes such as init systems, kernel modules, or startup scripts may execute without being logged.
-          - Attackers or misconfigurations could exploit this window to perform actions undetected.
-          - The system's audit trail may be incomplete, undermining trust in audit data and complicating incident response or compliance reviews.
+        An attacker who has already reached the host cares about that window, because it is the one place where privileged action leaves no audit record at all. Persistence installed as an early-boot unit, a module loaded before auditing starts, or a filesystem mounted somewhere unexpected all execute inside it, and the audit log opens afterwards showing a clean boot.
 
-        Adding audit=1 to the kernel command line ensures that the Linux kernel begins generating audit records as soon as it starts, capturing all auditable activity regardless of when auditd is fully initialized. This enhances the completeness and integrity of audit logging across the system lifecycle.
+        The gap is a problem in the ordinary case too. An audit trail with a recurring hole at every reboot cannot be used to establish that a file went untouched over a period, because the reboots are exactly the moments it does not cover.
+
+        Note that this parameter only preserves events; the rules still decide what is recorded. Pair it with the syscall and watch rules the rest of this policy requires, and confirm the change survived by reading the running kernel command line after the reboot.
       audit: |
         Run this command to confirm the kernel command line enables auditing of early-boot processes:
 
@@ -7210,18 +7211,19 @@ queries:
         auditd.config.params.max_log_file != 0
     docs:
       desc: |
-        This check verifies that the auditd configuration specifies a maximum storage size for audit logs by ensuring the `max_log_file` parameter in `/etc/audit/auditd.conf` is set to a value greater than zero.
+        This check verifies that a single audit log file has a bounded size, so the audit daemon rotates rather than growing one file without limit.
+
+        The check reads `max_log_file` in `/etc/audit/auditd.conf`, which sets the size in megabytes at which the current log is closed and rotated. The value must be present and non-zero, because zero means no limit at all.
 
         **Why this matters**
 
-        The `max_log_file` setting defines the maximum size (in megabytes) that an audit log file can grow before it is rotated. Without this limit, audit logs can consume excessive disk space, leading to system performance degradation or failures, especially on systems with limited storage or extensive auditing.
+        Audit logs grow quickly on a busy host, and the volume is not under the operator's control. A noisy syscall rule, a batch job that touches many files, or an attacker deliberately generating auditable events can all produce far more records than the daily average suggests.
 
-        If audit log size is not properly configured:
-          - Log files may grow indefinitely and fill the disk, potentially causing services to fail or the system to become unresponsive.
-          - Critical audit data may be lost if the system cannot write to a full disk.
-          - Administrators may be unaware of abnormal log volume trends, missing opportunities for early detection of suspicious activity.
+        Without a rotation threshold, that growth lands in one file on whatever filesystem holds `/var/log/audit`. When the filesystem fills, the effects reach past the audit system. Services that cannot write to `/var/log` start failing, and depending on the configured disk-space actions, the audit daemon either stops recording or takes the host out of service.
 
-        Configuring max_log_file helps maintain system stability by preventing uncontrolled log growth. It also supports log management practices such as automated rotation and retention policies, ensuring that audit data remains available without jeopardizing system operations.
+        There is an attacker-facing side to this as well. Filling the audit partition is a cheap way to blind the host: an unprivileged user who can generate auditable events in a loop pushes the log past the available space, and whatever happens next either goes unrecorded or is buried under millions of generated records. A bounded file size, paired with a rotation count and a dedicated partition, keeps that attempt from taking the whole filesystem with it.
+
+        Set the value against how much history the site needs and how much space is available. Pair it with `num_logs` and with the disk-space actions a companion check in this policy covers, and ship records off the host so that rotation ages out copies rather than the only record.
       audit: |
         Run this command to inspect the audit log file size setting:
 
@@ -7585,18 +7587,19 @@ queries:
         auditd.config.params.admin_space_left_action == /halt|single/
     docs:
       desc: |
-        This check verifies that auditd is configured to respond when audit log disk space runs low by ensuring three parameters in `/etc/audit/auditd.conf` are set: `space_left_action` must be set to `email`, `exec`, `single`, or `halt`; `action_mail_acct` must be set to `root`; and `admin_space_left_action` must be set to `halt` or `single`.
+        This check verifies that the audit daemon is configured to act, rather than silently continue, when the filesystem holding the audit logs runs low on space.
+
+        Three settings in `/etc/audit/auditd.conf` carry that behavior. `space_left_action` fires at the warning threshold and must be `email`, `exec`, `single`, or `halt`. `action_mail_acct` names the recipient of the warning and must be `root`, whose mail an administrator or a forwarding alias actually reads. `admin_space_left_action` fires at the critical threshold and must be `halt` or `single`, so the host powers off or drops to single-user mode instead of running on without a usable audit trail.
 
         **Why this matters**
 
-        The `space_left_action` setting determines what auditd does when disk space for audit logs is low, `action_mail_acct` defines which account is notified when the email action triggers, and `admin_space_left_action` specifies the action when space is critically low. Requiring `halt` or `single` at the critical threshold ensures the system stops normal multi-user operation rather than continuing without reliable audit logging.
+        The default behavior when the audit partition fills is to keep the system running and stop recording. Nothing is logged about the events that follow, because there is nowhere to write them, and the host looks entirely normal while producing no audit trail at all.
 
-        If these parameters are not configured:
-          - Audit records may be silently dropped once the disk fills, leaving gaps in security monitoring.
-          - Administrators receive no warning that audit capacity is running out, so the condition persists unnoticed.
-          - The system may continue operating without proper oversight, increasing the risk of undetected malicious activity and jeopardizing compliance with regulatory audit requirements.
+        An attacker with any local foothold can bring that state about deliberately and cheaply. Auditable events can be generated in a loop from an unprivileged shell, and once the partition is full the rules that would have recorded the next stage of the intrusion have nothing to write to. Blinding the audit system this way needs no privilege and no exploit, only patience and a small partition.
 
-        Configuring these parameters ensures administrators are alerted before audit space is exhausted and that the system halts or drops to single-user mode rather than running without a complete audit trail.
+        Configuring the thresholds removes the payoff. The warning gives an administrator time to act, and the critical action stops the host rather than letting it run unmonitored, which turns an invisible blinding attempt into a loud outage.
+
+        Choose the critical action deliberately, because both options interrupt service. `single` is the less disruptive of the two. Size a dedicated partition for `/var/log/audit` and forward records off the host first, so that the warning threshold is the one you meet in practice.
       audit: |
         Run this command to inspect the audit disk-space actions:
 
@@ -8217,18 +8220,19 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that auditd watch rules are in place for the session tracking files `/var/run/utmp`, `/var/log/wtmp`, and `/var/log/btmp`, so that session starts, login history, and failed login attempts are all recorded in the audit log.
+        This check verifies that the audit system watches the three files that hold the host's login record.
+
+        It requires watch rules with the `wa` permission mask and a non-empty key on `/var/run/utmp`, `/var/log/wtmp`, and `/var/log/btmp`. The `utmp` file lists sessions that are currently open, `wtmp` is the history of logins and logouts that `last` reads, and `btmp` records failed authentication attempts and is read by `lastb`. Rules go in a file under `/etc/audit/rules.d/` and are loaded with `augenrules --load`.
 
         **Why this matters**
 
-        These files form the system's record of who logged in, when, and from where. The `utmp` file tracks active sessions, `wtmp` keeps a history of logins and logouts, and `btmp` records failed login attempts. Together they provide vital context for analyzing user activity.
+        These are binary records that any process running as root can rewrite, and rewriting them is a well-worn step in covering an intrusion. Utilities to do it have shipped in rootkits for decades: they delete the session entry from `wtmp`, remove the current session from `utmp`, and clear the failed attempts from `btmp` that the password guessing produced on the way in. Afterwards `last` and `lastb` report a host that nobody unexpected logged into.
 
-        If changes to these files are not audited:
-          - User activity cannot be reliably correlated to specific sessions, weakening audit trails.
-          - Brute-force attempts recorded in `btmp` and tampering with login history may go undetected.
-          - Compliance with security standards and regulatory frameworks that require session logging may be compromised.
+        Watch rules break that, because the edit itself becomes an audit event with a process, a parent, and an audit ID attached. The attacker is then choosing between leaving the login record intact and leaving a record of having tampered with it, and either outcome is one the investigation can work from.
 
-        By auditing changes to these session files, organizations gain visibility into who accessed the system and when, and can detect attempts to manipulate the login record. This supports effective monitoring, incident investigation, and user accountability.
+        The records are worth having with nobody tampering at all. `btmp` is where a slow password-guessing campaign shows up before it succeeds, and `wtmp` is what answers whether a given account was in use at the time something happened.
+
+        Watching these three files does not protect their contents. Ship the audit records and the login history off the host, because everything discussed here is readable and writable by anyone who has already reached root locally.
       audit: |
         Run this command to confirm the session audit rules are loaded:
 
@@ -8808,18 +8812,19 @@ queries:
           mondoo.com/filter-icon: linux
     docs:
       desc: |
-        This check verifies that the audit system records changes to the system's network identity and core network configuration files. It requires syscall rules for `sethostname` and `setdomainname` on both 32-bit and 64-bit architectures, plus watch rules on `/etc/issue`, `/etc/issue.net`, and `/etc/hosts`. On Debian and Red Hat based systems it also requires a watch rule on the distribution's network configuration location, either `/etc/sysconfig/network` or `/etc/network`.
+        This check verifies that the audit system records changes to the host's network identity and to the files that define its local name resolution and its login banners.
+
+        It requires syscall rules with a non-empty key for `sethostname` and `setdomainname` on both the 32-bit and the 64-bit ABI, and watch rules with the `wa` permission mask on `/etc/issue`, `/etc/issue.net`, and `/etc/hosts`. On Red Hat and Debian based systems it also requires a watch on the distribution's network configuration location, `/etc/sysconfig/network` or `/etc/network`. Rules are written into a file under `/etc/audit/rules.d/` and loaded with `augenrules --load`.
 
         **Why this matters**
 
-        Changes to the system's hostname, domain name, or core network-related files can alter how the system identifies itself and interacts with other hosts. These modifications may indicate reconfiguration, misconfiguration, or unauthorized tampering.
+        `/etc/hosts` is the interesting one. It takes precedence over DNS in a default resolver configuration, so a single added line silently redirects a name to an address of the attacker's choosing for every process on the host. That is how an update server, a package mirror, a log collector, or an internal API endpoint gets repointed without touching DNS, without any network device seeing a change, and without anything in the application logs looking wrong.
 
-        If these events are not audited:
-          - Changes to system identity through the sethostname or setdomainname system calls may go untracked, affecting asset management and security visibility.
-          - Modifications to files like `/etc/hosts` or `/etc/issue` could enable social engineering, redirect network traffic, or disrupt connectivity.
-          - Attackers may exploit these files to mask their activity or persist on the system.
+        `sethostname` and `setdomainname` matter because the hostname is the field that ties a log line to a machine. Renaming a host mid-incident splits its records across two identities in the collector, and Kerberos, certificate validation, and configuration management all key off the same name.
 
-        By auditing these system calls and configuration files, administrators can detect critical network and identity changes. This supports system integrity, operational consistency, and incident investigation efforts.
+        `/etc/issue` and `/etc/issue.net` are displayed before authentication on console and network logins. They are a natural place to add text that steers a user somewhere, and on many sites they carry the legal banner that gives monitoring its authority.
+
+        These rules record that a change happened and who made it, not what the new content is. Pair them with configuration management or file integrity monitoring to recover the content of a change.
       audit: |
         Run this command to confirm the audit rules for network environment modification events are loaded:
 
@@ -10023,29 +10028,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the system is configured to monitor the use of system calls associated with the deletion or renaming of files and file attributes. It verifies that the `unlink`, `unlinkat`, `rename`, and `renameat` system calls are audited, which helps track file deletions and renames.
+        This check verifies that the audit system records file deletions and renames performed by ordinary user accounts.
+
+        It requires syscall rules with a non-empty key, filtered to `auid>=1000` and excluding the unset audit ID, covering `unlinkat` and `renameat` on the 32-bit and 64-bit ABI, and `unlink` and `rename` in addition on architectures that implement them. ARM kernels do not, so those two are not required there. Rules go in a file under `/etc/audit/rules.d/` and are loaded with `augenrules --load`. Where the site has changed `UID_MIN` in `/etc/login.defs`, replace `auid>=1000` with `auid>=<UID_MIN for your system>` so the filter still separates human accounts from service accounts.
 
         **Why this matters**
 
-        Monitoring file deletion and renaming events is critical for maintaining system security and integrity. If these events are not audited:
-          - Unauthorized file deletions or renames may go unnoticed, leading to data loss or tampering.
-          - Malicious actors could exploit this lack of visibility to hide their tracks or disrupt system operations.
-          - Compliance with security standards requiring audit logging may be compromised.
+        Deleting is what an intruder does last. Having used an account to reach data, run a tool, or drop a payload, the tidy-up is removing the tool, removing the payload, and removing whatever the tool wrote. Each of those is an `unlink`, and without a rule there is no record that the file ever existed, so the investigation begins with a host that looks untouched.
 
-        Auditing these system calls ensures that all file deletion and renaming activities are logged, providing visibility into potential security incidents and supporting forensic investigations.
+        Renaming is the same act performed more quietly, and it is worth auditing for a second reason. Moving a file over another one is how a binary gets replaced or a configuration file swapped, because a rename onto an existing path is atomic and leaves no window in which the target is missing.
 
-        **Note**
+        Destruction is also the goal in its own right in ransomware and sabotage, where the record of which paths disappeared and under which login is what scopes the recovery.
 
-        On ARM architectures, the `unlink` and `rename` system calls may not be available, so only the other system calls are checked.
-
-        **Note:**
-        Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run this command:
-
-        ```bash
-        awk '/^\s*UID_MIN/{print $2}' /etc/login.defs
-        ```
-
-        If your system's UID_MIN is not `1000`, replace `auid>=1000` with `auid>=<UID_MIN for your system>` in the audit and remediation procedures.
+        The `auid` filter is what keeps these rules usable. Service accounts churn through temporary files constantly, and auditing all of it would bury the events worth reading. Filtering on the audit ID keeps each record tied to the human who logged in, even after they have changed identity with `su` or `sudo`.
       audit: |
         Run this command to confirm the audit rules for file deletion events are loaded:
 
@@ -10747,16 +10742,19 @@ queries:
       sudoers.defaults.where(parameter == "logfile").any(value == "/var/log/sudo.log")
     docs:
       desc: |
-        This check ensures that sudo logs all events to a dedicated log file instead of the default `/var/log/auth.log` file, which contains all authentication events system-wide. Configuring a dedicated log file for sudo events improves the ability to audit and monitor sudo usage effectively.
+        This check verifies that `sudo` writes a dedicated log file rather than only mixing its records in with every other authentication event on the host.
+
+        The check reads the sudo defaults for a `logfile` setting pointing at `/var/log/sudo.log`. Administrators add it as a `Defaults logfile="/var/log/sudo.log"` line, edited through `visudo` in `/etc/sudoers` or in a file under `/etc/sudoers.d/`. The log file itself should be owned by `root` and readable only by its owner.
 
         **Why this matters**
 
-        By default, sudo logs are mixed with other authentication events in `/var/log/auth.log`, making it difficult to identify and analyze sudo-specific failures or activities. Without a dedicated log file:
-          - Sudo failures may go unnoticed due to the volume of unrelated log entries.
-          - Administrators may face challenges in auditing and investigating sudo usage.
-          - Critical security events related to sudo may be obscured, increasing the risk of unauthorized access or privilege escalation.
+        `sudo` is the boundary between an ordinary account and root, so its records answer the question that matters most after an incident: which account ran what as root, and when. By default those lines land in `/var/log/auth.log` alongside every SSH connection, every PAM session open and close, every cron job authentication, and every failed login on the host. On a busy machine the sudo lines are a fraction of a percent of the volume.
 
-        Configuring sudo to log to a dedicated file enhances visibility into sudo activities, supports effective auditing, and strengthens overall system security.
+        That ratio is what an attacker relies on. Commands run through a compromised account are recorded, but they are recorded in a stream nobody reads line by line, and the surrounding noise means an alert on the pattern is either drowned or switched off. A dedicated file makes the entire history of privilege escalation on the host readable in one place, and cheap to ship to a collector and alert on.
+
+        The separation also survives the ordinary failure modes of a shared log. A burst of authentication failures, or aggressive rotation tuned to that volume, ages sudo history out of `/var/log/auth.log` far sooner than anyone intends. A separate file rotates on its own much slower schedule.
+
+        A local log file is evidence for an investigation, not protection from one. Anyone who reaches root can edit or truncate it, so forward the records off the host as well.
       audit: |
         Run this command to confirm sudo is configured to write a log file:
 
@@ -18420,17 +18418,19 @@ queries:
       selinux.mode == "enforcing"
     docs:
       desc: |
-        This check verifies that SELinux is actively enforcing mandatory access control policies on the system.
+        This check verifies that SELinux is currently enforcing its policy rather than merely loaded and logging.
+
+        SELinux is the kernel's mandatory access control system. It labels every process and every object and consults a policy on each access, independently of the file permissions and of the process's user ID. It has three runtime states: enforcing, where a denied access fails; permissive, where the same access is allowed but logged; and disabled, where no policy is consulted. The check reads the running mode, the value `getenforce` reports, and requires it to be enforcing. A companion check in this policy covers the persistent setting that survives a reboot.
 
         **Why this matters**
 
-        SELinux in enforcing mode confines processes to the minimum set of privileges they need, limiting the damage from compromised services or applications. When SELinux is set to permissive or disabled:
+        Discretionary permissions answer whether a process may open a file. SELinux answers whether a process of this type may open a file of that type, which is a much narrower question, and it is the question that constrains a service after it has been exploited.
 
-          - Exploited services can access files and resources beyond their intended scope.
-          - Privilege escalation attacks become significantly easier.
-          - The system loses a critical defense-in-depth layer against zero-day exploits.
+        The difference shows up at the moment it is needed. A web server compromised through its own code runs as its own account and, without SELinux, may read anything that account may read: application configuration holding database credentials, private keys in its own certificate directory, and any world-readable file on the host. Under an enforcing targeted policy the same process is confined to the types its domain permits, so the exploit yields a shell that cannot read the key material, cannot write outside a handful of directories, and cannot connect outbound to a port the policy does not allow.
 
-        Running SELinux in enforcing mode is a baseline requirement for CIS benchmarks and many compliance frameworks including PCI DSS, DISA STIG, and FedRAMP.
+        Permissive mode gives none of that. The denials are written to the audit log and the access proceeds anyway, which is useful while a policy is being developed and worthless as a control.
+
+        Permissive is the right setting while collecting denials for a new workload. Do that for a bounded period, resolve the denials with correct file contexts and booleans rather than a blanket allow, and return the host to enforcing.
       audit: |
         Run this command to inspect the current SELinux mode:
 
@@ -18551,17 +18551,17 @@ queries:
       selinux.configMode == "enforcing"
     docs:
       desc: |
-        This check verifies that the SELinux persistent configuration in `/etc/selinux/config` is set to enforcing mode.
+        This check verifies that the SELinux mode chosen at boot is enforcing, so the protection is still in place after the host restarts.
+
+        The runtime mode and the persistent mode are two separate settings. `setenforce 1` changes the running kernel and nothing else; the mode the host comes back with is the `SELINUX=` line in `/etc/selinux/config`. The check reads that file and requires `SELINUX=enforcing`. A companion check in this policy covers the runtime mode.
 
         **Why this matters**
 
-        Even when SELinux is currently enforcing at runtime, the persistent configuration may be set to permissive or disabled. This means SELinux protection will be lost after the next reboot:
+        A host can pass a runtime check and still be one reboot away from having no mandatory access control at all. That is not an unusual state, it is the normal outcome of a common sequence. Someone hits a denial while installing an application, runs `setenforce 0` to get past it, finishes the work, and never returns the host to enforcing in the file. The runtime mode is later corrected, or the machine is left running untouched for months, and the discrepancy stays invisible until an unrelated reboot removes the confinement.
 
-          - An administrator may have temporarily set enforcing mode with `setenforce 1` without updating the configuration file.
-          - A system update or configuration management drift may have changed the persistent setting.
-          - An attacker with root access may have modified the config to disable SELinux on next reboot.
+        The same discrepancy is worth an attacker's attention precisely because it is quiet. Editing one line in `/etc/selinux/config` changes nothing observable: no service restarts, no denial appears, no monitoring alert fires, and the running system continues to enforce. The confinement disappears at the next reboot, which will be attributed to patching or to a hardware event rather than to the edit that caused it.
 
-        Setting `SELINUX=enforcing` in the persistent configuration ensures that SELinux protection survives reboots and is not silently weakened over time.
+        Moving from disabled to enforcing is not purely a configuration change. The filesystem carries no security labels while SELinux is off, so the next boot performs a full relabel, taking time proportional to the number of files. Plan that reboot rather than discovering the relabel during an incident, and confirm afterwards that the running mode and the file agree.
       audit: |
         Run this command to inspect the persistent SELinux mode:
 
@@ -18665,18 +18665,19 @@ queries:
       chrony.conf.servers != [] || chrony.conf.pools != []
     docs:
       desc: |
-        This check ensures that chrony, the time synchronization daemon, is configured with at least one upstream time source so the system clock is kept accurate. By default a chrony installation may ship without an active `server` or `pool` directive, leaving the host with an unsynchronized clock.
+        This check verifies that chrony has at least one upstream time source configured, so the daemon has something to synchronize the clock against.
+
+        chrony is the time synchronization daemon on most current distributions. It disciplines the system clock against remote reference clocks, but only against the ones it has been given. The check reads the chrony configuration, `/etc/chrony.conf` on Red Hat based systems and `/etc/chrony/chrony.conf` on Debian based ones, and requires at least one `server` or `pool` directive. Some packages ship the daemon with every source commented out, which leaves chrony running, reporting no error, and correcting nothing.
 
         **Why this matters**
 
-        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock agrees on the current time.
-        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so drift can break authentication or silently accept expired credentials.
-        - **Forensic integrity:** Accurate timestamps are essential when reconstructing the sequence of an incident.
+        Every security record on the host is stamped with the local clock, and a stamp is only useful relative to the stamps on other hosts. When one machine drifts, its events cannot be ordered against the firewall, the authentication server, or the application tier, and the reconstruction of an incident stops at the point where the sequence matters most.
 
-        **Risk mitigation**
+        Authentication depends on the same clock directly. Kerberos rejects a ticket whose timestamp falls outside a tolerance of a few minutes, so a drifting host loses domain authentication outright. TLS is the more dangerous case, because certificate validity is evaluated against local time: a clock set behind real time accepts certificates that have expired or been revoked and replaced, and a clock set ahead rejects valid ones. Time-based one-time passwords fail the same way.
 
-        - **Detect tampering:** A synchronized clock makes it harder for an attacker to disguise the timing of malicious activity.
-        - **Consistent enforcement:** Time-based access controls and scheduled jobs behave predictably when the clock is trustworthy.
+        Drift is also something an attacker can use. Where a host takes time from a source they influence, moving the clock moves the timestamps on the records of what they did, and it can push a session or a token outside the window in which it would have been questioned.
+
+        Point the host at sources the organization controls or explicitly trusts, and configure more than one so a single unreachable server does not leave the clock unattended.
       audit: |
         Run this command to confirm chrony is tracking at least one time source:
 
@@ -18812,18 +18813,19 @@ queries:
       systemd.timesyncd.servers != []
     docs:
       desc: |
-        This check ensures that systemd-timesyncd, when it is the active time synchronization client, has at least one NTP server explicitly configured rather than relying solely on the compiled-in fallback servers. An explicit `NTP=` setting guarantees the host synchronizes against the time sources the operator intends.
+        This check verifies that systemd-timesyncd, where it is the active time client, has its time servers set explicitly rather than falling back on the ones compiled into the distribution package.
+
+        The daemon reads `NTP=` from `/etc/systemd/timesyncd.conf`, or from a drop-in beneath it, and turns to its fallback list only when that setting is empty or unreachable. The check requires a configured server list, which `timedatectl show-timesync --all` reports as the system servers rather than the fallback ones.
 
         **Why this matters**
 
-        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock agrees on the current time.
-        - **Operator control:** Defining the NTP servers explicitly ensures the host uses approved, reachable time sources instead of distribution defaults that may be blocked or undesirable.
-        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so drift can break authentication or silently accept expired credentials.
+        Falling back is not the same as being unconfigured, and that is what makes it easy to miss. The clock is usually correct, `timedatectl` reports synchronization, and nothing looks wrong. What has actually happened is that the host takes its time from whichever public servers the distribution vendor chose, over the open internet, on a path nobody in the organization designed.
 
-        **Risk mitigation**
+        Three things follow. In a segmented or air-gapped network those servers are unreachable, so the daemon retries and the clock quietly free-runs until the drift is large enough to break authentication. Where they are reachable, the traffic leaves the network unauthenticated and can be answered by anyone in a position to do so, and a supplied offset is enough to make an expired certificate appear valid or to shift the timestamps written into logs. And when time goes wrong across a fleet, the fallback servers are outside the organization's ability to investigate or fix.
 
-        - **Predictable sources:** Pinning the time servers removes any dependency on fallback hosts that the operator does not control.
-        - **Detect tampering:** A synchronized clock makes it harder for an attacker to disguise the timing of malicious activity.
+        Pinning the sources also makes the configuration reviewable. An explicit list can be checked against the network design and against firewall policy; a compiled-in default cannot.
+
+        Set the servers the organization operates or has approved, list more than one, and confirm afterwards that the daemon reports them as its system servers rather than continuing on the fallback list.
       audit: |
         Run this command to display the configured NTP servers and synchronization state:
 
@@ -18959,18 +18961,19 @@ queries:
       systemd.timesyncd.synchronized == true
     docs:
       desc: |
-        This check ensures that when systemd-timesyncd is enabled it is actually running and has synchronized the system clock to a time source. A daemon that is enabled but inactive, or active but unable to reach a server, leaves the clock drifting without anyone noticing.
+        This check verifies that systemd-timesyncd is actually running and has synchronized the system clock, not merely enabled to do so.
+
+        Enabled, active, and synchronized are three different states, and only the last means the clock is correct. The check requires the daemon to be active and to report a synchronized clock, which is what `timedatectl status` shows as an active time service and a synchronized system clock. A companion check in this policy confirms that time servers are configured; this one confirms that reaching them worked.
 
         **Why this matters**
 
-        - **Confirmed accuracy:** A configured time source is only useful if the daemon is running and has successfully synchronized against it.
-        - **Reliable audit trails:** Security events recorded across many hosts can only be correlated and ordered when every clock is actually synchronized.
-        - **Certificate and ticket validity:** TLS certificate expiry and Kerberos ticket lifetimes are evaluated against the local clock, so an unsynchronized clock can break authentication or silently accept expired credentials.
+        The common failure here is silent. The unit is enabled, so every configuration review passes. The daemon started, so the service manager reports it running. But the configured servers are blocked by a firewall rule that closed outbound UDP port 123, or they resolve to nothing on a segmented network, and the daemon retries in the background while the clock free-runs on the hardware oscillator. Nothing logs an error that a human sees, and the drift accumulates at a few seconds a day until something breaks.
 
-        **Risk mitigation**
+        What breaks first is usually authentication. Kerberos rejects tickets once the offset passes a few minutes, so domain logins fail on that host alone, which reads as a host problem rather than a time problem. TLS validation is the more dangerous outcome, because a clock behind real time accepts certificates that have already expired or been replaced.
 
-        - **Detect failures early:** Verifying the synchronized state surfaces daemons that started but never reached a time source.
-        - **Forensic integrity:** Accurate timestamps are essential when reconstructing the sequence of an incident.
+        The audit trail degrades before any of that is noticed. Records written by a drifting host cannot be ordered against records from the rest of the fleet, and the discrepancy is not visible in the log lines themselves, so an investigation reaches the wrong conclusion about what happened first.
+
+        Alert on the synchronized state rather than on the unit being enabled. That is the state that changes when the network path to the time source breaks.
       audit: |
         Run this command to confirm the daemon is active and the clock is synchronized:
 
@@ -19070,18 +19073,19 @@ queries:
       yum.config.gpgcheck == true
     docs:
       desc: |
-        This check ensures that the system-wide `gpgcheck` option is enabled in the yum or dnf configuration so that the package manager verifies the cryptographic signature of every package before installing it. When `gpgcheck` is disabled the system will install packages whose authenticity and integrity have not been verified.
+        This check verifies that the package manager verifies the cryptographic signature of every package before installing it.
+
+        On Red Hat based systems and Amazon Linux, `gpgcheck` in the `[main]` section of `/etc/dnf/dnf.conf`, or of `/etc/yum.conf` on older releases, sets the default for every repository. The check requires it to be enabled. Note that an individual repository definition under `/etc/yum.repos.d/` can still override the global default with its own `gpgcheck=0`, so review those files as well.
 
         **Why this matters**
 
-        - **Authenticity:** Signature verification confirms that a package was produced by the expected vendor and not substituted by an attacker.
-        - **Integrity:** A valid signature guarantees the package was not modified in transit between the repository and the host.
-        - **Supply-chain protection:** A compromised mirror or a manipulated download cannot deliver unsigned malicious software when verification is enforced.
+        Package installation is the most privileged thing that happens routinely on a server. Scriptlets run as root before and after the files are unpacked, and the files themselves land in system directories and are executed by everything on the host. Signature verification is the only step that establishes the package came from the vendor whose key the host trusts.
 
-        **Risk mitigation**
+        With verification off, that assurance is gone and the trust falls back to whatever is protecting the transport. An attacker positioned between the host and the repository, on a compromised mirror, on a caching proxy, or on the network path where a repository is still reached over plain HTTP, substitutes a package with the same name and a higher version. The host installs it on the next update and the scriptlet runs as root. No exploit is involved and nothing on the host reports anything unusual, because from the package manager's point of view the update succeeded normally.
 
-        - **Prevent malicious installs:** Tampered or forged packages are rejected before any code runs.
-        - **Consistent enforcement:** Setting the option in the global `[main]` section applies the control to every repository rather than relying on per-repository settings.
+        The same setting catches a corrupted download or a mirror serving damaged content, which fails a signature check the way a tampered package does.
+
+        Enable it in the `[main]` section so it applies to every repository, then audit the repository definitions for per-repository overrides, and confirm that the vendor keys the host trusts are the ones actually expected.
       audit: |
         Run this command to confirm `gpgcheck` is enabled in the global configuration:
 
@@ -19205,18 +19209,19 @@ queries:
       apt.repos.where(enabled).all(trusted == false)
     docs:
       desc: |
-        This check ensures that no enabled APT repository is marked as trusted, which would bypass cryptographic signature verification. An entry carrying `[trusted=yes]` in a one-line sources file, or `Trusted: yes` in a deb822 `.sources` file, tells APT to install packages from that repository without checking their signatures.
+        This check verifies that no enabled APT repository is marked trusted, which would tell APT to install its packages without checking any signature.
+
+        APT normally refuses a repository whose release file is not signed by a key the host holds. Marking an entry trusted removes that requirement. In a one-line sources file the marker is `[trusted=yes]` in the options field; in a deb822 `.sources` file it is a `Trusted: yes` field. The check reads every enabled repository and requires the marker to be absent. The supported way to add a third-party repository is a `signed-by` option naming a keyring, which trusts one specific key for that one repository.
 
         **Why this matters**
 
-        - **Authenticity:** Signature verification confirms that packages originate from the expected repository owner rather than an impostor.
-        - **Integrity:** A valid signature guarantees that packages were not altered between the repository and the host.
-        - **Supply-chain protection:** A trusted repository accepts packages from a compromised mirror or a manipulated download without objection.
+        `[trusted=yes]` is usually added to make an error go away. The repository's key was never imported, or it was imported into a location APT no longer honors, `apt-get update` failed, and the flag suppressed the failure. What it actually did was switch that repository from cryptographically verified to unverified, permanently, with no further warning.
 
-        **Risk mitigation**
+        An unverified repository is a root shell available to whoever can answer for it. That includes the operator of the mirror, anyone who compromises it, and, where the repository is reached over plain HTTP, anyone on the network path between the host and the server. Substituting a package with the same name and a higher version is enough: `apt-get upgrade` installs it and the maintainer scripts run as root before anything else on the host has a chance to notice.
 
-        - **Prevent malicious installs:** Removing the trusted flag forces APT to reject unsigned or tampered packages.
-        - **Key pinning:** Replacing `[trusted=yes]` with a `signed-by` keyring restricts the repository to a specific signing key.
+        The exposure is wider than the one repository, too. APT resolves dependencies across every configured source, so an unverified repository that offers a higher version of a core library gets to supply it to the whole system.
+
+        Replace the flag with the key it was working around. Fetch the repository's signing key, place it in a keyring under `/usr/share/keyrings/`, and reference that keyring with `signed-by` so the trust is scoped to one key and one repository rather than granted to an address.
       audit: |
         Run this command to list any repository that bypasses signature verification:
 

--- a/content/mondoo-linux-snmp-policy.mql.yaml
+++ b/content/mondoo-linux-snmp-policy.mql.yaml
@@ -55,15 +55,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that `/var/lib/snmp/snmpd.conf` is owned by the `Debian-snmp` user and group and is not readable, writable, or executable by group or other users. This check applies to Debian-based distributions.
+        This check verifies that the file holding SNMPv3 user credentials is readable only by the account the SNMP daemon runs as.
+
+        When SNMPv3 users are created, net-snmp derives localized keys from their authentication and privacy passphrases and writes them into its persistent data file. On Debian-based distributions that file is `/var/lib/snmp/snmpd.conf`, owned by the `Debian-snmp` user and group. The check requires that ownership and no group or other access at all, which is mode `600`. Red Hat-family and SUSE systems run net-snmp under a different account and keep the same data elsewhere, so the equivalent file there needs the same treatment.
 
         **Why this matters**
 
-        The file `/var/lib/snmp/snmpd.conf` stores SNMPv3 user password hashes, which can use algorithms as weak as MD5. If the file is readable by unprivileged users, those hashes can be extracted and cracked offline.
+        The values in that file are not passwords, but they are password-equivalent. SNMPv3 authenticates each request with a keyed hash computed from the localized key, so anyone holding the key can produce valid requests as that user without ever learning the passphrase. Reading the file is the whole attack; there is no further step.
 
-        - **Protects credential hashes:** Restricting access prevents disclosure of SNMPv3 authentication secrets.
-        - **Limits offline cracking:** Keeping the file private denies attackers the material needed to brute-force weak hashes.
-        - **Reduces local attack surface:** Hardened permissions ensure only the SNMP daemon and root can read the file.
+        What that buys depends on the user's view, and on a monitoring account it is usually the entire device tree: interface names and addresses, the process and software inventory, routing and ARP tables, and on network equipment often the running configuration. That is a complete map of the host handed to any local account, and the same credential frequently works on every device the monitoring system polls, because the SNMPv3 user is provisioned identically across the fleet.
+
+        The passphrases themselves are also exposed to offline work, because the localization is a hash construction and net-snmp still permits MD5 as the authentication algorithm. A guessable passphrase falls to a wordlist run off the machine at whatever rate the attacker's hardware allows, with nothing on the host recording so much as one failed attempt.
+
+        Set the ownership and mode, prefer SHA over MD5 for new users, and rotate any SNMPv3 credential that was exposed, because permissions correct the future and do not recall a key that has already been read.
       audit: |
         Run this command to inspect the ownership and permissions of the SNMP user file:
 
@@ -132,15 +136,19 @@ queries:
       snmpd.config.rwCommunities.length == 0
     docs:
       desc: |
-        This check verifies that `/etc/snmp/snmpd.conf` and any files under `/etc/snmp/snmpd.conf.d` contain no `rwcommunity` or `rwcommunity6` directives.
+        This check verifies that the SNMP daemon defines no read-write community strings.
+
+        A community string is the entire authentication mechanism in SNMPv1 and SNMPv2c: a shared word carried in cleartext in every request. The `rwcommunity` and `rwcommunity6` directives grant write access to whoever presents the right word. The check requires that neither appears in `/etc/snmp/snmpd.conf` or in any file under `/etc/snmp/snmpd.conf.d`.
 
         **Why this matters**
 
-        A read-write community string grants full SNMP write access to anyone who knows it. Because SNMPv1 and v2c community strings travel in plaintext and are often left at well-known defaults, an attacker who learns one can reconfigure the host, alter system settings, or disrupt monitored services.
+        Write access over SNMP is not a monitoring feature, it is remote administration with no user, no session, and no meaningful credential. The string travels unencrypted in every request, so anyone able to observe traffic on a path the monitoring system uses reads it straight off the wire. Guessing works about as well, because the defaults are famous and the strings that replace them are usually one word derived from the organization's name.
 
-        - **Prevents unauthorized changes:** Removing write community strings blocks SNMP-based modification of the system.
-        - **Eliminates plaintext write credentials:** No read-write community string can be sniffed off the network.
-        - **Forces stronger access models:** Removing these directives pushes management toward authenticated SNMPv3.
+        With the string in hand, an attacker writes to the MIB. On a server, net-snmp's extend and exec facilities turn a settable object into command execution as the account the daemon runs as, which is often root. On network equipment the same access changes interface state, rewrites routing, and on many platforms triggers a configuration upload or download over TFTP, which both exfiltrates the running configuration and installs a replacement for it.
+
+        None of this requires an exploit or leaves an authentication failure anywhere, because from the daemon's point of view every one of those requests arrived with the correct credential.
+
+        Where a monitoring system genuinely needs read access, use `rocommunity` scoped to the source network it polls from. Where write access is genuinely required, move to SNMPv3 with an authenticated user, which is the model a companion check in this policy also assumes.
       audit: |
         Run this command to search for read-write community string directives:
 
@@ -233,15 +241,19 @@ queries:
       snmpd.config.content.lines.none(/(?i)^\s*rwuser\s+(-s\s+\S+\s+)?\S+\s+noauth(nopriv)?\b/)
     docs:
       desc: |
-        This check verifies that `/etc/snmp/snmpd.conf` and any files under `/etc/snmp/snmpd.conf.d` contain no `rwuser` directives that specify the `noauth` security level.
+        This check verifies that no SNMPv3 user is granted write access without having to authenticate.
+
+        An `rwuser` line names a user and the security level required of its requests. Given `rwuser ... noauth`, or its longer spelling `noauthnopriv`, the daemon accepts write requests carrying that user name with no keyed hash to verify and no encryption, which reproduces the weakness of a community string while wearing the version of the protocol that was meant to fix it. The check requires that no `rwuser` directive in `/etc/snmp/snmpd.conf` or under `/etc/snmp/snmpd.conf.d` specifies that level.
 
         **Why this matters**
 
-        An `rwuser ... noauth` directive grants SNMPv3 write access without requiring authentication. This effectively exposes full management control of the host to any network peer that can reach the SNMP port.
+        The security level, not the protocol version, is what does the work in SNMPv3. A configuration that reads as modern and a configuration that hands the host to the network can differ by one word at the end of a line, and the difference is invisible to any inventory recording only which protocol version is in use.
 
-        - **Requires authentication:** Removing `noauth` directives ensures every SNMPv3 write request is authenticated.
-        - **Prevents unauthorized control:** Authenticated access blocks anonymous peers from reconfiguring the system.
-        - **Enforces SNMPv3 best practice:** Using `authNoPriv` or `authPriv` keeps SNMP management aligned with secure configuration guidance.
+        At `noauth` the user name is the only thing required, and a user name is not a secret. It appears in the monitoring system's configuration, in documentation, in change tickets, and in the headers of ordinary polling traffic on the wire. Anyone who can reach the SNMP port then writes to the MIB as that user, which on a net-snmp host with extend or exec objects defined is command execution as the daemon's account, and on network equipment is a configuration change or a configuration upload to a server the attacker chose.
+
+        These lines are usually left over from bringing the daemon up. Authentication was turned off to get polling working, the passphrase step was deferred, and the line stayed.
+
+        Recreate the user with an authentication passphrase and require `authPriv`, which authenticates and encrypts, or `authNoPriv` where the payload genuinely needs no confidentiality. Note that raising the level on a user created without a passphrase removes that user's access until the credential exists, so create it first.
       audit: |
         Run this command to search for unauthenticated SNMP write directives:
 

--- a/content/mondoo-linux-workstation-security.mql.yaml
+++ b/content/mondoo-linux-workstation-security.mql.yaml
@@ -166,18 +166,20 @@ queries:
         }
       }
     docs:
-      desc: |-
-        This check verifies that bootloader configuration files such as `grub.cfg`, `menu.lst`, `user.cfg`, and `loader.conf` are owned by `root` and are not readable or writable by group or other users. On UEFI systems, it also verifies that the `/boot/efi` vfat filesystem is mounted with `fmask=0077`.
+      desc: |
+        This check verifies that the boot loader's configuration files are readable only by root, and that a UEFI system partition mounted from vfat carries an equivalent restriction.
+
+        The files covered are `grub.cfg` and `menu.lst` under `/boot/grub` or `/boot/grub2`, the `user.cfg` file that holds GRUB's password hash, and `loader.conf` where systemd-boot is in use. Each must be owned by `root` and carry no group or other access at all. A vfat filesystem has no permission bits of its own, so for `/boot/efi` the restriction comes from the mount options in `/etc/fstab`, where `fmask=0077` denies group and other access to every file on it.
 
         **Why this matters**
 
-        Bootloader configuration files hold boot parameters and, in some cases, the hashed password that protects boot-time menu entries. If these files are exposed to unprivileged users, an attacker with local access can extract sensitive boot settings or alter how the system starts.
+        `user.cfg` holds the hash of the GRUB password, the one that gates editing a boot entry from the menu. If any local account can read that file, the hash goes to a cracking rig off the machine, at whatever rate the attacker's hardware allows and with no failed-attempt record left on the host. Recovering it converts console access into the ability to edit the kernel command line, and the standard edit from there appends `init=/bin/bash` for a root shell with no authentication at all.
 
-        - **Protects boot-time passwords:** Restricting access prevents disclosure of the GRUB password hash that gates editing of boot entries.
-        - **Prevents boot tampering:** Read-only access for non-root users keeps attackers from injecting kernel parameters that disable security controls.
-        - **Reduces local attack surface:** Hardened permissions ensure only privileged users can inspect or modify the boot path.
+        Even without the password, the configuration itself is reconnaissance for the same attack. It names the kernels and initramfs images available, the root device and how it is unlocked, and any command line parameters already in place, including whether SELinux or AppArmor is enforcing, whether the IOMMU is on, and whether the console is redirected to a serial port that reaches beyond the room.
 
-        The vfat filesystem used for `/boot/efi` has no native permission model, so the `fmask` mount option is used to enforce equivalent restrictions.
+        A group-writable or world-writable configuration file removes the need for any of that, because a kernel parameter added to it takes effect on the next reboot with no further access required.
+
+        These permissions defend the boot path against a local account. They do not defend against someone who can detach the disk and attach it to another machine. Full-disk encryption covers that case, and a companion check in this policy requires it.
       audit: |
         Run these commands to inspect the ownership and permissions of the bootloader configuration files present on the system:
 
@@ -341,15 +343,19 @@ queries:
       machine.secureboot.enabled
     docs:
       desc: |
-        This check verifies that UEFI Secure Boot is enabled so the firmware validates the signature of the kernel and boot components before executing them.
+        This check verifies that UEFI Secure Boot is enabled, so the firmware validates the signature of each boot component before executing it.
+
+        Secure Boot builds a chain. The firmware verifies the shim or boot loader against keys held in the platform database, the boot loader verifies the kernel, and the kernel verifies the modules it loads. On Linux this works through a distribution shim signed by Microsoft's UEFI key, which most vendors ship trusted in firmware, and a distribution key that validates the loader and kernel behind it. The check reads the current state, which `mokutil --sb-state` reports.
 
         **Why this matters**
 
-        Secure Boot establishes a chain of trust from the firmware through the bootloader and kernel. Without it, an attacker who can write to the boot path can load a tampered or malicious kernel that runs before any operating-system protections take effect.
+        Everything an operating system does to protect itself starts after the kernel is running. Code that executes before that point decides what the kernel is, which means it can hand control to a kernel modified to hide processes, ignore particular file reads, and accept an attacker's authentication, and no tool running on that system afterwards can report the difference. Secure Boot closes that window, because unsigned code in the boot path is refused rather than executed.
 
-        - **Prevents bootkits:** Signature verification blocks unsigned or modified boot code from running.
-        - **Protects the kernel:** Only kernels signed by a trusted key are allowed to boot.
-        - **Anchors platform integrity:** A verified boot path is the foundation for measured boot and full-disk encryption protections.
+        For a workstation the way in is usually physical rather than remote. Laptops are left in hotel rooms, in checked luggage, and on desks in shared offices, and a few minutes of unattended access with a USB drive is enough to write a modified boot loader onto an unprotected disk. The device boots normally afterwards and behaves normally, which is precisely why the technique is used.
+
+        An attacker who has already reached root locally has the same option available, and it is the one that survives a reinstall of the operating system.
+
+        Secure Boot works alongside full-disk encryption rather than replacing it. Encryption keeps the data unreadable when the disk is removed; Secure Boot keeps the boot path trustworthy when the machine is started. A workstation needs both, and companion checks in this policy require the other pieces.
       audit: |
         Run this command to inspect the Secure Boot state:
 
@@ -399,15 +405,19 @@ queries:
       }
     docs:
       desc: |
-        This check verifies that the `/` and `/home` filesystems reside on encrypted block devices, confirmed by a `crypt` device type in the `lsblk` device tree.
+        This check verifies that the filesystems holding the operating system and the users' data sit on encrypted block devices.
+
+        It resolves the devices backing `/` and, where it is mounted separately, `/home`, then walks the device stack for each and requires a `crypt` layer, the device-mapper target that an unlocked LUKS volume presents. `lsblk` shows the same relationship, with the crypt device sitting between the physical partition and the mounted filesystem. Where `/home` is part of the root filesystem rather than a separate mount, encrypting the root volume covers both.
 
         **Why this matters**
 
-        Workstations are frequently lost or stolen. Without full-disk encryption, anyone with physical possession of the drive can read every file on it by attaching it to another system.
+        A workstation leaves the building. Laptops are stolen from cars, left in taxis, taken in office break-ins, and lost in transit, and in every one of those cases the attacker ends up holding the disk with unlimited time and no need to defeat anything the operating system does. Login passwords, screen locks, and file permissions are enforced by a running kernel. Remove the drive, attach it to another machine, and none of them are involved: the filesystem mounts and every file is readable.
 
-        - **Protects data at rest:** Encryption renders the contents of `/` and `/home` unreadable without the unlock key.
-        - **Mitigates device theft:** A stolen laptop yields no usable data when its system and home partitions are encrypted.
-        - **Supports compliance:** Encrypting endpoint storage satisfies data-protection requirements for systems that handle sensitive information.
+        What sits on that disk is the reason it matters. A developer or administrator workstation carries SSH private keys, cloud credentials in shell profiles and configuration directories, browser session cookies and saved passwords, VPN certificates, and local copies of whatever the person was working on. A stolen laptop with an unencrypted disk is therefore not an equipment loss, it is a credential compromise, and the attacker walks into the environment as that employee.
+
+        Encrypting root as well as home matters because credentials do not stay in home directories. Service configuration, system-wide credential files, log files, swap, and the temporary directory all sit outside `/home` and all hold material worth reading.
+
+        Encryption protects the disk at rest and nothing more. It gives no protection while the machine is running and unlocked, so pair it with screen locking and with a boot path validated by Secure Boot, which a companion check in this policy requires.
       audit: |
         Run these commands to identify the devices serving `/` and `/home` and confirm they are encrypted:
 
@@ -474,15 +484,17 @@ queries:
       )
     docs:
       desc: |
-        This check verifies that every LUKS-encrypted volume uses an AES cipher in XTS mode, such as `aes-xts-plain64` or `aes-xts-benbi`.
+        This check verifies that every LUKS-encrypted volume uses AES in XTS mode.
+
+        XTS is the mode designed for storage. A disk cipher has to encrypt each sector independently, because sectors are read and written in any order, and it has to do so without letting two sectors holding identical plaintext produce identical ciphertext. XTS achieves that by tweaking the encryption with the sector number. The check reads the cipher from each LUKS header and accepts an AES cipher in XTS mode, written as `aes-xts-plain64` on current systems and `aes-xts-benbi` on some older ones. `cryptsetup luksDump` shows the value in the Cipher field.
 
         **Why this matters**
 
-        The strength of full-disk encryption depends on the cipher protecting the data. A weak or non-standard cipher can leave encrypted volumes vulnerable to cryptographic attack even when encryption appears to be enabled.
+        Full-disk encryption is either sound or it is decoration, and the cipher decides which. A volume set up with a legacy mode inherits attacks that XTS does not have. CBC with a predictable sector-derived initialization vector, which older installers configured, is vulnerable to watermarking: an attacker who can get a chosen file onto the volume, by emailing it or having it downloaded, can afterwards recognize its presence in the raw ciphertext of a stolen disk without holding any key. CBC also gives an attacker with write access to the device controlled bit flips in the following block, which is the basis for tampering with a volume between one boot and the next.
 
-        - **Ensures strong confidentiality:** AES in XTS mode is the established standard for block-device encryption and resists known attacks.
-        - **Avoids weak ciphers:** Confirming the cipher prevents volumes from being protected by deprecated or insecure algorithms.
-        - **Maintains consistent protection:** Verifying every encrypted volume ensures no partition relies on a substandard cipher.
+        Cipher choice is also where an obsolete algorithm hides. A volume created years ago and carried forward through reinstalls keeps whatever cipher it was made with, and nothing in normal operation surfaces it. The header says the disk is encrypted, the machine unlocks, and the strength of what is protecting the data is never questioned.
+
+        Changing the cipher rewrites every sector of the volume. Back the data up first and run the conversion from a live system with the filesystem unmounted, because an interruption partway through leaves the volume unreadable.
       audit: |
         Run this command for each encrypted device to inspect the cipher in use:
 
@@ -542,15 +554,19 @@ queries:
       parse.json(content: command('fwupdmgr get-updates -y --json').stdout).params["Devices"].length == 0
     docs:
       desc: |
-        This check verifies that no firmware updates are pending for the system, using `fwupdmgr` to confirm the BIOS is running the latest available version. The `fwupd` daemon contacts the Internet to retrieve the latest firmware metadata.
+        This check verifies that the system firmware is at the latest version its vendor has published.
+
+        The check queries `fwupdmgr` for pending updates and requires the list to be empty. The `fwupd` daemon retrieves metadata from the Linux Vendor Firmware Service, which most major hardware vendors publish to, and compares the advertised versions against what the machine currently runs. Because it needs that metadata, the check reports accurately only on a host that can reach the service, and it covers every device fwupd manages rather than the system BIOS alone.
 
         **Why this matters**
 
-        Firmware sits below the operating system and is a high-value target. Outdated BIOS firmware can carry unpatched vulnerabilities that allow persistent, OS-independent compromise.
+        Firmware runs before the kernel and keeps running underneath it, in a mode more privileged than the operating system can inspect. A flaw there is not contained by anything the operating system does: it is reachable before Secure Boot's chain begins, it survives a full reinstall, and it survives replacing the disk, because the code lives in flash on the board.
 
-        - **Closes firmware vulnerabilities:** Applying vendor updates remediates known flaws in the BIOS.
-        - **Maintains platform trust:** Current firmware keeps Secure Boot and other platform protections effective.
-        - **Reduces persistent-threat risk:** Patched firmware limits an attacker's ability to establish footholds that survive a reinstall.
+        The vulnerabilities fixed by these updates are of that kind. Firmware update routines that accepted unsigned images, System Management Mode handlers reachable from the operating system that let a local root account write to flash, and boot loader flaws allowing the Secure Boot chain to be bypassed have all shipped in mainstream hardware and been fixed by vendor releases. Until the release is applied, an attacker who reaches root once converts that into a foothold outlasting every response short of replacing the machine.
+
+        Firmware updates also carry the processor microcode that mitigates hardware-level flaws, so a stale BIOS usually means missing mitigations as well as missing fixes.
+
+        Two operational cautions. Updates are staged and applied during a reboot, so a machine that never restarts never receives them. And a firmware update changes the measurements that a TPM-sealed disk encryption key is bound to, so have the recovery passphrase to hand before applying one.
       audit: |
         Run this command to check for pending firmware updates:
 

--- a/content/mondoo-windows-11-compatibility.mql.yaml
+++ b/content/mondoo-windows-11-compatibility.mql.yaml
@@ -1067,14 +1067,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows-hardware/design/minimum/windows-processor-requirements
           title: Windows supported processors
       desc: |
-        This check confirms that the installed processor appears on Microsoft's list of processors approved for Windows 11. Microsoft supports Windows 11 only on a defined set of CPU models, and an unlisted processor blocks a supported upgrade.
+        This check verifies that the processor in the device appears on Microsoft's published list of processors supported for Windows 11.
+
+        Windows 11 has a hard compatibility gate that Windows 10 did not. Beyond the memory, storage, firmware, and TPM requirements, Microsoft maintains an explicit list of processor models, and setup refuses to install on a model that is not on it. The check reads the processor name the system reports, which System Information shows as the Processor value and which PowerShell returns from the `Win32_Processor` class, and compares it against that list.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 installs and receives feature updates only on approved processors; an unlisted CPU prevents a supported upgrade path.
-        - **Security feature support:** Approved processors provide the virtualization and platform features Windows 11 security depends on.
-        - **End-of-support exposure:** A device that cannot move to Windows 11 will eventually run an operating system that no longer receives security updates.
-        - **Planning:** Identifying unsupported processors early lets teams budget and schedule hardware replacement before support deadlines.
+        A processor is not a setting. Nothing in Windows, in firmware, or in Group Policy makes an unlisted model eligible, so a device that fails this check will not be upgraded in place. The paths forward are replacing the processor, on the few platforms that allow it, or replacing the device.
+
+        That makes this the check that determines the shape and the cost of the fleet refresh. Every device on the failing list is a hardware purchase with a lead time attached, and discovering them a quarter before Windows 10 support ends turns a planned replacement cycle into emergency procurement at whatever price and delivery date the market happens to offer.
+
+        Leaving those devices in place has a definite end date. Once Windows 10 stops receiving updates, the machines keep running and keep working, and every vulnerability disclosed after that date stays open on them for as long as they remain in service. No configuration mitigates that, because the operating system has stopped being maintained at all.
+
+        Microsoft does allow installation on unsupported hardware through a documented registry override, but the result is an unsupported configuration that Microsoft states may not receive updates. Treat a failing device as one to replace on a schedule, not one to force.
       audit: |
         ### Audit via System Information
 
@@ -1110,14 +1115,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the system has enough installed memory to run Windows 11. Windows 11 requires a minimum of 4 GB of RAM, and this check applies a more comfortable workstation threshold of at least 8 GB. The check allows a small margin below the nominal figure so that devices whose firmware reserves a portion of memory still pass.
+        This check verifies that the device has at least 8 GB of installed memory.
+
+        Windows 11 requires a minimum of 4 GB, and this check applies a higher workstation threshold of 8 GB. The comparison allows a small margin below the nominal figure, because firmware and integrated graphics reserve a portion of physical memory before Windows sees it, so an 8 GB device typically reports slightly less than that. Settings shows the value as Installed RAM under Device specifications, and PowerShell returns `TotalPhysicalMemory` from `Win32_ComputerSystem`.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup blocks installation on devices that do not meet its minimum memory requirement.
-        - **Usable performance:** Memory below the threshold leads to heavy paging and a poor experience once Windows 11 and modern applications are running.
-        - **Security feature headroom:** Virtualization-based security and other Windows 11 protections consume memory; insufficient RAM forces those features off or degrades the system.
-        - **Planning:** Identifying under-provisioned devices early lets teams add memory or replace hardware before support deadlines.
+        Four gigabytes clears Microsoft's floor and leaves nothing over. Windows 11 itself, a browser with a working set of tabs, a mail client, and a collaboration application together exceed it, and once physical memory is committed the system pages to disk. Paging is orders of magnitude slower than memory, so the device does not fail, it becomes slow in a way that is hard to attribute and expensive in lost time across a fleet.
+
+        The security features are the part that gets sacrificed. Memory integrity and Credential Guard reserve memory for the isolated environment they run in, and on a device already short of it the usual resolution is to turn them off. That leaves the machines with the least capacity as the ones running without the protections, and it makes the baseline inconsistent across the fleet in a way no policy report shows.
+
+        Memory is a hardware property. Some laptops accept additional or larger modules, and many current designs solder memory to the board, in which case the only remedy is replacing the device.
+
+        Use a failing result to decide which of the two applies well before Windows 10 support ends, since a memory upgrade is a small cost with a short lead time and a device replacement is neither.
       audit: |
         ### Audit via Settings
 
@@ -1152,14 +1162,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the system disk is large enough to run Windows 11. Windows 11 requires at least 64 GB of storage, and this check applies a more comfortable workstation threshold of at least 120 GB.
+        This check verifies that the system disk is at least 120 GB.
+
+        Windows 11 requires 64 GB of storage, and this check applies a higher workstation threshold of 120 GB. The value read is the total capacity of the boot disk, which File Explorer shows for the system drive and PowerShell returns from `Get-Disk` for the disk marked as the boot disk. It is total capacity rather than free space, so a disk large enough to pass may still need space cleared before an upgrade will run.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup needs free space for installation files; an undersized disk blocks the upgrade.
-        - **Update headroom:** Feature updates stage large payloads on disk; a drive near capacity causes update failures.
-        - **Usable workspace:** A drive sized only to the bare minimum leaves little room for applications and user data.
-        - **Planning:** Identifying undersized disks early lets teams upgrade storage or replace hardware before support deadlines.
+        A 64 GB disk technically qualifies and then runs out. Windows itself, the recovery partition, the page file, and hibernation reserve a substantial share of it before any application is installed, and what remains has to hold the applications, the user profile, and cached mail and files.
+
+        Feature updates are where an undersized disk actually fails. A Windows feature update stages a full copy of the new operating system on disk, applies it, and keeps the previous installation for a rollback window. That needs several gigabytes free at once, and a device close to capacity fails the update, retries on the next cycle, fails again, and quietly falls behind on servicing while reporting nothing worse than a drive that is low on space. Devices in that state stop receiving quality updates as well, once the release they are stuck on goes out of support.
+
+        The remedy is capacity, not cleanup. Clearing files buys one update cycle and the next one arrives at the same problem. Where the drive can be replaced with a larger one that resolves it, and where storage is soldered the device needs replacing.
+
+        Identify the undersized devices before Windows 10 support ends, since a drive swap and a device purchase carry very different costs and lead times.
       audit: |
         ### Audit via File Explorer
 
@@ -1194,14 +1209,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the processor provides at least the two cores Windows 11 requires; the workstation threshold applied here is four or more cores for comfortable performance.
+        This check verifies that the processor reports at least four physical cores.
+
+        Windows 11 sets its own floor at two cores, and this check applies a higher workstation threshold of four. The value read is the physical core count of the installed processor, which Task Manager shows under Performance and PowerShell returns as `NumberOfCores` from the `Win32_Processor` class. It is a property of the part, not something firmware or Windows can change.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup blocks installation on processors that do not meet its minimum core count.
-        - **Responsive performance:** Modern workloads run many processes concurrently; too few cores leads to a sluggish experience.
-        - **Security feature overhead:** Virtualization-based security and background protection consume processor capacity that low-core devices cannot spare.
-        - **Planning:** Identifying under-provisioned processors early lets teams schedule hardware replacement before support deadlines.
+        Two cores clears Microsoft's floor and nothing else. Windows 11 runs a substantially larger set of background work than Windows 10 did, and most of it is not optional: the antimalware engine scanning on access, search indexing, telemetry, update servicing, and on managed devices an endpoint detection agent alongside all of it. On a two-core machine that work competes directly with whatever the person at the keyboard is doing, and the result is a device that meets the requirement on paper and is unpleasant to use in practice.
+
+        Virtualization-based security is where the gap shows most clearly. Memory integrity and Credential Guard run parts of the system inside a hypervisor-isolated environment, which costs processor time on every transition. On a device with adequate cores that cost is small. On one at the minimum it is large enough that the usual response is to turn the protection off, which leaves the fleet inconsistent and the security baseline unmet on exactly the machines least able to absorb an incident.
+
+        The count cannot be raised by configuration. A failing device needs a processor replacement, on a platform that allows one, or replacement of the device.
+
+        Read the result as inventory data for the refresh plan. A device below the threshold today will not improve, and identifying it early is what makes the replacement a budgeted purchase rather than an urgent one.
       audit: |
         ### Audit via Task Manager
 
@@ -1236,14 +1256,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the processor runs at a clock speed of 1 GHz or faster, the minimum frequency Windows 11 requires.
+        This check verifies that the processor's base clock speed is at least 1 GHz.
+
+        Windows 11 sets 1 GHz as its minimum frequency. The value compared here is the maximum clock speed the processor reports, which must be `1000` MHz or higher, shown in Task Manager as Base speed and returned by PowerShell as `MaxClockSpeed` from the `Win32_Processor` class. Turbo and boost frequencies do not enter into it; the reported base figure is what setup evaluates.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup blocks installation on processors that do not meet its minimum clock-speed requirement.
-        - **Responsive performance:** A processor below the threshold struggles to keep the operating system and applications responsive.
-        - **Security feature overhead:** Background protection features add processing load that slow processors cannot absorb without noticeable lag.
-        - **Planning:** Identifying slow processors early lets teams schedule hardware replacement before support deadlines.
+        Setup enforces this directly, so a device below the threshold cannot be upgraded in place. In practice a processor reporting under 1 GHz is an older low-power part, and the failure is rarely isolated: the same devices usually miss the core count, the memory, or the firmware requirement as well.
+
+        Where a device does otherwise qualify, the frequency still governs how it behaves once Windows 11 is on it. Single-threaded responsiveness, which is what makes an interface feel immediate, tracks clock speed rather than core count, so a slow part produces a machine that is technically supported and visibly sluggish through ordinary work. Background servicing makes that worse, because update installation, on-access scanning, and search indexing all take proportionally longer and end up overlapping with the user's own work instead of finishing between sessions.
+
+        Clock speed is fixed in the part. Firmware power settings can lower it but cannot raise it above what the processor is rated for, so no configuration change resolves a failing result.
+
+        Use the result to plan. Devices that fail this check are replacement candidates, and identifying them well before Windows 10 support ends is what keeps the refresh on a schedule and inside a budget rather than turning it into an emergency.
       audit: |
         ### Audit via Task Manager
 
@@ -1281,14 +1306,17 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the device has a Trusted Platform Module present and reporting specification version 2.0. Windows 11 requires TPM 2.0; earlier versions such as TPM 1.2 do not meet the requirement.
+        This check verifies that the device has a Trusted Platform Module present and reporting specification version 2.0.
+
+        A TPM is a small isolated processor with its own storage, used to generate keys, hold them where software cannot read them, and record measurements of the boot sequence. Windows 11 requires version 2.0. A TPM 1.2 module does not satisfy the requirement, and the older specification lacks the algorithm agility and the key hierarchy that 2.0 introduced. The check reads presence and specification version, which the TPM management console displays and which PowerShell returns from `Get-Tpm` and the `Win32_Tpm` class.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup blocks installation on devices without a TPM 2.0 module.
-        - **Hardware-backed security:** TPM 2.0 provides the secure key storage that BitLocker, Windows Hello, and device attestation rely on.
-        - **Credential protection:** A TPM keeps cryptographic keys isolated from the operating system, making credential theft significantly harder.
-        - **Planning:** Identifying devices without TPM 2.0 early lets teams enable a firmware TPM where available or schedule hardware replacement.
+        Setup enforces the requirement, so a device without a TPM 2.0 module is not upgraded in place. The common case, though, is not a missing module. Most processors of the last several years include a firmware TPM that ships disabled, labeled by vendors as fTPM, PTT, Security Device, or Trusted Platform Module. Enabling it in firmware resolves the check at no hardware cost, which makes this the one Windows 11 requirement that a fleet frequently fails for a reason fixable in an afternoon.
+
+        What the module provides is worth having independently of the upgrade. BitLocker binds its volume key to the TPM and to the measured boot state, so the disk unlocks on that machine with unmodified boot components and nowhere else. Windows Hello holds its credentials there, and device attestation lets a management service verify boot integrity before granting access to resources.
+
+        One caution when enabling it. Firmware menus frequently place an option to clear the TPM next to the option to enable it, and clearing destroys the keys the module holds, including BitLocker protectors. Suspend BitLocker before changing firmware settings, do not clear the module, and confirm the recovery key is escrowed first.
       audit: |
         ### Audit via the TPM management console
 
@@ -1332,14 +1360,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that the system boots with UEFI firmware rather than legacy BIOS, which Windows 11 requires.
+        This check verifies that the device boots through UEFI firmware rather than in legacy BIOS mode.
+
+        UEFI replaced the PC BIOS. It boots from a GPT-partitioned disk through a loader on an EFI system partition, rather than executing whatever code sits in the first sector of an MBR disk. Windows 11 requires it. The check reads the firmware boot type, which System Information shows as BIOS Mode and which the `firmware_type` environment variable reports in PowerShell.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup blocks installation on devices booting in legacy BIOS mode.
-        - **Secure Boot dependency:** Secure Boot, itself a Windows 11 requirement, is a UEFI feature and is unavailable under legacy BIOS.
-        - **Boot integrity:** UEFI supports a verified boot chain that legacy BIOS cannot provide, reducing exposure to bootkits.
-        - **Planning:** Identifying devices booting in legacy mode early lets teams convert the disk or schedule replacement before support deadlines.
+        Setup blocks the upgrade on a device booting in legacy mode, and the dependency runs further than that. Secure Boot is a UEFI feature and does not exist under legacy BIOS, so a device in legacy mode fails that requirement as a direct consequence of failing this one. Fixing the firmware mode is the prerequisite for both.
+
+        Unlike the processor and memory requirements, this one is usually fixable on the existing hardware. Most devices that shipped with Windows 10 have UEFI-capable firmware and were installed in legacy or compatibility support mode, often to match an imaging process that predated UEFI. Converting the system disk from MBR to GPT with `mbr2gpt` and then switching the firmware to UEFI resolves it without reinstalling Windows.
+
+        The conversion is the one step in this policy that can leave a device unbootable. The disk layout and the firmware setting have to match: once the disk is GPT the machine will not start in legacy mode, so the firmware change has to follow immediately. Back the device up first, suspend BitLocker so the firmware change does not trigger a recovery prompt, and run the validation pass before the conversion.
+
+        Where the firmware genuinely offers no UEFI mode, the device is old enough that it will fail other requirements too, and replacement is the answer.
       audit: |
         ### Audit via System Information
 
@@ -1389,14 +1422,19 @@ queries:
         - url: https://learn.microsoft.com/en-us/windows/whats-new/windows-11-requirements
           title: Windows 11 System Requirements
       desc: |
-        This check confirms that Secure Boot is enabled. Windows 11 requires UEFI firmware that is Secure Boot capable, and Secure Boot allows the system to start only with trusted, signed boot software.
+        This check verifies that Secure Boot is enabled.
+
+        Secure Boot is the UEFI mechanism that checks a digital signature on each piece of boot code before running it, from the firmware through the boot loader and into the Windows kernel. Anything not signed by a key in the platform's database is refused. Windows 11 requires the device to be Secure Boot capable and expects it turned on. The check reads the current state, which System Information shows as Secure Boot State and `Confirm-SecureBootUEFI` returns in PowerShell.
 
         **Why this matters**
 
-        - **Upgrade eligibility:** Windows 11 setup requires Secure Boot capability and expects it to be enabled.
-        - **Bootkit defense:** Secure Boot blocks unsigned or tampered boot code from loading before the operating system starts.
-        - **Boot chain integrity:** Only firmware and boot loaders trusted by the platform can run, establishing a verified foundation for the system.
-        - **Planning:** Identifying devices with Secure Boot disabled early lets teams enable it or schedule replacement before support deadlines.
+        Setup treats this as a requirement, so a device with Secure Boot off is not upgraded in place. Along with the firmware mode, it is one of the requirements most often failed for a reason that has nothing to do with the hardware: the device is perfectly capable, Secure Boot was left off by an imaging process or turned off years ago to load an unsigned driver, and nothing since has turned it back on.
+
+        What it prevents is boot code running before Windows does. Code loaded at that point runs before the kernel, before the antimalware engine, and before anything else that could observe it, which is what makes it durable across a reinstall of the operating system. Signature verification is the step that closes that position off.
+
+        It is also the foundation the later measurements rest on. BitLocker's TPM protector and device attestation both evaluate the boot state, and a boot sequence that will accept unsigned components gives those measurements nothing dependable to describe.
+
+        Two prerequisites before turning it on. The disk must be GPT with the firmware in UEFI mode, and any unsigned boot-time software on the device, typically an old storage or virtualization driver, has to be removed or replaced with a signed version or the machine will not start. Suspend BitLocker before changing firmware settings so the change does not trigger a recovery prompt.
       audit: |
         ### Audit via System Information
 

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -65,14 +65,19 @@ queries:
     mql: windows.bitlocker.volumes.all( protectionStatus["text"] == "Protected" )
     docs:
       desc: |
-        This check ensures that every disk volume is protected by BitLocker drive encryption. BitLocker encodes data so it is unreadable to anyone who does not hold the decryption key, which keeps information confidential if a workstation is lost or stolen.
+        This check verifies that every BitLocker volume on the workstation reports protection as on.
+
+        BitLocker encrypts a volume at the block level, holding the volume key sealed to the device rather than to a password the user types. On a machine with a TPM, the key is released only when the measured boot state matches, so the disk unlocks on that machine with unmodified boot components and nowhere else. The check reads the protection status of each volume and requires all of them to be protected, not the operating system drive alone.
 
         **Why this matters**
 
-        - **Data theft protection:** An encrypted drive cannot be read by attaching it to another system or booting an alternate operating system.
-        - **Loss and theft resilience:** Laptops are frequently lost or stolen; encryption renders the data on them useless to whoever ends up with the device.
-        - **Tamper resistance:** Pairing BitLocker with a TPM detects offline modification of boot components and blocks unauthorized changes.
-        - **Compliance:** Many regulatory frameworks require encryption of data at rest on end-user devices.
+        The threat here is possession of the hardware. A workstation that is stolen, lost, sent out for repair, or disposed of without the drive being wiped ends up in someone's hands with unlimited time. Windows account passwords have no bearing on it: the attacker removes the drive, attaches it to another machine, and reads the filesystem directly, or boots the device from a USB installer and gets the same result without opening the case.
+
+        What that yields on a work device is not just files. It is saved browser credentials and session cookies, cached domain credentials, VPN and certificate material, mailbox data cached by the mail client, and any documents kept locally. A single unencrypted laptop is therefore a route into the environment as that employee, not merely a lost asset.
+
+        Requiring every volume matters because the data does not stay on one. A second fixed drive used for projects or as a data disk is encrypted separately, and an operating system drive protected while the data drive is not leaves exactly the material an attacker wants in the clear.
+
+        Two conditions before enabling it. Escrow the recovery key to Entra ID, Active Directory, or a Microsoft account first, because without it a TPM fault or a firmware update makes the data unrecoverable. And note that BitLocker is unavailable on Home editions, so a fleet containing them needs an edition change rather than a configuration one.
       audit: |
         ### Audit via Settings
 
@@ -198,14 +203,19 @@ queries:
       machine.secureboot.enabled == true
     docs:
       desc: |
-        This check ensures that Secure Boot is active. Secure Boot is a boot-integrity feature of the Unified Extensible Firmware Interface (UEFI) standard that allows the system to start only with firmware and boot loaders signed by trusted keys.
+        This check verifies that Secure Boot is active on the workstation.
+
+        Secure Boot is the UEFI mechanism that checks a signature on each component in the boot path before running it, refusing anything not signed by a key in the platform's database. The check reads the current state, which System Information reports as Secure Boot State and `Confirm-SecureBootUEFI` returns from PowerShell. Enabling it requires firmware access; it cannot be turned on from inside Windows.
 
         **Why this matters**
 
-        - **Bootkit defense:** Secure Boot blocks unsigned or tampered boot code, preventing malware from loading before the operating system starts.
-        - **Boot chain integrity:** Only software trusted by the firmware can run during startup, establishing a verified foundation for the rest of the system.
-        - **Persistence resistance:** Firmware-level malware that survives operating system reinstalls is far harder to install when Secure Boot is enforced.
-        - **Compliance:** Secure Boot is a baseline configuration requirement in common Windows hardening benchmarks.
+        Code that runs before Windows starts sits above everything Windows can do about it. A bootkit installed in the boot path loads before the kernel, before Microsoft Defender, and before any endpoint agent, which puts it in a position to patch the kernel as it loads, hide its own files and processes from every tool that asks the kernel for them, and survive a reinstall of Windows because the reinstall never touches where it lives. Signature verification is what makes that placement impossible.
+
+        For a workstation, the way in is usually the machine itself. Devices are left unattended in hotels, in checked luggage, and at desks, and with Secure Boot off a few minutes with a USB drive is enough to write a modified boot loader. The device then starts and behaves exactly as it did before.
+
+        Secure Boot is also what gives BitLocker's TPM protector its meaning. The TPM releases the volume key based on measurements of the boot sequence, and a sequence willing to run unsigned components gives those measurements nothing dependable to attest to.
+
+        Check the firmware mode before changing anything. A device installed in legacy BIOS mode on an MBR disk cannot boot with Secure Boot on, and needs the disk converted to GPT and the firmware switched to UEFI first. Suspend BitLocker before the firmware change so it does not trigger a recovery prompt at the next start.
       audit: |
         ### Audit via System Information
 
@@ -273,14 +283,19 @@ queries:
       }
     docs:
       desc: |
-        This check ensures that the workstation is configured to download and install Windows updates automatically on a daily schedule. Automatic updates close the gap between the release of a security fix and its application to the device.
+        This check verifies that the workstation downloads and installs Windows updates automatically, every day, without waiting for someone to click.
+
+        The setting lives in Group Policy under Computer Configuration, Administrative Templates, Windows Components, Windows Update, as Configure Automatic Updates. Choosing `4`, auto download and schedule the install, and setting the scheduled install day to `0`, every day, writes `AUOptions` and `ScheduledInstallDay` into the Windows Update policy key, which is what the check reads. Options `2` and `3` leave installation waiting on the user and do not satisfy this.
 
         **Why this matters**
 
-        - **Vulnerability remediation:** Security patches close flaws that attackers actively exploit; applying them promptly removes those entry points.
-        - **Reduced exposure window:** Automatic installation shrinks the time a device runs with a known, unpatched vulnerability.
-        - **Consistent posture:** Removing the dependency on users to apply updates keeps the whole fleet at a known patch level.
-        - **Stability:** Updates also resolve defects that cause crashes and data loss, improving reliability alongside security.
+        The interval that matters is the one between a patch being published and it being installed. Microsoft's monthly release is public, and so is the vulnerability detail accompanying it, so working exploits for the more attractive bugs appear within days. Every device still unpatched during that period is exploitable by anyone who read the same bulletin.
+
+        Leaving the decision with the user reliably lengthens that interval. The prompt to restart arrives during work, gets deferred, gets deferred again, and on a laptop that is suspended rather than shut down it can be deferred indefinitely. The device shows as managed and compliant in every inventory, because the policy is present. What is absent is the restart that makes the patch effective.
+
+        The failure is also uneven across the fleet, which is what makes it hard to see. Most devices update, a minority do not, and the ones that do not are not identifiable from a policy report. An attacker needs one of them.
+
+        Automatic installation is not a substitute for reporting. Pair the policy with update compliance reporting, so that devices failing to install repeatedly, usually for lack of disk space or because they are never restarted, become visible rather than staying silently behind.
       audit: |
         ### Audit via Settings
 
@@ -386,14 +401,19 @@ queries:
       )
     docs:
       desc: |
-        This check ensures that an antivirus product is installed, actively running, and using threat signatures updated within the last 25 hours. Current signatures and active scanning are what allow the product to recognize and block recent malware.
+        This check verifies that an antivirus product is installed, actively protecting the device, and running on signatures no more than 25 hours old.
+
+        Windows keeps a central register of security products. The check reads it for a product of type antivirus whose state is on and whose signature state is up to date, with a signature timestamp inside the last 25 hours. The window sits just past a day so that a device updating once daily is not flagged for ordinary variation in when the update lands. Microsoft Defender satisfies this on its own, and a third-party product registers the same way.
 
         **Why this matters**
 
-        - **Real-time protection:** Active antivirus scans files as they are accessed, downloaded, or executed, blocking threats before they can run.
-        - **Malware defense:** Antivirus products detect viruses, trojans, worms, spyware, and ransomware that would otherwise compromise data or disable the system.
-        - **Fresh detection:** Up-to-date signatures are required to recognize newly released malware variants; stale signatures leave the device blind to current threats.
-        - **Baseline control:** Endpoint malware protection is a fundamental security control expected by every major hardening benchmark.
+        Three things have to be true at once, and a device can fail on any one of them while appearing fine from the outside. A product that is installed but not scanning inspects nothing. A product scanning with definitions from three weeks ago inspects everything and recognizes only what was known three weeks ago.
+
+        The stale-signature case is the common one, and it is the reason for the time bound rather than a plain installed-or-not test. Commodity malware is repacked continuously, and detection for a given campaign frequently ships within hours of its first appearance. A device whose definitions stopped updating, because it has been off the network, because a proxy is blocking the update endpoint, or because the update service failed without saying so, executes the current campaign's payload without objection while its console still reports protection as on.
+
+        Real-time protection being off is the more deliberate failure. It is the setting an attacker turns off first after reaching a device, and it is also what a user disables to make a blocked download run. Either way the product stays installed and keeps reporting itself as present.
+
+        Monitor all three properties rather than presence alone, and turn on Tamper Protection so the settings cannot be changed from the device by a script or by whatever has just landed on it.
       audit: |
         ### Audit via Windows Security
 


### PR DESCRIPTION
## What changed

The operating-system policies had most of their check descriptions converted to the house prose format in an earlier pass. This converts the **41 stragglers** that still carried the old bulleted skeleton. Every already-converted description in these files is left byte-identical, so the diff is confined to the checks that needed work.

| Bundle | Rewritten / total | Category |
|---|---|---|
| `mondoo-linux-security` | 17 / 120 | security |
| `mondoo-windows-11-compatibility` | 8 / 8 | best-practices |
| `mondoo-linux-workstation-security` | 5 / 5 | security |
| `mondoo-windows-workstation-security` | 4 / 4 | security |
| `mondoo-linux-snmp-policy` | 3 / 3 | best-practices |
| `mondoo-linux-operational-policy` | 2 / 2 | best-practices |
| `mondoo-freebsd-security` | 2 / 56 | security |

Each rewritten description leads with the capability rather than the setting, names the setting where the reader administers it, and says concretely what goes wrong without the control. Two banned headings are removed along the way: the `**Risk mitigation**` section that five `mondoo-linux-security` descriptions still carried, which duplicated `docs.remediation`, and the `**Scope**` heading in the FreeBSD pkg signature check, which is folded into prose.

`mondoo-windows-11-compatibility` and `mondoo-linux-operational-policy` are best-practices policies, so those descriptions state the engineering failure the check prevents rather than inventing an attacker.

Median word count across the 41 rewritten descriptions: **122 before, 303 after**. No policy versions were bumped.

## Gates

All run against all seven modified files.

- `cnspec policy lint` — `valid policy bundle(s)` for each of the seven files
- `typos` — silent
- `go test -count=1 ./internal/bundle/...` — ok
- structural diff against `origin/main` — `trees identical apart from docs.desc and policy version` for each of the seven files
- substance gate — **6 specifics lost, all in `mondoo-linux-security`, all on the deliberate exception list. Zero losses in the other six bundles.**

The six:

- `mondoo-linux-security-aide-is-installed`, four numbers: `11.5`, `800`, `53`, `7`. These are the PCI-DSS and NIST citation numbers from the old text. Compliance framework citations do not belong in prose; the `compliance/*` tags carry the mapping.
- `mondoo-linux-security-file-deletion-events-by-users-are-collected`, two literals. Both are artifacts of a fenced shell block in the old description: the `awk` one-liner that read `UID_MIN` out of `/etc/login.defs`, and the sentence fragment the backtick regex split off from around it. The fact survives in words, which name `UID_MIN`, `/etc/login.defs`, and the `auid>=1000` substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)