### PR TITLE
✨ clickhousedb: restore the TLS listener check on the fixed provider

### DIFF
--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -32,6 +32,10 @@ policies:
         checks:
           - uid: mondoo-clickhousedb-security-users-have-passwords
           - uid: mondoo-clickhousedb-security-users-strong-authentication
+      - title: Transport Encryption
+        filters: asset.platform == "clickhousedb"
+        checks:
+          - uid: mondoo-clickhousedb-security-secure-tcp-port-enabled
       - title: Access Control
         filters: asset.platform == "clickhousedb"
         checks:
@@ -454,3 +458,78 @@ queries:
         title: ClickHouse quotas
       - url: https://clickhouse.com/docs/en/operations/settings/query-complexity
         title: ClickHouse query complexity restrictions
+  - uid: mondoo-clickhousedb-security-secure-tcp-port-enabled
+    filters: asset.platform == "clickhousedb"
+    title: Ensure ClickHouse enables the secure native TCP port
+    impact: 70
+    tags:
+      compliance/bsi-sys-1-5: false
+      compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-ivs-03
+      compliance/dora: dora-art-9
+      compliance/hipaa: hipaa-security-ss164-312-e-1-transmission
+      compliance/iso-27001-2022: iso-27001-2022-a-8-24
+      compliance/nis-2: nis-2-21-2-h
+      compliance/nist-csf-1: nist-csf-1-pr-ds-2
+      compliance/nist-csf-2: nist-csf-2-pr-ds-02
+      compliance/nist-sp-800-53-rev5: nist-sp-800-53-rev5-sc-8
+      compliance/nist-sp-800-171: nist-sp-800-171--3-13-8
+      compliance/owasp-top-10-2025: owasp-top-10-2025-a04
+      compliance/pci-dss-4: pcidss-requirement-4-2-1
+      compliance/soc2-2017: soc2-control-cc6-7-2
+      compliance/vda-isa-5: vda-isa-5-5-2-6
+    mql: |
+      clickhousedb.instance.tcpPortSecure != 0
+    docs:
+      desc: |
+        This check verifies that ClickHouse offers its native protocol over TLS.
+
+        The native protocol has two listeners. `tcp_port` is the plain one, conventionally 9000, and `tcp_port_secure` is the encrypted one, conventionally 9440. Setting `tcp_port_secure` to a non-zero port in `config.xml` or a file in `config.d/`, alongside an `openSSL` block naming a `certificateFile` and a `privateKeyFile`, brings the encrypted listener up. This check reads the port the server resolved at startup and requires it to name a listener rather than being absent.
+
+        Note that listeners do not appear in `system.server_settings`: that table covers the settings declared in the server's own settings struct, while ports are read straight from the configuration files. The resolved value is available only through the `getServerPort()` function, which is where this check reads it from.
+
+        **Why this matters**
+
+        Without the secure listener, native clients have nowhere to connect except the plain port, and the native protocol sends the credential at the start of the session. An attacker positioned anywhere on that path, on a compromised host in the same subnet, at a mirrored switch port, or on any hop between an application in one region and a cluster in another, captures the username and password from the handshake of a single connection and then authenticates as that account whenever they like, from wherever they like.
+
+        The same capture yields the data without the credential being used at all. Query text and result blocks travel in the clear on the plain port, so an observer reads exactly the rows the legitimate application is reading, for as long as they hold the position.
+
+        Cleartext also permits modification rather than only observation. An on-path attacker who can rewrite packets alters a query before it reaches the server or alters the result on its way back, which is the difference between someone who learns what a dashboard says and someone who decides what it says.
+
+        Bringing up `tcp_port_secure` does not stop clients using the plain listener. Once the secure port is serving and clients have moved to it, remove or zero `tcp_port` as well. Use a certificate from an authority the clients actually verify rather than a self-signed one they are configured to ignore, because an unverified certificate encrypts the session while leaving impersonation wide open.
+      audit: |-
+        ### Audit via clickhouse-client
+
+        1. Ask the server which port it resolved for the secure native listener:
+
+           ```sql
+           SELECT getServerPort('tcp_port_secure');
+           ```
+
+        If it returns a port, the check passes. On a server with the secure listener switched off the function raises `There is no port named tcp_port_secure` rather than returning zero, and the check fails.
+
+        2. Confirm which listeners the server is actually offering:
+
+           ```sql
+           SELECT getServerPort('tcp_port'), getServerPort('http_port');
+           ```
+
+        Searching `system.server_settings` for these names returns nothing on any version; ports are not among the settings it covers.
+      remediation:
+        - id: config
+          desc: |-
+            To enable the secure native TCP port, configure TLS and set `tcp_port_secure` in the server configuration (`config.xml` or a file in `config.d/`), then restart:
+
+            ```xml
+            <clickhouse>
+              <tcp_port_secure>9440</tcp_port_secure>
+              <openSSL>
+                <server>
+                  <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>
+                  <privateKeyFile>/etc/clickhouse-server/server.key</privateKeyFile>
+                </server>
+              </openSSL>
+            </clickhouse>
+            ```
+    refs:
+      - url: https://clickhouse.com/docs/en/guides/sre/configuring-ssl
+        title: ClickHouse configuring SSL-TLS

--- a/content/validation/live/clickhousedb.py
+++ b/content/validation/live/clickhousedb.py
@@ -28,7 +28,7 @@ in, used, and written back out before the scan.
 
 import hashlib
 
