### PR TITLE
🐛 cnquery-update: route bump PR to v{major} support branch

### DIFF
--- a/.github/scripts/determine-mql-bump-base.sh
+++ b/.github/scripts/determine-mql-bump-base.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Determine base branch for cnspec's mql bump PR.
+#
+# When main's mql import major matches the incoming mql release's major,
+# the bump PR opens against main. Otherwise it opens against the v{major}
+# support branch (e.g. v13.35.1 while main is on mql v14 -> v13).
+#
+# Inputs:
+#   $1 (required)  incoming mql version (e.g. v13.35.1 or 14.0.0-rc.1)
+#   $MAIN_GOMOD    content of main's go.mod. If unset, fetched via `gh api`
+#                  using $GH_REPO (owner/repo) and $GH_TOKEN.
+#
+# Output: prints the base branch to stdout ("main" or "v{major}").
+#         Exits non-zero if main's mql import major cannot be determined.
+set -euo pipefail
+
+MQL_VERSION="${1:?mql version required as first argument}"
+
+V="${MQL_VERSION#v}"
+RELEASE_MAJOR="${V%%.*}"
+
+if [ -z "${MAIN_GOMOD:-}" ]; then
+  : "${GH_REPO:?GH_REPO or MAIN_GOMOD required}"
+  MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
+fi
+
+MAIN_MAJOR=$(printf '%s' "$MAIN_GOMOD" \
+  | grep -oE 'go\.mondoo\.com/mql/v[0-9]+' \
+  | head -1 \
+  | grep -oE '[0-9]+$' || true)
+
+if [ -z "$MAIN_MAJOR" ]; then
+  echo "Could not extract mql major from main's go.mod" >&2
+  exit 1
+fi
+
+if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+  echo main
+else
+  echo "v${RELEASE_MAJOR}"
+fi

--- a/.github/scripts/determine-mql-bump-base.sh
+++ b/.github/scripts/determine-mql-bump-base.sh
@@ -19,7 +19,10 @@ MQL_VERSION="${1:?mql version required as first argument}"
 V="${MQL_VERSION#v}"
 RELEASE_MAJOR="${V%%.*}"
 
-if [ -z "${MAIN_GOMOD:-}" ]; then
+if [ -z "${MAIN_GOMOD+set}" ]; then
+  # MAIN_GOMOD not passed in at all — fetch it. An explicit empty value
+  # is respected (and will fail the "Could not extract" check below), so
+  # tests can exercise failure paths without touching the network.
   : "${GH_REPO:?GH_REPO or MAIN_GOMOD required}"
   MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
 fi

--- a/.github/scripts/determine-mql-bump-base.sh
+++ b/.github/scripts/determine-mql-bump-base.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
 # Determine base branch for cnspec's mql bump PR.
 #
 # When main's mql import major matches the incoming mql release's major,

