### PR TITLE
🐛 aws: stop counting an unreadable IAM policy as MFA enforcement

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3411,6 +3411,11 @@ queries:
     filters: asset.platform == "aws"
     mql: |
       aws.iam.credentialReport.where(passwordEnabled == true).all(mfaActive == true)
+  # A policy body the HCL parser cannot resolve is NOT treated as compliant. A jsonencode()
+  # collapses to an empty list when any leaf inside it is a resource reference, so an
+  # unresolvable body carries no evidence either way and this check fails closed. Templates
+  # that build the MFA policy from references are covered by the -terraform-plan and
+  # -terraform-state variants, which see resolved values.
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iam_user_login_profile")
     mql: |
@@ -3422,8 +3427,7 @@ queries:
           _["Condition"]["BoolIfExists"]["aws:MultiFactorAuthPresent"] == false
         ) != empty
       )
-      unresolvedPolicies = terraform.resources.where(nameLabel == "aws_iam_policy").where(arguments["policy"].where(_["Statement"] != null) == empty)
-      mfaDenyPolicies.length + unresolvedPolicies.length > 0
+      mfaDenyPolicies.length > 0
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
     mql: |

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-hcl/fail/unresolvable-policy-body/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-hcl/fail/unresolvable-policy-body/main.tf
@@ -1,0 +1,29 @@
+# Non-compliant, and the regression case for a false pass that shipped:
+# this is fail/allow-only with one change, `Resource` points at another
+# resource instead of a literal. That makes jsonencode() collapse to an
+# empty list, so the policy body cannot be read. No MFA is enforced, and
+# an unreadable body must not be counted as evidence that it is.
+resource "aws_s3_bucket" "data" {
+  bucket = "example-data"
+}
+
+resource "aws_iam_policy" "allow_read" {
+  name = "allow-read"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRead"
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = aws_s3_bucket.data.arn
+      }
+    ]
+  })
+}
+
+# A console user exists, so the MFA-enforcement check applies.
+resource "aws_iam_user_login_profile" "example" {
+  user = "example-user"
+}


### PR DESCRIPTION
## The defect

The Terraform HCL variant of `mfa-enabled-for-iam-console-access` ended with:

```mql
mfaDenyPolicies    = <policies that Deny when MFA is absent>
unresolvedPolicies = <policies whose body could not be parsed>
mfaDenyPolicies.length + unresolvedPolicies.length > 0
```

A template passed when an `aws_iam_policy` body merely **failed to parse**. An HCL `jsonencode()` collapses to an empty list as soon as one leaf inside it is a resource reference — which is how IAM policies are normally written — so an Allow-only policy enforcing no MFA at all passed a CRITICAL check.

## Proof

Three fixtures, one variable:

| fixture | MFA enforced? | verdict on `main` |
|---|---|---|
| committed `fail/allow-only` — literal `jsonencode` | no | ✕ CRITICAL (90) ✅ |
| committed `pass/deny-no-mfa-bool` — real MFA deny | yes | ✓ ✅ |
| **same as `fail/allow-only` + `Resource = aws_s3_bucket.data.arn`** | **no** | **✓ ❌** |

One token — a resource reference instead of a string literal — flips CRITICAL into a pass.

## The fix

Drop the `unresolvedPolicies` term. An unreadable body carries no evidence either way, and a security check must not read that as compliance.

This only removes the false-pass path: a template whose MFA policy *is* literal still passes even if some unrelated policy is unparseable, because `mfaDenyPolicies.length > 0` on its own.

**The trade, stated plainly:** a template that genuinely enforces MFA through a reference-built policy will now fail this variant. That is deliberate — the HCL parser cannot see inside such a body (`arguments["policy"]` resolves to `[]`, not text, so there is no string to fall back on). Per this repo's convention, HCL sees author intent and plan/state see resolved values, so those templates are covered by the `-terraform-plan` and `-terraform-state` variants. A comment on the variant records this.

## Regression fixture

`fail/unresolvable-policy-body` is the reference-bearing twin of `fail/allow-only`. It passed before this change and fails after.

## Verification

- `cnspec policy lint` — valid
- `TestTerraformVariants/.../mfa-enabled-for-iam-console-access-terraform-hcl/` — all 4 scenarios pass
- `TestRemediationSatisfiesCheck/...-terraform-hcl` — pass, the shipped remediation still closes its own check
- `TestTerraformVariantCoverage`, bundle smoke, `typos` — pass

No version bump: this is a fix.

Found while auditing check correctness across `content/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)