-from common import Exec, Fixture, Restart, Scan, Suite, WaitFor, Write, credential
+from common import Exec, Fixture, Restart, Scan, Suite, WaitFor, Write, credential, mint_certs
 
 # Accounts are declared with sha256 hashes rather than <password> elements,
 # because a plaintext element is exactly what the strong-authentication check
@@ -78,6 +78,25 @@ def _users_xml(admin: bool, admin_sha: str, scanner_sha: str) -> str:
 # no authentication method. Verified — it is a startup crash, not a warning.
 _USERS_D = "/etc/clickhouse-server/users.d/zz-cnspec-live.xml"
 
+# Listeners are configured in config.d rather than users.d, and only the
+# hardened fixture brings the secure one up — the two others exist to be found
+# serving in the clear.
+_CONFIG_D = "/etc/clickhouse-server/config.d/zz-cnspec-live-tls.xml"
+
+_TLS_CONFIG = """\
+<clickhouse>
+  <tcp_port_secure>9440</tcp_port_secure>
+  <https_port>8443</https_port>
+  <openSSL>
+    <server>
+      <certificateFile>/tls/server.crt</certificateFile>
+      <privateKeyFile>/tls/server.key</privateKeyFile>
+      <verificationMode>none</verificationMode>
+      <cacheSessions>true</cacheSessions>
+    </server>
+  </openSSL>
+</clickhouse>
+"""
 
 # A bootstrap account for the permissive fixture. The account the image creates
 # has no access management, so there is no way to add the passwordless user that
@@ -121,6 +140,7 @@ def build_suite(workdir):
     scanner_password = credential()
     admin_sha = hashlib.sha256(admin_password.encode()).hexdigest()
     scanner_sha = hashlib.sha256(scanner_password.encode()).hexdigest()
+    certs = mint_certs(workdir)
     return Suite(
         provider="clickhousedb",
         policy="mondoo-clickhousedb-security.mql.yaml",
@@ -159,6 +179,7 @@ def build_suite(workdir):
                             "mondoo-clickhousedb-security-users-host-restricted": "fail",
                             "mondoo-clickhousedb-security-users-least-privilege": "fail",
                             "mondoo-clickhousedb-security-quota-applies-to-all-users": "fail",
+                            "mondoo-clickhousedb-security-secure-tcp-port-enabled": "fail",
                         },
                     )
                 ],
@@ -190,6 +211,9 @@ def build_suite(workdir):
                             "mondoo-clickhousedb-security-users-host-restricted": "fail",
                             "mondoo-clickhousedb-security-users-least-privilege": "fail",
                             "mondoo-clickhousedb-security-quota-applies-to-all-users": "fail",
+                            # getServerPort() predates the users tables this
+                            # fixture cannot read, so this one answers on 24.8.
+                            "mondoo-clickhousedb-security-secure-tcp-port-enabled": "fail",
                         },
                     )
                 ],
@@ -202,9 +226,14 @@ def build_suite(workdir):
                 # No CLICKHOUSE_PASSWORD: setting it makes the entrypoint write a
                 # plaintext default account back in on every start, which would
                 # undo this fixture at the restart below.
+                mounts={
+                    "/tls/server.crt": certs["server.crt"],
+                    "/tls/server.key": certs["server.key"],
+                },
                 setup=[
                     WaitFor(["clickhouse-client", "--query", "SELECT 1"], timeout=120),
                     Write(_USERS_D, _users_xml(True, admin_sha, scanner_sha)),
+                    Write(_CONFIG_D, _TLS_CONFIG),
                     Restart(),
                     _ready_as("admin", admin_password),
                     _client(
@@ -228,6 +257,7 @@ def build_suite(workdir):
                             "mondoo-clickhousedb-security-users-host-restricted": "pass",
                             "mondoo-clickhousedb-security-users-least-privilege": "pass",
                             "mondoo-clickhousedb-security-quota-applies-to-all-users": "pass",
+                            "mondoo-clickhousedb-security-secure-tcp-port-enabled": "pass",
                         },
                     )
                 ],


### PR DESCRIPTION
Stacked on #3525. **Blocked on a provider release carrying mondoohq/mql#10078** — do not merge before then.

## Why this is its own PR

`cnspec policy lint` compiles every check against the *installed* provider schema. `clickhousedb.instance.tcpPortSecure` does not exist in the released clickhousedb 13.0.1, so a bundle referencing it fails lint outright:

```
failed to compile: cannot find field 'tcpPortSecure' in clickhousedb.instance
```

That is one red check taking the whole bundle with it. Splitting it out keeps #3525 mergeable today and isolates the part that genuinely has to wait.

## What it restores

`mondoo-clickhousedb-security-secure-tcp-port-enabled`, removed in #3525 because `system.server_settings` contains no ports on any ClickHouse version, so its query was `[].any()` — false on every server, forever.

The question it asked was always the right one. mondoohq/mql#10078 adds `tcpPort`, `tcpPortSecure`, `httpPort`, `httpsPort`, and `tlsEnabled` on `clickhousedb.instance` via `getServerPort()`, and the check now reads `tcpPortSecure` directly. Its audit steps name `getServerPort()` and say explicitly that the settings table will never carry this, so the next reader does not repeat the search.

The hardened fixture gains a certificate and a secure listener, so the check has a real pass side rather than an exemption.

## Verified

Against a locally-built provider from mql#10078:

```
make test/content/live/clickhousedb   →  30 passed, 0 failed
```

with the check seen failing on both plaintext fixtures and passing on the TLS one.

## Merge order

1. mondoohq/mql#10078
2. a provider release carrying it
3. #3522 → #3525
4. this

🤖 Generated with [Claude Code](https://claude.com/claude-code)