### PR TITLE
✨ validation: validate stackit CLI remediation commands

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -160,6 +160,26 @@ jobs:
           sudo mv /tmp/databricks-extract/databricks /usr/local/bin/databricks
           databricks version
 
+      - name: Install STACKIT CLI
+        # Pinned release tarball from
+        # https://github.com/stackitcloud/stackit-cli/releases. Bump
+        # STACKIT_VERSION and STACKIT_SHA256 in lockstep when STACKIT ships new
+        # commands or flags — the SHA-256 is published in the per-release
+        # `stackit-cli_<version>_checksums.txt` file. No auth needed for the
+        # `__complete` / `--help` introspection the validator performs.
+        env:
+          STACKIT_VERSION: "0.71.0"
+          STACKIT_SHA256: "091836594293e3cdf957015caa336f855b103f4ffe14ca07688b01a54dfefb15"
+        run: |
+          curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
+            "https://github.com/stackitcloud/stackit-cli/releases/download/v${STACKIT_VERSION}/stackit-cli_${STACKIT_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/stackit.tar.gz
+          echo "${STACKIT_SHA256}  /tmp/stackit.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/stackit-extract
+          tar -xzf /tmp/stackit.tar.gz -C /tmp/stackit-extract
+          sudo mv /tmp/stackit-extract/stackit /usr/local/bin/stackit
+          stackit --version
+
       - name: Validate remediation commands
         run: python3 content/validation/remediation/commands/validate.py --github-actions
 

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -45,7 +45,7 @@ content/validation/
 │   └── commands/              CLI and REST API call validation
 │       ├── validate.py           entry point and dispatch
 │       ├── common.py             shared extraction and reporting
-│       ├── cobra.py              kubectl / gh / glab / hcloud / databricks
+│       ├── cobra.py              kubectl / gh / glab / hcloud / databricks / stackit
 │       ├── openapi.py            every REST API provider
 │       └── aws.py azure.py gcloud.py alicloud.py digitalocean.py nutanix.py
 │           oci.py openstack.py vercel.py
