### PR TITLE
✨ content: add Terraform variants to mondoo-databricks-security

### DIFF
--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -75,7 +75,6 @@ queries:
   - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled
     title: Ensure enhanced security monitoring is enabled on the workspace
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-02
@@ -91,8 +90,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-5-2-1
       compliance/soc2-2017: soc2-control-cc6-8-4
       compliance/vda-isa-5: vda-isa-5-5-2-3
-    mql: |
-      databricks.workspaceConf.enhancedSecurityMonitoringEnabled == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the compute nodes behind a workspace boot a hardened operating system image and run antivirus and behavior based monitoring agents.
@@ -162,10 +176,28 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-monitoring
         title: Databricks enhanced security monitoring documentation
+  - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.enhancedSecurityMonitoringEnabled == true
+  # The workspace setting has its own resource rather than a workspace_conf key, and the
+  # nested block is the only place is_enabled lives. `.any()` rather than `.all()` on purpose:
+  # a resource declared without the block would pass an `.all()` vacuously.
+  - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_enhanced_security_monitoring_workspace_setting")
+    mql: |
+      terraform.resources("databricks_enhanced_security_monitoring_workspace_setting").all(blocks.where(type == "enhanced_security_monitoring_workspace").any(arguments["is_enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_enhanced_security_monitoring_workspace_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_enhanced_security_monitoring_workspace_setting").all(change.after["enhanced_security_monitoring_workspace"] != empty && change.after["enhanced_security_monitoring_workspace"].any(_["is_enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_enhanced_security_monitoring_workspace_setting")
+    mql: |
+      terraform.state.resources.where(type == "databricks_enhanced_security_monitoring_workspace_setting").all(values["enhanced_security_monitoring_workspace"] != empty && values["enhanced_security_monitoring_workspace"].any(_["is_enabled"] == true))
   - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled
     title: Ensure the compliance security profile is enabled on the workspace
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
@@ -181,8 +213,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      databricks.workspaceConf.complianceSecurityProfileEnabled == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the workspace runs under the hardened baseline that the compliance security profile applies.
@@ -255,10 +302,27 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-compliance
         title: Databricks enhanced security and compliance settings documentation
+  - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.complianceSecurityProfileEnabled == true
+  # compliance_standards is required alongside is_enabled, so a declared block always names
+  # at least one standard; only the enablement flag needs asserting here.
+  - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_compliance_security_profile_workspace_setting")
+    mql: |
+      terraform.resources("databricks_compliance_security_profile_workspace_setting").all(blocks.where(type == "compliance_security_profile_workspace").any(arguments["is_enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_compliance_security_profile_workspace_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_compliance_security_profile_workspace_setting").all(change.after["compliance_security_profile_workspace"] != empty && change.after["compliance_security_profile_workspace"].any(_["is_enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_compliance_security_profile_workspace_setting")
+    mql: |
+      terraform.state.resources.where(type == "databricks_compliance_security_profile_workspace_setting").all(values["compliance_security_profile_workspace"] != empty && values["compliance_security_profile_workspace"].any(_["is_enabled"] == true))
   - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled
     title: Ensure automatic cluster update is enabled on the workspace
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-tvm-03
@@ -274,8 +338,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-5
-    mql: |
-      databricks.workspaceConf.automaticClusterUpdateEnabled == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the virtual machine images behind the workspace's compute are patched on a schedule instead of drifting.
@@ -355,10 +434,26 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/privacy/enhanced-security-compliance
         title: Databricks enhanced security and compliance settings documentation
+  - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.automaticClusterUpdateEnabled == true
+  # The flag is named `enabled` here, not `is_enabled` as in the neighbouring settings resources.
+  - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_automatic_cluster_update_workspace_setting")
+    mql: |
+      terraform.resources("databricks_automatic_cluster_update_workspace_setting").all(blocks.where(type == "automatic_cluster_update_workspace").any(arguments["enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_automatic_cluster_update_workspace_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_automatic_cluster_update_workspace_setting").all(change.after["automatic_cluster_update_workspace"] != empty && change.after["automatic_cluster_update_workspace"].any(_["enabled"] == true))
+  - uid: mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_automatic_cluster_update_workspace_setting")
+    mql: |
+      terraform.state.resources.where(type == "databricks_automatic_cluster_update_workspace_setting").all(values["automatic_cluster_update_workspace"] != empty && values["automatic_cluster_update_workspace"].any(_["enabled"] == true))
   - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled
     title: Ensure IP access lists are enabled for the workspace
     impact: 80
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -374,8 +469,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      databricks.workspaceConf.ipAccessListsEnabled == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the workspace only accepts connections from networks an administrator has approved.
@@ -462,10 +572,28 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list
         title: Databricks IP access lists documentation
+  - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.ipAccessListsEnabled == true
+  # custom_config is a map of strings, so the value is the string "true", not a bool.
+  # Databricks leaves IP access lists off until a workspace enables them, so a workspace_conf
+  # that never sets the key describes a workspace with no network allowlist and fails.
+  - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_workspace_conf")
+    mql: |
+      terraform.resources("databricks_workspace_conf").all(arguments["custom_config"]["enableIpAccessLists"] == "true")
+  - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_workspace_conf").all(change.after["custom_config"]["enableIpAccessLists"] == "true")
+  - uid: mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.state.resources.where(type == "databricks_workspace_conf").all(values["custom_config"]["enableIpAccessLists"] == "true")
   - uid: mondoo-databricks-security-workspace-legacy-access-disabled
     title: Ensure legacy access protocols are disabled on the workspace
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
@@ -481,8 +609,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-4
       compliance/soc2-2017: soc2-control-cc6-1-6
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: |
-      databricks.workspaceConf.disableLegacyAccess == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-legacy-access-disabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that data access in the workspace is forced through Unity Catalog rather than the legacy paths that predate it.
@@ -552,10 +695,26 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/data-governance/unity-catalog/hive-metastore
         title: Databricks legacy Hive metastore and Unity Catalog documentation
+  - uid: mondoo-databricks-security-workspace-legacy-access-disabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.disableLegacyAccess == true
+  # The nested block's attribute is `value`, and true means legacy access is disabled.
+  - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_disable_legacy_access_setting")
+    mql: |
+      terraform.resources("databricks_disable_legacy_access_setting").all(blocks.where(type == "disable_legacy_access").any(arguments["value"] == true))
+  - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_disable_legacy_access_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_disable_legacy_access_setting").all(change.after["disable_legacy_access"] != empty && change.after["disable_legacy_access"].any(_["value"] == true))
+  - uid: mondoo-databricks-security-workspace-legacy-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_disable_legacy_access_setting")
+    mql: |
+      terraform.state.resources.where(type == "databricks_disable_legacy_access_setting").all(values["disable_legacy_access"] != empty && values["disable_legacy_access"].any(_["value"] == true))
   - uid: mondoo-databricks-security-workspace-token-lifetime-capped
     title: Ensure personal access tokens are disabled or lifetime is capped
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
@@ -571,8 +730,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-6-3
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      databricks.workspaceConf.tokensEnabled == false || databricks.workspaceConf.maxTokenLifetimeDays != empty && databricks.workspaceConf.maxTokenLifetimeDays <= 90
+    variants:
+      - uid: mondoo-databricks-security-workspace-token-lifetime-capped-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the workspace either refuses to issue personal access tokens at all or caps how long a newly issued one stays valid.
@@ -646,10 +820,28 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-workspace-token-lifetime-capped-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.tokensEnabled == false || databricks.workspaceConf.maxTokenLifetimeDays != empty && databricks.workspaceConf.maxTokenLifetimeDays <= 90
+  # custom_config values are strings and MQL cannot parse one into a number inside a variant
+  # query, so the 90-day cap is matched as a regex over the decimal digits: 1-9, 10-89, or 90.
+  # The workspace-conf key is `enableTokens`, matching the API rather than the resource field.
+  - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_workspace_conf")
+    mql: |
+      terraform.resources("databricks_workspace_conf").all(arguments["custom_config"]["enableTokens"] == "false" || arguments["custom_config"]["maxTokenLifetimeDays"] == /^([1-9]|[1-8][0-9]|90)$/)
+  - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_workspace_conf").all(change.after["custom_config"]["enableTokens"] == "false" || change.after["custom_config"]["maxTokenLifetimeDays"] == /^([1-9]|[1-8][0-9]|90)$/)
+  - uid: mondoo-databricks-security-workspace-token-lifetime-capped-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.state.resources.where(type == "databricks_workspace_conf").all(values["custom_config"]["enableTokens"] == "false" || values["custom_config"]["maxTokenLifetimeDays"] == /^([1-9]|[1-8][0-9]|90)$/)
   - uid: mondoo-databricks-security-workspace-admins-restricted
     title: Ensure workspace admin privileges are restricted
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
@@ -665,8 +857,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      databricks.workspaceConf.restrictWorkspaceAdminsStatus == "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+    variants:
+      - uid: mondoo-databricks-security-workspace-admins-restricted-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that a workspace administrator cannot act as identities they do not own.
@@ -739,10 +946,26 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-workspace-admins-restricted-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.restrictWorkspaceAdminsStatus == "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+  # status is a string enum; RESTRICT_TOKENS_AND_JOB_RUN_AS is the only restricting value.
+  - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_restrict_workspace_admins_setting")
+    mql: |
+      terraform.resources("databricks_restrict_workspace_admins_setting").all(blocks.where(type == "restrict_workspace_admins").any(arguments["status"] == "RESTRICT_TOKENS_AND_JOB_RUN_AS"))
+  - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_restrict_workspace_admins_setting")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_restrict_workspace_admins_setting").all(change.after["restrict_workspace_admins"] != empty && change.after["restrict_workspace_admins"].any(_["status"] == "RESTRICT_TOKENS_AND_JOB_RUN_AS"))
+  - uid: mondoo-databricks-security-workspace-admins-restricted-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_restrict_workspace_admins_setting")
+    mql: |
+      terraform.state.resources.where(type == "databricks_restrict_workspace_admins_setting").all(values["restrict_workspace_admins"] != empty && values["restrict_workspace_admins"].any(_["status"] == "RESTRICT_TOKENS_AND_JOB_RUN_AS"))
   - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled
     title: Ensure deprecated global init scripts are disabled
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
@@ -758,8 +981,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      databricks.workspaceConf.deprecatedGlobalInitScriptsEnabled == false
+    variants:
+      - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the workspace has retired the legacy global init script mechanism in favor of the named, versioned replacement.
@@ -823,10 +1061,28 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.deprecatedGlobalInitScriptsEnabled == false
+  # Asserted as `!= "true"` rather than `== "false"`. Databricks disabled legacy global init
+  # scripts by default when it deprecated them, so a workspace_conf that omits the key leaves
+  # them off. Only a config that explicitly turns them back on is a finding.
+  - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_workspace_conf")
+    mql: |
+      terraform.resources("databricks_workspace_conf").all(arguments["custom_config"]["enableDeprecatedGlobalInitScripts"] != "true")
+  - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_workspace_conf").all(change.after["custom_config"]["enableDeprecatedGlobalInitScripts"] != "true")
+  - uid: mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.state.resources.where(type == "databricks_workspace_conf").all(values["custom_config"]["enableDeprecatedGlobalInitScripts"] != "true")
   - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled
     title: Ensure deprecated cluster-named init scripts are disabled
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
@@ -842,8 +1098,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
-    mql: |
-      databricks.workspaceConf.deprecatedClusterNamedInitScriptsEnabled == false
+    variants:
+      - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the workspace no longer executes init scripts selected by matching a cluster's name against a DBFS path.
@@ -907,10 +1178,27 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.deprecatedClusterNamedInitScriptsEnabled == false
+  # Same default reasoning as the global init script check: the deprecated feature is off
+  # unless a config asks for it, so the Terraform version fails only on an explicit opt-in.
+  - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_workspace_conf")
+    mql: |
+      terraform.resources("databricks_workspace_conf").all(arguments["custom_config"]["enableDeprecatedClusterNamedInitScripts"] != "true")
+  - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_workspace_conf").all(change.after["custom_config"]["enableDeprecatedClusterNamedInitScripts"] != "true")
+  - uid: mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.state.resources.where(type == "databricks_workspace_conf").all(values["custom_config"]["enableDeprecatedClusterNamedInitScripts"] != "true")
   - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account
     title: Ensure interactive notebook results are stored in the customer account
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-19
@@ -927,8 +1215,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-5-3-4
-    mql: |
-      databricks.workspaceConf.storeInteractiveNotebookResultsInCustomerAccount == true
+    variants:
+      - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the output of interactive notebook commands is persisted in your own cloud storage account rather than in the Databricks control plane.
@@ -992,10 +1295,27 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.workspaceConf.storeInteractiveNotebookResultsInCustomerAccount == true
+  # Databricks stores interactive results in the control plane until a workspace opts out,
+  # so an absent key leaves results outside the customer account and fails.
+  - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_workspace_conf")
+    mql: |
+      terraform.resources("databricks_workspace_conf").all(arguments["custom_config"]["storeInteractiveNotebookResultsInCustomerAccount"] == "true")
+  - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_workspace_conf").all(change.after["custom_config"]["storeInteractiveNotebookResultsInCustomerAccount"] == "true")
+  - uid: mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_workspace_conf")
+    mql: |
+      terraform.state.resources.where(type == "databricks_workspace_conf").all(values["custom_config"]["storeInteractiveNotebookResultsInCustomerAccount"] == "true")
   - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled
     title: Ensure local disk encryption is enabled on all compute clusters
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a28
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
@@ -1011,8 +1331,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: |
-      databricks.clusters.all(localDiskEncryptionEnabled == true)
+    variants:
+      - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every compute cluster encrypts the local disks its nodes use for scratch storage.
@@ -1103,10 +1438,26 @@ queries:
               enable_local_disk_encryption = true
             }
             ```
+  - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.clusters.all(localDiskEncryptionEnabled == true)
+  # Local disk encryption is off unless a cluster asks for it, so an omitted argument fails.
+  - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_cluster")
+    mql: |
+      terraform.resources("databricks_cluster").all(arguments["enable_local_disk_encryption"] == true)
+  - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_cluster").all(change.after["enable_local_disk_encryption"] == true)
+  - uid: mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_cluster")
+    mql: |
+      terraform.state.resources.where(type == "databricks_cluster").all(values["enable_local_disk_encryption"] == true)
   - uid: mondoo-databricks-security-cluster-access-mode-user-isolation
     title: Ensure compute clusters enforce an access mode with user isolation
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a15
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-06
@@ -1122,8 +1473,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-1
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      databricks.clusters.all(dataSecurityMode != empty && dataSecurityMode != "NONE")
+    variants:
+      - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every compute cluster runs under an access mode that keeps Unity Catalog governance and table access controls in the request path.
@@ -1190,10 +1556,27 @@ queries:
               data_security_mode = "USER_ISOLATION"
             }
             ```
+  - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.clusters.all(dataSecurityMode != empty && dataSecurityMode != "NONE")
+  # A cluster with no data_security_mode runs in the legacy no-isolation mode, which is what
+  # `!= empty` catches; NONE is the same thing spelled explicitly.
+  - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_cluster")
+    mql: |
+      terraform.resources("databricks_cluster").all(arguments["data_security_mode"] != empty && arguments["data_security_mode"] != "NONE")
+  - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_cluster").all(change.after["data_security_mode"] != empty && change.after["data_security_mode"] != "NONE")
+  - uid: mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_cluster")
+    mql: |
+      terraform.state.resources.where(type == "databricks_cluster").all(values["data_security_mode"] != empty && values["data_security_mode"] != "NONE")
   - uid: mondoo-databricks-security-cluster-autotermination-configured
     title: Ensure compute clusters have auto-termination configured
     impact: 40
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: false
@@ -1209,8 +1592,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-2-8
       compliance/soc2-2017: false
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: |
-      databricks.clusters.all(autoterminationMinutes > 0 && autoterminationMinutes <= 120)
+    variants:
+      - uid: mondoo-databricks-security-cluster-autotermination-configured-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that compute clusters shut themselves down after a bounded idle period instead of running until someone stops them by hand.
@@ -1277,10 +1675,28 @@ queries:
               autotermination_minutes = 60
             }
             ```
+  - uid: mondoo-databricks-security-cluster-autotermination-configured-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.clusters.all(autoterminationMinutes > 0 && autoterminationMinutes <= 120)
+  # The provider defaults autotermination_minutes to 60, so an omitted argument is already
+  # within the cap and passes. The guard is `== null` and not `== empty` because `empty` also
+  # matches 0, and 0 is the value that disables auto-termination entirely.
+  - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_cluster")
+    mql: |
+      terraform.resources("databricks_cluster").all(arguments["autotermination_minutes"] == null || arguments["autotermination_minutes"] > 0 && arguments["autotermination_minutes"] <= 120)
+  - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_cluster").all(change.after["autotermination_minutes"] == null || change.after["autotermination_minutes"] > 0 && change.after["autotermination_minutes"] <= 120)
+  - uid: mondoo-databricks-security-cluster-autotermination-configured-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_cluster")
+    mql: |
+      terraform.state.resources.where(type == "databricks_cluster").all(values["autotermination_minutes"] == null || values["autotermination_minutes"] > 0 && values["autotermination_minutes"] <= 120)
   - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets
     title: Ensure no plaintext secrets are set in cluster Spark configuration
     impact: 80
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-15
@@ -1296,8 +1712,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-6-2
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      databricks.clusters.all(sparkConf.where( key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/ ).all( value == /\{\{secrets\// ))
+    variants:
+      - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that credential shaped entries in a cluster's Spark configuration point at the Databricks secrets store instead of holding the credential itself.
@@ -1393,10 +1824,28 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.clusters.all(sparkConf.where( key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/ ).all( value == /\{\{secrets\// ))
+  # spark_conf is a map, so it is filtered rather than indexed: an absent key and an empty
+  # map are indistinguishable through indexing. A cluster with no spark_conf has nothing to
+  # leak, which is why the null case short-circuits to a pass.
+  - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_cluster")
+    mql: |
+      terraform.resources("databricks_cluster").all(arguments["spark_conf"] == null || arguments["spark_conf"].where(key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/).all(value == /\{\{secrets\//))
+  - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_cluster").all(change.after["spark_conf"] == null || change.after["spark_conf"].where(key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/).all(value == /\{\{secrets\//))
+  - uid: mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_cluster")
+    mql: |
+      terraform.state.resources.where(type == "databricks_cluster").all(values["spark_conf"] == null || values["spark_conf"].where(key == /(?i)(password|secret|token|passwd|pwd|apikey|access.?key|credential)/).all(value == /\{\{secrets\//))
   - uid: mondoo-databricks-security-cluster-governed-by-policy
     title: Ensure every compute cluster is governed by a cluster policy
     impact: 40
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: bsi-sys-1-5-a14
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-04
@@ -1412,8 +1861,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-2-2-1
       compliance/soc2-2017: soc2-control-cc7-1-1
       compliance/vda-isa-5: false
-    mql: |
-      databricks.clusters.all(policy != empty)
+    variants:
+      - uid: mondoo-databricks-security-cluster-governed-by-policy-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every compute cluster was created against a cluster policy rather than as unconstrained ad hoc compute.
@@ -1501,6 +1965,23 @@ queries:
               policy_id     = databricks_cluster_policy.baseline.id
             }
             ```
+  - uid: mondoo-databricks-security-cluster-governed-by-policy-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.clusters.all(policy != empty)
+  # `!= empty` rather than `!= null` so an explicit policy_id = "" is also a finding.
+  - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_cluster")
+    mql: |
+      terraform.resources("databricks_cluster").all(arguments["policy_id"] != empty)
+  - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_cluster")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_cluster").all(change.after["policy_id"] != empty)
+  - uid: mondoo-databricks-security-cluster-governed-by-policy-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_cluster")
+    mql: |
+      terraform.state.resources.where(type == "databricks_cluster").all(values["policy_id"] != empty)
   - uid: mondoo-databricks-security-token-no-nonexpiring
     title: Ensure access tokens and service principal secrets are not non-expiring
     impact: 70
@@ -1528,6 +2009,18 @@ queries:
         tags:
           mondoo.com/filter-title: Databricks Account
           mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no Databricks credential is set to never expire, covering both personal access tokens in a workspace and the OAuth secrets of account level service principals.
@@ -1624,10 +2117,28 @@ queries:
     filters: asset.platform == "databricks-account"
     mql: |
       databricks.servicePrincipals.all(secrets.where(status == "active").all(expireTime != empty))
+  # lifetime_seconds is optional in both token resources, and omitting it is exactly how a
+  # non-expiring token is written, so the absent argument is the finding. Each resource type
+  # is asserted separately: a config that declares only one of them leaves the other list
+  # empty, and an empty list passes its own `.all()`.
+  - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_token" || nameLabel == "databricks_obo_token")
+    mql: |
+      terraform.resources("databricks_token").all(arguments["lifetime_seconds"] != null)
+      terraform.resources("databricks_obo_token").all(arguments["lifetime_seconds"] != null)
+  - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_token" || type == "databricks_obo_token")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_token").all(change.after["lifetime_seconds"] != null)
+      terraform.plan.resourceChanges.where(type == "databricks_obo_token").all(change.after["lifetime_seconds"] != null)
+  - uid: mondoo-databricks-security-token-no-nonexpiring-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_token" || type == "databricks_obo_token")
+    mql: |
+      terraform.state.resources.where(type == "databricks_token").all(values["lifetime_seconds"] != null)
+      terraform.state.resources.where(type == "databricks_obo_token").all(values["lifetime_seconds"] != null)
   - uid: mondoo-databricks-security-token-lifetime-under-90-days
     title: Ensure personal access token lifetimes do not exceed 90 days
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-02
@@ -1643,8 +2154,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-6-3
       compliance/soc2-2017: soc2-control-cc6-1-8
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      databricks.tokens.all(expiryTime - creationTime <= 90 * time.day)
+    variants:
+      - uid: mondoo-databricks-security-token-lifetime-under-90-days-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no personal access token in the workspace was issued with a lifetime longer than 90 days.
@@ -1729,10 +2255,29 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/admin/access-control/tokens
         title: Monitor and revoke Databricks personal access tokens
+  - uid: mondoo-databricks-security-token-lifetime-under-90-days-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.tokens.all(expiryTime - creationTime <= 90 * time.day)
+  # 90 days expressed in the seconds the resources take: 90 * 24 * 60 * 60.
+  - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_token" || nameLabel == "databricks_obo_token")
+    mql: |
+      terraform.resources("databricks_token").all(arguments["lifetime_seconds"] != null && arguments["lifetime_seconds"] <= 7776000)
+      terraform.resources("databricks_obo_token").all(arguments["lifetime_seconds"] != null && arguments["lifetime_seconds"] <= 7776000)
+  - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_token" || type == "databricks_obo_token")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_token").all(change.after["lifetime_seconds"] != null && change.after["lifetime_seconds"] <= 7776000)
+      terraform.plan.resourceChanges.where(type == "databricks_obo_token").all(change.after["lifetime_seconds"] != null && change.after["lifetime_seconds"] <= 7776000)
+  - uid: mondoo-databricks-security-token-lifetime-under-90-days-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_token" || type == "databricks_obo_token")
+    mql: |
+      terraform.state.resources.where(type == "databricks_token").all(values["lifetime_seconds"] != null && values["lifetime_seconds"] <= 7776000)
+      terraform.state.resources.where(type == "databricks_obo_token").all(values["lifetime_seconds"] != null && values["lifetime_seconds"] <= 7776000)
   - uid: mondoo-databricks-security-secret-scope-not-world-readable
     title: Ensure secret scopes are not readable by all workspace users
     impact: 80
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-05
@@ -1748,8 +2293,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-7-2-2
       compliance/soc2-2017: soc2-control-cc6-3-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      databricks.secretScopes.all(acls["users"] == empty)
+    variants:
+      - uid: mondoo-databricks-security-secret-scope-not-world-readable-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no secret scope grants a permission to the built-in `users` group, which contains every member of the workspace.
@@ -1834,10 +2394,27 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/secrets/acl
         title: Databricks secret access control lists
+  - uid: mondoo-databricks-security-secret-scope-not-world-readable-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.secretScopes.all(acls["users"] == empty)
+  # `users` is the Databricks group containing every workspace user, so an ACL granting it
+  # any permission makes the scope world-readable regardless of which permission it is.
+  - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_secret_acl")
+    mql: |
+      terraform.resources("databricks_secret_acl").all(arguments["principal"] != "users")
+  - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_secret_acl")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_secret_acl").all(change.after["principal"] != "users")
+  - uid: mondoo-databricks-security-secret-scope-not-world-readable-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_secret_acl")
+    mql: |
+      terraform.state.resources.where(type == "databricks_secret_acl").all(values["principal"] != "users")
   - uid: mondoo-databricks-security-ip-access-list-no-allow-all
     title: Ensure IP access lists contain no unrestricted (allow-all) ranges
     impact: 70
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -1853,8 +2430,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      databricks.ipAccessLists.where(listType == "ALLOW").all(ipAddresses.none(_ == "0.0.0.0/0" || _ == "::/0"))
+    variants:
+      - uid: mondoo-databricks-security-ip-access-list-no-allow-all-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that no allow entry in the workspace's IP access lists opens the workspace to the entire internet.
@@ -1939,10 +2531,26 @@ queries:
     refs:
       - url: https://docs.databricks.com/aws/en/security/network/front-end/ip-access-list
         title: Databricks IP access lists
+  - uid: mondoo-databricks-security-ip-access-list-no-allow-all-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.ipAccessLists.where(listType == "ALLOW").all(ipAddresses.none(_ == "0.0.0.0/0" || _ == "::/0"))
+  # Only ALLOW lists are relevant: 0.0.0.0/0 on a BLOCK list denies everything, it does not open anything.
+  - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_ip_access_list")
+    mql: |
+      terraform.resources("databricks_ip_access_list").where(arguments["list_type"] == "ALLOW").all(arguments["ip_addresses"].none(_ == "0.0.0.0/0" || _ == "::/0"))
+  - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_ip_access_list")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_ip_access_list").where(change.after["list_type"] == "ALLOW").all(change.after["ip_addresses"].none(_ == "0.0.0.0/0" || _ == "::/0"))
+  - uid: mondoo-databricks-security-ip-access-list-no-allow-all-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_ip_access_list")
+    mql: |
+      terraform.state.resources.where(type == "databricks_ip_access_list").where(values["list_type"] == "ALLOW").all(values["ip_addresses"].none(_ == "0.0.0.0/0" || _ == "::/0"))
   - uid: mondoo-databricks-security-workspace-public-access-disabled
     title: Ensure public network access is disabled for workspaces
     impact: 80
-    filters: asset.platform == "databricks-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -1958,8 +2566,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      databricks.privateAccessSettings.all(publicAccessEnabled == false)
+    variants:
+      - uid: mondoo-databricks-security-workspace-public-access-disabled-account
+        tags:
+          mondoo.com/filter-title: Databricks Account
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the private access settings registered in the Databricks account keep public network access turned off, so workspaces bound to them are reachable only through a private endpoint.
@@ -2050,10 +2673,27 @@ queries:
               private_access_settings_id = databricks_mws_private_access_settings.this.private_access_settings_id
             }
             ```
+  - uid: mondoo-databricks-security-workspace-public-access-disabled-account
+    filters: asset.platform == "databricks-account"
+    mql: |
+      databricks.privateAccessSettings.all(publicAccessEnabled == false)
+  # public_access_enabled defaults to true on the account API, so private access settings
+  # that never mention it leave the workspace reachable from the internet and fail.
+  - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.resources("databricks_mws_private_access_settings").all(arguments["public_access_enabled"] == false)
+  - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_mws_private_access_settings").all(change.after["public_access_enabled"] == false)
+  - uid: mondoo-databricks-security-workspace-public-access-disabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.state.resources.where(type == "databricks_mws_private_access_settings").all(values["public_access_enabled"] == false)
   - uid: mondoo-databricks-security-private-access-restrict-endpoints
     title: Ensure private access settings restrict connections to allowed endpoints
     impact: 70
-    filters: asset.platform == "databricks-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -2069,8 +2709,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      databricks.privateAccessSettings.all(privateAccessLevel == "ENDPOINT" && allowedVpcEndpointIds != empty)
+    variants:
+      - uid: mondoo-databricks-security-private-access-restrict-endpoints-account
+        tags:
+          mondoo.com/filter-title: Databricks Account
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that a private access setting names the specific endpoints allowed to reach the workspace instead of admitting every endpoint registered in the account.
@@ -2164,10 +2819,27 @@ queries:
               allowed_vpc_endpoint_ids     = [databricks_mws_vpc_endpoint.backend.vpc_endpoint_id]
             }
             ```
+  - uid: mondoo-databricks-security-private-access-restrict-endpoints-account
+    filters: asset.platform == "databricks-account"
+    mql: |
+      databricks.privateAccessSettings.all(privateAccessLevel == "ENDPOINT" && allowedVpcEndpointIds != empty)
+  # private_access_level defaults to ACCOUNT, which admits every endpoint registered to the
+  # account. ENDPOINT narrows it to the listed endpoints, so the allowlist has to be there too.
+  - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.resources("databricks_mws_private_access_settings").all(arguments["private_access_level"] == "ENDPOINT" && arguments["allowed_vpc_endpoint_ids"] != empty)
+  - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_mws_private_access_settings").all(change.after["private_access_level"] == "ENDPOINT" && change.after["allowed_vpc_endpoint_ids"] != empty)
+  - uid: mondoo-databricks-security-private-access-restrict-endpoints-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_mws_private_access_settings")
+    mql: |
+      terraform.state.resources.where(type == "databricks_mws_private_access_settings").all(values["private_access_level"] == "ENDPOINT" && values["allowed_vpc_endpoint_ids"] != empty)
   - uid: mondoo-databricks-security-workspace-customer-managed-keys
     title: Ensure workspaces use customer-managed encryption keys
     impact: 70
-    filters: asset.platform == "databricks-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-03
@@ -2183,8 +2855,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-6-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: |
-      databricks.workspaces.all(managedServicesCustomerManagedKey != empty && storageCustomerManagedKey != empty)
+    variants:
+      - uid: mondoo-databricks-security-workspace-customer-managed-keys-account
+        tags:
+          mondoo.com/filter-title: Databricks Account
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that each workspace in the account is encrypted with keys the organization controls, for both managed services and workspace storage.
@@ -2290,10 +2977,28 @@ queries:
               storage_customer_managed_key_id          = databricks_mws_customer_managed_keys.storage.customer_managed_key_id
             }
             ```
+  - uid: mondoo-databricks-security-workspace-customer-managed-keys-account
+    filters: asset.platform == "databricks-account"
+    mql: |
+      databricks.workspaces.all(managedServicesCustomerManagedKey != empty && storageCustomerManagedKey != empty)
+  # Two separate key references: managed services covers notebooks and secrets in the control
+  # plane, storage covers the workspace root bucket. Either one missing leaves data on
+  # Databricks-managed keys, so both are required.
+  - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_mws_workspaces")
+    mql: |
+      terraform.resources("databricks_mws_workspaces").all(arguments["managed_services_customer_managed_key_id"] != empty && arguments["storage_customer_managed_key_id"] != empty)
+  - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_mws_workspaces")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_mws_workspaces").all(change.after["managed_services_customer_managed_key_id"] != empty && change.after["storage_customer_managed_key_id"] != empty)
+  - uid: mondoo-databricks-security-workspace-customer-managed-keys-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_mws_workspaces")
+    mql: |
+      terraform.state.resources.where(type == "databricks_mws_workspaces").all(values["managed_services_customer_managed_key_id"] != empty && values["storage_customer_managed_key_id"] != empty)
   - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted
     title: Ensure token-authenticated Delta Sharing recipients are IP restricted
     impact: 70
-    filters: asset.platform == "databricks-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
@@ -2309,8 +3014,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      databricks.deltaSharingRecipients.where(authenticationType == "TOKEN").all(ipAccessList != empty)
+    variants:
+      - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-account
+        tags:
+          mondoo.com/filter-title: Databricks Account
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every Delta Sharing recipient authenticating with a bearer token is limited to network ranges you approved.
@@ -2392,10 +3112,28 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-account
+    filters: asset.platform == "databricks-account"
+    mql: |
+      databricks.deltaSharingRecipients.where(authenticationType == "TOKEN").all(ipAccessList != empty)
+  # Only TOKEN recipients carry a bearer credential that anyone holding it can replay, so
+  # DATABRICKS-to-DATABRICKS sharing is out of scope. The allowlist is a nested block, which
+  # serializes as a list, hence the `.any()`.
+  - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_recipient")
+    mql: |
+      terraform.resources("databricks_recipient").where(arguments["authentication_type"] == "TOKEN").all(blocks.where(type == "ip_access_list").any(arguments["allowed_ip_addresses"] != empty))
+  - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_recipient")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_recipient").where(change.after["authentication_type"] == "TOKEN").all(change.after["ip_access_list"] != empty && change.after["ip_access_list"].any(_["allowed_ip_addresses"] != empty))
+  - uid: mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_recipient")
+    mql: |
+      terraform.state.resources.where(type == "databricks_recipient").where(values["authentication_type"] == "TOKEN").all(values["ip_access_list"] != empty && values["ip_access_list"].any(_["allowed_ip_addresses"] != empty))
   - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails
     title: Ensure AI Gateway guardrails are configured on model serving endpoints
     impact: 60
-    filters: asset.platform == "databricks-workspace"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-dsp-10
@@ -2412,8 +3150,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc6-7-1
       compliance/vda-isa-5: false
-    mql: |
-      databricks.servingEndpoints.all(aiGateway != empty && aiGateway.guardrails != empty)
+    variants:
+      - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-workspace
+        tags:
+          mondoo.com/filter-title: Databricks Workspace
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that model serving endpoints screen the prompts they receive and the responses they return.
@@ -2513,10 +3266,28 @@ queries:
               }
             }
             ```
