### PR TITLE
🧹 broaden is_prerelease to match alpha/beta/pre/rc suffixes

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -244,7 +244,7 @@ jobs:
         id: is_prerelease
         run: echo "is_pre=${IS_PRE}" >> $GITHUB_OUTPUT
         env:
-          IS_PRE: ${{ contains(github.ref_name, '-pre') }}
+          IS_PRE: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-pre') || contains(github.ref_name, '-rc') }}
 
       - name: Trigger installer release
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1


### PR DESCRIPTION
## Summary

- The `Check if pre-release` step in the `trigger-installer-release` job only matched `-pre`, while the outer `Skip Publish for non-release tags` gate (line 71) matches all four of `alpha`/`beta`/`pre`/`rc`.
- Today the outer gate already skips the whole `trigger-installer-release` job for pre-release tags, so this is defense-in-depth: the two conditions should agree so a future change to the outer gate doesn't silently reintroduce a case where installer gets dispatched with `skip-publish: false` for a `-rc` tag.
- Puts cnspec on par with mql's `Skip Publish for non-release tags` gate.

## Test plan
- [ ] No behavior change today (outer job gate still skips this step for pre-releases).
- [ ] Confirm no other consumer of `steps.is_prerelease.outputs.is_pre` in this workflow relies on the `-pre`-only semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)