### PR TITLE
📝 validation: powershell.py has no allowlist, stop telling authors it does

### DIFF
--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -454,7 +454,7 @@ Five things gate a content change, and each fails differently:
 
 Three traps worth knowing before you hit them:
 
-- **A validator only sees the policies in its `TARGETS`.** When a policy gains its first `terraform`/`ansible`/`powershell`/`chef` remediation, add it to that validator's `TARGETS` in the same change — otherwise it ships unlinted and CI stays green. Terraform needs a `PROVIDER_MAP` entry too. (`bash.py` is the exception: it globs every policy, deliberately.)
+- **A validator only sees the policies in its `TARGETS`.** When a policy gains its first `terraform`/`ansible`/`chef` remediation, add it to that validator's `TARGETS` in the same change — otherwise it ships unlinted and CI stays green. Terraform needs a `PROVIDER_MAP` entry too. (`bash.py` and `powershell.py` are the exceptions: both glob every policy, deliberately, so a shell or PowerShell fence is linted wherever it appears.)
 - **A skipped check is a fixture bug, not a pass.** A variant whose filter never matches anything looks identical to one that passes, in every report, forever.
 - **A stale `KNOWN_BUG.md` marker fails the build.** Adding a check means deleting its markers in the same change.
 
@@ -462,7 +462,7 @@ Three traps worth knowing before you hit them:
 
 ### A new policy is not covered until it is registered
 
-A new *check* inherits the coverage its policy already has. A new *policy* inherits nothing. Every validator above is allowlist-driven except `bash.py` and the compliance suites, so a brand-new `*.mql.yaml` is not reported as unvalidated; it is simply never visited. The bundle merges with its variants untested, its HCL unlinted and its CLI commands unverified, and every gate stays green.
+A new *check* inherits the coverage its policy already has. A new *policy* inherits nothing. Every validator above is allowlist-driven except `bash.py`, `powershell.py` and the compliance suites, so a brand-new `*.mql.yaml` is not reported as unvalidated; it is simply never visited. The bundle merges with its variants untested, its HCL unlinted and its CLI commands unverified, and every gate stays green.
 
 This is not hypothetical. The four SaaS policies added in PR #3338 were invisible to the remediation validators. Registering them with `terraform.py` in a follow-up commit failed **8 of their 11** HCL snippets against the real provider schemas, and hand-checking their CLI snippets found an entire invented `hcp vault` / `hcp consul` command surface and two `neonctl` flags that do not exist.
 
@@ -470,7 +470,7 @@ Wire the policy up in the **same change** that adds it. [`validation/README.md`]
 
 - `content/README.md`, the user-facing catalog, always.
 - `tfVariantPolicies` in `validation/scans/iac_variants_test.go`, if it has any IaC variant, plus that file's `extraProviders` if its runtime variant needs a provider beyond the base six.
-- `TARGETS` in each `validation/remediation/code/<language>.py` whose method it ships, and `PROVIDER_MAP` as well for Terraform.
+- `TARGETS` in each `validation/remediation/code/<language>.py` whose method it ships, and `PROVIDER_MAP` as well for Terraform. Not `bash.py` or `powershell.py` — those two glob every policy already.
 - a registry under `validation/remediation/commands/`, if it ships `id: cli` / `id: api` blocks or `audit:` steps that invoke a CLI or REST call.
 - `typos.toml`, if the vendor's terminology trips the spell checker.
 

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -221,13 +221,15 @@ Remediation that is *code* rather than a CLI invocation gets linted with the too
 | `cloudformation.py` | `id: cloudformation` | cfn-lint |
 | `bicep.py` | `id: bicep` | `bicep build` |
 | `ansible.py` | `id: ansible` | ansible-lint |
-| `powershell.py` | every ```` ```powershell ```` fence, including `audit:` | the PowerShell parser |
-| `bash.py` | `id: bash` / `script` / `sh` | shellcheck |
+| `powershell.py` | every ```` ```powershell ```` fence in every policy, including `audit:` | the PowerShell parser |
+| `bash.py` | `id: bash` / `script` / `sh`, in every policy | shellcheck |
 | `chef.py` | `id: chef` | cookstyle |
 
 Each takes an optional target (`linux`, `windows`, `macos`, `kubernetes`, `chef`, …) and `--github-actions`.
 
-**A validator only sees the policies in its `TARGETS`.** Adding a remediation method to a policy that is not listed there means it ships unlinted and CI stays green, so when a policy gains its first `terraform`/`ansible`/`bash` remediation, add it to that validator's `TARGETS` in the same change. `bash.py` is the exception: it has no allowlist, deliberately, because a `TARGETS` list is a standing invitation to exactly that failure.
+**A validator only sees the policies in its `TARGETS`.** Adding a remediation method to a policy that is not listed there means it ships unlinted and CI stays green, so when a policy gains its first `terraform`/`ansible`/`chef` remediation, add it to that validator's `TARGETS` in the same change.
+
+**`bash.py` and `powershell.py` are the exceptions, deliberately.** Both default to every policy in `content/`, because a `TARGETS` list is a standing invitation to exactly that failure and neither linter needs per-policy setup: shellcheck lints a shell script, and the PowerShell parser parses PowerShell, wherever the fence appears. Their `TARGETS` dicts name groups for running one area locally (`bash.py linux`) and do not define what CI covers, so a new policy needs no entry in either.
 
 For Terraform there is a second step: the resource prefix needs an entry in `PROVIDER_MAP` too. Without one the generated `required_providers` block comes out empty and the `terraform_required_providers` rule fails *every* resource in that policy, which looks like 20 content bugs rather than one missing line.
 
