### PR TITLE
🐛 github: scan the whole file tree for binary artifacts

### DIFF
--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -1751,16 +1751,14 @@ queries:
       compliance/soc2-2017: soc2-control-cc6-8-1
       compliance/vda-isa-5: vda-isa-5-5-2-1
     mql: |
-      github.repository.files
+      github.repository.allFiles
+        .where( type == "file" )
         .all( isBinary == false )
-      github.repository.files
-        .where( type == "dir" )
-        .all( files.where( type != "dir").all( isBinary == false) )
     docs:
       desc: |
-        This check verifies that the repository does not carry committed binary files in its top levels.
+        This check verifies that the repository does not carry committed binary files.
 
-        Nothing in the GitHub interface configures this. The instrument is the repository's own committed files, the ones a reader sees when browsing the repository. The check looks at the files sitting in the repository root and the files one directory level below it, and requires that none of them is a binary. Anything nested deeper than one directory is never inspected.
+        Nothing in the GitHub interface configures this. The instrument is the repository's own committed files, the ones a reader sees when browsing the repository. The check reads the entire file tree of the default branch and requires that none of the files in it is a binary. A file counts as a binary when its extension names a known executable or package format, such as `exe`, `dll`, `so`, `jar`, `class`, `rpm`, `deb`, `msi`, or `whl`.
 
         **Why this matters**
 
@@ -1768,12 +1766,12 @@ queries:
 
         The consequence extends past the repository. Committed binaries are frequently the ones executed by build scripts, developer setup steps, and CI jobs, so the modified artifact runs on maintainer workstations and on runners holding deploy credentials. Because it was built somewhere off the record, there is no source, no build log, and no way to reproduce it, so after an incident you cannot prove what the shipped bytes actually did. Any vulnerable dependency compiled into it is invisible to dependency scanning as well.
 
-        Some repositories legitimately contain binary data: images used in documentation, fonts, compiled test fixtures, and sample media. Those will fail here, and the answer is to move them out of the reviewed source tree, to Git LFS or to a release asset, or to accept the exception deliberately. Because the scan stops one directory below the root, a binary buried deeper still needs review discipline.
+        Some repositories legitimately contain binary data: images used in documentation, fonts, compiled test fixtures, and sample media. Those will fail here when their extension is one of the recognized executable or package formats, and the answer is to move them out of the reviewed source tree, to Git LFS or to a release asset, or to accept the exception deliberately.
       audit: |
         ### Audit via Console
 
         1. Navigate to the repository on GitHub.
-        2. Browse the file tree, including subdirectories, for committed executable or compiled files (for example, `.exe`, `.dll`, `.jar`, `.so`, or `.pyc`).
+        2. Browse the file tree, including subdirectories, for committed executable or compiled files such as `.exe`, `.dll`, `.jar`, `.so`, or `.pyc`.
 
         If no generated binary artifacts are committed to the repository, the check passes. If binary artifacts are present, the check fails.
 


### PR DESCRIPTION
Fixes #3380

> [!IMPORTANT]
> **Blocked on mondoohq/mql#10022**, which adds the `github.repository.allFiles` field this query reads. Lint will fail here until that ships and the dependency is bumped.

## The remaining item

Items 1 and 2 of #3380 (the org security-policy check reading `github.repository` on an org asset, and the Dependabot check's title/`.one()` mismatch) are already fixed on `main`. This carries item 3.

`mondoo-github-repository-security-binary-artifacts`:

```mql
github.repository.files.all( isBinary == false )
github.repository.files.where( type == "dir" )
  .all( files.where( type != "dir").all( isBinary == false) )
```

The first statement covers the root; the second covers one directory below it. Nothing recurses further, so a committed binary at `tools/vendor/bin/x` is never examined and the check passes — a false negative on the exact case the check exists for, since committed binaries are usually buried rather than sitting in the root.

## The change

```mql
github.repository.allFiles
  .where( type == "file" )
  .all( isBinary == false )
```

`allFiles` is one Git Trees API call with `recursive=1`, so it reaches arbitrary depth *and* replaces one API call per directory. Description and audit text updated: the old prose stated the one-level limit as a caveat, which no longer applies.

## Verification

`golang/go`, scanned live, is a repository where the two queries disagree:

```
old (root + one level):  true   ← passes
new (whole tree):        false  ← fails
binaries found: src/cmd/objdump/testdata/go116.o,
                src/debug/dwarf/testdata/{cppunsuptypes,cycle,line-clang,
                line-clang-dwarf5,line-gcc,line-gcc-dwarf5,line-gcc-zstd,
                ranges,rnglistx,split,typedef}.elf
```

Twelve committed object and ELF files at depths three and four, invisible to the old query.

`mondoohq/cnspec` and `tas50/cookstyle` both still pass under the new query.

`cnspec policy lint ./content/mondoo-github-security.mql.yaml` → valid, against a locally built provider carrying mondoohq/mql#10022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)