### PR TITLE
✨ content: add Terraform variants to mondoo-netlify-security

### DIFF
--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -13,28 +13,30 @@ policies:
     authors:
       - name: Mondoo, Inc.
         email: hello@mondoo.com
-    summary: Enforce Netlify account multi-factor authentication and HTTPS on published sites
+    summary: Enforce Netlify multi-factor authentication, HTTPS on published sites, and Git-based production deploys
     docs:
       desc: |
-        The Mondoo Netlify Security policy connects to a Netlify account and reads its team accounts and published sites. Because it evaluates what the Netlify API reports for the account and its sites, the checks reflect the controls Netlify is actually enforcing rather than a file on disk.
+        The Mondoo Netlify Security policy connects to a Netlify account and reads its team accounts and published sites. Because it evaluates what the Netlify API reports for the account and its sites, the checks reflect the controls Netlify is actually enforcing rather than a file on disk. Where the same control is expressed in Terraform, the check also runs against Terraform HCL, plan output, and state.
 
-        This policy focuses on the account-level guardrails that protect a Netlify team and its visitors. It verifies that every team account enforces multi-factor authentication for its members, so a stolen password alone cannot sign in. It also confirms that every published site forces HTTPS, so visitors never exchange data with the site over an unencrypted connection.
+        This policy focuses on the account-level guardrails that protect a Netlify team and its visitors. It verifies that every team account enforces multi-factor authentication for its members, so a stolen password alone cannot sign in. It confirms that every published site forces HTTPS, so visitors never exchange data with the site over an unencrypted connection. It also checks that production deploys have to come from a Git push, so a bundle nobody reviewed cannot be published straight from a laptop or an API token.
 
         Learn more about scanning with cnspec in the [cnspec documentation](https://mondoo.com/docs/cnspec).
     groups:
       - title: Authentication
-        filters: asset.platform == "netlify-account"
         checks:
           - uid: mondoo-netlify-security-account-enforce-mfa
       - title: Transport Encryption
-        filters: asset.platform == "netlify-account"
         checks:
           - uid: mondoo-netlify-security-sites-force-ssl
+      - title: Deployment Integrity
+        checks:
+          - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys
     scoring_system: highest impact
 queries:
-  # No Terraform variant or remediation: MFA enforcement has no Terraform surface. The netlify/netlify provider
-  # exposes no team security resource, and the public Netlify API carries no MFA field, so the UI is the only
-  # place the setting can be read or changed.
+  # No Terraform variant or remediation: MFA enforcement has no Terraform surface. netlify/netlify 0.4.4 reaches
+  # the team only through the netlify_team data source, and declares no team resource of any kind, so there is
+  # nothing for terraform.resources to match. The public Netlify API carries no MFA field either, which leaves
+  # the UI as the only place the setting can be read or changed. Revisit if the provider grows a team resource.
   - uid: mondoo-netlify-security-account-enforce-mfa
     filters: asset.platform == "netlify-account"
     title: Ensure Netlify accounts enforce multi-factor authentication
@@ -93,10 +95,11 @@ queries:
     refs:
       - url: https://docs.netlify.com/accounts-and-billing/team-management/team-level-security/
         title: Netlify team-level security
-  # No Terraform variant or remediation: the netlify/netlify provider has no site resource and its
-  # netlify_site_domain_settings resource has no forced-TLS attribute, so forced HTTPS cannot be expressed in
-  # HCL. The API does carry force_ssl on the site, which is why the remediation below uses it. Revisit if the
-  # provider grows the attribute.
+  # No Terraform variant or remediation: netlify/netlify 0.4.4 has no site resource, only settings resources
+  # that attach to a site created elsewhere, and netlify_site_domain_settings carries just the four custom
+  # domain arguments and domain_aliases. No resource in the provider exposes forced TLS, so it cannot be
+  # expressed in HCL. The API does carry force_ssl on the site, which is why the remediation below uses it.
+  # Revisit if netlify_site_domain_settings grows the attribute.
   - uid: mondoo-netlify-security-sites-force-ssl
     filters: asset.platform == "netlify-account"
     title: Ensure Netlify sites force HTTPS
@@ -178,3 +181,139 @@ queries:
         title: Netlify HTTPS/SSL
       - url: https://open-api.netlify.com/#tag/site/operation/updateSite
         title: Netlify API updateSite
+  - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys
+    title: Ensure Netlify sites require Git-based production deploys
+    impact: 80
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ccc-04
+      compliance/dora: dora-art-9
+      compliance/hipaa: false
+      compliance/iso-27001-2022: iso-27001-2022-a-8-32
+      compliance/nis-2: nis-2-21-2-e
+      compliance/nist-csf-1: nist-csf-1-pr-ip-3
+      compliance/nist-csf-2: nist-csf-2-pr-ps-05
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-cm-5
+      compliance/nist-sp-800-171: nist-sp-800-171--3-4-5
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a08
+      compliance/pci-dss-4: pcidss-requirement-6-5-1
+      compliance/soc2-2017: soc2-control-cc6-8-3
+      compliance/vda-isa-5: vda-isa-5-5-2-1
+    variants:
+      - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-netlify
+        tags:
+          mondoo.com/filter-title: Netlify Account
+          mondoo.com/filter-icon: netlify
+      - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl
+        tags:
+          mondoo.com/filter-title: Terraform HCL
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-plan
+        tags:
+          mondoo.com/filter-title: Terraform Plan
+          mondoo.com/filter-icon: terraform
+      - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-state
+        tags:
+          mondoo.com/filter-title: Terraform State
+          mondoo.com/filter-icon: terraform
+    docs:
+      desc: |
+        This check verifies that every Netlify site requires production deploys to come from a Git push to the production branch.
+
+        Netlify calls this **Enforce deployment methods**, reached from a project by opening Project configuration, then Build & deploy, then Continuous deployment. Once it is configured, the only way to publish to the production context is a push to the project's production branch. The Netlify CLI, the MCP server, and the API can still deploy branch deploys and Deploy Previews, and a Deploy Preview can no longer be promoted to production from the Netlify UI without merging first. The site record reports the state as `prevent_non_git_prod_deploys`, and Netlify leaves the restriction off by default.
+
+        **Why this matters**
+
+        Every deploy path Netlify offers reaches production with the same authority, and most of them skip the repository entirely. A directory dragged onto the Netlify UI, a `netlify deploy --prod` from a laptop, a build hook fired by a URL, and an API call carrying a personal access token all publish a bundle that no reviewer approved and no branch records. Whatever that bundle contains then runs in every visitor's browser on the site's real domain, under a valid certificate, with access to the site's own origin and the cookies scoped to it.
+
+        That turns a single stolen credential into a code-execution path. A personal access token pasted into a CI log, a laptop with a live CLI session, and a build hook URL committed to a public repository each grant production publish rights on their own, without ever touching the source-control account the team actually watches. Requiring the Git push moves the gate onto the repository, where branch protection, required reviews, and signed commits already live, and where the change leaves a history someone can audit afterwards.
+
+        It also closes the accidental version of the same problem. Publishing the wrong directory to production, or promoting a Deploy Preview built from an unmerged branch, is a routine mistake that this setting turns into an error message instead of a live outage.
+
+        Apply it to sites Netlify builds from a connected repository. A site published only through the CLI or the API has no production branch to push to, so enforcing the Git path would leave it with no way to deploy at all.
+      audit: |-
+        ### Audit via the Netlify UI
+
+        1. Sign in to the Netlify UI and open each project.
+        2. Go to **Project configuration > Build & deploy > Continuous deployment > Enforce deployment methods**.
+        3. Confirm that production deploys are restricted to a Git push to the production branch.
+
+        If the restriction is configured, the check passes. If deployment methods are unrestricted, the check fails.
+
+        ### Audit via the Netlify API
+
+        1. List the sites and read each site's `prevent_non_git_prod_deploys` field:
+
+           ```bash
+           curl -s \
+             --header "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+             "https://api.netlify.com/api/v1/sites" \
+             | jq '.[] | {name, prevent_non_git_prod_deploys}'
+           ```
+
+        If every site reports `prevent_non_git_prod_deploys` as true, the check passes. If any site reports false, the check fails.
+      remediation:
+        - id: console
+          desc: |-
+            To require Git-based production deploys in the Netlify UI:
+
+            1. Open the affected project and go to **Project configuration > Build & deploy > Continuous deployment > Enforce deployment methods**.
+            2. Select **Configure**, then choose the option that restricts production deploys to a Git push.
+            3. Confirm the change. Netlify records it in the team audit log.
+
+            Changing this setting requires the Developer or Team Owner role.
+        - id: api
+          desc: |-
+            To require Git-based production deploys with the Netlify API, set `prevent_non_git_prod_deploys` on the site:
+
+            ```bash
+            curl -s -X PATCH \
+              --header "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+              --header "Content-Type: application/json" \
+              --data '{"prevent_non_git_prod_deploys":true}' \
+              "https://api.netlify.com/api/v1/sites/$SITE_ID"
+            ```
+        - id: terraform
+          desc: |-
+            To require Git-based production deploys with the Netlify Terraform provider, set `prevent_non_git_prod_deploys` on the site's build settings:
+
+            ```hcl
+            data "netlify_site" "example" {
+              name = "example"
+            }
+
+            resource "netlify_site_build_settings" "example" {
+              site_id           = data.netlify_site.example.id
+              build_command     = "npm run build"
+              publish_directory = "dist"
+              production_branch = "main"
+
+              prevent_non_git_prod_deploys = true
+            }
+            ```
+    refs:
+      - url: https://docs.netlify.com/build/git-workflows/overview/
+        title: Netlify Git workflows
+      - url: https://open-api.netlify.com/#tag/site/operation/updateSite
+        title: Netlify API updateSite
+      - url: https://registry.terraform.io/providers/netlify/netlify/latest/docs/resources/site_build_settings
+        title: Terraform netlify_site_build_settings
+  - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-netlify
+    filters: asset.platform == "netlify-account"
+    mql: |
+      netlify.sites.all(preventNonGitProdDeploys == true)
+  # prevent_non_git_prod_deploys is optional and Netlify leaves the restriction off by default, so an absent
+  # argument is a site that still accepts a CLI or API publish to production. Asserting == true fails that
+  # case, which is the intended verdict.
+  - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "netlify_site_build_settings")
+    mql: |
+      terraform.resources("netlify_site_build_settings").all(arguments["prevent_non_git_prod_deploys"] == true)
+  - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-plan
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "netlify_site_build_settings")
+    mql: |
+      terraform.plan.resourceChanges.where(type == "netlify_site_build_settings").all(change.after["prevent_non_git_prod_deploys"] == true)
+  - uid: mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-state
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "netlify_site_build_settings")
+    mql: |
+      terraform.state.resources.where(type == "netlify_site_build_settings").all(values["prevent_non_git_prod_deploys"] == true)