@@ -257,7 +257,7 @@ python3 content/validation/remediation/commands/validate.py            # everyth
 python3 content/validation/remediation/commands/validate.py aws        # one target
 ```
 
-Targets: `aws`, `azure`, `oci`, `gcp`, `digitalocean`, `nutanix`, `alicloud`, `openstack`, `vercel`, the Cobra CLIs (`kubernetes`, `github`, `gitlab`, `hetzner`, `databricks`), and the REST APIs (`cloudflare`, `tailscale`, `slack`, `atlassian`, `grafana`, `mongodbatlas`, `okta`, `portainer`).
+Targets: `aws`, `azure`, `oci`, `gcp`, `digitalocean`, `nutanix`, `alicloud`, `openstack`, `vercel`, the Cobra CLIs (`kubernetes`, `github`, `gitlab`, `hetzner`, `databricks`, `stackit`), and the REST APIs (`cloudflare`, `tailscale`, `slack`, `atlassian`, `grafana`, `mongodbatlas`, `okta`, `portainer`).
 
 A provider whose fixes are all UI click-through still belongs here. `okta` and `portainer` have no CLI for the settings their checks target, so their entire API surface is `audit:` steps — and a wrong audit command is exactly as misleading as a wrong remediation.
 

--- a/content/validation/remediation/commands/cobra.py
+++ b/content/validation/remediation/commands/cobra.py
@@ -1,6 +1,6 @@
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
-# Generic validation for Cobra-based CLIs (kubectl, gh, glab, hcloud).
+# Generic validation for Cobra-based CLIs (kubectl, gh, glab, hcloud, stackit).
 #
 # Like doctl, these are Go binaries with no Python introspection surface.
 # Unlike doctl, their --help layouts differ wildly (gh and glab render
@@ -107,6 +107,15 @@ COBRA_CLIS = {
             "  All platforms:    https://docs.databricks.com/dev-tools/cli/install.html"
         ),
     },
+    "stackit": {
+        "cli": "stackit",
+        "policies": ["mondoo-stackit-security.mql.yaml"],
+        "include_audit": True,
+        "install": (
+            "  macOS (Homebrew): brew install stackitcloud/tap/stackit\n"
+            "  All platforms:    https://github.com/stackitcloud/stackit-cli/releases"
+        ),
+    },
 }
 
 
@@ -119,6 +128,9 @@ def _walk_env() -> dict:
     # Keep the databricks CLI from loading a ~/.databrickscfg profile and
     # reaching a live workspace/account during completion.
     env["DATABRICKS_CONFIG_FILE"] = "/dev/null"
+    # Same for the STACKIT CLI's credentials file, which it reads from
+    # $HOME/.stackit/credentials.json unless this points elsewhere.
+    env["STACKIT_CREDENTIALS_PATH"] = "/dev/null"
     for var in (
         "GH_TOKEN", "GITHUB_TOKEN",
         "GITLAB_TOKEN", "GLAB_TOKEN",
@@ -126,6 +138,11 @@ def _walk_env() -> dict:
         "DATABRICKS_HOST", "DATABRICKS_TOKEN",
         "DATABRICKS_CLIENT_ID", "DATABRICKS_CLIENT_SECRET",
         "DATABRICKS_ACCOUNT_ID",
+        "STACKIT_SERVICE_ACCOUNT_TOKEN", "STACKIT_SERVICE_ACCOUNT_KEY",
+        "STACKIT_SERVICE_ACCOUNT_KEY_PATH", "STACKIT_PRIVATE_KEY",
+        "STACKIT_PRIVATE_KEY_PATH", "STACKIT_ACCESS_TOKEN",
+        "STACKIT_USE_OIDC", "STACKIT_SERVICE_ACCOUNT_EMAIL",
+        "STACKIT_SERVICE_ACCOUNT_FEDERATED_TOKEN", "STACKIT_FEDERATED_TOKEN_FILE",
     ):
         env.pop(var, None)
     return env

--- a/content/validation/upstream/pins.py
+++ b/content/validation/upstream/pins.py
@@ -336,6 +336,7 @@ WORKFLOW_CHECKSUMMED = [
     ("glab", "GLAB", lambda: latest_gitlab_release("gitlab-org%2Fcli")),
     ("hcloud", "HCLOUD", lambda: latest_github_release("hetznercloud/cli")),
     ("databricks", "DATABRICKS", lambda: latest_github_release("databricks/cli")),
+    ("stackit", "STACKIT", lambda: latest_github_release("stackitcloud/stackit-cli")),
 ]
 
 


### PR DESCRIPTION
## What

`mondoo-stackit-security` ships **44 `stackit` invocations** across its remediation and `audit:` blocks. No validator has ever read them.

`stackit-cli` is a Cobra application — [`spf13/cobra v1.10.2`](https://raw.githubusercontent.com/stackitcloud/stackit-cli/main/go.mod) — so this needs no new machinery. `cobra.py` already walks the hidden `__complete` command Cobra builds into every CLI, and this is a `COBRA_CLIS` entry plus a pinned install step.

The walk discovers **377 command nodes and 3,269 flags**.

## Result

```
$ python3 content/validation/remediation/commands/validate.py stackit
44 passed, 0 failed
```

## Verified the gate can fail

A validator reporting zero failures and one checking nothing look identical from the outside, so:

| Input | Reported |
|---|---|
| `stackit ske cluster describe c --output-formatt json` | unknown flag `--output-formatt` |
| `stackit ske cluster describ c` | unknown subcommand `describ` for `stackit ske cluster` |
| `stackit ske cluster` | command group; missing subcommand |
| `stackit notaservice list` | unknown command |

## Determinism

The CLI reads credentials from `$HOME/.stackit/credentials.json` and from a set of `STACKIT_*` environment variables ([AUTHENTICATION.md](https://github.com/stackitcloud/stackit-cli/blob/main/AUTHENTICATION.md)). Both are neutralized in `_walk_env()` alongside the existing entries: Cobra completion callbacks can reach a live backend when authenticated, and a grammar that depends on whether the developer is logged in is not a grammar.

## Pin

`v0.71.0`, pinned by version **and** SHA-256 like the other Cobra CLIs, and registered in `WORKFLOW_CHECKSUMMED` so the weekly drift job watches it:

```
$ python3 content/validation/upstream/check.py
stackit    pinned=0.71.0    upstream=0.71.0    ok        (51 pins checked)

$ python3 content/validation/upstream/bump.py --verify-checksums
[PASS] stackit v0.71.0 https://github.com/stackitcloud/stackit-cli/releases/download/v0.71.0/stackit-cli_0.71.0_linux_amd64.tar.gz
```

The digest is re-derived from the URL read back out of the workflow's own `curl` line, so what is hashed is exactly what CI fetches.

## Note

`mondoo-stackit-security` also ships 26 lint-verified Terraform remediation blocks and has no IaC variants, which is a separate opportunity and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)