### PR TITLE
✨ content: add Terraform variants to mondoo-vercel-security

### DIFF
--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -1215,23 +1215,33 @@ queries:
       vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "::/0")
   # The provider's ip_rules take bypass, log, challenge, or deny, with no allow action: bypass is
   # the action that lets a source past the firewall, so it is what the runtime allow rule maps to.
-  # vercel_firewall_bypass is the declarative form of a system bypass rule.
+  # vercel_firewall_bypass is the declarative form of a system bypass rule. Either resource brings a
+  # configuration into scope, because a team can manage system bypasses without ever declaring a
+  # vercel_firewall_config. The disjunction stays on its own filter line: filter lines join with
+  # newline-as-AND, and adding an explicit && would regroup it as (platform && a) || b, which selects
+  # assets of any platform.
   - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_firewall_config")
+    filters: |
+      asset.platform == "terraform-hcl"
+      terraform.resources.contains(nameLabel == "vercel_firewall_config") || terraform.resources.contains(nameLabel == "vercel_firewall_bypass")
     mql: |
       terraform.resources("vercel_firewall_config").all(blocks.where(type == "ip_rules").all(blocks.where(type == "rule").none(arguments["action"] == "bypass" && arguments["ip"] == "0.0.0.0/0")))
       terraform.resources("vercel_firewall_config").all(blocks.where(type == "ip_rules").all(blocks.where(type == "rule").none(arguments["action"] == "bypass" && arguments["ip"] == "::/0")))
       terraform.resources("vercel_firewall_bypass").none(arguments["source_ip"] == "0.0.0.0/0")
       terraform.resources("vercel_firewall_bypass").none(arguments["source_ip"] == "::/0")
   - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_firewall_config")