@@ -351,14 +353,14 @@ Register the policy everywhere it applies, in the same change that adds it:
 | `scans/iac_variants_test.go` → `tfVariantPolicies` | the policy has any `-terraform-hcl`, `-terraform-plan`, `-terraform-state`, `-cloudformation` or `-bicep` variant | variants are never scanned, and coverage never asks for fixtures |
 | `scans/iac_variants_test.go` → `init()`'s `extraProviders` | its runtime variant needs a provider outside `terraform`/`k8s`/`aws`/`azure`/`gcp`/`cloudformation` (the base list in `main_test.go`) | parallel subtests race to auto-install it and lose with `cannot find resource for identifier '<provider>'` |
 | `remediation/code/terraform.py` → `TARGETS` **and** `PROVIDER_MAP` for each resource prefix | any `- id: terraform` remediation | snippets are never resolved against the provider schema; with `TARGETS` but no `PROVIDER_MAP` entry, `required_providers` comes out empty and `terraform_required_providers` fails *every* resource in the policy |
-| `remediation/code/{cloudformation,bicep,ansible,powershell,chef}.py` → `TARGETS` | that language appears in a remediation block (`powershell.py` also reads ```` ```powershell ```` fences in `audit:`) | same, for that language |
+| `remediation/code/{cloudformation,bicep,ansible,chef}.py` → `TARGETS` | that language appears in a remediation block | same, for that language |
 | `remediation/commands/` → `CLI_VALIDATORS`, `COBRA_CLIS`, or `API_PROVIDERS` | any `- id: cli` / `- id: api` block, or an `audit:` step that invokes a CLI or REST call | invented commands and endpoints ship unchallenged |
 | `compliance/owasp_mapping_test.go` → `llmAnchoredPolicies` | the policy is AI/LLM-focused | nothing guards its OWASP Top 10 for LLM Applications tags against silently going missing |
 | `typos.toml` → `[default.extend-words]` | the vendor's terminology trips the spell checker | `spell-check.yaml` fails |
 
 A policy in `PROVIDER_MAP` needs a real provider source and a version constraint that resolves; a constraint matching only prereleases silently fails to resolve.
 
-`remediation/code/bash.py` is the exception on purpose and needs no entry — it globs every policy in `content/`, because a `TARGETS` list is a standing invitation to exactly this failure, and the comment on its `TARGETS` says so. The compliance suites glob too (`../../mondoo-*.mql.yaml`), so tag coherence is covered from the first commit.
+`remediation/code/bash.py` and `remediation/code/powershell.py` are the exceptions on purpose and need no entry — both glob every policy in `content/`, because a `TARGETS` list is a standing invitation to exactly this failure, and the comment on each one's `TARGETS` says so. The compliance suites glob too (`../../mondoo-*.mql.yaml`), so tag coherence is covered from the first commit.
 
 ### Group filters and variants do not mix
 

--- a/content/validation/remediation/code/powershell.py
+++ b/content/validation/remediation/code/powershell.py
@@ -362,6 +362,17 @@ def check_snippet(s: Snippet, analysis: dict) -> list[str]:
 # Targets and main
 # ---------------------------------------------------------------------------
 
+# Like bash.py, and unlike the other code validators, this one has no policy
+# allowlist. A `TARGETS` list is a standing invitation to the failure it is
+# supposed to prevent: a policy gains its first PowerShell snippet, nobody adds
+# it to the list, and the snippet ships unlinted with CI green. Nothing here
+# needs per-policy setup — the PowerShell parser parses PowerShell wherever the
+# fence appears — so the default target is every policy in content/, which is
+# what CI runs.
+#
+# The named groups below stay as a convenience for running one area locally
+# (`remediation/code/powershell.py windows`), not as a definition of what CI
+# covers. Adding a policy here is never required.
 TARGETS = {
     "windows": [
         CONTENT_DIR / "mondoo-windows-security.mql.yaml",


### PR DESCRIPTION
## What

`powershell.py` defaults to `all_policy_files()` — every `*.mql.yaml` in `content/` — and `validate-remediation.yaml` invokes it with no target. Every ` ```powershell ` fence in the repository is already parsed and checked, in `audit:` blocks as well as remediation. Its `TARGETS` dict only backs the optional `--target` argument for scoping a local run, the same role `bash.py`'s plays.

Both `content/validation/README.md` and `content/CLAUDE.md` said the opposite: they grouped `powershell.py` with the allowlist-driven validators and named `bash.py` alone as the exception.

## Why it matters

The false rule reads as a coverage gap. Four policies ship PowerShell and are absent from `TARGETS` — `mondoo-ai-security` (25 fences), `mondoo-edr-policy` (2), `mondoo-tls-security` (1), `mondoo-mssql-security` (1) — so following the documented rule means opening a PR to "close" a gap that does not exist, and reviewing 29 snippets as though they had never been checked.

## Verification

Measured on `main`, before any change:

```
$ python3 content/validation/remediation/code/powershell.py
548 passed, 0 failed
```

All 29 fences from the four unlisted policies appear in that run and pass. The count is unchanged after this PR, which touches no extraction logic.

## Changes

- `content/validation/README.md` — `powershell.py` moved out of the registration table's allowlist row; the exception paragraph now covers both globbing validators and says why neither needs an entry.
- `content/CLAUDE.md` — same correction in the two places that stated the rule.
- `content/validation/remediation/code/powershell.py` — `TARGETS` gains the explanatory comment `bash.py`'s already carries, so the rule is discoverable at the code and not only in the README.

Docs and one comment. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)