### PR TITLE
🐛 aws: scope the Terraform filters to the resource each check reads

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2651,7 +2651,19 @@ queries:
             ```
         - id: terraform
           desc: |
-            To ensure no root user account access key exists in Terraform, AWS does not allow direct management of the root user's access key via Terraform. However, you should enforce IAM policies that prevent the creation of root access keys:
+            Terraform cannot manage the root user's access keys, so the key itself is removed in the console under **My Security Credentials**. What Terraform controls is whether a configuration issues access keys to the root account at all: bind every `aws_iam_access_key` to a named IAM user.
+
+            ```hcl
+            resource "aws_iam_user" "automation" {
+              name = "ci-automation"
+            }
+
+            resource "aws_iam_access_key" "automation" {
+              user = aws_iam_user.automation.name
+            }
+            ```
+
+            A Deny policy on `iam:CreateAccessKey` is worth adding as defense in depth, but it does not bind the root principal:
 
             ```hcl
             resource "aws_iam_policy" "deny_root_access_keys" {
@@ -2704,21 +2716,17 @@ queries:
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(accessKey1Active == false)
       aws.iam.credentialReport.where(properties.user == "<root_account>").all(accessKey2Active == false)
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_iam_access_key")
     mql: |
       terraform.resources("aws_iam_access_key").all(arguments["user"] != "root")
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_iam_access_key")
     mql: |
-      policyPlan = terraform.plan.resourceChanges.where(type == "aws_iam_policy").map(change.after.policy).first
-      policyPlan.contains('Action') && policyPlan.contains('iam:CreateAccessKey')
-      policyPlan.contains('Effect') && policyPlan.contains('Deny')
+      terraform.plan.resourceChanges.where(type == "aws_iam_access_key").all(change.after.user != "root")
   - uid: mondoo-aws-security-iam-root-access-key-check-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_iam_access_key")
     mql: |
-      policyState = terraform.state.resources.where(type == "aws_iam_policy").map(values.policy).first
-      policyState.contains('Action') && policyState.contains('iam:CreateAccessKey')
-      policyState.contains('Effect') && policyState.contains('Deny')
+      terraform.state.resources.where(type == "aws_iam_access_key").all(values.user != "root")
   # No Terraform variants: Root-user MFA enrollment is a console-only runtime operation; no Terraform resource can enable or represent MFA on the root account, and IAM policies never bind the root principal, so any aws_iam_policy proxy is unrelated to this control.
   - uid: mondoo-aws-security-root-account-mfa-enabled
     title: Ensure MFA is enabled for the "root user" account
@@ -3429,7 +3437,7 @@ queries:
       )
       mfaDenyPolicies.length > 0
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-plan
-    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == /^aws_/)
+    filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_iam_user_login_profile")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_iam_policy").any(
         change.after.policy.contains('Deny') &&
@@ -3437,7 +3445,7 @@ queries:
         change.after.policy.contains('false')
       )
   - uid: mondoo-aws-security-mfa-enabled-for-iam-console-access-terraform-state