+  - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-workspace
+    filters: asset.platform == "databricks-workspace"
+    mql: |
+      databricks.servingEndpoints.all(aiGateway != empty && aiGateway.guardrails != empty)
+  # guardrails sits two blocks deep, and an ai_gateway block that configures only rate limits
+  # or usage tracking is the common near-miss, so the inner block is asserted rather than the
+  # presence of ai_gateway alone.
+  - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_model_serving")
+    mql: |
+      terraform.resources("databricks_model_serving").all(blocks.where(type == "ai_gateway").any(blocks.any(type == "guardrails")))
+  - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_model_serving")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_model_serving").all(change.after["ai_gateway"] != empty && change.after["ai_gateway"].any(_["guardrails"] != empty))
+  - uid: mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_model_serving")
+    mql: |
+      terraform.state.resources.where(type == "databricks_model_serving").all(values["ai_gateway"] != empty && values["ai_gateway"].any(_["guardrails"] != empty))
   - uid: mondoo-databricks-security-no-inactive-service-principals
     title: Ensure there are no inactive account service principals
     impact: 40
-    filters: asset.platform == "databricks-account"
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-iam-07
@@ -2532,8 +3303,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-2-6
       compliance/soc2-2017: soc2-control-cc6-2-3
       compliance/vda-isa-5: vda-isa-5-4-1-3