--- a/.github/scripts/tests/determine-mql-bump-base.bats
+++ b/.github/scripts/tests/determine-mql-bump-base.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/determine-mql-bump-base.sh
+#
+# Each test sets MAIN_GOMOD in the environment so the script runs without
+# calling gh api. See the script's header for the input contract.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../determine-mql-bump-base.sh"
+}
+
+@test "matching major routes to main (v-prefixed tag)" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "matching major routes to main (no v prefix)" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" 14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "older major routes to v{major}" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "future major routes to v{major}" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v15.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v15" ]
+}
+
+@test "pre-release suffix does not change routing" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v14.0.0-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "pre-release suffix on older major routes to v{major}" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v13.35.1-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "main on v13 today: v13 release routes to main" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v13 v13.35.0' \
+    run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "go.mod without an mql import fails loudly" {
+  MAIN_GOMOD='require go.mondoo.com/other v1.0.0' \
+    run bash "$SCRIPT" v13.35.1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not extract mql major"* ]]
+}
+
+@test "missing version argument errors out" {
+  MAIN_GOMOD='require go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "picks the first mql import when multiple present" {
+  # If go.mod somehow has multiple mql majors (edge case), head -1 wins.
+  MAIN_GOMOD=$'require (\n\tgo.mondoo.com/mql/v14 v14.0.0\n\tgo.mondoo.com/mql/v13 v13.0.0 // indirect\n)' \
+    run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -35,6 +35,34 @@ jobs:
           fi
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      # Route the bump PR to the right branch by comparing the incoming mql
+      # major with the mql major currently imported on main. Matching major
+      # -> base=main; any other major -> base=v{major} support branch
+      # (e.g. an mql v13.35.1 tag while main is on mql v14 -> base=v13).
+      - name: Determine base branch
+        id: base
+        env:
+          MQL_VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          V="${MQL_VERSION#v}"
+          RELEASE_MAJOR="${V%%.*}"
+          MAIN_MAJOR=$(gh api "/repos/${{ github.repository }}/contents/go.mod?ref=main" --jq '.content' \
+            | base64 -d \
+            | grep -oE 'go\.mondoo\.com/mql/v[0-9]+' \
+            | head -1 \
+            | grep -oE '[0-9]+$')
+          if [ -z "$MAIN_MAJOR" ]; then
+            echo "Could not extract mql major from main's go.mod" >&2
+            exit 1
+          fi
+          if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+            BASE=main
+          else
+            BASE="v${RELEASE_MAJOR}"
+          fi
+          echo "Release major: ${RELEASE_MAJOR}, main mql major: ${MAIN_MAJOR}, base: ${BASE}"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
       # Mint a short-lived installation token from the mondoo-mergebot
       # GitHub App. App tokens bypass the same "PRs created by GITHUB_TOKEN
       # don't trigger downstream workflows" limit that motivated the old
@@ -52,6 +80,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ steps.base.outputs.base }}
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -85,7 +114,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          base: main
+          base: ${{ steps.base.outputs.base }}
           labels: dependencies,go
           committer: "Mondoo Tools <tools@mondoo.com>"
           commit-message: ${{ steps.branch.outputs.COMMIT_TITLE }}

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -9,6 +9,10 @@ on:
         description: "mql version"
         required: true
         type: string
+      dry-run:
+        description: "Skip Create PR (test the base-branch decision only)"
+        type: boolean
+        default: false
 
 jobs:
   bump-mql:
@@ -35,33 +39,29 @@ jobs:
           fi
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      # Sparse-checkout the scripts dir before we know the target branch, so
+      # we can run determine-mql-bump-base.sh to figure out where to open the
+      # bump PR. The full checkout of the target branch happens further down.
+      - name: Checkout scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: '.github/scripts'
+          sparse-checkout-cone-mode: false
       # Route the bump PR to the right branch by comparing the incoming mql
       # major with the mql major currently imported on main. Matching major
       # -> base=main; any other major -> base=v{major} support branch
       # (e.g. an mql v13.35.1 tag while main is on mql v14 -> base=v13).