-    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == /^aws_/)
+    filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_iam_user_login_profile")
     mql: |
       terraform.state.resources.where(type == "aws_iam_policy").any(
         values.policy.contains('Deny') &&
@@ -4349,9 +4357,8 @@ queries:
     mql: aws.ec2.ebsEncryptionByDefault.values.all(_ == true)
   # enabled == null passes deliberately: the AWS provider defaults aws_ebs_encryption_by_default.enabled to true, so declaring the resource without the argument still enables account-level encryption.
   - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.providers.contains(nameLabel == "aws")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_ebs_encryption_by_default")
     mql: |
-      terraform.resources.where(nameLabel == "aws_ebs_encryption_by_default").length > 0
       terraform.resources.where(nameLabel == "aws_ebs_encryption_by_default").where(arguments["enabled"] != /^(var|local|module|data|each)\./).all(
         arguments["enabled"] == null || arguments["enabled"] == true
       )
@@ -4359,13 +4366,13 @@ queries:
     filters: asset.platform == "terraform-plan" && terraform.plan.resourceChanges.contains(type == "aws_ebs_encryption_by_default")
     mql: |
       terraform.plan.resourceChanges.where(type == "aws_ebs_encryption_by_default").all(
-        change.after.enabled == true
+        change.after.enabled != false
       )
   - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-terraform-state
     filters: asset.platform == "terraform-state" && terraform.state.resources.contains(type == "aws_ebs_encryption_by_default")
     mql: |
       terraform.state.resources.where(type == "aws_ebs_encryption_by_default").all(
-        values.enabled == true
+        values.enabled != false
       )
   - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access
     title: Ensure public access to S3 buckets is blocked at the account level
@@ -4507,9 +4514,8 @@ queries:
       aws.s3control.accountPublicAccessBlock != empty &&
       aws.s3control.accountPublicAccessBlock.values.all(_ == true)
   - uid: mondoo-aws-security-s3-buckets-account-level-block-public-access-terraform-hcl
-    filters: asset.platform == "terraform-hcl" && terraform.providers.contains(nameLabel == "aws")
+    filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_s3_account_public_access_block")
     mql: |
-      terraform.resources("aws_s3_account_public_access_block").length > 0
       terraform.resources("aws_s3_account_public_access_block").all(
         arguments["block_public_acls"] == true &&
         arguments["ignore_public_acls"] == true &&

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-iam-root-access-key-check-terraform-hcl/fail/root/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-iam-root-access-key-check-terraform-hcl/fail/root/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-iam-root-access-key-check-terraform-hcl` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-iam-root-access-key-check-terraform-hcl/pass/non-root/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-iam-root-access-key-check-terraform-hcl/pass/non-root/KNOWN_BUG.md
@@ -1,5 +1,0 @@
-# Known bug: policy: check does not yet assert this form
-
-The `mondoo-aws-security-iam-root-access-key-check-terraform-hcl` check does not yet assert this realistic fixture correctly. This is a harness-found policy or provider issue whose fix is tracked outside the test framework pull request; the fixture is kept as a regression test.
-
-Remove this marker when the underlying fix lands and this scenario asserts correctly.


### PR DESCRIPTION
Fixes #3511, fixes #3514, fixes #3515.

## The defect

Four families filtered on *any* AWS resource, or on *any use of the aws provider*, rather than on the resource the body asserts about. Where the body also required a resource to exist, that produced CRITICAL findings against configurations that declare nothing of the kind.

A Terraform plan whose entire content is one S3 bucket:

| | before | after |
|---|---|---|
| Ensure MFA is enabled for all IAM users with console access | ✕ CRITICAL (90) | not run |
| Ensure no root user account access key exists | ✕ CRITICAL (90) | not run |
| **overall** | **CRITICAL (90)** | **LOW (0)** |

A two-line HCL configuration (`provider "aws"` + one `aws_s3_bucket`):

| | before | after |
|---|---|---|
| Ensure EBS volume encryption is enabled by default | ✕ CRITICAL (90) | not run |
| Ensure public access to S3 buckets is blocked at the account level | ✕ CRITICAL (100) | not run |

## `iam-root-access-key-check` was also wrong in the other direction

Its plan and state forms asked whether a `Deny` policy on `iam:CreateAccessKey` existed anywhere in the configuration. That is not what the title asserts, and not what the runtime and HCL forms check — so a plan that **creates an access key for the root user** passed.

```console
# before
$ cnspec scan terraform plan plan-rootkey.json ...
✓ Ensure no root user account access key exists

# after
✕ CRITICAL (90):  Ensure no root user account access key exists
```

They now mirror the HCL form and read `aws_iam_access_key` directly, which also drops a `.first` that inspected only one policy out of however many the plan contained.

## Consistency fixes

`ec2-ebs-encryption-by-default` and `s3-buckets-account-level-block-public-access` had HCL forms that required the resource to be declared, while their own plan and state forms only validated it when present (#3515). The HCL forms now match their siblings.

The EBS plan and state forms also move from `enabled == true` to `enabled != false`, so an omitted argument reads the same way in all three variants. The provider defaults that argument to `true`, so the HCL form's existing null handling is the correct reading.

I did not change what these checks assert once the resource *is* present. Every existing pass and fail fixture still produces the same verdict.

## Two stale KNOWN_BUG markers removed

`iam-root-access-key-check-terraform-hcl`'s `pass/non-root` and `fail/root` fixtures were parked with *"check does not yet assert this form"*. They were parked because the provider-scoped filter meant the check never fired on fixtures that carry no `provider "aws"` block. It fires now and both assert correctly, so the markers are stale and the build requires their removal.

## Remediation updated

The Terraform remediation for `iam-root-access-key-check` demonstrated only a Deny policy, which the check no longer reads, so `TestRemediationSatisfiesCheck` could not run against it. It now shows an access key bound to a named IAM user — what the check actually asks for — and keeps the Deny policy as defense in depth, with its existing caveat that IAM policies do not bind the root principal.

## Verification

- `cnspec policy lint` — valid
- `TestTerraformVariants/mondoo-aws-security/` — full suite, 317s, pass, no stale markers
- `TestRemediationSatisfiesCheck` for all four families — pass
- `TestTerraformVariantCoverage`, bundle smoke, `typos` — pass
- behavioural: minimal plan CRITICAL (90) → LOW (0); minimal HCL loses both CRITICALs; root-key plan now correctly CRITICAL (90)

## Related

Same root cause as #3518 (the Okta instances). Found while auditing check correctness across `content/`.

Worth noting separately: `-terraform-plan` and `-terraform-state` variants have **no fixtures anywhere in the tree**, and `iacVariantSuffixes` in `iac_variants_test.go` lists only `-terraform-hcl`, `-cloudformation` and `-bicep`. That is 2,789 variants excluded from the coverage gate, which is why these defects shipped in plan and state form and were invisible at 100% reported coverage. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)