-    mql: |
-      databricks.servicePrincipals.all(active == true)
+    variants:
+      - uid: mondoo-databricks-security-no-inactive-service-principals-account
+        tags:
+          mondoo.com/filter-title: Databricks Account
+          mondoo.com/filter-icon: databricks
+      - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the Databricks account carries no service principal left sitting in a deactivated state.
@@ -2602,3 +3388,22 @@ queries:
               active       = true
             }
             ```
+  - uid: mondoo-databricks-security-no-inactive-service-principals-account
+    filters: asset.platform == "databricks-account"
+    mql: |
+      databricks.servicePrincipals.all(active == true)
+  # active defaults to true in the provider, so the assertion is `!= false`: an omitted
+  # argument describes an active principal, and `== true` would fail every service principal
+  # that simply never mentions the field.
+  - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "databricks_service_principal")
+    mql: |
+      terraform.resources("databricks_service_principal").all(arguments["active"] != false)
+  - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "databricks_service_principal")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "databricks_service_principal").all(change.after["active"] != false)
+  - uid: mondoo-databricks-security-no-inactive-service-principals-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "databricks_service_principal")
+    mql: |
+      terraform.state.resources.where(type == "databricks_service_principal").all(values["active"] != false)

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/fail/no-isolation/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/fail/no-isolation/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  data_security_mode = "NONE"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/pass/single-user/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/pass/single-user/main.tf
@@ -1,0 +1,8 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  data_security_mode = "SINGLE_USER"
+  single_user_name   = "svc@example.com"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/pass/user-isolation/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-access-mode-user-isolation-terraform-hcl/pass/user-isolation/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  data_security_mode = "USER_ISOLATION"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/fail/eight-hours/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/fail/eight-hours/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  autotermination_minutes = 480
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/fail/never-terminates/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/fail/never-terminates/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  autotermination_minutes = 0
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/pass/absent/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/pass/thirty-minutes/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-autotermination-configured-terraform-hcl/pass/thirty-minutes/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  autotermination_minutes = 30
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/fail/empty-policy/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/fail/empty-policy/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  policy_id = ""
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/fail/ungoverned/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/fail/ungoverned/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/pass/policy-attached/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-governed-by-policy-terraform-hcl/pass/policy-attached/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  policy_id = databricks_cluster_policy.baseline.id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/fail/unencrypted/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/fail/unencrypted/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  enable_local_disk_encryption = false
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/pass/encrypted/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-local-disk-encryption-enabled-terraform-hcl/pass/encrypted/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  enable_local_disk_encryption = true
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/fail/inline-password/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/fail/inline-password/main.tf
@@ -1,0 +1,9 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  spark_conf = {
+    "spark.datasource.jdbc.password" = "hunter2"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/fail/inline-secret/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/fail/inline-secret/main.tf
@@ -1,0 +1,9 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  spark_conf = {
+    "spark.hadoop.fs.s3a.secret.key" = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/pass/no-spark-conf/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/pass/no-spark-conf/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/pass/secret-reference/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-cluster-no-plaintext-spark-secrets-terraform-hcl/pass/secret-reference/main.tf
@@ -1,0 +1,10 @@
+resource "databricks_cluster" "analytics" {
+  cluster_name  = "analytics"
+  spark_version = "15.4.x-scala2.12"
+  node_type_id  = "i3.xlarge"
+  num_workers   = 2
+  spark_conf = {
+    "spark.hadoop.fs.s3a.secret.key" = "{{secrets/prod/s3-secret-key}}"
+    "spark.sql.shuffle.partitions"   = "200"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/fail/empty-allowlist/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/fail/empty-allowlist/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_recipient" "partner" {
+  name                = "partner"
+  authentication_type = "TOKEN"
+  ip_access_list {
+    allowed_ip_addresses = []
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/fail/token-recipient-unrestricted/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/fail/token-recipient-unrestricted/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_recipient" "partner" {
+  name                = "partner"
+  authentication_type = "TOKEN"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/pass/databricks-to-databricks/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/pass/databricks-to-databricks/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_recipient" "internal" {
+  name                                 = "internal"
+  authentication_type                  = "DATABRICKS"
+  data_recipient_global_metastore_id   = "aws:us-east-1:abc"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/pass/token-recipient-restricted/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-delta-sharing-recipient-ip-restricted-terraform-hcl/pass/token-recipient-restricted/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_recipient" "partner" {
+  name                = "partner"
+  authentication_type = "TOKEN"
+  ip_access_list {
+    allowed_ip_addresses = ["203.0.113.42/32"]
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/fail/ipv4-any/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/fail/ipv4-any/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_ip_access_list" "open" {
+  label        = "open"
+  list_type    = "ALLOW"
+  ip_addresses = ["0.0.0.0/0"]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/fail/ipv6-any/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/fail/ipv6-any/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_ip_access_list" "open" {
+  label        = "open"
+  list_type    = "ALLOW"
+  ip_addresses = ["203.0.113.0/24", "::/0"]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/pass/block-list-catch-all/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/pass/block-list-catch-all/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_ip_access_list" "deny" {
+  label        = "deny-all-else"
+  list_type    = "BLOCK"
+  ip_addresses = ["0.0.0.0/0"]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/pass/office-ranges/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-ip-access-list-no-allow-all-terraform-hcl/pass/office-ranges/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_ip_access_list" "office" {
+  label        = "office"
+  list_type    = "ALLOW"
+  ip_addresses = ["203.0.113.0/24", "198.51.100.7/32"]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/fail/deactivated/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/fail/deactivated/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_service_principal" "jobs" {
+  display_name = "jobs runner"
+  active       = false
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/pass/absent/main.tf
@@ -1,0 +1,3 @@
+resource "databricks_service_principal" "jobs" {
+  display_name = "jobs runner"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/pass/active/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-no-inactive-service-principals-terraform-hcl/pass/active/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_service_principal" "jobs" {
+  display_name = "jobs runner"
+  active       = true
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/fail/account-wide/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/fail/account-wide/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+  public_access_enabled        = false
+  private_access_level         = "ACCOUNT"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/fail/endpoint-level-without-allowlist/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/fail/endpoint-level-without-allowlist/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+  public_access_enabled        = false
+  private_access_level         = "ENDPOINT"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/pass/endpoint-scoped/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-private-access-restrict-endpoints-terraform-hcl/pass/endpoint-scoped/main.tf
@@ -1,0 +1,7 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+  public_access_enabled        = false
+  private_access_level         = "ENDPOINT"
+  allowed_vpc_endpoint_ids     = [databricks_mws_vpc_endpoint.workspace.vpc_endpoint_id]
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/fail/all-users-manage/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/fail/all-users-manage/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_secret_acl" "prod" {
+  principal  = "users"
+  permission = "MANAGE"
+  scope      = "prod"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/fail/all-users-read/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/fail/all-users-read/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_secret_acl" "prod" {
+  principal  = "users"
+  permission = "READ"
+  scope      = "prod"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/pass/named-group/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-secret-scope-not-world-readable-terraform-hcl/pass/named-group/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_secret_acl" "prod" {
+  principal  = "data-engineering"
+  permission = "READ"
+  scope      = "prod"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/fail/gateway-without-guardrails/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/fail/gateway-without-guardrails/main.tf
@@ -1,0 +1,8 @@
+resource "databricks_model_serving" "chat" {
+  name = "chat"
+  ai_gateway {
+    usage_tracking_config {
+      enabled = true
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/fail/no-gateway/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/fail/no-gateway/main.tf
@@ -1,0 +1,3 @@
+resource "databricks_model_serving" "chat" {
+  name = "chat"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/pass/guardrails-configured/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-serving-endpoint-ai-gateway-guardrails-terraform-hcl/pass/guardrails-configured/main.tf
@@ -1,0 +1,13 @@
+resource "databricks_model_serving" "chat" {
+  name = "chat"
+  ai_gateway {
+    guardrails {
+      input {
+        safety = true
+      }
+      output {
+        safety = true
+      }
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/fail/no-lifetime/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/fail/no-lifetime/main.tf
@@ -1,0 +1,3 @@
+resource "databricks_token" "ci" {
+  comment = "ci pipeline"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/fail/one-year/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/fail/one-year/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_token" "ci" {
+  comment          = "ci pipeline"
+  lifetime_seconds = 31536000
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/pass/exactly-ninety-days/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/pass/exactly-ninety-days/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_token" "ci" {
+  comment          = "ci pipeline"
+  lifetime_seconds = 7776000
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/pass/thirty-days/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-lifetime-under-90-days-terraform-hcl/pass/thirty-days/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_token" "ci" {
+  comment          = "ci pipeline"
+  lifetime_seconds = 2592000
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/fail/no-lifetime/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/fail/no-lifetime/main.tf
@@ -1,0 +1,3 @@
+resource "databricks_token" "ci" {
+  comment = "ci pipeline"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/fail/obo-no-lifetime/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/fail/obo-no-lifetime/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_obo_token" "jobs" {
+  application_id = databricks_service_principal.jobs.application_id
+  comment        = "jobs runner"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/pass/lifetime-set/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/pass/lifetime-set/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_token" "ci" {
+  comment          = "ci pipeline"
+  lifetime_seconds = 3600
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/pass/obo-lifetime-set/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-token-no-nonexpiring-terraform-hcl/pass/obo-lifetime-set/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_obo_token" "jobs" {
+  application_id   = databricks_service_principal.jobs.application_id
+  comment          = "jobs runner"
+  lifetime_seconds = 86400
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-admins-restricted-terraform-hcl/fail/allow-all/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-admins-restricted-terraform-hcl/fail/allow-all/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_restrict_workspace_admins_setting" "this" {
+  restrict_workspace_admins {
+    status = "ALLOW_ALL"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-admins-restricted-terraform-hcl/pass/restricted/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-admins-restricted-terraform-hcl/pass/restricted/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_restrict_workspace_admins_setting" "this" {
+  restrict_workspace_admins {
+    status = "RESTRICT_TOKENS_AND_JOB_RUN_AS"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_automatic_cluster_update_workspace_setting" "this" {
+  automatic_cluster_update_workspace {
+    enabled = false
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-automatic-cluster-update-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_automatic_cluster_update_workspace_setting" "this" {
+  automatic_cluster_update_workspace {
+    enabled = true
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl/fail/standards-without-enablement/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl/fail/standards-without-enablement/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_compliance_security_profile_workspace_setting" "this" {
+  compliance_security_profile_workspace {
+    is_enabled           = false
+    compliance_standards = ["HIPAA"]
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-compliance-security-profile-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_compliance_security_profile_workspace_setting" "this" {
+  compliance_security_profile_workspace {
+    is_enabled           = true
+    compliance_standards = ["HIPAA"]
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/fail/no-keys/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/fail/no-keys/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_mws_workspaces" "this" {
+  account_id     = var.account_id
+  workspace_name = "prod"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/fail/storage-key-only/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/fail/storage-key-only/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_mws_workspaces" "this" {
+  account_id                      = var.account_id
+  workspace_name                  = "prod"
+  storage_customer_managed_key_id = databricks_mws_customer_managed_keys.storage.customer_managed_key_id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/pass/both-keys/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-customer-managed-keys-terraform-hcl/pass/both-keys/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_mws_workspaces" "this" {
+  account_id                               = var.account_id
+  workspace_name                           = "prod"
+  managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.services.customer_managed_key_id
+  storage_customer_managed_key_id          = databricks_mws_customer_managed_keys.storage.customer_managed_key_id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_enhanced_security_monitoring_workspace_setting" "this" {
+  enhanced_security_monitoring_workspace {
+    is_enabled = false
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-enhanced-security-monitoring-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_enhanced_security_monitoring_workspace_setting" "this" {
+  enhanced_security_monitoring_workspace {
+    is_enabled = true
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "false"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = "false"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/pass/enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-ip-access-lists-enabled-terraform-hcl/pass/enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl/fail/legacy-access-allowed/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl/fail/legacy-access-allowed/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_disable_legacy_access_setting" "this" {
+  disable_legacy_access {
+    value = false
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-access-disabled-terraform-hcl/pass/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_disable_legacy_access_setting" "this" {
+  disable_legacy_access {
+    value = true
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/fail/re-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/fail/re-enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableDeprecatedClusterNamedInitScripts" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/pass/absent/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-cluster-named-init-scripts-disabled-terraform-hcl/pass/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableDeprecatedClusterNamedInitScripts" = "false"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/fail/re-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/fail/re-enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableDeprecatedGlobalInitScripts" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/pass/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/pass/absent/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/pass/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-legacy-global-init-scripts-disabled-terraform-hcl/pass/disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableDeprecatedGlobalInitScripts" = "false"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/fail/control-plane/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/fail/control-plane/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "storeInteractiveNotebookResultsInCustomerAccount" = "false"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/pass/customer-account/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-notebook-results-in-customer-account-terraform-hcl/pass/customer-account/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "storeInteractiveNotebookResultsInCustomerAccount" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,4 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/fail/public-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/fail/public-enabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+  public_access_enabled        = true
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/pass/private-only/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-public-access-disabled-terraform-hcl/pass/private-only/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_mws_private_access_settings" "this" {
+  private_access_settings_name = "prod"
+  region                       = "us-east-1"
+  public_access_enabled        = false
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/just-over-cap/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/just-over-cap/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "true"
+    "maxTokenLifetimeDays" = "91"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/one-year/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/one-year/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "true"
+    "maxTokenLifetimeDays" = "365"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/uncapped/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/fail/uncapped/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "true"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/capped-at-7/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/capped-at-7/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "true"
+    "maxTokenLifetimeDays" = "7"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/capped-at-90/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/capped-at-90/main.tf
@@ -1,0 +1,6 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "true"
+    "maxTokenLifetimeDays" = "90"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/tokens-disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-databricks-security/mondoo-databricks-security-workspace-token-lifetime-capped-terraform-hcl/pass/tokens-disabled/main.tf
@@ -1,0 +1,5 @@
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableTokens" = "false"
+  }
+}

--- a/content/validation/scans/iac_variants_test.go
+++ b/content/validation/scans/iac_variants_test.go
@@ -54,7 +54,7 @@ func init() {
 		"bicep", "os",
 		"alicloud", "oci", "vsphere", "okta", "openstack", "gitlab", "cloudflare",
 		"github", "digitalocean", "unifi", "portainer", "snowflake",
-		"hetzner", "tailscale", "ms365",
+		"hetzner", "tailscale", "ms365", "databricks",
 	)
 }
 
@@ -99,6 +99,7 @@ var tfVariantPolicies = []tfVariantPolicy{
 	{"mondoo-clickhousecloud-security-", "mondoo-clickhousecloud-security.mql.yaml", ""},
 	{"mondoo-hcp-security-", "mondoo-hcp-security.mql.yaml", ""},
 	{"mondoo-neon-security-", "mondoo-neon-security.mql.yaml", ""},
+	{"mondoo-databricks-security-", "mondoo-databricks-security.mql.yaml", ""},
 }
 
 // checkOutcome distinguishes a check that ran and passed, ran and failed, or was


### PR DESCRIPTION
All 25 checks in `mondoo-databricks-security` now have `terraform-hcl`, `terraform-plan` and `terraform-state` variants alongside their Databricks API check, so a workspace or account configured through the `databricks/databricks` provider is assessed before it is applied.

Each flat check became a variant parent: its `filters:` and `mql:` moved into a `-workspace` or `-account` child, matching the shape `mondoo-databricks-security-token-no-nonexpiring` already used. The policy's groups carry no filters, so nothing had to be converted there.

## Resolving the assertions

Every Terraform assertion was checked against `terraform providers schema -json` for `databricks/databricks` 1.127.0 rather than inferred, and against the vendor default where "argument absent" had to mean something. That decided the direction of several:

| Where | Why it reads the way it does |
|---|---|
| the five `*_workspace_setting` resources | the flag lives in a nested block, so the HCL variants read `blocks`, not `arguments`; `.any()` rather than `.all()` because a resource declared without the block would pass an `.all()` vacuously |
| `databricks_workspace_conf.custom_config` | a `map(string)`, so the values are `"true"`, not `true`. Databricks leaves IP access lists, notebook-result storage and token caps off until a workspace sets them, so an absent key fails there |
| `enableDeprecatedGlobalInitScripts`, `enableDeprecatedClusterNamedInitScripts` | Databricks disabled both when it deprecated them, so these assert `!= "true"`: only a config that turns them back on is a finding |
| `autotermination_minutes` | guards on `== null`, not `== empty` — `empty` also matches `0`, which is exactly the "never terminate" value the check exists to catch |
| `databricks_service_principal.active` | defaults to true in the provider, so `!= false`, not `== true` |
| `maxTokenLifetimeDays` | a string in `custom_config`, and MQL cannot parse one into a number inside a variant query, so the 90-day cap is a regex over the decimal digits |
| `databricks_token` / `databricks_obo_token` | asserted separately rather than in one list: a config declaring only one leaves the other empty, and an empty list passes its own `.all()` |

## Validation

- `content/validation/scans/iac_variants_test.go`: policy registered in `tfVariantPolicies`, `databricks` added to `extraProviders`.
- 80 HCL fixtures across 25 variants, pass and fail for each. `TestTerraformVariantCoverage` reports `mondoo-databricks-security -terraform-hcl: 25/25 covered (100.0%)`.
- `make test/content` and `go test -tags iac_variants ./content/validation/scans -run 'TestTerraformVariants/mondoo-databricks-security/'` both green.

The fixtures caught one real defect during development: the Delta Sharing HCL variant initially read `arguments["ip_access_list"]`, the plan/state shape, which reads `null` for a nested HCL block. Both fail fixtures still failed, so only the pass fixture exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)