+      # Logic lives in .github/scripts/determine-mql-bump-base.sh and is
+      # unit-tested via .github/scripts/tests/determine-mql-bump-base.bats.
       - name: Determine base branch
         id: base
         env:
           MQL_VERSION: ${{ steps.version.outputs.version }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          V="${MQL_VERSION#v}"
-          RELEASE_MAJOR="${V%%.*}"
-          MAIN_MAJOR=$(gh api "/repos/${{ github.repository }}/contents/go.mod?ref=main" --jq '.content' \
-            | base64 -d \
-            | grep -oE 'go\.mondoo\.com/mql/v[0-9]+' \
-            | head -1 \
-            | grep -oE '[0-9]+$')
-          if [ -z "$MAIN_MAJOR" ]; then
-            echo "Could not extract mql major from main's go.mod" >&2
-            exit 1
-          fi
-          if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
-            BASE=main
-          else
-            BASE="v${RELEASE_MAJOR}"
-          fi
-          echo "Release major: ${RELEASE_MAJOR}, main mql major: ${MAIN_MAJOR}, base: ${BASE}"
+          BASE=$(.github/scripts/determine-mql-bump-base.sh "$MQL_VERSION")
+          echo "Release major: ${MQL_VERSION%%.*}, resolved base branch: ${BASE}"
           echo "base=${BASE}" >> "$GITHUB_OUTPUT"
       # Mint a short-lived installation token from the mondoo-mergebot
       # GitHub App. App tokens bypass the same "PRs created by GITHUB_TOKEN
@@ -109,8 +109,27 @@ jobs:
           echo "COMMIT_TITLE=${COMMIT_MSG}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
+      # Dry-run: print what the PR WOULD have looked like, and stop.
+      # Everything above (base decision, go get, VERSION write) still runs
+      # so a workflow_dispatch with dry-run=true exercises the routing end
+      # to end without opening a real PR.
+      - name: Dry run summary
+        if: ${{ inputs.dry-run }}
+        env:
+          MQL_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "::notice::DRY RUN — no PR opened."
+          echo "  version:    ${MQL_VERSION}"
+          echo "  base:       ${{ steps.base.outputs.base }}"
+          echo "  branch:     ${{ steps.branch.outputs.BRANCH_NAME }}"
+          echo "  commit msg: ${{ steps.branch.outputs.COMMIT_TITLE }}"
+          echo
+          echo "Local changes staged for the would-be PR:"
+          git diff --stat
+
       - name: Create PR
         id: cpr
+        if: ${{ !inputs.dry-run }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -124,7 +143,7 @@ jobs:
           body-path: .github/pr-body.md
 
       - name: PR infos
-        if: ${{ steps.cpr.outputs.pull-request-number }}
+        if: ${{ !inputs.dry-run && steps.cpr.outputs.pull-request-number }}
         env:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,25 @@
+name: Test .github/scripts
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats tests
+        run: bats -r .github/scripts/tests


### PR DESCRIPTION
## Summary

`cnquery-update.yml` opens the bump PR after cnspec receives an `update-mql` dispatch. `base:` was hardcoded to `main`, which breaks the moment main tracks a new mql major (e.g. mql v14): an incoming mql `v13.35.x` tag would try to backport onto v14 code and either conflict or land wrong.

## Fix

The base decision now lives in `.github/scripts/determine-mql-bump-base.sh`. It reads main's `go.mod` to learn cnspec's current mql import major, then:

- `release_major == main_mql_major` → `base=main`
- `release_major != main_mql_major` → `base=v{release_major}` (e.g. `v13`)

Self-updating: when main moves to `mql/v14`, an incoming mql `v13.35.1` bump automatically routes to `v13`.

## Testability

- **`bats` unit tests** in `.github/scripts/tests/determine-mql-bump-base.bats` — 10 cases covering matching/mismatched majors, v-prefixed and bare versions, pre-release suffixes, both v13-on-main and v14-on-main worlds, and the go.mod-missing-mql-import failure path. Runs in CI via the new `test-scripts.yml` workflow on any PR that touches `.github/scripts/**`.
- **`workflow_dispatch` dry-run**: `dry-run=true` runs the full workflow (base decision, checkout of resolved base branch, `go get`/`go mod tidy`, VERSION write) but skips the Create PR step and prints a summary of what would have been opened.

### Test recipes

Run bats tests locally:
```
bats -r .github/scripts/tests
```

Dry-run dispatch on this PR branch:
```
gh workflow run cnquery-update.yml -R mondoohq/cnspec \
  --ref philip/cnquery-update-route-by-major \
  -f version=v13.35.99 -f dry-run=true
# expect: base=main (today, while main is still on mql/v13)

gh workflow run cnquery-update.yml -R mondoohq/cnspec \
  --ref philip/cnquery-update-route-by-major \
  -f version=v14.0.0-rc.1 -f dry-run=true
# expect: base=v14 (the v14 branch doesn't exist yet, so the sparse
# checkout of main's scripts succeeds, the base decision resolves to
# v14, and the "checkout code" step fails visibly — this is the
# correct failure mode)
```

## Motivation
Prereq for cutting a `v13` support branch on cnspec while main becomes v14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
