### PR TITLE
🧹 oci: read the cipher suite through the typed field

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -4253,7 +4253,7 @@ queries:
     filters: asset.platform == "oci-loadbalancer"
     mql: |
       oci.loadBalancer.loadBalancer.listeners.where(protocol.in(["HTTPS", "HTTP2"])).all(
-        sslCipherSuiteName.downcase == /^oci-modern-ssl-cipher-suite-v1$|^oci-tls-1-2-[a-z0-9-]+$|^oci-tls-1-3-[a-z0-9-]+$|^oci-default-ssl-cipher-suite-v1$/
+        sslCipherSuite.name.downcase == /^oci-modern-ssl-cipher-suite-v1$|^oci-tls-1-2-[a-z0-9-]+$|^oci-tls-1-3-[a-z0-9-]+$|^oci-default-ssl-cipher-suite-v1$/
       )
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-terraform-hcl
     filters: |


### PR DESCRIPTION
`oci.loadBalancer.listener.sslCipherSuiteName` is deprecated. It was the **only** `query-deprecated-symbol` warning across all 80 policies in `content/`, so this clears the deprecation surface entirely.

## The change

```diff
 oci.loadBalancer.loadBalancer.listeners.where(protocol.in(["HTTPS", "HTTP2"])).all(
-  sslCipherSuiteName.downcase == /^oci-modern-ssl-cipher-suite-v1$|.../
+  sslCipherSuite.name.downcase == /^oci-modern-ssl-cipher-suite-v1$|.../
 )
```

`sslCipherSuite` is an `oci.loadBalancer.sslCipherSuite` whose `name` field carries the same value the deprecated string returned. The regex is untouched, so the accepted set of cipher suites is identical.

## Verification

- `cnspec policy lint content/mondoo-oci-security.mql.yaml` — valid, and the deprecation warning is gone (`grep -c deprecated` → 0)
- No behavior change intended; regex and impact unchanged, no version bump

Found by a lint sweep across all of `content/` while auditing check correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)