### PR TITLE
🐛 github: fail the README content checks when there is no README

### DIFF
--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -401,14 +401,15 @@ queries:
     title: Ensure the README.md includes authors
     impact: 20
     mql: |
-      github.repository.files.where(name.downcase  == "readme.md") {
+      github.repository.files.where(name.downcase == "readme.md") != empty
+      github.repository.files.where(name.downcase == "readme.md") {
         content == /Authors/i
       }
     docs:
       desc: |
         This check verifies that the README names the people or teams responsible for the project.
 
-        The check reads `README.md` from the repository root and looks for an authors section. Add one by opening the file with the pencil icon on GitHub, or in a normal commit, and writing a short block headed Authors or Maintainers that names the person or team and gives a way to reach them, such as a team alias or a shared mailbox. GitHub renders the README on the repository's main page, so those names are visible without opening a file.
+        The check reads `README.md` from the repository root and looks for an authors section. A repository with no `README.md` fails, since it names nobody. Add one by opening the file with the pencil icon on GitHub, or in a normal commit, and writing a short block headed Authors or Maintainers that names the person or team and gives a way to reach them, such as a team alias or a shared mailbox. GitHub renders the README on the repository's main page, so those names are visible without opening a file.
 
         **Why this matters**
 
@@ -426,7 +427,7 @@ queries:
         2. Open the rendered `README.md` on the repository main page.
         3. Look for an authors or maintainers section.
 
-        If the README names the project's authors, the check passes. If no authors section is present, the check fails.
+        If the README names the project's authors, the check passes. If no authors section is present, the check fails, and a repository with no `README.md` at all fails for the same reason.
 
         ### Audit via CLI
 
@@ -437,7 +438,7 @@ queries:
              --jq '.content' | base64 -d | grep -i 'authors'
            ```
 
-        If the command prints a matching line, the check passes. If it prints nothing, the check fails.
+        If the command prints a matching line, the check passes. If it prints nothing, or reports that the file does not exist, the check fails.
       remediation:
         - id: github
           desc: |
@@ -574,14 +575,15 @@ queries:
     title: Ensure the README.md includes a getting started guide
     impact: 30
     mql: |
-      github.repository.files.where(name.downcase  == "readme.md") {
+      github.repository.files.where(name.downcase == "readme.md") != empty
+      github.repository.files.where(name.downcase == "readme.md") {
         content == /Getting started/i
       }
     docs:
       desc: |
         This check verifies that the README includes a getting started guide.
 
-        The check reads `README.md` from the repository root and looks for a getting started or quick start section. Write it by editing the file on GitHub with the pencil icon or in an ordinary commit, under a heading such as "Getting started", and cover the path a newcomer actually walks: install the project, set whatever configuration it requires, and run it once successfully.
+        The check reads `README.md` from the repository root and looks for a getting started or quick start section. A repository with no `README.md` fails, since it offers no starting point. Write it by editing the file on GitHub with the pencil icon or in an ordinary commit, under a heading such as "Getting started", and cover the path a newcomer actually walks: install the project, set whatever configuration it requires, and run it once successfully.
 
         **Why this matters**
 
@@ -599,7 +601,7 @@ queries:
         2. Open the rendered `README.md` on the repository main page.
         3. Look for a getting started or quick start section.
 
-        If the README includes a getting started section, the check passes. If none is present, the check fails.
+        If the README includes a getting started section, the check passes. If none is present, the check fails, and a repository with no `README.md` at all fails for the same reason.
 
         ### Audit via CLI
 
@@ -610,7 +612,7 @@ queries:
              --jq '.content' | base64 -d | grep -i 'getting started'
            ```
 
-        If the command prints a matching line, the check passes. If it prints nothing, the check fails.
+        If the command prints a matching line, the check passes. If it prints nothing, or reports that the file does not exist, the check fails.
       remediation:
         - id: github
           desc: |

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -409,7 +409,7 @@ queries:
       desc: |
         This check verifies that the README names the people or teams responsible for the project.
 
-        The check reads `README.md` from the repository root and looks for an authors section. A repository with no `README.md` fails, since it names nobody. Add one by opening the file with the pencil icon on GitHub, or in a normal commit, and writing a short block headed Authors or Maintainers that names the person or team and gives a way to reach them, such as a team alias or a shared mailbox. GitHub renders the README on the repository's main page, so those names are visible without opening a file.
+        The check reads `README.md` from the repository root and looks for an authors section. A repository with no `README.md` fails, since it names no one. Add one by opening the file with the pencil icon on GitHub, or in a normal commit, and writing a short block headed Authors or Maintainers that names the person or team and gives a way to reach them, such as a team alias or a shared mailbox. GitHub renders the README on the repository's main page, so those names are visible without opening a file.
 
         **Why this matters**
 


### PR DESCRIPTION
Fixes #3512

The two README content checks run a block over the filtered file list, and a block over an *empty* list scores `Skipped` rather than pass or fail. A repository with no `README.md` therefore got no verdict at all on "the README must include authors", when failing is the right answer.

## What changed

A `!= empty` statement ahead of the block, on both `-include-authors` and `-readme-getting-started`:

```mql
github.repository.files.where(name.downcase == "readme.md") != empty
github.repository.files.where(name.downcase == "readme.md") {
  content == /Authors/i
}
```

**The guard is a separate statement, not a `&&` term.** The issue's note suggests `.where(…) != empty &&` ahead of the block; that shape compiles, but it discards the block's verdict. Measured on a scratch bundle:

```
✓ E and-guard then failing block over non-empty      <- WRONG, should fail
✕ D newline guard then failing block over non-empty  <- correct
✕ B newline guard then block over empty              <- correct
. Skipped:  A bare block over empty filtered list    <- the bug
```

`&&` coerces the block into a truthy value, so `list != empty && list { predicate }` passes whenever the list is non-empty, no matter what the predicate says. Newline is an implicit AND that keeps both verdicts, so the guard goes on its own line.

The audit and description prose now say that a repository with no README fails.

## Verification

`cnspec policy lint ./content/mondoo-github-best-practices.mql.yaml` passes.

Scanned live, both directions. `tas50/kismet-web-docs`, which has no README:

```
✕ LOW (20):       Ensure the README.md includes authors
✕ LOW (30):       Ensure repository has a README
✕ LOW (30):       Ensure the README.md includes a getting started guide
. Skipped:        Ensure repository has a CODE_OF_CONDUCT.md policy
. Skipped:        Ensure repository has a support policy
```

Both now fail instead of skipping. The two remaining `Skipped` checks are the erroring-`github.organization` cause tracked in #3461, untouched here.

Positive control, `mondoohq/cnspec`, which has a README:

```
✓ Ensure the README.md includes authors
✕ LOW (30):       Ensure the README.md includes a getting started guide
```

A present-but-lacking README is still assessed on its content, so the guard did not turn the checks into a blanket fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)