+    filters: |
+      asset.platform == "terraform-plan"
+      terraform.plan.resourceChanges.contains(type == "vercel_firewall_config") || terraform.plan.resourceChanges.contains(type == "vercel_firewall_bypass")
     mql: |
       terraform.plan.resourceChanges.where(type == "vercel_firewall_config").all(change.after["ip_rules"] == empty || change.after["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "0.0.0.0/0"))
       terraform.plan.resourceChanges.where(type == "vercel_firewall_config").all(change.after["ip_rules"] == empty || change.after["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "::/0"))
       terraform.plan.resourceChanges.where(type == "vercel_firewall_bypass").none(change.after["source_ip"] == "0.0.0.0/0")
       terraform.plan.resourceChanges.where(type == "vercel_firewall_bypass").none(change.after["source_ip"] == "::/0")
   - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_firewall_config")
+    filters: |
+      asset.platform == "terraform-state"
+      terraform.state.resources.contains(type == "vercel_firewall_config") || terraform.state.resources.contains(type == "vercel_firewall_bypass")
     mql: |
       terraform.state.resources.where(type == "vercel_firewall_config").all(values["ip_rules"] == empty || values["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "0.0.0.0/0"))
       terraform.state.resources.where(type == "vercel_firewall_config").all(values["ip_rules"] == empty || values["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "::/0"))

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -40,7 +40,6 @@ policies:
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
       - title: Vercel Deployment Protection
-        filters: asset.platform == "vercel-project"
         checks:
           - uid: mondoo-vercel-security-project-preview-deployments-authenticated
           - uid: mondoo-vercel-security-project-password-protection-enabled
@@ -48,37 +47,30 @@ policies:
           - uid: mondoo-vercel-security-project-trusted-ips-allowlist-configured
           - uid: mondoo-vercel-security-project-no-protection-bypass
       - title: Vercel Build and Source
-        filters: asset.platform == "vercel-project"
         checks:
           - uid: mondoo-vercel-security-project-git-fork-protection-enabled
           - uid: mondoo-vercel-security-project-source-not-public
           - uid: mondoo-vercel-security-project-supported-node-version
       - title: Vercel Environment Variables
-        filters: asset.platform == "vercel-project"
         checks:
           - uid: mondoo-vercel-security-project-no-plaintext-env-vars
       - title: Vercel Web Application Firewall
-        filters: asset.platform == "vercel-project"
         checks:
           - uid: mondoo-vercel-security-project-firewall-enabled
           - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow
       - title: Vercel API Tokens
-        filters: asset.platform == "vercel-team"
         checks:
           - uid: mondoo-vercel-security-tokens-have-expiration
           - uid: mondoo-vercel-security-tokens-not-stale
       - title: Vercel Storage
-        filters: asset.platform == "vercel-team"
         checks:
           - uid: mondoo-vercel-security-stores-no-public-blob
       - title: Vercel Domains and Certificates
-        filters: asset.platform == "vercel-team"
         checks:
           - uid: mondoo-vercel-security-certificates-auto-renew
           - uid: mondoo-vercel-security-domains-verified
           - uid: mondoo-vercel-security-domains-auto-renew
       - title: Vercel Team Governance
-        filters: asset.platform == "vercel-team"
         checks:
           - uid: mondoo-vercel-security-team-strict-protection-settings
           - uid: mondoo-vercel-security-team-shared-env-vars-not-plaintext
@@ -105,8 +97,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-1-4
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: |
-      vercel.project.ssoProtectionDeploymentType != empty
+    variants:
+      - uid: mondoo-vercel-security-project-preview-deployments-authenticated-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that Vercel Authentication is enabled for the project, so that loading any of its deployments requires signing in to Vercel first.
@@ -176,6 +183,25 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection
         title: Vercel deployment protection documentation
 
+  - uid: mondoo-vercel-security-project-preview-deployments-authenticated-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.ssoProtectionDeploymentType != empty
+  # vercel_authentication is optional and computed, and Vercel turns Standard Protection on for
+  # new projects, so an omitted argument leaves protection in force and passes. The failing state
+  # is the explicit deployment_type = "none", which is how the provider spells turning it off.
+  - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project").all(arguments["vercel_authentication"] == empty || arguments["vercel_authentication"]["deployment_type"] != "none")
+  - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_project").all(change.after["vercel_authentication"] == empty || change.after["vercel_authentication"]["deployment_type"] != "none")
+  - uid: mondoo-vercel-security-project-preview-deployments-authenticated-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.where(type == "vercel_project").all(values["vercel_authentication"] == empty || values["vercel_authentication"]["deployment_type"] != "none")
   - uid: mondoo-vercel-security-project-password-protection-enabled
     title: Ensure password protection is enabled for the project's deployments
     impact: 60
@@ -194,8 +220,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-3-1
       compliance/soc2-2017: soc2-control-cc6-6-3
       compliance/vda-isa-5: vda-isa-5-4-1-2
-    mql: |
-      vercel.project.passwordProtectionDeploymentType != empty
+    variants:
+      - uid: mondoo-vercel-security-project-password-protection-enabled-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that password protection is enabled for the project, so that viewing a deployment requires entering a shared password.
@@ -266,6 +307,24 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection
         title: Vercel deployment protection documentation
 
+  - uid: mondoo-vercel-security-project-password-protection-enabled-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.passwordProtectionDeploymentType != empty
+  # password_protection is optional and not computed, so Vercel leaves it off unless the author
+  # declares it. An absent argument is an unprotected project and fails.
+  - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project").all(arguments["password_protection"] != empty)
+  - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_project").all(change.after["password_protection"] != empty)
+  - uid: mondoo-vercel-security-project-password-protection-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.where(type == "vercel_project").all(values["password_protection"] != empty)
   - uid: mondoo-vercel-security-project-trusted-ips-enforced
     title: Ensure Trusted IPs protection is enforced rather than optional
     impact: 70
@@ -284,8 +343,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      vercel.project.trustedIpsProtectionMode == empty || vercel.project.trustedIpsProtectionMode == "additional"
+    variants:
+      - uid: mondoo-vercel-security-project-trusted-ips-enforced-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that when Trusted IPs protection is configured for the project, it is set to the mode that requires a trusted address rather than the mode that merely offers one.
@@ -359,7 +433,31 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips
         title: Vercel Trusted IPs documentation
 
+  - uid: mondoo-vercel-security-project-trusted-ips-enforced-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.trustedIpsProtectionMode == empty || vercel.project.trustedIpsProtectionMode == "additional"
+  # The provider names the two modes trusted_ip_required and trusted_ip_optional, which the API
+  # returns as additional and exclusive. A project with no trusted_ips argument is out of scope,
+  # and an omitted protection_mode leaves the required mode in force.
+  - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project").all(arguments["trusted_ips"] == empty || arguments["trusted_ips"]["protection_mode"] != "trusted_ip_optional")
+  - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_project").all(change.after["trusted_ips"] == empty || change.after["trusted_ips"]["protection_mode"] != "trusted_ip_optional")
+  - uid: mondoo-vercel-security-project-trusted-ips-enforced-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.where(type == "vercel_project").all(values["trusted_ips"] == empty || values["trusted_ips"]["protection_mode"] != "trusted_ip_optional")
+  # No Terraform variants: the provider requires trusted_ips.addresses to hold at least one
+  # entry, so terraform plan rejects a configuration that turns Trusted IPs on with an empty
+  # allowlist. The state this check exists to catch can be reached through the API but cannot be
+  # declared in HCL, and a variant would pass on every configuration that plans at all.
   - uid: mondoo-vercel-security-project-trusted-ips-allowlist-configured
+    filters: asset.platform == "vercel-project"
     title: Ensure a Trusted IPs allowlist is set when the protection is enabled
     impact: 70
     tags:
@@ -452,9 +550,6 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips
         title: Vercel Trusted IPs documentation
 
-  # ---------------------------------------------------------------------------
-  # Build and source
-  # ---------------------------------------------------------------------------
   - uid: mondoo-vercel-security-project-git-fork-protection-enabled
     title: Ensure Git fork protection is enabled for the project
     impact: 80
@@ -473,8 +568,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: soc2-control-cc8-1-2
       compliance/vda-isa-5: false
-    mql: |
-      vercel.project.gitForkProtection == true
+    variants:
+      - uid: mondoo-vercel-security-project-git-fork-protection-enabled-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the project requires authorization before it builds a pull request opened from a forked repository.
@@ -540,7 +650,29 @@ queries:
       - url: https://vercel.com/docs/git
         title: Vercel Git integration documentation
 
+  - uid: mondoo-vercel-security-project-git-fork-protection-enabled-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.gitForkProtection == true
+  # git_fork_protection defaults to true, so the Terraform forms assert != false: an omitted
+  # argument keeps fork protection on and passes, and only an explicit false fails.
+  - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project").all(arguments["git_fork_protection"] != false)
+  - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_project").all(change.after["git_fork_protection"] != false)
+  - uid: mondoo-vercel-security-project-git-fork-protection-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.where(type == "vercel_project").all(values["git_fork_protection"] != false)
+  # No Terraform variants: vercel_project still accepts public_source, but the provider marks
+  # it deprecated and states the feature has been removed from Vercel and the attribute no
+  # longer has any effect. A variant would assert an argument that changes nothing.
   - uid: mondoo-vercel-security-project-source-not-public
+    filters: asset.platform == "vercel-project"
     title: Ensure the project's deployment source is not publicly viewable
     impact: 75
     tags:
@@ -643,8 +775,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-3-3
       compliance/soc2-2017: soc2-control-cc7-1-5
       compliance/vda-isa-5: vda-isa-5-5-2-5
-    mql: |
-      vercel.project.nodeVersion == empty || ["14.x", "16.x", "18.x"].contains(vercel.project.nodeVersion) == false
+    variants:
+      - uid: mondoo-vercel-security-project-supported-node-version-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-supported-node-version-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-supported-node-version-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-supported-node-version-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the project is not pinned to a Node.js major version that has reached end of life.
@@ -710,10 +857,33 @@ queries:
       - url: https://vercel.com/docs/functions/runtimes/node-js
         title: Vercel Node.js runtime documentation
 
+  - uid: mondoo-vercel-security-project-supported-node-version-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.nodeVersion == empty || ["14.x", "16.x", "18.x"].contains(vercel.project.nodeVersion) == false
+  # An omitted node_version reads as null, and null matches none of the three end-of-life
+  # values, so a project that builds on the platform default passes.
+  - uid: mondoo-vercel-security-project-supported-node-version-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project").all(arguments["node_version"] != "14.x" && arguments["node_version"] != "16.x" && arguments["node_version"] != "18.x")
+  - uid: mondoo-vercel-security-project-supported-node-version-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_project").all(change.after["node_version"] != "14.x" && change.after["node_version"] != "16.x" && change.after["node_version"] != "18.x")
+  - uid: mondoo-vercel-security-project-supported-node-version-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.where(type == "vercel_project").all(values["node_version"] != "14.x" && values["node_version"] != "16.x" && values["node_version"] != "18.x")
   # ---------------------------------------------------------------------------
   # Environment variables
   # ---------------------------------------------------------------------------
+  # No Terraform variants: vercel_project_environment_variable exposes only a sensitive
+  # boolean, not the type enum this check reads, and the provider never creates a plaintext
+  # variable. A variant would either pass vacuously or assert a stricter control than the
+  # runtime check, which accepts encrypted as well as sensitive.
   - uid: mondoo-vercel-security-project-no-plaintext-env-vars
+    filters: asset.platform == "vercel-project"
     title: Ensure environment variables are not stored in plaintext
     impact: 75
     tags:
@@ -826,8 +996,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-6-4-2
       compliance/soc2-2017: soc2-control-cc6-6-4
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      vercel.project.firewall.enabled == true
+    variants:
+      - uid: mondoo-vercel-security-project-firewall-enabled-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-firewall-enabled-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-firewall-enabled-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-firewall-enabled-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the Vercel Web Application Firewall is enabled for the project.
@@ -893,6 +1078,24 @@ queries:
       - url: https://vercel.com/docs/vercel-firewall/vercel-waf
         title: Vercel Web Application Firewall documentation
 
+  - uid: mondoo-vercel-security-project-firewall-enabled-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.firewall.enabled == true
+  # enabled defaults to true on vercel_firewall_config, so the Terraform forms assert != false
+  # and only an explicit false fails.
+  - uid: mondoo-vercel-security-project-firewall-enabled-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_firewall_config")
+    mql: |
+      terraform.resources("vercel_firewall_config").all(arguments["enabled"] != false)
+  - uid: mondoo-vercel-security-project-firewall-enabled-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_firewall_config")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_firewall_config").all(change.after["enabled"] != false)
+  - uid: mondoo-vercel-security-project-firewall-enabled-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_firewall_config")
+    mql: |
+      terraform.state.resources.where(type == "vercel_firewall_config").all(values["enabled"] != false)
   - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow
     title: Ensure no firewall IP or bypass rule allows all source addresses
     impact: 80
@@ -911,11 +1114,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-3-1
       compliance/soc2-2017: soc2-control-cc6-6-1
       compliance/vda-isa-5: vda-isa-5-5-2-7
-    mql: |
-      vercel.project.firewall.ipRules.none(action == "allow" && ip == "0.0.0.0/0")
-      vercel.project.firewall.ipRules.none(action == "allow" && ip == "::/0")
-      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "0.0.0.0/0")
-      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "::/0")
+    variants:
+      - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the project's firewall carries no IP rule and no system bypass rule matching every source address.
@@ -991,6 +1206,37 @@ queries:
       - url: https://vercel.com/docs/vercel-firewall/vercel-waf/ip-blocking
         title: Vercel firewall IP rules documentation
 
+  - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.firewall.ipRules.none(action == "allow" && ip == "0.0.0.0/0")
+      vercel.project.firewall.ipRules.none(action == "allow" && ip == "::/0")
+      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "0.0.0.0/0")
+      vercel.project.firewall.bypassRules.none(action == "bypass" && ip == "::/0")
+  # The provider's ip_rules take bypass, log, challenge, or deny, with no allow action: bypass is
+  # the action that lets a source past the firewall, so it is what the runtime allow rule maps to.
+  # vercel_firewall_bypass is the declarative form of a system bypass rule.
+  - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_firewall_config")
+    mql: |
+      terraform.resources("vercel_firewall_config").all(blocks.where(type == "ip_rules").all(blocks.where(type == "rule").none(arguments["action"] == "bypass" && arguments["ip"] == "0.0.0.0/0")))
+      terraform.resources("vercel_firewall_config").all(blocks.where(type == "ip_rules").all(blocks.where(type == "rule").none(arguments["action"] == "bypass" && arguments["ip"] == "::/0")))
+      terraform.resources("vercel_firewall_bypass").none(arguments["source_ip"] == "0.0.0.0/0")
+      terraform.resources("vercel_firewall_bypass").none(arguments["source_ip"] == "::/0")
+  - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_firewall_config")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_firewall_config").all(change.after["ip_rules"] == empty || change.after["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "0.0.0.0/0"))
+      terraform.plan.resourceChanges.where(type == "vercel_firewall_config").all(change.after["ip_rules"] == empty || change.after["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "::/0"))
+      terraform.plan.resourceChanges.where(type == "vercel_firewall_bypass").none(change.after["source_ip"] == "0.0.0.0/0")
+      terraform.plan.resourceChanges.where(type == "vercel_firewall_bypass").none(change.after["source_ip"] == "::/0")
+  - uid: mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_firewall_config")
+    mql: |
+      terraform.state.resources.where(type == "vercel_firewall_config").all(values["ip_rules"] == empty || values["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "0.0.0.0/0"))
+      terraform.state.resources.where(type == "vercel_firewall_config").all(values["ip_rules"] == empty || values["ip_rules"]["rule"].none(_["action"] == "bypass" && _["ip"] == "::/0"))
+      terraform.state.resources.where(type == "vercel_firewall_bypass").none(values["source_ip"] == "0.0.0.0/0")
+      terraform.state.resources.where(type == "vercel_firewall_bypass").none(values["source_ip"] == "::/0")
   # ---------------------------------------------------------------------------
   # API tokens (team-scoped posture)
   # ---------------------------------------------------------------------------
@@ -1012,8 +1258,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-8-6-3
       compliance/soc2-2017: soc2-control-cc6-1-9
       compliance/vda-isa-5: vda-isa-5-4-1-1
-    mql: |
-      vercel.accessTokens.none(expiresAt == empty)
+    variants:
+      - uid: mondoo-vercel-security-tokens-have-expiration-vercel-team
+        tags:
+          mondoo.com/filter-title: Vercel Team
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-tokens-have-expiration-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-tokens-have-expiration-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-tokens-have-expiration-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that every API token owned by the authenticated account carries an expiration date.
@@ -1081,7 +1342,28 @@ queries:
       - url: https://vercel.com/docs/rest-api/reference/welcome/api-scopes
         title: Vercel access token documentation
 
+  - uid: mondoo-vercel-security-tokens-have-expiration-vercel-team
+    filters: asset.platform == "vercel-team"
+    mql: |
+      vercel.accessTokens.none(expiresAt == empty)
+  # expires_at is optional on vercel_user_token, so an omitted argument mints a token that never
+  # expires and fails. The provider takes a Unix timestamp in milliseconds.
+  - uid: mondoo-vercel-security-tokens-have-expiration-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_user_token")
+    mql: |
+      terraform.resources("vercel_user_token").all(arguments["expires_at"] != empty)
+  - uid: mondoo-vercel-security-tokens-have-expiration-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_user_token")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_user_token").all(change.after["expires_at"] != empty)
+  - uid: mondoo-vercel-security-tokens-have-expiration-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_user_token")
+    mql: |
+      terraform.state.resources.where(type == "vercel_user_token").all(values["expires_at"] != empty)
+  # No Terraform variants: staleness is derived from when a token was last used, which is
+  # activity Vercel records rather than configuration an author declares.
   - uid: mondoo-vercel-security-tokens-not-stale
+    filters: asset.platform == "vercel-team"
     title: Ensure unused Vercel API tokens are removed
     impact: 60
     tags:
@@ -1178,8 +1460,23 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-1-4-4
       compliance/soc2-2017: soc2-control-cc6-1-3
       compliance/vda-isa-5: vda-isa-5-4-2-1
-    mql: |
-      vercel.team.stores.where(storeType == "blob").none(access == "public")
+    variants:
+      - uid: mondoo-vercel-security-stores-no-public-blob-vercel-team
+        tags:
+          mondoo.com/filter-title: Vercel Team
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-stores-no-public-blob-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-stores-no-public-blob-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-stores-no-public-blob-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the team has no Vercel Blob store configured for public access.
@@ -1246,10 +1543,33 @@ queries:
       - url: https://vercel.com/docs/vercel-blob
         title: Vercel Blob documentation
 
+  - uid: mondoo-vercel-security-stores-no-public-blob-vercel-team
+    filters: asset.platform == "vercel-team"
+    mql: |
+      vercel.team.stores.where(storeType == "blob").none(access == "public")
+  # access defaults to public on vercel_blob_store, so an omitted argument creates a store that
+  # serves every object it holds to anyone with the URL. The Terraform forms require the explicit
+  # private value rather than accepting an absent one.
+  - uid: mondoo-vercel-security-stores-no-public-blob-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_blob_store")
+    mql: |
+      terraform.resources("vercel_blob_store").all(arguments["access"] == "private")
+  - uid: mondoo-vercel-security-stores-no-public-blob-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_blob_store")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "vercel_blob_store").all(change.after["access"] == "private")
+  - uid: mondoo-vercel-security-stores-no-public-blob-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_blob_store")
+    mql: |
+      terraform.state.resources.where(type == "vercel_blob_store").all(values["access"] == "private")
   # ---------------------------------------------------------------------------
   # Domains and certificates
   # ---------------------------------------------------------------------------
+  # No Terraform variants: vercel_custom_certificate uploads a certificate the team renews
+  # itself and carries no auto-renew argument, and the certificates Vercel issues and renews
+  # have no resource at all.
   - uid: mondoo-vercel-security-certificates-auto-renew
+    filters: asset.platform == "vercel-team"
     title: Ensure TLS certificates renew automatically
     impact: 60
     tags:
@@ -1331,7 +1651,10 @@ queries:
       - url: https://vercel.com/docs/domains/working-with-ssl
         title: Vercel SSL certificate documentation
 
+  # No Terraform variants: verified is read-only on vercel_project_domain. Verification is
+  # completed by publishing DNS records and is state Vercel reports, not state HCL sets.
   - uid: mondoo-vercel-security-domains-verified
+    filters: asset.platform == "vercel-team"
     title: Ensure all team domains are verified
     impact: 70
     tags:
@@ -1415,7 +1738,10 @@ queries:
       - url: https://vercel.com/docs/domains/working-with-domains/add-a-domain
         title: Vercel domain verification documentation
 
+  # No Terraform variants: the provider has no resource for registering a domain through
+  # Vercel, so the renewal setting on a purchased domain cannot be declared.
   - uid: mondoo-vercel-security-domains-auto-renew
+    filters: asset.platform == "vercel-team"
     title: Ensure purchased domains renew automatically
     impact: 65
     tags:
@@ -1498,9 +1824,6 @@ queries:
   # ---------------------------------------------------------------------------
   # Deployment-protection bypass
   # ---------------------------------------------------------------------------
-  # No Terraform variants: outstanding protection-bypass secrets are runtime
-  # state generated through the dashboard or API, not a declarative resource,
-  # so Terraform HCL, plan, and state have no analog to assert against.
   - uid: mondoo-vercel-security-project-no-protection-bypass
     title: Ensure projects have no deployment-protection bypass secrets
     impact: 80
@@ -1519,8 +1842,23 @@ queries:
       compliance/pci-dss-4: false
       compliance/soc2-2017: false
       compliance/vda-isa-5: false
-    mql: |
-      vercel.project.protectionBypassCount == 0
+    variants:
+      - uid: mondoo-vercel-security-project-no-protection-bypass-vercel-project
+        tags:
+          mondoo.com/filter-title: Vercel Project
+          mondoo.com/filter-icon: vercel
+      - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
     docs:
       desc: |
         This check verifies that the project carries no deployment-protection bypass secrets.
@@ -1580,12 +1918,33 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
         title: Vercel protection bypass for automation documentation
 
+  - uid: mondoo-vercel-security-project-no-protection-bypass-vercel-project
+    filters: asset.platform == "vercel-project"
+    mql: |
+      vercel.project.protectionBypassCount == 0
+  # vercel_project_protection_bypass is the declarative form of a Protection Bypass for
+  # Automation secret, so a configuration that declares one registers a bypass. The filters select
+  # on vercel_project, the resource being protected, so a project with no bypass passes rather
+  # than dropping out of scope.
+  - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "vercel_project")
+    mql: |
+      terraform.resources("vercel_project_protection_bypass").length == 0
+  - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "vercel_project")
+    mql: |
+      terraform.plan.resourceChanges.none(type == "vercel_project_protection_bypass")
+  - uid: mondoo-vercel-security-project-no-protection-bypass-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "vercel_project")
+    mql: |
+      terraform.state.resources.none(type == "vercel_project_protection_bypass")
   # ---------------------------------------------------------------------------
   # Team governance and shared secrets
   # ---------------------------------------------------------------------------
   # No Terraform variants: these read team-wide account settings exposed only
   # through the Vercel API; the runtime check has no Terraform asset analog.
   - uid: mondoo-vercel-security-team-strict-protection-settings
+    filters: asset.platform == "vercel-team"
     title: Ensure protection setting changes require the team owner role
     impact: 70
     tags:
@@ -1665,7 +2024,11 @@ queries:
       - url: https://vercel.com/docs/security/deployment-protection
         title: Vercel deployment protection documentation
 
+  # No Terraform variants: vercel_shared_environment_variable exposes only a sensitive
+  # boolean rather than the type enum this check reads, and the provider never creates a
+  # plaintext shared variable.
   - uid: mondoo-vercel-security-team-shared-env-vars-not-plaintext
+    filters: asset.platform == "vercel-team"
     title: Ensure shared environment variables are not stored in plaintext
     impact: 75
     tags:

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,8 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+  enabled    = false
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/pass/explicitly-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/pass/explicitly-enabled/main.tf
@@ -1,0 +1,8 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+  enabled    = true
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/pass/platform-default/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-enabled-terraform-hcl/pass/platform-default/main.tf
@@ -1,0 +1,17 @@
+# enabled defaults to true on vercel_firewall_config, so declaring rules without touching the
+# toggle leaves the firewall on.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  ip_rules {
+    rule {
+      action   = "deny"
+      ip       = "198.51.100.0/24"
+      hostname = "*"
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/bypass-only-no-firewall-config/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/bypass-only-no-firewall-config/main.tf
@@ -1,0 +1,11 @@
+# No vercel_firewall_config is declared, so the firewall keeps its platform defaults, but a system
+# bypass covering the whole internet still takes every request around it.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_bypass" "everyone" {
+  project_id = vercel_project.storefront.id
+  domain     = "storefront.example.com"
+  source_ip  = "0.0.0.0/0"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/ipv4-internet-bypass/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/ipv4-internet-bypass/main.tf
@@ -1,0 +1,16 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  ip_rules {
+    rule {
+      action   = "bypass"
+      ip       = "0.0.0.0/0"
+      hostname = "*"
+      notes    = "temporary while we debug the login flow"
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/ipv6-internet-bypass/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/ipv6-internet-bypass/main.tf
@@ -1,0 +1,15 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  ip_rules {
+    rule {
+      action   = "bypass"
+      ip       = "::/0"
+      hostname = "*"
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/system-bypass-internet/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/fail/system-bypass-internet/main.tf
@@ -1,0 +1,23 @@
+# The IP rules are scoped, but a system bypass covering the whole internet takes every request
+# around the firewall regardless.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  ip_rules {
+    rule {
+      action   = "deny"
+      ip       = "203.0.113.0/24"
+      hostname = "*"
+    }
+  }
+}
+
+resource "vercel_firewall_bypass" "everyone" {
+  project_id = vercel_project.storefront.id
+  domain     = "storefront.example.com"
+  source_ip  = "0.0.0.0/0"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/bypass-only-scoped/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/bypass-only-scoped/main.tf
@@ -1,0 +1,11 @@
+# A project that declares system bypasses without a vercel_firewall_config is still in scope, and
+# this one names a single monitoring host rather than the whole internet.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_bypass" "monitoring" {
+  project_id = vercel_project.storefront.id
+  domain     = "storefront.example.com"
+  source_ip  = "198.51.100.14"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/no-ip-rules/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/no-ip-rules/main.tf
@@ -1,0 +1,15 @@
+# A firewall with only managed rulesets configures no IP rules at all, so nothing is let past.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  managed_rulesets {
+    bot_protection {
+      active = true
+      action = "deny"
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/scoped-rules/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-firewall-no-broad-ip-allow-terraform-hcl/pass/scoped-rules/main.tf
@@ -1,0 +1,28 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}
+
+resource "vercel_firewall_config" "storefront" {
+  project_id = vercel_project.storefront.id
+
+  ip_rules {
+    rule {
+      action   = "bypass"
+      ip       = "198.51.100.14/32"
+      hostname = "*"
+      notes    = "synthetic monitoring"
+    }
+
+    rule {
+      action   = "deny"
+      ip       = "203.0.113.0/24"
+      hostname = "*"
+    }
+  }
+}
+
+resource "vercel_firewall_bypass" "monitoring" {
+  project_id = vercel_project.storefront.id
+  domain     = "storefront.example.com"
+  source_ip  = "198.51.100.14"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/fail/disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/fail/disabled/main.tf
@@ -1,0 +1,9 @@
+resource "vercel_project" "storefront" {
+  name                = "storefront"
+  git_fork_protection = false
+
+  git_repository = {
+    type = "github"
+    repo = "example-org/storefront"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/pass/explicitly-enabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/pass/explicitly-enabled/main.tf
@@ -1,0 +1,9 @@
+resource "vercel_project" "storefront" {
+  name                = "storefront"
+  git_fork_protection = true
+
+  git_repository = {
+    type = "github"
+    repo = "example-org/storefront"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/pass/platform-default/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-git-fork-protection-enabled-terraform-hcl/pass/platform-default/main.tf
@@ -1,0 +1,10 @@
+# git_fork_protection defaults to true, so a project that never mentions it holds fork builds
+# for authorization.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  git_repository = {
+    type = "github"
+    repo = "example-org/storefront"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-no-protection-bypass-terraform-hcl/fail/automation-bypass/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-no-protection-bypass-terraform-hcl/fail/automation-bypass/main.tf
@@ -1,0 +1,13 @@
+# The bypass secret lets any request presenting it reach the deployments without satisfying the
+# Vercel Authentication configured above.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}
+
+resource "vercel_project_protection_bypass" "e2e" {
+  project_id = vercel_project.storefront.id
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-no-protection-bypass-terraform-hcl/pass/no-bypass/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-no-protection-bypass-terraform-hcl/pass/no-bypass/main.tf
@@ -1,0 +1,7 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-password-protection-enabled-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-password-protection-enabled-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,4 @@
+# password_protection is optional and not computed, so Vercel leaves it off until it is declared.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-password-protection-enabled-terraform-hcl/pass/password-set/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-password-protection-enabled-terraform-hcl/pass/password-set/main.tf
@@ -1,0 +1,13 @@
+variable "preview_password" {
+  type      = string
+  sensitive = true
+}
+
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  password_protection = {
+    deployment_type = "standard_protection_new"
+    password        = var.preview_password
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/fail/authentication-disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/fail/authentication-disabled/main.tf
@@ -1,0 +1,8 @@
+resource "vercel_project" "storefront" {
+  name      = "storefront"
+  framework = "nextjs"
+
+  vercel_authentication = {
+    deployment_type = "none"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/pass/platform-default/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/pass/platform-default/main.tf
@@ -1,0 +1,6 @@
+# vercel_authentication is optional and computed. Vercel turns Standard Protection on for new
+# projects, so a project that never mentions the argument keeps its deployments behind a login.
+resource "vercel_project" "storefront" {
+  name      = "storefront"
+  framework = "nextjs"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/pass/standard-protection/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-preview-deployments-authenticated-terraform-hcl/pass/standard-protection/main.tf
@@ -1,0 +1,8 @@
+resource "vercel_project" "storefront" {
+  name      = "storefront"
+  framework = "nextjs"
+
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/fail/end-of-life-version/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/fail/end-of-life-version/main.tf
@@ -1,0 +1,4 @@
+resource "vercel_project" "storefront" {
+  name         = "storefront"
+  node_version = "18.x"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/pass/platform-default/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/pass/platform-default/main.tf
@@ -1,0 +1,4 @@
+# No node_version pins the project, so it builds on whatever Vercel currently defaults to.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/pass/supported-version/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-supported-node-version-terraform-hcl/pass/supported-version/main.tf
@@ -1,0 +1,4 @@
+resource "vercel_project" "storefront" {
+  name         = "storefront"
+  node_version = "22.x"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/fail/trusted-ip-optional/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/fail/trusted-ip-optional/main.tf
@@ -1,0 +1,9 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  trusted_ips = {
+    deployment_type = "standard_protection_new"
+    protection_mode = "trusted_ip_optional"
+    addresses       = [{ value = "203.0.113.0/24", note = "office" }]
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/pass/not-configured/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/pass/not-configured/main.tf
@@ -1,0 +1,8 @@
+# Trusted IPs is not in use on this project, so there is no enforcement mode to get wrong.
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/pass/trusted-ip-required/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-project-trusted-ips-enforced-terraform-hcl/pass/trusted-ip-required/main.tf
@@ -1,0 +1,9 @@
+resource "vercel_project" "storefront" {
+  name = "storefront"
+
+  trusted_ips = {
+    deployment_type = "standard_protection_new"
+    protection_mode = "trusted_ip_required"
+    addresses       = [{ value = "203.0.113.0/24", note = "office" }]
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/fail/default-public/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/fail/default-public/main.tf
@@ -1,0 +1,5 @@
+# access defaults to public on vercel_blob_store, so a store that never sets it serves every
+# object it holds to anyone holding the URL.
+resource "vercel_blob_store" "uploads" {
+  name = "customer-uploads"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/fail/explicitly-public/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/fail/explicitly-public/main.tf
@@ -1,0 +1,4 @@
+resource "vercel_blob_store" "uploads" {
+  name   = "customer-uploads"
+  access = "public"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/pass/private-store/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-stores-no-public-blob-terraform-hcl/pass/private-store/main.tf
@@ -1,0 +1,4 @@
+resource "vercel_blob_store" "uploads" {
+  name   = "customer-uploads"
+  access = "private"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-tokens-have-expiration-terraform-hcl/fail/never-expires/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-tokens-have-expiration-terraform-hcl/fail/never-expires/main.tf
@@ -1,0 +1,4 @@
+# expires_at is optional, so omitting it mints a token that stays valid until someone revokes it.
+resource "vercel_user_token" "deploy" {
+  name = "ci-deploy"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-tokens-have-expiration-terraform-hcl/pass/expiring-token/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-vercel-security/mondoo-vercel-security-tokens-have-expiration-terraform-hcl/pass/expiring-token/main.tf
@@ -1,0 +1,4 @@
+resource "vercel_user_token" "deploy" {
+  name       = "ci-deploy"
+  expires_at = 1798761600000
+}

--- a/content/validation/scans/iac_variants_test.go
+++ b/content/validation/scans/iac_variants_test.go
@@ -100,6 +100,7 @@ var tfVariantPolicies = []tfVariantPolicy{
 	{"mondoo-hcp-security-", "mondoo-hcp-security.mql.yaml", ""},
 	{"mondoo-neon-security-", "mondoo-neon-security.mql.yaml", ""},
 	{"mondoo-databricks-security-", "mondoo-databricks-security.mql.yaml", ""},
+	{"mondoo-vercel-security-", "mondoo-vercel-security.mql.yaml", ""},
 }
 
 // checkOutcome distinguishes a check that ran and passed, ran and failed, or was


### PR DESCRIPTION
Ten of the nineteen checks in `mondoo-vercel-security` can be expressed against the `vercel/vercel` provider, and each now carries `terraform-hcl`, `terraform-plan` and `terraform-state` variants beside its API check.

| Check | Terraform surface |
|---|---|
| preview-deployments-authenticated | `vercel_project.vercel_authentication.deployment_type` |
| password-protection-enabled | `vercel_project.password_protection` |
| trusted-ips-enforced | `vercel_project.trusted_ips.protection_mode` |
| git-fork-protection-enabled | `vercel_project.git_fork_protection` |
| supported-node-version | `vercel_project.node_version` |
| no-protection-bypass | presence of `vercel_project_protection_bypass` |
| firewall-enabled | `vercel_firewall_config.enabled` |
| firewall-no-broad-ip-allow | `vercel_firewall_config.ip_rules` + `vercel_firewall_bypass` |
| tokens-have-expiration | `vercel_user_token.expires_at` |
| stores-no-public-blob | `vercel_blob_store.access` |

## What decided each query

Four provider details decide which way an omitted argument goes, all read out of the schema and the provider source rather than from memory:

- `git_fork_protection` and `vercel_firewall_config.enabled` both carry `booldefault.StaticBool(true)`, so those variants assert `!= false` and an absent argument passes.
- `vercel_blob_store.access` carries `stringdefault.StaticString("public")`, so an absent argument creates a world-readable store. The variants require the explicit `private` value, and the fail fixture is the store with no `access` line at all.
- `vercel_authentication` is optional and computed and Vercel turns Standard Protection on for new projects, so the failing state is the explicit `deployment_type = "none"`, not an omitted block.
- `ip_rules.rule.action` validates to `bypass`, `log`, `challenge`, `deny`. There is no `allow`, so `bypass` is what the runtime allow rule maps to: it is the action that lets a source past the firewall.

## Two corrections to what the policy asserted

- The protection-bypass check was marked `# No Terraform variants: ... not a declarative resource`. `vercel_project_protection_bypass` is exactly that resource, so the check gains variants and the note is replaced.
- The trusted-ips allowlist check goes the other way. The provider requires `trusted_ips.addresses` to hold at least one entry, so `terraform plan` rejects the empty allowlist this check exists to catch. A variant would pass on every configuration that plans at all, so it gets a note instead.

## Worth a separate look

The provider marks `vercel_project.public_source` **deprecated**, stating the feature has been removed from Vercel and the attribute no longer has any effect. That is why `project-source-not-public` gets no variant, and it puts the runtime check in question too. Not changed here.

## Group filters

Registering the policy with `tfVariantPolicies` required dropping the group-level platform filters: a group filter is evaluated before the check's own filter, so a Terraform asset never reached the variant and every fixture would have reported as *skipped*. The eight checks that keep no variant carry the platform filter themselves now.

## Verification

Each of the thirty variants was run against an input that should pass and one that should fail.

- The ten HCL variants went through the fixture suite: 29 scenarios, all green, `-terraform-hcl` coverage 10/10 at 100%.
- The twenty plan and state variants ran against `terraform show -json` documents produced by a real `terraform plan` of a compliant and a violating configuration: 40 of 40 verdicts as expected. Those suffixes take no fixtures, so this is the same manual path #3375 used.
- `cnspec policy lint`, `make test/content/iac/coverage`, `make test/content/iac/remediation` (9 snippets close their own check), `terraform.py vercel` (13 snippets), `make test/content/scans` and `make test/content/compliance` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)