### PR TITLE
🐛 linux: pass ssh-protocol-is-set-to-2 when the directive is absent

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -12295,12 +12295,12 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     filters: package('openssh-server').version  >= semver("6") && package('openssh-server').version < semver("7.6")
     mql: |
-      sshd.config.params["Protocol"] == 2
+      sshd.config.params["Protocol"] == null || sshd.config.params["Protocol"] == 2
     docs:
       desc: |
         This check verifies that the SSH server speaks only protocol version 2.
 
-        The check reads `Protocol` in `/etc/ssh/sshd_config`, which must be `2`. It applies only to hosts running OpenSSH 6.0 through 7.5, the versions where the directive still exists and protocol 1 can still be selected. OpenSSH 7.4 removed server support for protocol 1 and 7.6 removed the directive entirely, so newer hosts are out of scope and are not evaluated.
+        The check reads `Protocol` in `/etc/ssh/sshd_config`. An explicit `Protocol 1` or `Protocol 2,1` fails; an explicit `Protocol 2` passes, and so does an absent directive, because every OpenSSH release in scope already defaults to protocol 2. It applies only to hosts running OpenSSH 6.0 through 7.5, the versions where the directive still exists and protocol 1 can still be selected. OpenSSH 7.4 removed server support for protocol 1 and 7.6 removed the directive entirely, so newer hosts are out of scope and are not evaluated.
 
         **Why this matters**
 
@@ -12316,7 +12316,7 @@ queries:
         grep -i '^Protocol' /etc/ssh/sshd_config
         ```
 
-        A passing result shows `Protocol 2`, or no `Protocol` line on modern OpenSSH where only protocol 2 is supported. A failing result shows `Protocol 1` or a mixed setting.
+        A passing result shows `Protocol 2`, or no `Protocol` line, since the default on every version in scope is already protocol 2. A failing result shows `Protocol 1` or a mixed setting such as `Protocol 2,1`.
       remediation:
         - id: cli
           desc: |


### PR DESCRIPTION
Fixes #3374

`mondoo-linux-security-ssh-protocol-is-set-to-2` required `Protocol` to equal 2:

```mql
sshd.config.params["Protocol"] == 2
```

`sshd.config.params` parses `/etc/ssh/sshd_config` rather than running `sshd -T`, so an absent directive reads `null`, and `null == 2` is false. Every OpenSSH release the filter admits (6.0 through 7.5) already defaults to protocol 2, and 7.4/7.5 cannot select protocol 1 at all — so a securely configured host in range failed for not restating the default.

## The change

```mql
sshd.config.params["Protocol"] == null || sshd.config.params["Protocol"] == 2
```

The check now fails only on what it can detect: an explicit `Protocol 1` or `Protocol 2,1`. Description and audit text updated to match.

## On removing the check instead

The issue leaned toward deleting it, since the filter admits no currently supported distribution. Its UID is referenced by 13 framework maps in `cnspec-enterprise-policies` (`iso-27001-2022`, `nis-2`, `nist-csf-1`, `nist-csf-2`, `csa-cloud-controls-matrix-4`, `nist-sp-800-53-rev5`, `nist-sp-800-171`, `owasp-top-10-2025`, `pci-dss-4`, `dora`, …), so removal would strand those mappings and cannot land from this repo alone. Fixing the query is the half that stands on its own; the reachability question is worth keeping open.

## Verification

- Null semantics confirmed by running the expression rather than inferring it: absent key → pass, `"1"` → fail, `"2"` → pass. MQL coerces `"2" == 2`, so the string-typed `params` map compares correctly against the integer literal.
- `cnspec policy lint ./content/mondoo-linux-security.mql.yaml` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)