--- a/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/fail/absent/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/fail/absent/main.tf
@@ -1,0 +1,12 @@
+# Netlify leaves the restriction off by default, so omitting the argument leaves
+# the site accepting a CLI, API, or drag-and-drop publish straight to production.
+data "netlify_site" "app" {
+  name = "app"
+}
+
+resource "netlify_site_build_settings" "app" {
+  site_id           = data.netlify_site.app.id
+  build_command     = "npm run build"
+  publish_directory = "dist"
+  production_branch = "main"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/fail/explicitly-disabled/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/fail/explicitly-disabled/main.tf
@@ -1,0 +1,14 @@
+# The restriction is named and turned off, which keeps every non-git deploy path
+# open to production.
+data "netlify_site" "app" {
+  name = "app"
+}
+
+resource "netlify_site_build_settings" "app" {
+  site_id           = data.netlify_site.app.id
+  build_command     = "npm run build"
+  publish_directory = "dist"
+  production_branch = "main"
+
+  prevent_non_git_prod_deploys = false
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/pass/git-only-prod-deploys/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-netlify-security/mondoo-netlify-security-sites-prevent-non-git-prod-deploys-terraform-hcl/pass/git-only-prod-deploys/main.tf
@@ -1,0 +1,14 @@
+# Production deploys must arrive as a git push to the production branch, so a CLI
+# or API publish cannot reach production.
+data "netlify_site" "app" {
+  name = "app"
+}
+
+resource "netlify_site_build_settings" "app" {
+  site_id           = data.netlify_site.app.id
+  build_command     = "npm run build"
+  publish_directory = "dist"
+  production_branch = "main"
+
+  prevent_non_git_prod_deploys = true
+}

--- a/content/validation/scans/iac_variants_test.go
+++ b/content/validation/scans/iac_variants_test.go
@@ -49,12 +49,15 @@ import (
 // connection lives in the os provider); the rest back the non-cloud policies in
 // tfVariantPolicies. The base list (terraform/k8s/aws/azure/gcp/cloudformation)
 // lives in main_test.go.
+//
+// Every policy in tfVariantPolicies needs its runtime provider here.
 func init() {
 	extraProviders = append(extraProviders,
 		"bicep", "os",
 		"alicloud", "oci", "vsphere", "okta", "openstack", "gitlab", "cloudflare",
 		"github", "digitalocean", "unifi", "portainer", "snowflake",
-		"hetzner", "tailscale", "ms365", "databricks",
+		"hetzner", "tailscale", "ms365", "databricks", "vercel",
+		"clickhousecloud", "hcp", "neon", "netlify",
 	)
 }
 

--- a/content/validation/scans/iac_variants_test.go
+++ b/content/validation/scans/iac_variants_test.go
@@ -101,6 +101,7 @@ var tfVariantPolicies = []tfVariantPolicy{
 	{"mondoo-neon-security-", "mondoo-neon-security.mql.yaml", ""},
 	{"mondoo-databricks-security-", "mondoo-databricks-security.mql.yaml", ""},
 	{"mondoo-vercel-security-", "mondoo-vercel-security.mql.yaml", ""},
+	{"mondoo-netlify-security-", "mondoo-netlify-security.mql.yaml", ""},
 }
 
 // checkOutcome distinguishes a check that ran and passed, ran and failed, or was


### PR DESCRIPTION
## What

`mondoo-netlify-security` had no Terraform coverage. It now has a check with `terraform-hcl`, `terraform-plan` and `terraform-state` variants beside its Netlify runtime variant, and the policy is registered with `tfVariantPolicies`.

## The two existing checks still cannot have variants, and now that is recorded against a resolved schema

`terraform providers schema -json` on `netlify/netlify` 0.4.4 lists twelve resources and five data sources:

- **There is no site resource at all.** The provider only manages settings resources that attach to a site created elsewhere, and `netlify_site_domain_settings` carries the four custom-domain arguments plus `domain_aliases`. Nothing in the provider exposes forced TLS.
- **The team is reachable only as the `netlify_team` data source.** There is no team resource of any kind, so team MFA has nothing for `terraform.resources` to match.

Both `# No Terraform variant` comments now name the version and say what was looked at, so the next pass does not re-derive it.

## The one control that does have both surfaces

`netlify_site_build_settings.prevent_non_git_prod_deploys` is the HCL form of Netlify's **Enforce deployment methods** setting, and the netlify provider exposes the same site field as `preventNonGitProdDeploys`. Enabled, the only way to publish to production is a push to the project's production branch: the CLI, MCP server, API, build hooks, and drag-and-drop are all shut out of production, and a Deploy Preview can no longer be promoted from the UI without merging.

New check: `mondoo-netlify-security-sites-prevent-non-git-prod-deploys`, impact 80.

The argument is optional and Netlify leaves the restriction off by default, so an absent argument is a site that still accepts a publish straight to production. All four variants assert `== true`, which fails the absent case, and a `fail/absent` fixture pins that alongside `fail/explicitly-disabled`.

## Group filters

Registering the policy with `tfVariantPolicies` required dropping the group-level `filters: asset.platform == "netlify-account"`. A group filter is evaluated before the check's own filter, so a Terraform asset never reaches the variant and every fixture reports as *skipped* rather than pass or fail.

## Second commit: the terraform shard, and a flake already on main

The first push turned `terraform (shard 5/8)` red, and the red subtest named **tailscale**, not netlify:

```
installing provider 'netlify'
failed to compile ... cannot find resource for identifier 'netlify'
failed to compile ... cannot find resource for identifier 'clickhousecloud'
cannot find provider for conn type=terraform-hcl
--- FAIL: .../mondoo-tailscale-security-user-approval-required-terraform-hcl/pass/enabled
```

Scanning a Terraform asset still loads the whole bundle, so a policy registered in `tfVariantPolicies` needs its runtime provider pre-installed. Left out, the scanner installs it lazily mid-run and invalidates the provider cache that the parallel scans are reading, and the job that goes red is whichever scan was in flight. The comment above `extraProviders` already spells this out; the list had just fallen behind.

`netlify` is new. `clickhousecloud`, `hcp` and `neon` have been registered without an entry since #3375, which is the same shard failing intermittently on `main` (run 32067401726, identical signature, naming hetzner).

I cross-checked all 26 registered bundles against the list. After this commit the only remaining mismatch is `mondoo-m365-security` declaring `require: - provider: network`, and that one is not the same bug: no query in that policy references any `network` resource, nothing triggers a lazy install of it, and no CI log mentions it. It reads as stale `require:` metadata, left alone here.

## Compliance tags

Resolved against the framework text, not copied from the neighbouring checks, which map identity (IAM-02, IA-2) and transport (CEK-03, SC-8) controls. This one is change control:

| Framework | Control |
|---|---|
| CSA CCM v4 | `ccc-04` Unauthorized Change Protection |
| ISO 27001:2022 | `A.8.32` Change management |
| NIST CSF 2 | `PR.PS-05` Installation and execution of unauthorized software are prevented |
| NIST SP 800-53r5 | `CM-5` Access Restrictions for Change |
| NIST SP 800-171 | `3.4.5` enforce access restrictions associated with changes |
| NIST CSF 1 | `PR.IP-3` Configuration change control processes are in place |
| PCI DSS 4 | `6.5.1` changes to system components in production |
| SOC 2 | `CC6.8.3` a management-defined change control process is used for the implementation of software |
| NIS 2 | `21.2(e)` acquisition, development and maintenance |
| VDA ISA 5 | `5.2.1` To what extent are changes managed? |
| DORA | `art-9` Protection and Prevention |

HIPAA has no configuration-management control and BSI SYS.1.5 is virtualization, so both are `false` rather than mapped two hops away.

## Verification

- HCL variant through the fixture suite: `pass/git-only-prod-deploys`, `fail/absent`, `fail/explicitly-disabled`.
- Plan and state variants against hand-built `terraform show -json` documents, three states each (`true`, `false`, absent), since those suffixes take no fixtures. Worth knowing: the state document has to be the `terraform show -json` shape, not a raw `terraform.tfstate`. The raw form leaves `terraform.state.resources` empty, the filter never matches, and the check silently never runs.
- Terraform shard 5 re-run locally against a **clean `PROVIDERS_PATH`**, which is the condition CI runs in and the one that exposed the missing providers. Green.
- `cnspec policy lint ./content`, `TestTerraformVariantCoverage`, `TestRemediationSatisfiesCheck`, `go test ./content/validation/scans`, `go test ./content/validation/compliance`, `terraform.py netlify` against the real provider schema, and `bash.py` (3600 passed).

## Noted, not fixed here

`content/README.md` lists neither `mondoo-netlify-security` nor the other three policies added in #3338. That is a pre-existing catalog gap from that PR rather than something this change introduces, so it is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
