### PR TITLE
✨ cli: an interactive launcher for picking and scanning a target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,22 @@ This section is for any automated reviewer (mondoo-code-review, Claude, etc.) co
   - To check a real query end to end: `cnquery run <provider> -c '<mql>'` (no TTY needed) or `cnspec policy lint ./content/<file>.mql.yaml`. **Run the query before claiming it returns the wrong thing.**
 - **Operator precedence** — MQL precedence is fixed; consult [`mqlc/parser/operators.go`](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) before flagging precedence. Notably `&&` binds tighter than `||`, so `a || b && c` already parses as `a || (b && c)` — that is usually intentional, not a bug.
 
+### Go changes: three facts that make a green run misleading
+
+These are specific to this repo and each has already let a defect through.
+
+- **The installed provider JSON is the authority for connector metadata** — `~/.config/mondoo/providers/<name>/<name>.json` (flags, options, `MinArgs`/`MaxArgs`, `Discovery`), and the shipped binary for anything read from the environment. A flag's *description* is prose and has been wrong. A previous pass invented a plausible flag mapping that survived review because it looked right.
+- **Two golangci configs must pass, and they are not the same.** `.golangci.yaml` (run by `pr-test-lint.yml`) enables only `depguard`. `.github/.golangci.yaml` (run by `pr-extended-linting.yml`) adds `unused`, `staticcheck`, `errcheck` and `ineffassign` — it is the one that fails CI on this repo. Run both:
+  ```bash
+  golangci-lint run --config=.golangci.yaml ./...
+  golangci-lint run --config=.github/.golangci.yaml ./...
+  ```
+  Note `only-new-issues: true` on the second: `unused` fires only on the code the change adds.
+- **CI runs Go tests with no providers installed.** `pr-test-lint.yml` creates an empty directory and points `PROVIDERS_PATH` at it, so `providers.ListActive()` returns nothing and any test over installed-provider metadata **skips every case and passes**. A test in that shape must report how many connectors it checked and how many it skipped, or reproduce the condition locally:
+  ```bash
+  PROVIDERS_PATH=$(mktemp -d) go test ./apps/cnspec/cmd/interactive/
+  ```
+
 ### Do not flag these — they are correct MQL
 
 Each is verified against the compiler and explained in full in [`content/CLAUDE.md`](content/CLAUDE.md). The one-liners here exist so a reviewer that never opens that file still does not raise the false positive.

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,33 @@ policy/generate:
 reporter/generate:
 	go generate ./cli/reporter
 
+# Connector metadata for the interactive launcher, extracted from mql provider
+# source. Deliberately not part of cnspec/generate: cnspec has to build with no
+# mql checkout present, so the artifact is checked in and this refreshes it.
+#
+#   make connectors/generate MQL=../mql
+#   make connectors/generate MQL=../mql ENTERPRISE=../mql-enterprise-providers
+#
+# Without ENTERPRISE the connectors that ship from the second repository are not
+# re-derived; they are carried forward from the checked-in artifact and reported
+# as such.
+.PHONY: connectors/generate
+connectors/generate:
+ifndef MQL
+	$(error MQL is not set. Point it at an mql checkout: make connectors/generate MQL=../mql)
+endif
+	go run ./internal/connectorgen/gen -mql "$(MQL)" $(if $(ENTERPRISE),-enterprise "$(ENTERPRISE)")
+
+# The same walk, printing the extraction report and writing nothing. The gap
+# list is the output that matters: it is what the provider SDK would have to
+# carry for cnspec to stop reading Go source.
+.PHONY: connectors/report
+connectors/report:
+ifndef MQL
+	$(error MQL is not set. Point it at an mql checkout: make connectors/report MQL=../mql)
+endif
+	go run ./internal/connectorgen/gen -mql "$(MQL)" $(if $(ENTERPRISE),-enterprise "$(ENTERPRISE)") -report
+
 #   🏗 Binary   #
 
 .PHONY: cnspec/build
@@ -114,6 +141,21 @@ cnspec/build/windows: cnspec/winres
 .PHONY: cnspec/install
 cnspec/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnspec/cnspec.go
+
+# cnspec/install/dev installs a build that will actually run.
+#
+# cnspec/install stamps the newest tag reachable from the current branch, which
+# during development is older than whatever release sits in the auto-update
+# cache at ~/.config/mondoo/bin. On startup cnspec compares the two and execs
+# the newer one, so a locally built binary silently hands off to a release and
+# your changes never run -- the symptom is a new subcommand reporting
+# "unknown command".
+#
+# Stamping a version no release will outrank keeps the binary you just built in
+# charge. Use this for local work; cnspec/install remains what CI and releases use.
+.PHONY: cnspec/install/dev
+cnspec/install/dev:
+	$(MAKE) cnspec/install LATEST_VERSION_TAG=v99.0.0-dev
 
 cnspec/dist/goreleaser/stable:
 	goreleaser release --clean --skip=validate,publish -f .goreleaser.yml --timeout 120m

--- a/apps/cnspec/cmd/interactive/actions.go
+++ b/apps/cnspec/cmd/interactive/actions.go
@@ -1,0 +1,99 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+// Action is one thing cnspec can do with a target, e.g. "scan" or "shell".
+type Action struct {
+	// Name is the subcommand word (e.g. "scan").
+	Name string
+	// Short describes the action for the picker.
+	Short string
+	// supported, when non-empty, restricts the action to those connector
+	// names. An empty set means the action applies to every connector.
+	supported map[string]bool
+	// primary marks the actions the launcher leads with. The rest stay one
+	// keystroke away rather than filling the pane: scanning and discovering is
+	// what a launcher is for, and seven rows of alternatives buried the fields
+	// underneath them.
+	primary bool
+}
+
+// AppliesTo reports whether this action can be used with the given connector.
+func (a Action) AppliesTo(connectorName string) bool {
+	if len(a.supported) == 0 {
+		return true
+	}
+	return a.supported[connectorName]
+}
+
+func set(names ...string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+// Actions is the ordered list of things a user can launch from the TUI. The
+// supported-connector sets mirror the SupportedConnectors declared when these
+// commands are attached in apps/cnspec/cmd/root.go, so the launcher only ever
+// offers an action that will actually run.
+var Actions = []Action{
+	{
+		Name:    "scan",
+		Short:   "Run security & compliance policies and score the target",
+		primary: true,
+	},
+	{
+		Name:  "shell",
+		Short: "Open an interactive MQL shell to explore the target",
+	},
+	{
+		Name:  "run",
+		Short: "Run a single MQL query against the target",
+	},
+	{
+		Name:    "discover",
+		Short:   "List the assets cnspec can see through this connection",
+		primary: true,
+	},
+	{
+		Name:      "vuln",
+		Short:     "Check the target for known vulnerabilities (CVEs)",
+		supported: set("docker", "container", "filesystem", "local", "ssh", "vagrant", "winrm", "vsphere", "sbom"),
+	},
+	{
+		Name:      "sbom",
+		Short:     "Generate a software bill of materials (SBOM)",
+		supported: set("docker", "container", "filesystem", "local", "ssh", "vagrant", "winrm", "sbom"),
+	},
+	{
+		Name:      "aibom",
+		Short:     "Generate an AI bill of materials (AIBOM)",
+		supported: set("local", "docker", "container", "filesystem", "ssh", "vagrant", "winrm", "ollama", "huggingface", "aws", "gcp", "azure"),
+	},
+}
+
+// ActionsFor returns the actions applicable to a connector, preserving order.
+func ActionsFor(connectorName string) []Action {
+	var out []Action
+	for _, a := range Actions {
+		if a.AppliesTo(connectorName) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// scanAction is the verb the launcher runs. The others remain declared, and
+// remain what root.go attaches, but the launcher does not offer them: a picker
+// for six verbs above the target fields cost more navigation than it saved.
+func scanAction() Action {
+	for _, a := range Actions {
+		if a.Name == "scan" {
+			return a
+		}
+	}
+	return Action{Name: "scan"}
+}

--- a/apps/cnspec/cmd/interactive/catalog.go
+++ b/apps/cnspec/cmd/interactive/catalog.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"go.mondoo.com/cnspec/cli/launcher/catalog"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The catalog itself now lives in cli/launcher/catalog. What stays here is the
+// launcher's spelling of it: `Connector`, the category names, and the two
+// entry points. Without these the extraction would have been a rename of every
+// line in this package that mentions a connector or a category -- hundreds of
+// sites, none of which was the point of moving the file.
+//
+// Connector is an alias rather than a defined type so that a value crossing
+// into cli/launcher/catalog, or arriving from it, needs no conversion and stays
+// the same type on both sides.
+
+type Connector = catalog.Connector
+
+const (
+	catHosts     = catalog.CatHosts
+	catContainer = catalog.CatContainer
+	catCloud     = catalog.CatCloud
+	catIaC       = catalog.CatIaC
+	catIdentity  = catalog.CatIdentity
+	catSaaS      = catalog.CatSaaS
+	catNetwork   = catalog.CatNetwork
+	catDatabase  = catalog.CatDatabase
+	catAI        = catalog.CatAI
+	catDev       = catalog.CatDev
+	catOther     = catalog.CatOther
+)
+
+var (
+	categoryOrder     = catalog.CategoryOrder
+	excludedProviders = catalog.ExcludedProviders
+)
+
+func BuildCatalog() []Connector { return catalog.BuildCatalog() }
+
+func connectorsOf(name string, p *plugin.Provider, installed bool) []Connector {
+	return catalog.ConnectorsOf(name, p, installed)
+}
+
+func categorize(provider, connector string) string {
+	return catalog.Categorize(provider, connector)
+}

--- a/apps/cnspec/cmd/interactive/delivery.go
+++ b/apps/cnspec/cmd/interactive/delivery.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"time"
+
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// How a credential gets from the form to the scan now lives in
+// cli/launcher/delivery, and this file is the launcher's names for it.
+//
+// The rule it enforces has not moved: the launcher runs commands by
+// re-executing cnspec, so a secret on that command line is world-readable
+// through `ps auxww`. A credential goes to the OS keychain and is referenced by
+// id; where that fails it goes into a 0600 inventory in a private directory,
+// removed on every exit this process can observe.
+//
+// What has moved is who decides what the inventory looks like. It used to be a
+// table here, one line per connector, each line a claim about a provider that
+// only somebody reading that provider's source could make. Now the connector's
+// own ParseCLI is asked, over the same gRPC call `cnspec scan` makes, and the
+// asset it answers with is the inventory. Nothing in this package has an
+// opinion about which option key a flag lands under any more, which is why
+// there is no registry left to keep in step with the providers.
+//
+// The aliases are aliases rather than a rewrite at every use for the reason
+// cli/tui/form's were: the rename would otherwise have been the change, across
+// every file that launches, curates a connector, or tests one. What the
+// boundary is for survives them -- the delivery package takes a connector as a
+// name and a flag list, so nothing here can hand it a screen, and nothing there
+// can reach back for one.
+
+type (
+	// delivery is the route a form's answers travel.
+	delivery = deliverypkg.Kind
+	// EnvSpec declares that one field's value reaches the child through the
+	// environment, in the case where naming a variable is not enough because
+	// something has to be built first.
+	EnvSpec = deliverypkg.EnvSpec
+	// savedEntry is one credential the launcher put in the keychain.
+	savedEntry = deliverypkg.SavedEntry
+)
+
+const (
+	deliverPlain     = deliverypkg.Plain
+	deliverInventory = deliverypkg.Inventory
+
+	// keychainTimeout is how long the launcher waits for the OS keychain.
+	keychainTimeout = deliverypkg.KeychainTimeout
+)
+
+// The registry itself, not a copy of it: registerEnv is called from the init of
+// the files that curate a connector, and the tests read back what those inits
+// declared.
+var envSpecs = deliverypkg.EnvSpecs
+
+// envSpecsFor returns the environment contributors declared for a connector.
+func envSpecsFor(connector string) []EnvSpec {
+	return deliverypkg.EnvSpecsFor(connector)
+}
+
+// deliveryFor decides whether the form's answers need a file to travel in.
+func deliveryFor(f form) delivery {
+	return deliverypkg.RouteFor(f)
+}
+
+// parseCLI asks a connector's provider what a filled-in form means. It is a
+// variable because the alternative is a plugin subprocess per test case: the
+// launcher's own tests care what it does with the answer, not what a provider
+// gives. The round trip against real providers is asserted separately, over
+// whatever is installed; see parsecli_test.go.
+var parseCLI = func(provider, connector string, args []string, flags map[string]*llx.Primitive) (*inventory.Asset, error) {
+	return deliverypkg.Parser.ParseCLI(provider, connector, args, flags)
+}
+
+// trackTemp registers a cleanup for something the launcher wrote and returns it
+// wrapped so that running it -- however it is reached -- also unregisters it.
+var trackTemp = deliverypkg.TrackTemp
+
+// cleanupTempFiles removes everything the launcher has written and not yet
+// cleaned up. Every exit this process can observe calls it.
+var cleanupTempFiles = deliverypkg.CleanupTempFiles
+
+// writeInventory marshals the inventory to a private 0600 file in a private
+// directory and returns its path along with a cleanup func.
+var writeInventory = deliverypkg.WriteInventory
+
+// newSecretID mints an id for a credential the launcher is about to save.
+var newSecretID = deliverypkg.NewSecretID
+
+// recordSaved adds an entry to the launcher's index of ids it created.
+var recordSaved = deliverypkg.RecordSaved
+
+// kubeEnvForContext returns the environment a child needs to target a
+// Kubernetes context, having written the kubeconfig copy that carries it.
+var kubeEnvForContext = deliverypkg.KubeEnvForContext
+
+// storeCredentialFn is the keychain write, replaceable in tests: the failure
+// path matters more than the success one and cannot be provoked otherwise.
+var storeCredentialFn = deliverypkg.StoreCredential
+
+// storeCredentialWithin is the keychain write with a bound on how long it may
+// take, whatever the backend does with the context it is given.
+//
+// The variable is read here, in the caller's goroutine, and handed over: the
+// write is left running when the wait gives up, so a goroutine that read the
+// variable itself could still be reading it after a test had put the real one
+// back.
+func storeCredentialWithin(limit time.Duration, id string, cred *vault.Credential) error {
+	return deliverypkg.StoreCredentialWithin(limit, storeCredentialFn, id, cred)
+}

--- a/apps/cnspec/cmd/interactive/detail.go
+++ b/apps/cnspec/cmd/interactive/detail.go
@@ -1,0 +1,307 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// spot is where the keys are inside the detail pane: on a field, on the row
+// that reveals the folded options, or on the scan button.
+//
+// It is one field because it is one fact, and as two bools -- moreFocused and
+// scanFocused -- it was three. The two could both be set, and when they were,
+// nothing agreed about what that meant: moveFocus read "more" first, the
+// renderer banded the reveal row *and* accented the button, and enter launched
+// a scan. Two selection bands on one screen was the visible half of it.
+type spot int
+
+const (
+	// spotField is the field at form.Cursor(). It is the resting state: a pane
+	// with fields opens on one, and every other position is left deliberately.
+	spotField spot = iota
+	// spotMore is the row that unfolds the options section.
+	spotMore
+	// spotButton is the scan button, which sits after the last field. Scanning
+	// is an explicit act: nothing else in the pane starts it.
+	spotButton
+)
+
+// detailState is the detail pane: the form for the connector under the cursor,
+// the box editing whichever of its fields has the keys, where in the pane those
+// keys are, whether the long tail of provider flags is folded away, and how far
+// the pane is scrolled.
+//
+// They are one type because they are one screen and they change together. The
+// input mirrors the field under the cursor -- loadCursorField and
+// storeCursorField are the whole of that invariant -- so a cursor that moved
+// without them was silent input loss, which is a bug this package has already
+// shipped once. showOptions decides which fields the cursor can reach at all,
+// which is why spot cannot be read without it.
+type detailState struct {
+	// form is the input screen for the connector under the cursor.
+	form form
+	// input edits whichever form field has the cursor; its value is written
+	// back to the field on every keystroke so the command bar stays live.
+	input textinput.Model
+	// spot is which of the pane's three kinds of row the keys are on.
+	spot spot
+	// showOptions reveals the long tail of provider flags, which stays folded
+	// away until asked for.
+	showOptions bool
+	// offset scrolls the pane, which outgrows the screen as soon as a form has
+	// more than a handful of fields.
+	offset tui.Scroll
+}
+
+// onMore and onButton read the pane's cursor. They exist so that the two rows
+// that are not fields are asked about by name rather than by comparing against
+// a constant at twenty call sites.
+func (d detailState) onMore() bool   { return d.spot == spotMore }
+func (d detailState) onButton() bool { return d.spot == spotButton }
+
+// onField reports whether the keys are on a field rather than on the reveal row
+// or the button, which is what decides whether a keystroke is input.
+func (d detailState) onField() bool { return d.spot == spotField }
+
+// leaveMore and leaveButton put the keys back on a field, but only from the row
+// named. They are two methods rather than one assignment because the callers
+// are undoing one specific position -- the reveal row is gone because the
+// options were just unfolded, the button is released because focus left the
+// pane -- and an unconditional reset would move the keys off a row the caller
+// said nothing about.
+func (d *detailState) leaveMore() {
+	if d.spot == spotMore {
+		d.spot = spotField
+	}
+}
+
+func (d *detailState) leaveButton() {
+	if d.spot == spotButton {
+		d.spot = spotField
+	}
+}
+
+// focusableFields are the fields the keyboard can currently reach: the visible
+// ones, minus the folded-away options.
+func (d detailState) focusableFields() []int {
+	out := make([]int, 0, len(d.form.Fields()))
+	for _, i := range d.form.VisibleIndices() {
+		if !d.showOptions && d.form.Fields()[i].Section == sectionOptions {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// hasMoreRow reports whether the folded options are worth a row of their own.
+func (d detailState) hasMoreRow() bool {
+	if d.showOptions {
+		return false
+	}
+	for _, i := range d.form.VisibleIndices() {
+		if d.form.Fields()[i].Section == sectionOptions {
+			return true
+		}
+	}
+	return false
+}
+
+// loadCursorField binds the shared text input to the field under the cursor.
+func (d *detailState) loadCursorField() {
+	if d.form.Cursor() < 0 || d.form.Cursor() >= len(d.form.Fields()) {
+		return
+	}
+	fd := d.form.Fields()[d.form.Cursor()]
+	// A credential-state field is a readout, not an input: binding the shared
+	// text box to it would put a cursor on a sentence the user cannot edit.
+	if fd.Kind == fieldCredentialState {
+		d.input.SetValue("")
+		d.input.Blur()
+		return
+	}
+	d.input.SetValue(fd.Value())
+	d.input.CursorEnd()
+	d.input.EchoMode = textinput.EchoNormal
+	if fd.Secret || fd.Kind == fieldPaste {
+		d.input.EchoMode = textinput.EchoPassword
+	}
+	d.input.Focus()
+}
+
+// storeCursorField writes the shared input back into the focused field.
+func (d *detailState) storeCursorField() {
+	if d.form.Cursor() < 0 || d.form.Cursor() >= len(d.form.Fields()) {
+		return
+	}
+	// A credential-state field's value is what the launcher discovered, not
+	// what the shared input holds, so writing the input back over it would
+	// erase the readout the moment the cursor passed through.
+	if fd := &d.form.Fields()[d.form.Cursor()]; fd.Kind != fieldBool &&
+		fd.Kind != fieldMultiChoice && fd.Kind != fieldCredentialState {
+		fd.SetValue(d.input.Value())
+	}
+}
+
+// applyPrefill fills a field whose picker came back with an unambiguous answer.
+// It never overwrites what the user typed: a late-arriving source must not move
+// the ground under someone who is already editing.
+//
+// focused is whether the pane has the keys, which the pane cannot answer for
+// itself -- see Model.focus, which says which of the two panes they are in.
+func (d *detailState) applyPrefill(source string, values []string, focused bool) {
+	value, why := preferredValue(source, values)
+	if value == "" {
+		return
+	}
+	for i := range d.form.Fields() {
+		fd := &d.form.Fields()[i]
+		if fd.Source() != source || fd.Value() != "" {
+			continue
+		}
+		fd.SetValue(value)
+		fd.SetPrefilled(why)
+		for j, opt := range fd.Options {
+			if opt == value {
+				fd.SetOptCursor(j)
+			}
+		}
+		// The shared input mirrors the focused field, so it has to follow.
+		if focused && d.form.Cursor() == i {
+			d.loadCursorField()
+		}
+	}
+}
+
+// The command preview lives on launchRequest, not here. See preview in
+// launch.go: it is the same words plan() runs, and it moved because assembling
+// them twice is what let the bar and the command disagree.
+
+// The detail pane is described once, as a flat list of items, and both the
+// renderer and the layout walk that list. One item is exactly one line, so a
+// click zone cannot land on a row the renderer drew something else on -- the
+// two cannot drift because there is only one description to drift from.
+
+type detailItemKind int
+
+const (
+	diBlank   detailItemKind = iota
+	diLabel                  // a section heading
+	diText                   // a plain line
+	diField                  // idx is the form field index
+	diMore                   // the row that reveals the options
+	diButton                 // the scan button
+	diCommand                // the command bar
+)
+
+// expandedRows is how many values an open picker shows at once. Enough to
+// browse, not so many that the fields below it disappear.
+
+type detailItem struct {
+	kind detailItemKind
+	idx  int
+	text string
+}
+
+// detailPlan lays out the connector detail pane.
+func (m Model) detailPlan() []detailItem {
+	c, ok := m.list.current()
+	if !ok {
+		return nil
+	}
+
+	// No action list. The launcher is for scanning; showing six alternatives
+	// above the fields meant a whole navigation layer, and a focus stop, before
+	// reaching the thing the user came to fill in.
+	out := []detailItem{
+		{kind: diBlank},
+		{kind: diText, text: c.Short},
+	}
+
+	// A pane with no fields on it has to say why, and there are two different
+	// reasons -- which is what the single "install its provider" line used to
+	// get wrong. `device` is installed and declares nine flags, all of them
+	// Hidden or Deprecated, so there is nothing to ask and nothing to install;
+	// `mondoo` is installed and declares nothing at all, because its target is
+	// the workstation's own registration. Telling either of them to install a
+	// provider they already have is the wrong sentence.
+	//
+	// The condition is what the form actually built, not what the connector
+	// claims. A spec's positional fields survive on an uninstalled connector --
+	// kustomize asks for its overlay path whether or not the provider is here
+	// yet -- so a pane can be usefully full while the metadata behind it is
+	// still the flagless static entry.
+	if m.list.downloading(c) {
+		out = append(out,
+			detailItem{kind: diBlank},
+			detailItem{kind: diText, text: "installing the " + c.Provider + " provider…"})
+	} else if len(m.detail.form.Fields()) == 0 {
+		text := "nothing to configure — press Scan"
+		if !c.Installed {
+			text = "open this connector to install its provider"
+		}
+		out = append(out, detailItem{kind: diBlank}, detailItem{kind: diText, text: text})
+	}
+
+	sections, bySection := m.detail.form.Ordered()
+	for _, s := range sections {
+		var shown []int
+		for _, idx := range bySection[s] {
+			if m.detail.form.Visible(idx) {
+				shown = append(shown, idx)
+			}
+		}
+		if len(shown) == 0 {
+			continue
+		}
+
+		// Everything a connector declares is not a configuration screen. The
+		// target and the credential are the questions worth asking; the rest is
+		// a long tail that belongs behind one row until it is wanted -- k8s
+		// alone puts eight of them between the target and the scan button.
+		if s == sectionOptions && !m.detail.showOptions {
+			out = append(out, detailItem{kind: diBlank},
+				detailItem{kind: diMore, idx: len(shown)})
+			continue
+		}
+
+		out = append(out, detailItem{kind: diBlank}, detailItem{kind: diLabel, text: s})
+		for _, idx := range shown {
+			out = append(out, detailItem{kind: diField, idx: idx})
+		}
+	}
+
+	out = append(out, detailItem{kind: diBlank}, detailItem{kind: diButton})
+	return out
+}
+
+// splitPlan separates the scrolling body from the command bar, which is pinned
+// to the last line of the pane. It is what the whole screen is building toward,
+// so it must never be the thing that scrolls out of view.
+func splitPlan(plan []detailItem) (body []detailItem, command detailItem) {
+	return plan, detailItem{kind: diCommand}
+}
+
+// ensureFieldVisible scrolls the detail pane so the focused field is on screen.
+func (m *Model) ensureFieldVisible() {
+	if m.focus != focusForm {
+		return
+	}
+	plan := m.detailPlan()
+	row := -1
+	for i, item := range plan {
+		if item.kind == diField && item.idx == m.detail.form.Cursor() {
+			row = i
+			break
+		}
+	}
+	if row < 0 {
+		return
+	}
+	l := tui.Dims(m.width, m.height)
+	visible := tui.InnerHeight(l.BodyH) - 1 // the pinned command bar
+	m.detail.offset.EnsureVisible(row, len(plan), visible)
+}

--- a/apps/cnspec/cmd/interactive/entries.go
+++ b/apps/cnspec/cmd/interactive/entries.go
@@ -1,0 +1,19 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import "strings"
+
+// The launcher's list holds connectors and nothing else. Every row leads to a
+// command; a row that leads nowhere is a dead end in a UI built around running
+// things, which is why the AI-agent skills that used to sit here were removed.
+
+func matchesTokens(haystack string, tokens []string) bool {
+	for _, t := range tokens {
+		if !strings.Contains(haystack, t) {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/cnspec/cmd/interactive/export.go
+++ b/apps/cnspec/cmd/interactive/export.go
@@ -1,0 +1,532 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/cockroachdb/errors"
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// A scan configured here is already an inventory: the connector's own ParseCLI
+// builds the asset, the launcher writes it to a 0600 file, points a child at it
+// and deletes it. Exporting keeps that file instead of deleting it, at a path
+// the user names, which is the whole feature -- an exported inventory is a
+// valid `cnspec scan --inventory-file` input, so a cron entry or a CI job runs
+// the identical scan without anybody retyping the flags.
+//
+// # What the box has to say, and why it is not the same as the scan's warning
+//
+// The launcher puts a credential in the OS keychain and leaves a reference to
+// it in the inventory (see delivery/parsecli.go: vault.VaultType_KeyRing, with
+// no vault picker, because a TUI is not where a CI runner is configured). That
+// is invisible and harmless for a file that lives for the length of one scan,
+// and it is the defining property of a file the user is about to carry
+// somewhere: the reference resolves against *this* machine's keychain, as
+// *this* user. Someone moving the file to a runner has to be told that here,
+// not by a secret that fails to resolve at 3am.
+//
+// Some connectors need more than a line. A provider that keeps its key in
+// conn.Options never sees a vault reference, so its inventory carries the
+// secret itself. The scan's copy of that file is 0600 and deleted when it
+// finishes; an exported one is 0600 and stays where it was put, which is a
+// materially different exposure -- it can be copied, backed up, or committed.
+// The box says so before the write, naming the provider and the flag.
+//
+// It reads that out of deliverypkg.Locate rather than from a list of connector
+// names, and the list is why. Everything here used to name four -- openai,
+// ollama, huggingface, claude -- and the installed provider set has thirteen
+// such fields across eleven connectors, four of which put a *different*
+// credential from the same form somewhere the keychain can hold. A box that
+// disclosed from the list would have been silent for datadog's --app-key while
+// writing it into the file. Locate looks for the value the launcher sent in the
+// asset that came back, so a provider that changes its mind changes this text
+// with it.
+//
+// # Shape
+//
+// It follows the report viewer's export modal (cli/reportview/export.go) rather
+// than inventing a second idiom: a box that takes the body, a destination the
+// user can see before pressing the key, O_EXCL so a write never replaces a file
+// that is already there, and a one-line footer notice afterwards. The
+// difference is what is chosen. The viewer picks a format out of four and
+// derives the name; here there is one format and the *path* is what the user
+// picks, because the path is where a scheduled job will look for it.
+
+// exportState is the export modal: whether it is open, what the provider made
+// of the form, and the name the file will be written under.
+//
+// It carries its own copy of the connector and the launch request rather than
+// reading them off the Model when the write happens. The two are separated by
+// however long an OS keychain dialog stays up, and in between the user can
+// still be moved off this connector by a provider finishing its install --
+// rebuildForm runs underneath whatever is on screen. Writing the inventory that
+// was described in the box is the only correct answer to that race.
+type exportState struct {
+	open bool
+
+	// seq identifies this opening of the box. Both halves of the flow answer
+	// asynchronously, and the answer to a box that has since been closed and
+	// reopened must not land in the new one.
+	seq int
+
+	// asking is true while the connector's provider is being asked what the
+	// form means; writing is true while the file is being written.
+	asking  bool
+	writing bool
+
+	// ready is set once the provider has answered, and is what the enter key
+	// waits for. It is not "asking == false": a refusal also ends the asking
+	// and leaves nothing to write.
+	ready bool
+
+	// name is the path as typed. It is edited in place with the keys rather
+	// than by a textinput.Model, the way the value picker's filter is: a second
+	// focus-managing widget on a screen that already has one is how the shared
+	// input ends up bound to two things at once.
+	name string
+
+	connector Connector
+	req       launchRequest
+	parsed    parsedForm
+
+	// err is the last refusal, shown in the box. It leaves the box open on
+	// purpose -- "your export did not happen" is not a message to show for one
+	// keystroke, which is what the footer would do with it.
+	err error
+}
+
+// busy reports whether something is happening that the keys must not interrupt.
+func (x exportState) busy() bool { return x.asking || x.writing }
+
+// The prose the box is built from.
+const (
+	exportTitle = "Export inventory"
+	// The subtitle says what the file is *for*, which is the only reason to
+	// keep one rather than let the scan delete it.
+	exportSubtitle = "a reusable scan: cnspec scan --inventory-file <this file>"
+
+	// exportKeychainNote is the one line the whole feature owes the user. See
+	// the package comment above for why it is not optional.
+	exportKeychainNote = "The secret stays in this machine's OS keychain and the file only " +
+		"references it, so this inventory reproduces the scan on this machine, as this user — " +
+		"on another machine or a CI runner the reference will not resolve."
+
+	// exportAmbientNote is what an inventory with no secret in it says instead.
+	// It is deliberately not silence: "nothing to warn about" and "we did not
+	// look" read the same on screen.
+	exportAmbientNote = "This inventory carries no secret: the scan will use whatever credentials " +
+		"and files the machine running it already provides."
+)
+
+// exportPlaintextNote is the case the one line above is not enough for.
+//
+// It names the provider and the flag because that is the actionable part -- the
+// user can move the key out of the file and into that provider's own
+// environment variable afterwards -- and it draws the contrast with the scan's
+// own inventory, which is the reason this is worth saying at all: the exposure
+// the user has already accepted is not the exposure they are about to create.
+func exportPlaintextNote(connector string, flags []string) string {
+	return "The " + connector + " provider reads " + flagList(flags) + " as a connection option " +
+		"rather than as a credential, so the OS keychain cannot hold it and this file carries the " +
+		"secret in plain text. A scan's own inventory is deleted when it finishes; this one stays " +
+		"where you put it, so keep it out of version control and off shared machines."
+}
+
+// exportNote is one thing the box says about the file before it is written.
+type exportNote struct {
+	// warn marks a note describing a weaker guarantee than the file's 0600
+	// suggests, which is drawn in the warning color.
+	warn bool
+	text string
+}
+
+// notes is what this particular export has to disclose, read from what the
+// provider did with the secrets rather than from a table of connector names.
+func (x exportState) notes() []exportNote {
+	if !x.ready {
+		return nil
+	}
+	var out []exportNote
+	if deliverypkg.Keychainable(x.parsed.placed) != nil {
+		out = append(out, exportNote{text: exportKeychainNote})
+	}
+	if plain := x.parsed.plaintextFlags(); len(plain) > 0 {
+		out = append(out, exportNote{warn: true, text: exportPlaintextNote(x.connector.Name, plain)})
+	}
+	if len(out) == 0 {
+		out = append(out, exportNote{text: exportAmbientNote})
+	}
+	return out
+}
+
+// defaultExportName is what the box opens with.
+//
+// Nothing has to be slugged out of it, which is the difference from the report
+// viewer's exportSlug: that one derives a file name from an asset name, which
+// can be an ARN or a container digest, and this one derives it from a connector
+// name -- a flag-shaped identifier the provider declared. What follows it is
+// typed by the user, whose target this is to name.
+func defaultExportName(c Connector) string { return c.Name + ".inventory.yml" }
+
+// path resolves what was typed into the file that will be written.
+func (x exportState) path() (string, error) {
+	name := strings.TrimSpace(x.name)
+	if name == "" {
+		return "", errors.New("give the file a name")
+	}
+
+	// ~ is expanded here because there is no shell to expand it: a TUI that
+	// takes "~/scans/prod.yml" literally creates a directory called "~" in the
+	// working directory and puts the file somewhere the user will never look
+	// for it again.
+	if name == "~" || name == "~/" {
+		return "", errors.New("~ is a directory, not a file name")
+	}
+	if rest, ok := strings.CutPrefix(name, "~/"); ok {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", errors.Wrap(err, "cannot resolve ~")
+		}
+		name = filepath.Join(home, rest)
+	}
+
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return "", errors.Wrapf(err, "cannot resolve %s", name)
+	}
+	// Caught here rather than by the open: O_EXCL on a directory reports EISDIR
+	// or EEXIST depending on the platform, and neither says what the user did.
+	if info, err := os.Stat(abs); err == nil && info.IsDir() {
+		return "", errors.Newf("%s is a directory", abs)
+	}
+	return abs, nil
+}
+
+// exportDisplay is a written path as the user would type it again: relative to
+// the working directory when it is below it, absolute otherwise.
+//
+// The footer says the path twice -- what was written, and the command that
+// reads it -- and two absolute paths do not fit on a line.
+func exportDisplay(path string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	rel, err := filepath.Rel(wd, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return "./" + rel
+}
+
+// exportNotice is the footer line after a successful write. It hands over the
+// command the file exists for, so the next step is a paste rather than a
+// recollection of what --inventory-file is called.
+func exportNotice(path string) string {
+	shown := exportDisplay(path)
+	return "wrote " + shown + " — run it with: cnspec scan --inventory-file " + shown
+}
+
+// --- the two asynchronous halves --------------------------------------------
+
+// exportParsedMsg is the provider's reading of the form, on its way back.
+type exportParsedMsg struct {
+	seq    int
+	parsed parsedForm
+	err    error
+}
+
+// exportWroteMsg is the outcome of a write.
+type exportWroteMsg struct {
+	seq  int
+	path string
+	err  error
+}
+
+// exportParseCmd asks the connector's provider what the form means, off the
+// event loop.
+//
+// It writes nothing and touches no keychain, which is what makes it safe to run
+// on a key press the user has not yet confirmed: opening the box costs a plugin
+// subprocess and a gRPC round trip, and nothing else.
+func exportParseCmd(seq int, r launchRequest, c Connector) tea.Cmd {
+	return func() tea.Msg {
+		parsed, err := r.parseForm(c)
+		return exportParsedMsg{seq: seq, parsed: parsed, err: err}
+	}
+}
+
+// exportWriteCmd saves the credential and writes the file, off the event loop
+// for the same reason prepareLaunchCmd is: a locked keychain raises an OS
+// dialog and does not return until it is answered, and doing that from Update
+// freezes the TUI behind a window it is not drawing.
+func exportWriteCmd(seq int, r launchRequest, c Connector, parsed parsedForm, path string) tea.Cmd {
+	return func() tea.Msg {
+		err := r.exportInventory(c, parsed, path)
+		return exportWroteMsg{seq: seq, path: path, err: err}
+	}
+}
+
+// exportInventory saves the credential to the OS keychain and writes the
+// inventory that references it.
+//
+// A keychain failure refuses the export, where the launch path warns and
+// carries on. That is not an inconsistency: the launch falls back to a 0600
+// file that is deleted when the scan ends, and this one would fall back to a
+// file at a path the user chose, holding their password, after a box that had
+// just told them the secret stays in the keychain. Silently making that
+// sentence false is worse than not writing the file.
+func (r launchRequest) exportInventory(c Connector, parsed parsedForm, path string) error {
+	secretID, saved, err := r.saveCredential(c, parsed.placed)
+	if err != nil {
+		return errors.Wrap(err, "the OS keychain would not hold the credential, and the "+
+			"exported file must not carry it in plain text instead")
+	}
+	return deliverypkg.ExportInventory(
+		deliverypkg.InventoryFor(c.Name, parsed.asset, saved, secretID), path)
+}
+
+// --- frame integration ------------------------------------------------------
+
+// openExport opens the box on the connector under the cursor.
+//
+// An incomplete form does not export, for the same reason it does not launch:
+// what would be written is a target the provider could not make sense of, and
+// the useful answer is the field that is missing rather than a file that does
+// not scan anything.
+func (m Model) openExport() (tea.Model, tea.Cmd) {
+	c, ok := m.list.current()
+	if !ok {
+		return m, nil
+	}
+	if err := m.detail.form.Validate(); err != nil {
+		m.lastErr = err.Error()
+		m.focus = focusForm
+		m.focusFirstMissing()
+		return m, textinput.Blink
+	}
+
+	m.export = exportState{
+		open:      true,
+		asking:    true,
+		seq:       m.export.seq + 1,
+		name:      defaultExportName(c),
+		connector: c,
+		req:       m.launchRequestFrom(),
+	}
+	// The spinner is only ticking while something is loading, so restart it.
+	return m, tea.Batch(exportParseCmd(m.export.seq, m.export.req, c), m.spinner.Tick)
+}
+
+// exportKey drives the open box. Nothing here reaches a pane and nothing here
+// quits: a modal that lets a key end the program underneath it is a modal that
+// loses the form the user just filled in.
+func (m Model) exportKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+e":
+		// seq survives the close, so an answer still in flight lands nowhere.
+		m.export = exportState{seq: m.export.seq}
+		return m, nil
+	case "enter":
+		return m.startExport()
+	case "backspace":
+		if !m.export.busy() {
+			m.export.name = trimLastRune(m.export.name)
+			m.export.err = nil
+		}
+		return m, nil
+	}
+
+	// KeySpace as well as KeyRunes: bubbletea reports a lone space as its own
+	// key type with the rune still attached (key.go, "a single KeyRunes or
+	// KeySpace event"), so matching only KeyRunes silently drops every space --
+	// and a file name with spaces in it is an ordinary thing to want,
+	// especially on macOS.
+	if !m.export.busy() && (msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace) {
+		m.export.name += string(msg.Runes)
+		// The name just changed, so whatever the last attempt was refused for
+		// is no longer what the box is describing.
+		m.export.err = nil
+	}
+	return m, nil
+}
+
+// startExport writes the file, having resolved where it goes first: a path the
+// launcher cannot use is a message in the box, not a failed write.
+func (m Model) startExport() (tea.Model, tea.Cmd) {
+	if m.export.busy() || !m.export.ready {
+		return m, nil
+	}
+	path, err := m.export.path()
+	if err != nil {
+		m.export.err = err
+		return m, nil
+	}
+	m.export.err = nil
+	m.export.writing = true
+	return m, tea.Batch(
+		exportWriteCmd(m.export.seq, m.export.req, m.export.connector, m.export.parsed, path),
+		m.spinner.Tick)
+}
+
+// exportParsed takes the provider's answer.
+func (m Model) exportParsed(msg exportParsedMsg) (tea.Model, tea.Cmd) {
+	if !m.export.open || msg.seq != m.export.seq {
+		// The box was closed, or closed and reopened, while the provider was
+		// being asked. Nothing was written and nothing was saved, so there is
+		// nothing to report.
+		return m, nil
+	}
+	m.export.asking = false
+	if msg.err != nil {
+		m.export.err = msg.err
+		return m, nil
+	}
+	m.export.parsed = msg.parsed
+	m.export.ready = true
+	return m, nil
+}
+
+// exportWrote takes the outcome of a write.
+//
+// A completed write is a fact about the filesystem, so it is reported whether
+// or not the box that started it is still up -- dismissing the box while an OS
+// keychain dialog is on screen is an ordinary thing to do, and a file that
+// appeared without a word is worse than one that is announced late.
+func (m Model) exportWrote(msg exportWroteMsg) (tea.Model, tea.Cmd) {
+	mine := m.export.open && msg.seq == m.export.seq
+	if mine && msg.err != nil {
+		m.export.writing = false
+		m.export.err = msg.err
+		return m, nil
+	}
+	if mine {
+		m.export = exportState{seq: m.export.seq}
+	}
+	if msg.err != nil {
+		m.lastErr = "export failed: " + tui.OneLine(msg.err.Error())
+		return m, nil
+	}
+	m.lastNote = exportNotice(msg.path)
+	return m, nil
+}
+
+// --- rendering --------------------------------------------------------------
+
+// viewExport draws the box, occupying exactly bodyH lines so the footer does
+// not move. The geometry is the launcher's other two modals' (modalGeom,
+// modalBox, lipgloss.Place), so the three read as one program.
+func (m Model) viewExport(l layout) string {
+	x := m.export
+	boxW, contentW := modalGeom(l.Width)
+
+	var b strings.Builder
+	b.WriteString(tui.StyleAccent.Render(tui.Truncate(exportTitle, contentW)))
+	b.WriteString("\n")
+	b.WriteString(tui.StyleFaint.Render(tui.Truncate(exportSubtitle, contentW)))
+	b.WriteString("\n\n")
+
+	if x.asking {
+		b.WriteString(m.spinner.View() + " " + tui.StyleDim.Render(tui.Truncate(
+			"asking the "+x.connector.Name+" provider what these settings mean…", contentW-2)))
+		b.WriteString("\n\n")
+	} else if x.ready {
+		// The name is a band rather than a bordered box because it is the only
+		// thing on this screen the keys can reach, and the launcher already
+		// spells "the keys are here" as a band everywhere else.
+		b.WriteString(tui.Bar(tui.Truncate("  "+x.name+"▌", contentW), contentW, tui.BandSelected))
+		b.WriteString("\n\n")
+	}
+
+	for _, note := range x.notes() {
+		style := tui.StyleDim
+		prefix := "  "
+		if note.warn {
+			style = tui.StyleWarn
+			prefix = "! "
+		}
+		for i, wrapped := range tui.WrapWords(note.text, contentW-2) {
+			if i > 0 {
+				prefix = "  "
+			}
+			b.WriteString(style.Render(prefix + wrapped))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(x.status(m.spinner.View(), contentW))
+	b.WriteString("\n\n")
+	b.WriteString(tui.StyleFaint.Render(tui.Truncate(x.help(), contentW)))
+
+	box := modalBox.Width(boxW).Render(b.String())
+	return lipgloss.Place(l.Width, l.BodyH, lipgloss.Center, lipgloss.Center, box)
+}
+
+// status is the line above the key hints: why nothing was written, what is
+// being written, or -- the ordinary case -- the exact path the enter key would
+// write to, so "where does it go" is answered before the key is pressed.
+//
+// Every string that came from outside this package goes through tui.OneLine
+// first. A provider's refusal is a wrapped error chain from somewhere else and
+// several of them contain newlines; truncating to a width does not remove a
+// newline, so an unflattened one adds rows to a box whose height the layout has
+// already committed to.
+func (x exportState) status(spinner string, w int) string {
+	switch {
+	case x.err != nil:
+		return tui.StyleBad.Render(tui.Truncate("! "+tui.OneLine(x.err.Error()), w))
+	case x.writing:
+		return spinner + " " + tui.StyleDim.Render(tui.Truncate("writing "+x.name+"…", w-2))
+	case !x.ready:
+		return ""
+	}
+	path, err := x.path()
+	if err != nil {
+		return tui.StyleWarn.Render(tui.Truncate("! "+tui.OneLine(err.Error()), w))
+	}
+	// The head of a path is what goes, not its tail. An absolute path under a
+	// deep working directory overflows the box, and cutting the end of it hides
+	// the one part the user chose and can check -- the file name.
+	return tui.StyleDim.Render("→ " + truncateTail(path, w-2))
+}
+
+// help is the key line. It says what enter does rather than naming the action,
+// because for the four connectors whose secret cannot go to the keychain what
+// enter does is the thing the user is being asked to agree to.
+func (x exportState) help() string {
+	switch {
+	case x.busy():
+		return "esc cancel"
+	case !x.ready:
+		return "esc close"
+	case len(x.parsed.plaintextFlags()) > 0:
+		// Kept inside the box's content width rather than written out in full:
+		// a hint that says what enter agrees to and is then truncated to
+		// "…in plain t…" has said nothing. The whole of it is in the note above.
+		return "type to name · enter write, secret in plain text · esc cancel"
+	default:
+		return "type to name the file · enter write · esc cancel"
+	}
+}
+
+// exportHint is the footer's offer of this box.
+//
+// It is offered only for a form that could be launched, which is the same rule
+// the ^o hint follows: an export of an incomplete target is a file that scans
+// nothing, and a key hint for it would be a promise the launcher cannot keep.
+func (m Model) exportHint() string {
+	if !m.readyToRun() {
+		return ""
+	}
+	return tui.HintSep + tui.Kbd("^e", "export")
+}

--- a/apps/cnspec/cmd/interactive/export_test.go
+++ b/apps/cnspec/cmd/interactive/export_test.go
@@ -1,0 +1,782 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/viper"
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/mql/cli/inventoryloader"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// An exported inventory is only worth anything if `cnspec scan --inventory-file`
+// can read it, so nothing here asserts that a file is non-empty yaml. Every
+// write goes back in through inventoryloader.Parse, which is the function
+// scan.go calls (apps/cnspec/cmd/scan.go, via ParseOrUse) -- the same reading,
+// the same PreProcess, the same failure if a credential reference is malformed.
+
+// stubKeychain replaces the OS keychain write and the index it records to.
+//
+// Without it every test here would raise a real authentication dialog on the
+// developer's machine and then leave a real credential in their login keyring.
+// The returned map is what was "saved", keyed by the id the inventory will
+// reference.
+func stubKeychain(t *testing.T) map[string]*vault.Credential {
+	t.Helper()
+	saved := map[string]*vault.Credential{}
+	prevStore, prevRecord := storeCredentialFn, recordSaved
+	t.Cleanup(func() { storeCredentialFn, recordSaved = prevStore, prevRecord })
+
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		saved[id] = cred
+		return nil
+	}
+	recordSaved = func(savedEntry) error { return nil }
+	return saved
+}
+
+// loadExported reads a written file the way `cnspec scan --inventory-file` does.
+//
+// The path travels through viper because that is the only way in: Parse reads
+// the flag out of the global config rather than taking an argument, so a test
+// that wants the real loader has to set it the way cobra would.
+func loadExported(t *testing.T, path string) *inventory.Inventory {
+	t.Helper()
+	prev := viper.GetString("inventory-file")
+	viper.Set("inventory-file", path)
+	t.Cleanup(func() { viper.Set("inventory-file", prev) })
+
+	inv, err := inventoryloader.Parse()
+	if err != nil {
+		data, _ := os.ReadFile(path)
+		t.Fatalf("cnspec cannot read the inventory we exported: %v\n%s", err, data)
+	}
+	if inv == nil || len(inv.Spec.GetAssets()) == 0 {
+		t.Fatalf("the exported inventory loaded with no assets in it")
+	}
+	return inv
+}
+
+// exportSSHForm is the filled ssh form the export tests start from: a target
+// and a password, which is the shape that puts a credential in the keychain.
+func exportSSHForm(t *testing.T) (Connector, form) {
+	t.Helper()
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+	return c, f
+}
+
+// exportTo runs the export the way the box does and returns the path written.
+func exportTo(t *testing.T, c Connector, f form, path string) {
+	t.Helper()
+	r := launchRequest{form: f}
+	parsed, err := r.parseForm(c)
+	if err != nil {
+		t.Fatalf("the provider refused the form: %v", err)
+	}
+	if err := r.exportInventory(c, parsed, path); err != nil {
+		t.Fatalf("the export failed: %v", err)
+	}
+}
+
+// The claim the whole feature rests on: what the box writes is a file the scan
+// command reads.
+func TestTheExportedInventoryLoadsThroughTheScanLoader(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+	c, f := exportSSHForm(t)
+
+	path := filepath.Join(t.TempDir(), "ssh.inventory.yml")
+	exportTo(t, c, f, path)
+
+	inv := loadExported(t, path)
+	asset := inv.Spec.Assets[0]
+	if len(asset.Connections) == 0 {
+		t.Fatalf("the exported asset has no connection: %+v", asset)
+	}
+	if got := asset.Connections[0].Type; got != c.Name {
+		t.Errorf("connection type = %q, want %q", got, c.Name)
+	}
+	// A loaded inventory that names the keyring is what makes the reference
+	// resolvable at scan time; without it the id points at nothing.
+	if inv.Spec.Vault == nil || inv.Spec.Vault.Type != vault.VaultType_KeyRing {
+		t.Fatalf("the exported inventory does not name the OS keychain: %+v", inv.Spec.Vault)
+	}
+}
+
+// The secret is in the keychain, and therefore not in the file.
+//
+// This is the assertion behind the sentence the box shows. If it ever fails,
+// the box is telling the user their password stayed in the keychain while the
+// file they just put in a repository holds it.
+func TestTheExportedFileHoldsAReferenceAndNotTheSecret(t *testing.T) {
+	keychain := stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+	c, f := exportSSHForm(t)
+
+	path := filepath.Join(t.TempDir(), "ssh.inventory.yml")
+	exportTo(t, c, f, path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), sentinel) {
+		t.Fatalf("the exported file carries the secret:\n%s", data)
+	}
+	if len(keychain) != 1 {
+		t.Fatalf("the keychain holds %d credentials, want the one the file references", len(keychain))
+	}
+
+	var id string
+	for k := range keychain {
+		id = k
+	}
+	inv := loadExported(t, path)
+	refs := 0
+	for _, conn := range inv.Spec.Assets[0].Connections {
+		for _, cred := range conn.Credentials {
+			if cred.SecretId == id {
+				refs++
+			}
+		}
+	}
+	if refs != 1 {
+		t.Fatalf("the loaded inventory references the saved credential %d times, want once", refs)
+	}
+}
+
+// The exported file is the user's, so it is written where they said, once, and
+// readable only by them.
+func TestTheExportedFileIsPrivateAndNeverOverwritten(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+	c, f := exportSSHForm(t)
+
+	path := filepath.Join(t.TempDir(), "ssh.inventory.yml")
+	exportTo(t, c, f, path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("the exported inventory is %v, want 0600", perm)
+	}
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second export to the same path must refuse rather than replace: the
+	// launcher cannot tell a collision from an intention, and only one of the
+	// two readings can be undone.
+	r := launchRequest{form: f}
+	parsed, err := r.parseForm(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = r.exportInventory(c, parsed, path)
+	if err == nil {
+		t.Fatal("exporting over an existing file was allowed")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("the refusal does not say what happened: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Error("the refused export still changed the file that was there")
+	}
+}
+
+// A keychain that will not hold the credential refuses the export, where the
+// same failure only warns a scan.
+//
+// The difference is the file. A scan falls back to a 0600 inventory that is
+// deleted when it finishes; an export would fall back to a file at a path the
+// user chose, holding their password, immediately after a box that told them
+// the secret stays in the keychain.
+func TestExportRefusesWhenTheKeychainWillNotHoldTheSecret(t *testing.T) {
+	prev := storeCredentialFn
+	t.Cleanup(func() { storeCredentialFn = prev })
+	storeCredentialFn = func(string, *vault.Credential) error {
+		return errors.New("keyring unavailable")
+	}
+	withParser(t, &fakeParser{secretFlag: "password"})
+	c, f := exportSSHForm(t)
+
+	path := filepath.Join(t.TempDir(), "ssh.inventory.yml")
+	r := launchRequest{form: f}
+	parsed, err := r.parseForm(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = r.exportInventory(c, parsed, path)
+	if err == nil {
+		t.Fatal("the export was written with the secret in it after the keychain failed")
+	}
+	if !strings.Contains(err.Error(), "keychain") || !strings.Contains(err.Error(), "plain text") {
+		t.Errorf("the refusal does not explain itself: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("a file was written anyway: %v", err)
+	}
+
+	// And the same failure still lets a scan run, which is the behaviour this
+	// must not have changed.
+	plan, planErr := r.plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if planErr != nil {
+		t.Fatalf("a keychain failure must not stop a scan: %v", planErr)
+	}
+	if plan.warn == "" {
+		t.Error("the scan's fallback to a file stopped warning")
+	}
+}
+
+// The four connectors whose provider keeps the key in conn.Options get a file
+// with the secret in it -- and a box that said so first.
+//
+// Both halves are asserted together on purpose. The warning is only honest
+// because the secret really is there, and the write is only defensible because
+// the warning really is shown.
+func TestAPlaintextProviderIsDisclosedAndThenExportedAsDisclosed(t *testing.T) {
+	stubKeychain(t)
+	// No secretFlag: every flag becomes a connection option, which is what
+	// openai, ollama, huggingface and claude do with their key.
+	withParser(t, &fakeParser{})
+	withAmbientEnv(t, nil)
+
+	c, f := formFor(t, "openai")
+	fieldByLabel(t, f, "API key").SetValue(aiKey)
+
+	r := launchRequest{form: f}
+	parsed, err := r.parseForm(c)
+	if err != nil {
+		t.Fatalf("the provider refused the form: %v", err)
+	}
+	plain := parsed.plaintextFlags()
+	if len(plain) != 1 || plain[0] != "token" {
+		t.Fatalf("the key was located as %v, want the --token option", plain)
+	}
+
+	// What the user reads before pressing enter.
+	note := exportPlaintextNote(c.Name, plain)
+	for _, want := range []string{"openai", "--token", "plain text", "version control"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("the disclosure does not mention %q: %q", want, note)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "openai.inventory.yml")
+	if err := r.exportInventory(c, parsed, path); err != nil {
+		t.Fatalf("the export failed: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), aiKey) {
+		t.Fatalf("the key is not in the file, so the disclosure is wrong about it:\n%s", data)
+	}
+	// Disclosed is not the same as careless: the file is still owner-only, and
+	// it still has to load.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("a file holding a key in the clear is %v, want 0600", perm)
+	}
+	loadExported(t, path)
+}
+
+// The box says the one thing the file's own contents cannot: that it depends on
+// this machine's keychain, as this user.
+func TestTheExportBoxNamesTheKeychainDependency(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	m := openedExportBox(t, "ssh", func(f form) {
+		fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+		fieldByLabel(t, f, "password").SetValue(sentinel)
+	})
+
+	out := ansi.Strip(m.View())
+	for _, want := range []string{"OS keychain", "this machine", "this user", "CI runner"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the export box never says %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, sentinel) {
+		t.Errorf("the export box rendered the secret:\n%s", out)
+	}
+}
+
+// And for a provider that cannot use the keychain it names the provider and the
+// flag, on screen, before the write.
+func TestTheExportBoxNamesThePlaintextProviderAndFlag(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{})
+	withAmbientEnv(t, nil)
+
+	m := openedExportBox(t, "openai", func(f form) {
+		fieldByLabel(t, f, "API key").SetValue(aiKey)
+	})
+
+	out := ansi.Strip(m.View())
+	for _, want := range []string{"openai", "--token", "plain text"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the export box never says %q:\n%s", want, out)
+		}
+	}
+	// The key hint says what enter agrees to, not just that it writes.
+	if !strings.Contains(out, "secret in plain text") {
+		t.Errorf("the confirm key does not say what it agrees to:\n%s", out)
+	}
+	if strings.Contains(out, aiKey) {
+		t.Errorf("the export box rendered the key:\n%s", out)
+	}
+}
+
+// openedExportBox drives the launcher to an open, answered export box for one
+// connector, through the keys a user would press.
+func openedExportBox(t *testing.T, connector string, fill func(form)) Model {
+	t.Helper()
+	snap, ok := snapshotByName(t)[connector]
+	if !ok {
+		t.Fatalf("%s is not in %s", connector, connectorSnapshotPath)
+	}
+	c := snap.connector()
+
+	m := NewModel([]Connector{c})
+	m.upstream = upstreamState{configured: true, scope: "test-space"}
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = nm.(Model)
+	fill(m.detail.form)
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = nm.(Model)
+	if !m.export.open || !m.export.asking {
+		t.Fatalf("ctrl+e did not open the export box: %+v", m.export)
+	}
+	nm, _ = m.Update(runBatch(t, cmd, exportParsedMsg{}))
+	m = nm.(Model)
+	if !m.export.ready {
+		t.Fatalf("the export box never got an answer: %v", m.export.err)
+	}
+	return m
+}
+
+// runBatch runs a batched command and returns the one message of the same type
+// as want. The launcher batches its animation clock into everything, and the
+// tick is not what a test is waiting for.
+func runBatch(t *testing.T, cmd tea.Cmd, want tea.Msg) tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("no command to run")
+	}
+	msgs := []tea.Msg{cmd()}
+	if batch, ok := msgs[0].(tea.BatchMsg); ok {
+		msgs = nil
+		for _, c := range batch {
+			if c != nil {
+				msgs = append(msgs, c())
+			}
+		}
+	}
+	for _, msg := range msgs {
+		if reflectSameType(msg, want) {
+			return msg
+		}
+	}
+	t.Fatalf("no %T came back from the command", want)
+	return nil
+}
+
+func reflectSameType(a, b tea.Msg) bool {
+	switch a.(type) {
+	case exportParsedMsg:
+		_, ok := b.(exportParsedMsg)
+		return ok
+	case exportWroteMsg:
+		_, ok := b.(exportWroteMsg)
+		return ok
+	}
+	return false
+}
+
+// The whole flow, key by key, ending in a file on disk and a footer that hands
+// over the command that reads it.
+func TestTheExportFlowWritesTheFileAndSaysHowToUseIt(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	dir := t.TempDir()
+	m := openedExportBox(t, "ssh", func(f form) {
+		fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+		fieldByLabel(t, f, "password").SetValue(sentinel)
+	})
+	if m.export.name != "ssh.inventory.yml" {
+		t.Errorf("the box opened on %q, want the connector's own name", m.export.name)
+	}
+
+	// The name is typed over, the way a user names one target among several.
+	for range len("ssh.inventory.yml") {
+		nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = nm.(Model)
+	}
+	if m.export.name != "" {
+		t.Fatalf("backspace left %q behind", m.export.name)
+	}
+	m = typeString(m, filepath.Join(dir, "prod-web.yml"))
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = nm.(Model)
+	if !m.export.writing {
+		t.Fatal("enter did not start the write")
+	}
+	nm, _ = m.Update(runBatch(t, cmd, exportWroteMsg{}))
+	m = nm.(Model)
+
+	if m.export.open {
+		t.Error("the box stayed open after a successful write")
+	}
+	if m.lastErr != "" {
+		t.Fatalf("the export reported an error: %s", m.lastErr)
+	}
+	path := filepath.Join(dir, "prod-web.yml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("nothing was written to the path that was typed: %v", err)
+	}
+	if !strings.Contains(m.lastNote, "cnspec scan --inventory-file") {
+		t.Errorf("the footer does not say how to use the file: %q", m.lastNote)
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "cnspec scan --inventory-file") {
+		t.Error("the footer notice never reached the screen")
+	}
+	loadExported(t, path)
+}
+
+// esc leaves without writing, and the answer still in flight lands nowhere.
+func TestEscapeClosesTheExportBoxWithoutWriting(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	m := openedExportBox(t, "ssh", func(f form) {
+		fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+		fieldByLabel(t, f, "password").SetValue(sentinel)
+	})
+	seq := m.export.seq
+
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = nm.(Model)
+	if m.export.open {
+		t.Fatal("esc did not close the export box")
+	}
+	// The provider's answer to the box that was just closed must not reopen it.
+	nm, _ = m.Update(exportParsedMsg{seq: seq, parsed: parsedForm{}})
+	if m := nm.(Model); m.export.open || m.export.ready {
+		t.Fatalf("a late answer revived the closed box: %+v", m.export)
+	}
+}
+
+// An incomplete form does not export. It puts the keys on the field that is
+// missing instead, which is what pressing the scan button does with the same
+// form.
+func TestExportingAnIncompleteFormPointsAtTheMissingField(t *testing.T) {
+	m := newTestModel()
+	m = selectEntry(t, m, "ssh")
+
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = nm.(Model)
+	if m.export.open {
+		t.Fatal("an incomplete form opened the export box")
+	}
+	if m.lastErr == "" {
+		t.Error("nothing said why the export did not happen")
+	}
+	if m.focus != focusForm {
+		t.Error("the keys were not moved to the field that is missing")
+	}
+}
+
+// The footer offers the key only for a form that could be launched, the way it
+// offers ^o only once a report exists.
+func TestTheExportHintAppearsWithACompleteTarget(t *testing.T) {
+	m := newTestModel()
+	m = selectEntry(t, m, "ssh")
+	if strings.Contains(ansi.Strip(m.View()), "^e") {
+		t.Error("the export key is offered for a form that cannot be launched")
+	}
+
+	fieldByLabel(t, m.detail.form, "user@host").SetValue("chris@10.0.0.4")
+	if !strings.Contains(ansi.Strip(m.View()), "^e") {
+		t.Errorf("the export key is not offered for a complete target:\n%s", ansi.Strip(m.View()))
+	}
+}
+
+// Where the file goes is decided here rather than by a shell, so the two
+// spellings a shell would have handled are handled.
+func TestTheExportPathIsResolvedBeforeAnythingIsWritten(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory here")
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name, typed, want, wantErr string
+	}{
+		{name: "relative", typed: "ssh.inventory.yml", want: filepath.Join(wd, "ssh.inventory.yml")},
+		{name: "tilde", typed: "~/scans/prod.yml", want: filepath.Join(home, "scans", "prod.yml")},
+		{name: "absolute", typed: "/tmp/prod.yml", want: "/tmp/prod.yml"},
+		{name: "empty", typed: "   ", wantErr: "name"},
+		{name: "bare tilde", typed: "~", wantErr: "directory"},
+		{name: "a directory", typed: wd, wantErr: "is a directory"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := exportState{name: tc.typed}.path()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("%q resolved to %q, want a refusal", tc.typed, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("the refusal for %q does not mention %q: %v", tc.typed, tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%q was refused: %v", tc.typed, err)
+			}
+			if got != tc.want {
+				t.Errorf("%q resolved to %q, want %q", tc.typed, got, tc.want)
+			}
+		})
+	}
+}
+
+// A file name is typed, and a name is not bytes.
+//
+// The picker's filter had the same handling and the same bug: one backspace cut
+// one byte off the end, so a multi-byte character left half of itself behind.
+// In a filter that renders as a replacement glyph; in a path it is a file name
+// with an invalid byte in it.
+func TestBackspaceRemovesACharacterRatherThanAByte(t *testing.T) {
+	x := exportState{name: "scan-münchen.yml"}
+	x.name = trimLastRune(x.name)
+	x.name = trimLastRune(x.name)
+	x.name = trimLastRune(x.name)
+	x.name = trimLastRune(x.name)
+	if x.name != "scan-münchen" {
+		t.Fatalf("four backspaces left %q", x.name)
+	}
+	for range len([]rune(x.name)) {
+		x.name = trimLastRune(x.name)
+	}
+	if x.name != "" {
+		t.Errorf("backspacing every character left %q", x.name)
+	}
+
+	s := modalState{filter: "prüfung"}
+	s.backspace()
+	if s.filter != "prüfun" {
+		t.Errorf("the picker filter lost a byte rather than a character: %q", s.filter)
+	}
+}
+
+// A file name can hold a space, so the box has to be able to take one.
+//
+// bubbletea reports a lone space as tea.KeySpace rather than tea.KeyRunes, with
+// the rune still attached, so a handler that matches only KeyRunes drops every
+// space without a sign. What that produced was "myscans.yml" from a user who
+// had typed "my scans.yml", which is a file written somewhere they did not ask
+// for under a name they did not choose.
+func TestASpaceCanBeTypedIntoTheFileName(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	m := openedExportBox(t, "ssh", func(f form) {
+		fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+		fieldByLabel(t, f, "password").SetValue(sentinel)
+	})
+	m.export.name = ""
+
+	for _, msg := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'m', 'y'}},
+		{Type: tea.KeySpace, Runes: []rune{' '}},
+		{Type: tea.KeyRunes, Runes: []rune{'s', 'c', 'a', 'n', 's'}},
+	} {
+		nm, _ := m.Update(msg)
+		m = nm.(Model)
+	}
+	if m.export.name != "my scans" {
+		t.Fatalf("the typed name came out as %q", m.export.name)
+	}
+}
+
+// While a modal owns the body, a click must not reach the screen behind it.
+//
+// The keys have always been routed to whichever box is up. The mouse was not,
+// so the zones computeLayout registers for a list and a detail pane that are
+// not being drawn stayed live underneath: clicking where the scan button would
+// have been started a scan from behind an open box, and the wheel moved the
+// connector selection -- which rebuilds the form the box is describing.
+func TestAClickDoesNotReachTheScreenBehindAModal(t *testing.T) {
+	stubKeychain(t)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	m := openedExportBox(t, "ssh", func(f form) {
+		fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+		fieldByLabel(t, f, "password").SetValue(sentinel)
+	})
+
+	// Where the scan button is drawn when no box is over it.
+	var run tui.Rect
+	for _, z := range computeLayout(m).Zones {
+		if z.Kind == tui.ZoneRun {
+			run = z.Rect
+		}
+	}
+	if run.W == 0 {
+		t.Fatal("the layout registers no scan button to click")
+	}
+
+	nm, cmd := m.Update(tea.MouseMsg{
+		X: run.X, Y: run.Y, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	got := nm.(Model)
+	if got.launching.preparing || cmd != nil {
+		t.Error("a click behind the export box started a scan")
+	}
+	if !got.export.open {
+		t.Error("the click closed the box it was supposed to be blocked by")
+	}
+
+	// And the wheel leaves the selection where the box found it.
+	before := got.list.cursor
+	nm, _ = got.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if after := nm.(Model).list.cursor; after != before {
+		t.Errorf("the wheel moved the selection under the box: %d to %d", before, after)
+	}
+}
+
+// The gate, over the real providers: every connector the launcher can offer is
+// exported and read back through the scan loader.
+//
+// This is the equivalent of the report viewer's TestEveryOfferedFormatWrites,
+// and it is here for the same reason: a format that cannot be written, or a
+// shape the loader rejects, is only discovered by writing one and reading it
+// back. What it would catch is a provider whose asset does not survive a
+// round trip through yaml -- an option key yaml cannot represent, a credential
+// the loader refuses -- for a connector nobody exported by hand.
+//
+// The counts are logged and the test skips when it checked nothing. CI points
+// PROVIDERS_PATH at an empty directory, so a total asserted here would pass
+// vacuously there, and the vacuous pass is the dangerous half.
+func TestEveryConnectorExportsSomethingTheLoaderAccepts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a provider plugin per connector")
+	}
+	stubKeychain(t)
+
+	// The real parser, not the package-wide stand-in TestMain installs: the
+	// question here is whether what the *providers* build survives being
+	// written and read back.
+	prev := parseCLI
+	t.Cleanup(func() { parseCLI = prev })
+	parseCLI = deliverypkg.Parser.ParseCLI
+
+	dir := t.TempDir()
+	installed := installedProviders()
+
+	checked, skipped, refused := 0, 0, 0
+	withKeychain := 0
+	// Named rather than counted. The package comment in export.go says openai,
+	// ollama, huggingface and claude are the connectors whose secret cannot go
+	// to the keychain, and the only honest way to keep that sentence true is to
+	// print the set every run rather than to assert the four.
+	var plaintext []string
+	for _, c := range BuildCatalog() {
+		if !c.DeclaresMetadata() || !installed[c.Provider] {
+			skipped++
+			continue
+		}
+		f := fillOneCredential(c, firstSecretIdentity(c))
+		r := launchRequest{form: f}
+		parsed, err := r.parseForm(c)
+		if err != nil {
+			// Either the provider refused the probe's settings or it kept a
+			// secret nowhere -- both are facts about the filling rather than
+			// about the export, and both are what a user sees as a refusal.
+			refused++
+			t.Logf("%s: not exportable from this probe (%v)", c.Name, err)
+			continue
+		}
+
+		path := filepath.Join(dir, c.Name+".inventory.yml")
+		if err := r.exportInventory(c, parsed, path); err != nil {
+			t.Errorf("%s: the export failed: %v", c.Name, err)
+			continue
+		}
+		checked++
+		if plain := parsed.plaintextFlags(); len(plain) > 0 {
+			plaintext = append(plaintext, c.Name+" "+flagList(plain))
+		} else if len(parsed.placed) > 0 {
+			withKeychain++
+		}
+		loadExported(t, path)
+	}
+
+	sort.Strings(plaintext)
+	t.Logf("exported and re-read %d connectors: %d put a credential in the keychain, "+
+		"%d were refused by the provider, %d catalog entries skipped for having no "+
+		"metadata installed here.\n%d write a secret in plain text and say so: %s",
+		checked, withKeychain, refused, skipped, len(plaintext), strings.Join(plaintext, ", "))
+	// Skipped rather than passed when most of the catalog was unavailable.
+	//
+	// "checked == 0" is not a strict enough gate here, and the difference is
+	// not theoretical: with PROVIDERS_PATH pointed at an empty directory this
+	// still finds one connector to export and would otherwise report a green
+	// pass for a claim about a hundred. The claim is about the provider set, so
+	// a run that did not have the provider set has not tested it.
+	if checked <= skipped {
+		t.Skipf("only %d of %d catalog entries had a provider installed here, so this did "+
+			"not check the provider set", checked, checked+skipped)
+	}
+}
+
+// firstSecretIdentity names the credential field the probe fills, or nothing
+// for a connector that has none.
+func firstSecretIdentity(c Connector) string {
+	f := newForm(c)
+	for i := range f.Fields() {
+		fd := f.Fields()[i]
+		if fd.Secret && !fd.Reference && fd.Flag != "" && f.Visible(i) {
+			return fd.Identity()
+		}
+	}
+	return ""
+}

--- a/apps/cnspec/cmd/interactive/form.go
+++ b/apps/cnspec/cmd/interactive/form.go
@@ -1,0 +1,286 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// A form is what stands between picking a connector and running it: the
+// positional target, the connector's flags, and the credential. It is built in
+// two layers. The generic layer below derives every field from the connector's
+// own declared metadata, so a connector nobody has curated still gets a usable
+// screen. The curated layer -- forms.go here, applying the specs registered in
+// cli/launcher/forms -- then reorders, relabels and attaches value pickers for
+// the connectors people actually reach for.
+//
+// The engine underneath both -- what a field is, what a form emits, which rows
+// apply -- is cli/tui/form, and it knows nothing about connectors. This file is
+// the whole of the translation: everything here reads provider metadata, and
+// nothing in the engine does.
+
+// The launcher's names for the engine's types.
+//
+// They are aliases rather than a rewrite at every use because the rename would
+// then have been the change, across eight hundred uses in this package. What
+// the boundary is for survives an alias untouched: a field's answer is
+// unexported in cli/tui/form, so nothing here can put a value on a command line
+// without going through Emitted, and nothing here can attach a value picker
+// without the mapping that says what its values mean.
+type (
+	field = tuiform.Field
+	form  = tuiform.Form
+)
+
+const (
+	fieldText            = tuiform.KindText
+	fieldBool            = tuiform.KindBool
+	fieldChoice          = tuiform.KindChoice
+	fieldMultiChoice     = tuiform.KindMultiChoice
+	fieldKeyValue        = tuiform.KindKeyValue
+	fieldCredentialState = tuiform.KindCredentialState
+	fieldPaste           = tuiform.KindPaste
+)
+
+const (
+	sectionTarget     = tuiform.SectionTarget
+	sectionCredential = tuiform.SectionCredential
+	sectionOptions    = tuiform.SectionOptions
+)
+
+// newForm builds the input form for a connector: the generic layer from its
+// declared metadata, then the curated overlay if one exists.
+func newForm(c Connector) form {
+	f := tuiform.New(c.Name, genericFields(c))
+	if spec, ok := specFor(c); ok {
+		applySpec(&f, c, spec)
+	}
+	// After the overlay, so a curated label and section for the token flag
+	// survive and only the widget drawn over it changes; before resolveSources,
+	// which is what fills the readouts in. See source_ambient.go.
+	applyAmbient(&f, c)
+	// After the overlay too, and for the same reason: whether a list has
+	// anything to pick from is not known until a spec has had its say.
+	f.TypeEmptyLists()
+	resolveSources(&f)
+	return f
+}
+
+// resolveSources re-points every dependent field at the picker its selector
+// currently calls for, and re-reads the ambient credentials.
+//
+// The two are one operation, which is why this exists rather than a bare call
+// into the engine. A readout is honest only because this runs when a form is
+// built and after every keystroke: pasting a token flips the row from naming a
+// variable to saying so, and clearing it flips the row back.
+func resolveSources(f *form) {
+	f.ResolveSources(sourceEmitFor)
+	refreshAmbient(f)
+}
+
+// carryOver copies what the user entered on old onto a freshly built form, and
+// re-derives the credential readouts on top of it.
+//
+// The readouts on the rebuilt form were derived before the carried values
+// arrived. Without the second half a row would name an environment variable
+// while a pasted token sat in the box below it.
+func carryOver(f *form, old form) {
+	f.CarryOver(old)
+	refreshAmbient(f)
+}
+
+// genericFields derives fields straight from the connector's declaration.
+func genericFields(c Connector) []field {
+	var out []field
+
+	// Show every required positional, plus at most one optional slot. A high
+	// MaxArgs usually encodes sub-command forms rather than that many
+	// independent arguments -- aws declares MaxArgs=4 for `aws ec2 ebs
+	// snapshot <id>` -- and rendering one box per slot buries the fields that
+	// matter. Connectors whose sub-command shape is worth modelling get a
+	// curated overlay that replaces these outright.
+	labels := positionalLabels(c)
+	if n := int(c.MinArgs) + 1; len(labels) > n {
+		labels = labels[:n]
+	}
+	for i, label := range labels {
+		out = append(out, tuiform.NewField(tuiform.Decl{
+			Label:    label,
+			Flag:     "",
+			Pos:      i,
+			Kind:     fieldText,
+			Required: uint(i) < c.MinArgs,
+			Section:  sectionTarget,
+		}))
+	}
+
+	for _, fl := range c.Flags {
+		if fl.Option&plugin.FlagOption_Hidden != 0 || fl.Option&plugin.FlagOption_Deprecated != 0 {
+			continue
+		}
+		if isInertPromptFlag(fl) {
+			continue
+		}
+		out = append(out, fieldForFlag(fl))
+	}
+
+	// --discover is synthesized for every connector by the CLI, so it is never
+	// in Flags; "all" and "auto" are always valid on top of what is declared.
+	if len(c.Discovery) > 0 {
+		opts := append([]string{"auto", "all"}, c.Discovery...)
+		out = append(out, tuiform.NewField(tuiform.Decl{
+			Label:   "discover",
+			Desc:    "Discover nested assets",
+			Flag:    "discover",
+			Kind:    fieldMultiChoice,
+			Options: dedupeStrings(opts),
+			Section: sectionOptions,
+		}))
+	}
+
+	return out
+}
+
+// builtinAskPass is the one prompt flag mql honours by name. Everything else
+// has to declare itself; see isInertPromptFlag.
+const builtinAskPass = "ask-pass"
+
+// isInertPromptFlag reports whether a bool flag is named like a prompt that
+// nothing will act on.
+//
+// mql prompts for --ask-pass, which it reads by name, and for any flag carrying
+// FlagOption_AskInput, which it collects into an "ask-flags" annotation.
+// clickhousecloud's --ask-secret and weaviate's --ask-api-key are declared as
+// plain bools with neither property, so the CLI parses them and no one reads
+// them. Verified against the shipped binary: `cnspec shell weaviate --host
+// 127.0.0.1 --ask-api-key </dev/null` never asks anything and goes straight to
+// a 404 from an unauthenticated request, where the same shape on ssh --ask-pass
+// fails with "asking input is only supported when used with an interactive
+// terminal", which is a prompt refusing a pipe.
+//
+// A toggle labelled "prompt for API key" that leads to an unauthenticated scan
+// is worse than an absent row, so the row is absent. The flag it names is still
+// on the form and still classified as a secret; what it loses is a partner that
+// was never going to arrive.
+func isInertPromptFlag(fl plugin.Flag) bool {
+	return fl.Type == plugin.FlagType_Bool &&
+		strings.HasPrefix(fl.Long, "ask-") &&
+		fl.Long != builtinAskPass &&
+		fl.Option&plugin.FlagOption_AskInput == 0
+}
+
+func fieldForFlag(fl plugin.Flag) field {
+	d := tuiform.Decl{
+		Label:     fl.Long,
+		Desc:      fl.Desc,
+		Flag:      fl.Long,
+		Required:  fl.Option&plugin.FlagOption_Required != 0,
+		Secret:    tuiform.IsSecretFlag(fl),
+		Reference: tuiform.IsSecretReference(fl),
+		Section:   sectionOptions,
+	}
+	if d.Secret {
+		d.Section = sectionCredential
+	}
+
+	switch fl.Type {
+	case plugin.FlagType_Bool:
+		d.Kind = fieldBool
+	case plugin.FlagType_List:
+		d.Kind = fieldMultiChoice
+	case plugin.FlagType_KeyValue:
+		d.Kind = fieldKeyValue
+	default: // String, Int and anything unrecognized are typed as text
+		d.Kind = fieldText
+	}
+
+	f := tuiform.NewField(d)
+	if fl.Type == plugin.FlagType_Bool {
+		// A declared default is the connector's, not the user's, so it is set
+		// rather than prefilled: nothing on the row claims the launcher chose
+		// it.
+		on, _ := strconv.ParseBool(fl.Default)
+		f.SetOn(on)
+	}
+	return f
+}
+
+// positionalLabels names the connector's positional arguments. The usage string
+// is the only description of them, and it is not machine-readable, so this
+// falls back to numbered labels whenever it cannot line the tokens up with the
+// declared argument count.
+func positionalLabels(c Connector) []string {
+	n := int(c.MaxArgs)
+	if n < int(c.MinArgs) {
+		n = int(c.MinArgs)
+	}
+	if n == 0 {
+		return nil
+	}
+
+	hint := c.ArgHint()
+	tokens := strings.Fields(hint)
+	switch {
+	case len(tokens) == n:
+		return tokens
+	case n == 1 && hint != "":
+		return []string{hint}
+	}
+
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("argument %d", i+1)
+	}
+	return out
+}
+
+// attachSource points a field at a value picker, and at what that picker says
+// its displayed values mean on a command line. See Source.Emit: the two are one
+// decision, and a picker attached without its mapping emits the annotation it
+// put there for the reader.
+func attachSource(fd *field, id string) {
+	fd.SetSource(id, sourceEmitFor(id))
+}
+
+// sourceEmitFor is what the engine asks when it attaches a picker to a field.
+func sourceEmitFor(id string) tuiform.Emit {
+	if e := sourceEmit(id); e != nil {
+		return tuiform.Emit(e)
+	}
+	return nil
+}
+
+// emitTable is a spec's declared value mapping as a field carries it. A value
+// with no entry emits nothing, which is how a selector steers the screen
+// without adding a word cnspec would not understand.
+func emitTable(table map[string]string) tuiform.Emit {
+	return func(display string) string { return table[display] }
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+func containsString(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/cnspec/cmd/interactive/form_test.go
+++ b/apps/cnspec/cmd/interactive/form_test.go
@@ -1,0 +1,442 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// sshConnector mirrors what the installed os provider declares for ssh,
+// including the one flag in the whole tree that actually sets
+// FlagOption_Password.
+func sshConnector() Connector {
+	return Connector{
+		Provider: "os", Name: "ssh", Use: "ssh user@host", Category: catHosts,
+		Installed: true, MinArgs: 1, MaxArgs: 1,
+		Flags: []plugin.Flag{
+			{Long: "sudo", Type: plugin.FlagType_Bool, Default: "false", Desc: "Elevate privileges with sudo"},
+			{Long: "insecure", Type: plugin.FlagType_Bool, Default: "false"},
+			{Long: "ask-pass", Type: plugin.FlagType_Bool, Default: "false", ConfigEntry: "-"},
+			{Long: "password", Short: "p", Type: plugin.FlagType_String, Option: plugin.FlagOption_Password},
+			{Long: "identity-file", Short: "i", Type: plugin.FlagType_String},
+			{Long: "id-detector", Type: plugin.FlagType_String, Option: plugin.FlagOption_Hidden},
+		},
+	}
+}
+
+func awsConnector() Connector {
+	return Connector{
+		Provider: "aws", Name: "aws", Use: "aws", Category: catCloud,
+		Installed: true, MaxArgs: 4,
+		Flags: []plugin.Flag{
+			{Long: "profile", Type: plugin.FlagType_String, Desc: "Profile to use"},
+			{Long: "region", Type: plugin.FlagType_String},
+			{Long: "role", Type: plugin.FlagType_String},
+			{Long: "filters", Type: plugin.FlagType_KeyValue},
+		},
+		Discovery: []string{"instances", "s3-buckets", "accounts"},
+	}
+}
+
+func githubConnector() Connector {
+	return Connector{
+		Provider: "github", Name: "github", Use: "github", Category: catSaaS,
+		Installed: true, MinArgs: 2, MaxArgs: 2,
+		Flags: []plugin.Flag{
+			{Long: "token", Type: plugin.FlagType_String, Desc: "GitHub personal access token"},
+			{Long: "repos", Type: plugin.FlagType_String},
+			{Long: "app-private-key-content", Type: plugin.FlagType_String},
+		},
+		Discovery: []string{"repos", "organization"},
+	}
+}
+
+func fieldByLabel(t *testing.T, f form, label string) *field {
+	t.Helper()
+	for i := range f.Fields() {
+		if f.Fields()[i].Label == label {
+			return &f.Fields()[i]
+		}
+	}
+	t.Fatalf("no field labelled %q in %v", label, fieldLabels(f))
+	return nil
+}
+
+func fieldLabels(f form) []string {
+	out := make([]string, len(f.Fields()))
+	for i, fd := range f.Fields() {
+		out[i] = fd.Label
+	}
+	return out
+}
+
+// Hidden and deprecated flags are noise in a launcher and must not appear.
+func TestGenericFormSkipsHiddenFlags(t *testing.T) {
+	f := newForm(sshConnector())
+	for _, fd := range f.Fields() {
+		if fd.Label == "id-detector" {
+			t.Fatal("hidden flag id-detector should not be a form field")
+		}
+	}
+}
+
+// The positional field comes from MinArgs/MaxArgs, and the usage string names
+// it when the token count lines up.
+func TestPositionalFieldFromMetadata(t *testing.T) {
+	f := newForm(sshConnector())
+	fd := fieldByLabel(t, f, "user@host")
+	if fd.Flag != "" || fd.Pos != 0 || !fd.Required {
+		t.Fatalf("ssh positional = %+v, want positional 0 and required", fd)
+	}
+}
+
+// --discover is synthesized by the CLI rather than declared, so the form has to
+// add it, with all/auto always valid on top of the declared targets.
+func TestDiscoverIsAMultiChoice(t *testing.T) {
+	f := newForm(awsConnector())
+	fd := fieldByLabel(t, f, "discover")
+	if fd.Kind != fieldMultiChoice {
+		t.Fatalf("discover kind = %v, want multi-choice", fd.Kind)
+	}
+	for _, want := range []string{"auto", "all", "instances", "s3-buckets"} {
+		if !containsString(fd.Options, want) {
+			t.Errorf("discover options missing %q: %v", want, fd.Options)
+		}
+	}
+}
+
+func TestFormEmitsArgs(t *testing.T) {
+	f := newForm(sshConnector())
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "sudo").SetOn(true)
+
+	got := strings.Join(f.Args(), " ")
+	if got != "chris@10.0.0.4 --sudo" {
+		t.Fatalf("args = %q, want %q", got, "chris@10.0.0.4 --sudo")
+	}
+}
+
+func TestMultiChoiceEmitsCommaSeparated(t *testing.T) {
+	f := newForm(awsConnector())
+	fieldByLabel(t, f, "profile").SetValue("prod")
+	d := fieldByLabel(t, f, "discover")
+	d.SetPicks(map[string]bool{"instances": true, "s3-buckets": true})
+
+	got := strings.Join(f.Args(), " ")
+	// Options order decides the rendering, so this is stable.
+	if got != "--profile prod --discover instances,s3-buckets" {
+		t.Fatalf("args = %q", got)
+	}
+}
+
+// A connector that leads with an optional selector must collapse to just the
+// later argument when the selector is left blank -- `terraform PATH` rather
+// than `terraform "" PATH`.
+func TestOptionalLeadingPositionalIsSkipped(t *testing.T) {
+	c := Connector{
+		Provider: "terraform", Name: "terraform", Use: "terraform PATH",
+		Installed: true, MinArgs: 1, MaxArgs: 2,
+	}
+	f := newForm(c)
+	fieldByLabel(t, f, "path").SetValue("./infra")
+
+	if got := strings.Join(f.Args(), " "); got != "./infra" {
+		t.Fatalf("args = %q, want %q", got, "./infra")
+	}
+
+	fieldByLabel(t, f, "kind").SetValue("plan")
+	if got := strings.Join(f.Args(), " "); got != "plan ./infra" {
+		t.Fatalf("args = %q, want %q", got, "plan ./infra")
+	}
+}
+
+func TestValidateRequiresPositional(t *testing.T) {
+	f := newForm(sshConnector())
+	if err := f.Validate(); err == nil {
+		t.Fatal("expected an error for an empty required positional")
+	}
+	fieldByLabel(t, f, "user@host").SetValue("chris@host")
+	if err := f.Validate(); err != nil {
+		t.Fatalf("unexpected error once set: %v", err)
+	}
+}
+
+// The overlay must not invent flags. github declares no --enterprise-url in
+// this fixture, so the curated entry for it has to vanish rather than render.
+func TestOverlayDropsFlagsTheProviderDoesNotDeclare(t *testing.T) {
+	f := newForm(githubConnector())
+	for _, fd := range f.Fields() {
+		if fd.Flag == "enterprise-url" {
+			t.Fatal("overlay emitted a flag the provider does not declare")
+		}
+	}
+}
+
+// github takes two positional args that the usage string does not describe;
+// only the overlay knows they are a kind and a name.
+func TestGitHubOverlayShapesPositionals(t *testing.T) {
+	f := newForm(githubConnector())
+	kind := fieldByLabel(t, f, "kind")
+	if kind.Kind != fieldChoice || !containsString(kind.Options, "repo") {
+		t.Fatalf("github kind = %+v, want a choice including repo", kind)
+	}
+	kind.SetValue("repo")
+	fieldByLabel(t, f, "name").SetValue("mondoohq/cnspec")
+
+	if got := strings.Join(f.Args(), " "); got != "repo mondoohq/cnspec" {
+		t.Fatalf("args = %q", got)
+	}
+}
+
+// Sections order TARGET, then CREDENTIAL, then OPTIONS, and the curated fields
+// lead their section.
+func TestOverlayOrdersSections(t *testing.T) {
+	f := newForm(awsConnector())
+	sections, bySection := f.Ordered()
+	if len(sections) == 0 || sections[0] != sectionTarget {
+		t.Fatalf("sections = %v, want TARGET first", sections)
+	}
+	target := bySection[sectionTarget]
+	if len(target) < 3 {
+		t.Fatalf("expected profile/region/role promoted to TARGET, got %d fields", len(target))
+	}
+	if f.Fields()[target[0]].Label != "profile" {
+		t.Errorf("first TARGET field = %q, want profile", f.Fields()[target[0]].Label)
+	}
+}
+
+func TestOverlayAttachesPickers(t *testing.T) {
+	if got := fieldByLabel(t, newForm(awsConnector()), "profile").Source(); got != srcAWSProfile {
+		t.Errorf("aws profile source = %q, want %q", got, srcAWSProfile)
+	}
+	if got := fieldByLabel(t, newForm(sshConnector()), "user@host").Source(); got != srcSSHHost {
+		t.Errorf("ssh host source = %q, want %q", got, srcSSHHost)
+	}
+}
+
+func containerConnector() Connector {
+	return Connector{
+		Provider: "os", Name: "docker", Use: "docker", Category: catContainer,
+		Installed: true, MinArgs: 1, MaxArgs: 2,
+		Flags:     []plugin.Flag{{Long: "sudo", Type: plugin.FlagType_Bool, Default: "false"}},
+		Discovery: []string{"container", "container-images"},
+	}
+}
+
+// cnspec infers what a container reference points at from the reference
+// itself, and the only sub-command word the connector accepts is `file`. The
+// kind selector therefore steers the UI without adding a word to the command.
+func TestContainerKindEmitsNoExtraWord(t *testing.T) {
+	f := newForm(containerConnector())
+	kind := fieldByLabel(t, f, "kind")
+	ref := fieldByLabel(t, f, "reference")
+
+	for _, k := range []string{"running container", "local image", "registry image"} {
+		kind.SetValue(k)
+		ref.SetValue("nginx:1.27")
+		if got := strings.Join(f.Args(), " "); got != "nginx:1.27" {
+			t.Errorf("kind %q emitted %q, want just the reference", k, got)
+		}
+	}
+
+	// A Dockerfile is the one case where cnspec really does take a word.
+	kind.SetValue("dockerfile")
+	ref.SetValue("./Dockerfile")
+	if got := strings.Join(f.Args(), " "); got != "file ./Dockerfile" {
+		t.Errorf("dockerfile emitted %q, want %q", got, "file ./Dockerfile")
+	}
+}
+
+// typeEmptyLists must not touch a list that does have a picker: --discover
+// always has options, and turning it into a text box would lose the one screen
+// in the launcher that shows what a connector can find.
+func TestAListWithOptionsKeepsItsPicker(t *testing.T) {
+	f := newForm(containerConnector())
+	fd := fieldByFlag(t, f, "discover")
+	if fd.Kind != fieldMultiChoice {
+		t.Errorf("--discover is a %v, want the multi-select", fd.Kind)
+	}
+	if len(fd.Options) == 0 {
+		t.Error("--discover has no options, so it would have been demoted to a text box")
+	}
+	// The selection has to be writable. It used to be a nil map on a field
+	// nobody had picked from yet, which is a panic rather than a no-op.
+	fd.TogglePick(fd.Options[0])
+	if !fd.Picked(fd.Options[0]) {
+		t.Error("--discover cannot record a selection")
+	}
+}
+
+// The docker context is a target with no flag to travel in: docker and
+// container declare none, so it reaches the child as DOCKER_CONTEXT and puts
+// nothing on the command line.
+//
+// It also has to be between `kind` and `reference` on screen, because it
+// decides what the reference can be -- which is the case that made the
+// positional chain worth fixing rather than working around. `reference` takes
+// its picker from `kind`, and a launcher-owned field declared between them must
+// not become the thing it reads.
+func TestDockerContextTravelsInTheEnvironmentOnly(t *testing.T) {
+	f := newForm(containerConnector())
+	ctx := fieldByLabel(t, f, "docker context")
+	if ctx.Special != specialDockerContext {
+		t.Fatalf("the context field is %q, want the launcher-owned marker %q",
+			ctx.Special, specialDockerContext)
+	}
+	if ctx.Source() != srcDockerContext {
+		t.Errorf("the context field has source %q, want %q", ctx.Source(), srcDockerContext)
+	}
+
+	fieldByLabel(t, f, "kind").SetValue("running container")
+	resolveSources(&f)
+	ctx.SetValue("staging")
+	fieldByLabel(t, f, "reference").SetValue("web")
+
+	// The chain behind it is intact: the reference still follows the kind.
+	if got := fieldByLabel(t, f, "reference").Source(); got != srcDockerContainer {
+		t.Errorf("reference source = %q, want %q; the context field broke the chain",
+			got, srcDockerContainer)
+	}
+	if got := strings.Join(f.Args(), " "); got != "web" {
+		t.Errorf("args = %q, want just the reference -- the context is not an argument", got)
+	}
+
+	r := launchRequest{form: f}
+	env, cleanup, err := r.environment()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(env, dockerContextEnv+"=staging") {
+		t.Errorf("the chosen context did not reach the child: %v", env)
+	}
+	// DOCKER_HOST outranks DOCKER_CONTEXT in the docker CLI and in mql's own
+	// dockerclient, so an inherited one has to be cleared or the choice does
+	// nothing at all.
+	if !containsString(env, dockerHostEnv+"=") {
+		t.Errorf("an inherited DOCKER_HOST would still win: %v", env)
+	}
+
+	// And the pickers are scoped to it, or they would list the default
+	// daemon's containers for a scan pointed somewhere else.
+	for _, id := range []string{srcDockerContainer, srcDockerImage} {
+		s, ok := sourceByID(id)
+		if !ok {
+			t.Fatalf("%s is not registered", id)
+		}
+		if !containsString(s.Needs, "s:"+specialDockerContext) {
+			t.Errorf("%s does not depend on the chosen context: Needs = %v", id, s.Needs)
+		}
+	}
+	params := sourceParamsFor(f, srcDockerContainer)
+	if !containsString(params, "s:"+specialDockerContext+"=staging") {
+		t.Fatalf("the picker is not keyed on the chosen context: %v", params)
+	}
+	if got := dockerContextEnvFrom(params); !containsString(got, dockerContextEnv+"=staging") {
+		t.Errorf("the picker would run against the wrong daemon: %v", got)
+	}
+	// With no context chosen the picker inherits whatever the user's own shell
+	// already says, which is what it did before there was a field at all.
+	if got := dockerContextEnvFrom(nil); got != nil {
+		t.Errorf("an unset context still forced an environment: %v", got)
+	}
+}
+
+// Choosing a kind switches which picker the reference field uses, and drops
+// values belonging to the previous one.
+func TestContainerKindSwitchesPicker(t *testing.T) {
+	f := newForm(containerConnector())
+	kind := fieldByLabel(t, f, "kind")
+
+	kind.SetValue("running container")
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "reference").Source(); got != srcDockerContainer {
+		t.Errorf("running container source = %q, want %q", got, srcDockerContainer)
+	}
+
+	// Values found for containers must not be offered once images are asked for.
+	fieldByLabel(t, f, "reference").Options = []string{"web", "db"}
+	kind.SetValue("local image")
+	resolveSources(&f)
+	ref := fieldByLabel(t, f, "reference")
+	if ref.Source() != srcDockerImage {
+		t.Errorf("local image source = %q, want %q", ref.Source(), srcDockerImage)
+	}
+	if len(ref.Options) != 0 {
+		t.Errorf("stale container values survived the switch: %v", ref.Options)
+	}
+
+	// A registry reference is not enumerated: listing a registry needs
+	// credentials and a round trip, and --discover already does it properly.
+	kind.SetValue("registry image")
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "reference").Source(); got != "" {
+		t.Errorf("registry image should have no local picker, got %q", got)
+	}
+}
+
+// A registry reference is enumerated by cnspec's own discovery, so choosing it
+// asks for that enumeration instead of trying to list the registry locally.
+func TestRegistryKindRequestsDiscovery(t *testing.T) {
+	f := newForm(containerConnector())
+	kind := fieldByLabel(t, f, "kind")
+
+	kind.SetValue("registry image")
+	resolveSources(&f)
+	d := fieldByLabel(t, f, "discover")
+	if !d.Picked("container-images") {
+		t.Fatalf("expected container-images discovery to be requested, picks=%v", d.Selected())
+	}
+	if got := strings.Join(f.Args(), " "); !strings.Contains(got, "--discover container-images") {
+		t.Fatalf("args = %q", got)
+	}
+}
+
+// Re-resolving must not stamp over a choice the user made themselves.
+func TestResolveDoesNotClobberUserChoices(t *testing.T) {
+	f := newForm(containerConnector())
+	fieldByLabel(t, f, "kind").SetValue("registry image")
+	resolveSources(&f)
+
+	d := fieldByLabel(t, f, "discover")
+	d.SetPicks(map[string]bool{"container": true})
+	resolveSources(&f) // same kind, so nothing should change
+	if !d.Picked("container") || d.Picked("container-images") {
+		t.Fatalf("re-resolving overwrote the user's discovery choice: %v", d.Selected())
+	}
+}
+
+// The tests below assemble a form by hand rather than from a connector, which
+// the launcher itself never does: a field's answer is the engine's, so a
+// declaration and the answer to it arrive separately. These say the two in one
+// line so a table of cases stays a table.
+
+// valued is a field carrying an answer.
+func valued(d tuiform.Decl, value string) field {
+	fd := tuiform.NewField(d)
+	fd.SetValue(value)
+	return fd
+}
+
+// sourced is a field with a value picker attached, and whatever that picker
+// says its values mean on a command line.
+func sourced(d tuiform.Decl, source string) field {
+	fd := tuiform.NewField(d)
+	attachSource(&fd, source)
+	return fd
+}
+
+// prefilled is a field carrying an answer it derived for the user, and why.
+func prefilled(d tuiform.Decl, value, why string) field {
+	fd := tuiform.NewField(d)
+	fd.Prefill(value, why)
+	return fd
+}

--- a/apps/cnspec/cmd/interactive/formfixture_test.go
+++ b/apps/cnspec/cmd/interactive/formfixture_test.go
@@ -1,0 +1,328 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The fixtures and accessors every curated-form test is written against.
+//
+// There used to be one set per file: nine `xForm(t, name)` constructors that
+// differed only in the words of their fatal message, two field-finders that
+// differed only in whether they took a pointer, two "fill this field" helpers
+// that differed only in whether they addressed it by flag or by label, and two
+// positional collectors of which one sorted and the other did not. Nine copies
+// of a helper is nine places a fix has to be made and eight places it can be
+// forgotten -- and the sorted/unsorted pair was the version of that already
+// waiting to happen, since the two disagreed about a form whose fields arrive
+// out of argument order.
+//
+// One set, used by all of them. The two that remain distinct are distinct for a
+// reason stated where they are defined.
+
+// connectorFor rebuilds one connector from the recorded metadata rather than
+// from whatever is installed, so these tests say the same thing where CI runs
+// them: with PROVIDERS_PATH pointed at an empty directory.
+//
+// The snapshot is preferred whenever it has an entry, and today it has one for
+// every connector with a spec. A connector it does not carry falls back to the
+// fixtures below; see staticConnectorFixtures for what that fallback is for and
+// why nothing currently reaches it.
+func connectorFor(t *testing.T, name string) Connector {
+	t.Helper()
+	if snap, ok := snapshotByName(t)[name]; ok {
+		return snap.connector()
+	}
+	c, ok := staticConnectorFixtures[name]
+	if !ok {
+		t.Fatalf("%s: no entry in %s and no fixture to build a form from",
+			name, connectorSnapshotPath)
+	}
+	// The category is computed rather than declared, for the reason
+	// connectorSnapshot gives for not recording one: categorize() owns it, and a
+	// second copy is a second thing to keep in step. The fixtures below carried
+	// one until Identity & Access was split out of SaaS, after which four of the
+	// six claimed a category the launcher had stopped showing them under.
+	c.Category = categorize(c.Provider, c.Name)
+	t.Logf("%s: not in the snapshot, so this ran against the recorded fixture", name)
+	return c
+}
+
+// formFor builds a connector's real curated form -- the generic layer from its
+// declared metadata, then whatever cli/launcher/forms registered over it.
+func formFor(t *testing.T, name string) (Connector, form) {
+	t.Helper()
+	c := connectorFor(t, name)
+	return c, newForm(c)
+}
+
+// hermeticFormFor is formFor with the ambient environment emptied first.
+//
+// It is a separate call rather than the default because it is not free: a test
+// that asserts what a credential readout says has to control the environment,
+// and a test that asserts what the *provider* falls back to must not, or it
+// asserts against a fixture instead of against the machine. Which of the two a
+// test is doing is a decision, so it is made at the call site.
+func hermeticFormFor(t *testing.T, name string) (Connector, form) {
+	t.Helper()
+	withAmbientEnv(t, nil)
+	return formFor(t, name)
+}
+
+// findFieldByFlag returns the field emitting a flag, or nil when the overlay never
+// put one on the form.
+func findFieldByFlag(f form, flag string) *field {
+	for i := range f.Fields() {
+		if f.Fields()[i].Flag == flag {
+			return &f.Fields()[i]
+		}
+	}
+	return nil
+}
+
+// fieldByFlag is findFieldByFlag for the tests that cannot continue without it.
+func fieldByFlag(t *testing.T, f form, flag string) *field {
+	t.Helper()
+	fd := findFieldByFlag(f, flag)
+	if fd == nil {
+		t.Fatalf("no field for --%s in %v", flag, fieldLabels(f))
+	}
+	return fd
+}
+
+// hasFlagField reports whether a flag reached the screen at all.
+func hasFlagField(f form, flag string) bool { return findFieldByFlag(f, flag) != nil }
+
+// sectionOf reports which section a flag's field landed in, and whether it is
+// on the screen at all.
+func sectionOf(f form, flag string) (string, bool) {
+	if fd := findFieldByFlag(f, flag); fd != nil {
+		return fd.Section, true
+	}
+	return "", false
+}
+
+// positionalFields are the form's argument slots, in argument order: the fields
+// with no flag and no launcher-owned marker.
+//
+// The order is asserted rather than assumed. applySpec sorts the fields it
+// built, so a form usually arrives in argument order already -- but "usually"
+// is what a test must not depend on, and the unsorted copy of this helper
+// agreed with the sorted one only for as long as that held.
+func positionalFields(f *form) []*field {
+	var out []*field
+	for i := range f.Fields() {
+		if f.Fields()[i].Flag == "" && f.Fields()[i].Special == "" {
+			out = append(out, &f.Fields()[i])
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Pos < out[j].Pos })
+	return out
+}
+
+// setFlag fills the field emitting a flag, failing if the overlay never put it
+// on the form. "Reachable" is the property being asserted: a flag the overlay
+// silently dropped has no field to find.
+func setFlag(t *testing.T, f *form, flag, value string) *field {
+	t.Helper()
+	i := f.IndexOfFlag(flag)
+	if i < 0 {
+		t.Fatalf("--%s is not on the form; fields are %v", flag, fieldLabels(*f))
+	}
+	f.Fields()[i].SetValue(value)
+	return &f.Fields()[i]
+}
+
+// setLabelled writes a value into the field with this label, which is how a
+// positional is addressed -- it has no flag.
+func setLabelled(t *testing.T, f *form, label, value string) {
+	t.Helper()
+	for i := range f.Fields() {
+		if f.Fields()[i].Label == label {
+			f.Fields()[i].SetValue(value)
+			return
+		}
+	}
+	t.Fatalf("no field labelled %q in %v", label, fieldLabels(*f))
+}
+
+// staticConnectorFixtures record what six connectors declare once their
+// provider is installed, read from ~/.config/mondoo/providers/<name>/<name>.json
+// after installing each into a scratch PROVIDERS_PATH.
+//
+// They exist because the recorded artifact did not carry these six: they
+// reached the catalog only through the compiled-in static list, which strips
+// Flags, so every check that needs a flag had nothing to run against. That is
+// no longer true -- the artifact carries all six, connectorFor prefers it
+// whenever it has an entry, and TestEverySpecIsCoveredByTheSnapshotGate is
+// what proves none of them slipped back out. So nothing reaches these today.
+//
+// They are kept rather than deleted because the fallback is the only thing
+// standing between "this connector left the artifact" and a test suite that
+// cannot build a form for it at all. Be clear about what a fixture proves: it
+// is written by the same hand as the spec, so it cannot prove the flag names
+// are the ones the provider ships -- only the artifact can do that. What it
+// proves is everything downstream of the names: that the spec's sections
+// resolve, that a filled credential has a delivery route instead of a form that
+// refuses to launch, and that no secret reaches argv.
+var staticConnectorFixtures = map[string]Connector{
+	// auth0 13.0.0
+	"auth0": {
+		Provider: "auth0", Name: "auth0", Use: "auth0",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "domain", Type: plugin.FlagType_String, Desc: "Auth0 tenant domain (e.g. your-tenant.us.auth0.com)"},
+			{Long: "client-id", Type: plugin.FlagType_String, Desc: "Auth0 machine-to-machine application client ID"},
+			{Long: "client-secret", Type: plugin.FlagType_String, Desc: "Auth0 machine-to-machine application client secret"},
+		},
+	},
+	// bitwarden 13.0.0
+	"bitwarden": {
+		Provider: "bitwarden", Name: "bitwarden", Use: "bitwarden",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "client-id", Type: plugin.FlagType_String, Desc: "Bitwarden organization client ID (e.g. organization.<uuid>)"},
+			{Long: "client-secret", Type: plugin.FlagType_String, Desc: "Bitwarden organization client secret"},
+			{Long: "api-url", Type: plugin.FlagType_String, Desc: "Bitwarden Public API base URL, for self-hosted deployments"},
+			{Long: "identity-url", Type: plugin.FlagType_String, Desc: "Bitwarden identity token URL, for self-hosted deployments"},
+		},
+	},
+	// dropbox 13.0.1
+	"dropbox": {
+		Provider: "dropbox", Name: "dropbox", Use: "dropbox",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "token", Type: plugin.FlagType_String, Desc: "Dropbox Business team access token"},
+		},
+	},
+	// jumpcloud 13.0.0
+	"jumpcloud": {
+		Provider: "jumpcloud", Name: "jumpcloud", Use: "jumpcloud",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "api-key", Type: plugin.FlagType_String, Desc: "JumpCloud API key"},
+			{Long: "org-id", Type: plugin.FlagType_String, Desc: "JumpCloud organization id (required for multi-tenant API keys)"},
+		},
+	},
+	// keycloak 13.0.0
+	"keycloak": {
+		Provider: "keycloak", Name: "keycloak", Use: "keycloak",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "url", Type: plugin.FlagType_String, Desc: "Base URL of the Keycloak server, for example https://keycloak.example.com"},
+			{Long: "realm", Type: plugin.FlagType_String, Desc: "Scope the scan to a single realm instead of every realm the credentials can read"},
+			{Long: "auth-realm", Type: plugin.FlagType_String, Desc: "Realm the token is requested from (defaults to master for a user, or the scanned realm for a service account)"},
+			{Long: "client-id", Type: plugin.FlagType_String, Desc: "Client the token is requested for (defaults to admin-cli for a user)"},
+			{Long: "client-secret", Type: plugin.FlagType_String, Desc: "Secret of a confidential client, which selects service account authentication"},
+			{Long: "username", Type: plugin.FlagType_String, Desc: "Admin user to authenticate as, which selects password authentication"},
+			{Long: "password", Type: plugin.FlagType_String, Desc: "Password of the admin user"},
+			{Long: "ca-cert", Type: plugin.FlagType_String, Desc: "Certificate authority to trust for the server certificate, either the PEM itself or a path to it"},
+		},
+		Discovery: []string{"all", "auto", "realms"},
+	},
+	// zoom 13.0.0
+	"zoom": {
+		Provider: "zoom", Name: "zoom", Use: "zoom",
+		Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "account-id", Type: plugin.FlagType_String, Desc: "Zoom account ID"},
+			{Long: "client-id", Type: plugin.FlagType_String, Desc: "Zoom Server-to-Server OAuth app client ID"},
+			{Long: "client-secret", Type: plugin.FlagType_String, Desc: "Zoom Server-to-Server OAuth app client secret"},
+		},
+	},
+}
+
+// fillEveryField answers every field on a form the way a user would, writing
+// secret into each credential, and returns how many credentials it found.
+//
+// It is shared because it was not: two category files each grew their own copy
+// of this loop and the copies had drifted. One filled a picker with its first
+// option and the other with the word "placeholder", which is not a value any
+// strict list would accept; one skipped a launcher-owned readout by its Kind
+// and the other by its Special marker, so each typed into fields the other left
+// alone. Neither difference was a decision -- they are the same sweep, and this
+// is the strict side of each.
+//
+// The launcher-owned rows are skipped by both tests: a credential readout holds
+// the name of a variable rather than a value, and a Special field is the
+// launcher's own question, so typing into either asserts nothing about the
+// connector.
+func fillEveryField(f *form, secret string) int {
+	secrets := 0
+	for i := range f.Fields() {
+		fd := &f.Fields()[i]
+		switch {
+		case fd.Kind == fieldCredentialState || fd.Special != "":
+			// A launcher-owned row; it is not typed into.
+		case fd.Secret:
+			fd.SetValue(secret)
+			secrets++
+		case fd.Kind == fieldBool:
+			fd.SetOn(true)
+		case fd.Kind == fieldMultiChoice:
+			if len(fd.Options) > 0 {
+				fd.SetPicks(map[string]bool{fd.Options[0]: true})
+			}
+		case len(fd.Options) > 0:
+			fd.SetValue(fd.Options[0])
+		default:
+			fd.SetValue("placeholder")
+		}
+	}
+	return secrets
+}
+
+// assertPathShapedConnector is the one thing a curated form owes a connector
+// whose whole input is a path: an argument slot that says what the argument is.
+//
+// The derived slot spells the usage string, so an uncurated bicep asks for
+// "PATH" and an uncurated sbom -- whose Use the recorded artifact does not
+// carry -- asks for "argument 1". Neither tells a reader what to type.
+//
+// It lives here rather than in one category file because the connectors it
+// applies to are in four of them: kustomize is Containers & Kubernetes, ansible
+// and bicep and cloudformation are Infrastructure as Code, sbom is Developer &
+// Supply Chain. They were one loop over one list while that list was named for
+// the person who wrote it.
+func assertPathShapedConnector(t *testing.T, name string) {
+	t.Helper()
+	c, f := formFor(t, name)
+
+	pos := positionalFields(&f)
+	if len(pos) != 1 {
+		t.Fatalf("%s has %d argument slots, want exactly one: %v",
+			name, len(pos), fieldLabels(f))
+	}
+	fd := pos[0]
+	if fd.Section != sectionTarget {
+		t.Errorf("the path sits in %q rather than TARGET", fd.Section)
+	}
+	if !fd.Required {
+		t.Errorf("%s declares MinArgs=%d but its path is optional", name, c.MinArgs)
+	}
+	if fd.Label == "" || fd.Label == "PATH" || strings.HasPrefix(fd.Label, "argument ") {
+		t.Errorf("the path slot is still labelled %q", fd.Label)
+	}
+	if fd.Desc == "" {
+		t.Errorf("%s does not say what its path should point at", name)
+	}
+
+	// Empty is refused in place rather than launched into a usage error, and a
+	// filled one is the whole command.
+	if err := f.Validate(); err == nil {
+		t.Error("an empty path launched")
+	}
+	f.Fields()[0].SetValue("/srv/infra")
+	if err := f.Validate(); err != nil {
+		t.Errorf("a filled path was still refused: %v", err)
+	}
+	if got := f.Args(); len(got) != 1 || got[0] != "/srv/infra" {
+		t.Errorf("args = %v, want just the path", got)
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms.go
+++ b/apps/cnspec/cmd/interactive/forms.go
@@ -1,0 +1,435 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+
+	"go.mondoo.com/cnspec/cli/launcher/forms"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/cnspec/internal/connectors"
+)
+
+// The curated overlays themselves now live in cli/launcher/forms, one file per
+// catalog category, and this file is what the launcher does with one.
+//
+// The split is by what each half needs. A spec needs the FormSpec shape, the
+// source ids a picker is named by, and the launcher-owned field markers -- none
+// of which is a screen. Applying a spec needs the connector's declared
+// metadata, the field types and the sections they sort into, all of which are
+// this package's. So the data went and the engine stayed: providerFormSpec,
+// specFor, mergeSpec and applySpec are all still here and all unchanged.
+//
+// The names below are aliases rather than a rewrite at every use, for the same
+// reason catalog.go's and source.go's are: the rename would otherwise have been
+// the change, across every file in this package that tests a form.
+
+type (
+	// FormSpec describes a connector's input screen. See forms.FormSpec.
+	FormSpec = forms.FormSpec
+	// PositionalSpec describes one field in the TARGET section.
+	PositionalSpec = forms.PositionalSpec
+)
+
+const (
+	specialAlicloudProfile = forms.SpecialAlicloudProfile
+	specialDockerContext   = forms.SpecialDockerContext
+)
+
+// The registry itself, read once. Every registration happens in the init of a
+// file in cli/launcher/forms, and an imported package is fully initialized
+// before this one, so there is nothing left to arrive after this runs.
+var (
+	formSpecs      = forms.Specs()
+	duplicateSpecs = forms.Duplicates()
+)
+
+// uncuratedReason returns the recorded reason a connector has no spec.
+func uncuratedReason(connector string) (string, bool) {
+	return forms.UncuratedReason(connector)
+}
+
+// providerFormSpec returns the part of a connector's form that comes from the
+// provider rather than from a person.
+//
+// The source is internal/connectors: the artifact internal/connectorgen derives
+// by walking mql provider source, embedded in the binary. It stands in for the
+// provider SDK declaring a form itself, and when the SDK grows that field this
+// is still the one function that changes.
+//
+// # What it can supply, and what it cannot
+//
+// Very little, and the reason is worth writing down because the obvious
+// assumption is the opposite. A Connector reaching here from an installed
+// provider already carries Flags, MinArgs, MaxArgs, Discovery, Long and
+// Aliases; genericFields reads all of them. So the artifact only adds value
+// where it knows something the runtime metadata does not, and there are exactly
+// two such facts: the environment variables behind each flag, and the
+// sub-command vocabulary.
+//
+// The environment routes are deliberately not returned. Reading a variable to
+// discover that a credential is already present is source_ambient.go's job and
+// is fine; putting a secret into a variable to hand it to a child process is a
+// delivery mechanism cnspec is moving away from, because providers resolve the
+// inventory first and the environment last. Returning Env here would grow the
+// route that is being retired.
+//
+// That leaves the vocabulary, and note what it does not include: no label, no
+// description, no ordering, no grouping, no value picker, no choice list. Those
+// are the whole content of a curated FormSpec and none of them is a fact about
+// the provider -- they are decisions about a screen. This function therefore
+// contributes Options and nothing else, and takes each field's label from the
+// same positionalLabels() the generic layer uses, so it invents no prose.
+func providerFormSpec(c Connector) (FormSpec, bool) {
+	rec, ok := connectors.ByName(c.Name)
+	if !ok || len(rec.Positional) == 0 {
+		return FormSpec{}, false
+	}
+
+	// The vocabulary is indexed the way the provider counts arguments, so a
+	// gap in the indices is a real gap: aws records `ec2` at 0 and
+	// `instance-connect|ssm|ebs` at 1, and nothing at 2. Slots with no recorded
+	// vocabulary still have to exist, or the ones after them shift left.
+	vocab := map[int][]string{}
+	highest := -1
+	for _, p := range rec.Positional {
+		if p.Index < 0 || len(p.Values) == 0 {
+			continue
+		}
+		vocab[p.Index] = p.Values
+		if p.Index > highest {
+			highest = p.Index
+		}
+	}
+	if highest < 0 {
+		return FormSpec{}, false
+	}
+
+	// One slot past the last word, for the value those words are selecting --
+	// `github org <ORG>` is the selector plus the thing selected -- but never
+	// past what the connector says it accepts.
+	n := highest + 2
+	if max := int(c.MaxArgs); max > 0 && n > max {
+		n = max
+	}
+
+	labels := positionalLabels(c)
+	spec := FormSpec{Positional: make([]PositionalSpec, 0, n)}
+	for i := 0; i < n; i++ {
+		p := PositionalSpec{
+			Label:    fmt.Sprintf("argument %d", i+1),
+			Required: uint(i) < c.MinArgs,
+			Options:  vocab[i],
+		}
+		if i < len(labels) {
+			p.Label = labels[i]
+		}
+		spec.Positional = append(spec.Positional, p)
+	}
+	return spec, true
+}
+
+// specFor resolves a connector's form by merging what the provider supplies
+// with what a person curated on top of it.
+//
+// It used to return the provider's declaration outright when there was one, and
+// that was a trap rather than a simplification. A provider shipping a *partial*
+// form -- a vocabulary and nothing else, which is exactly what the artifact
+// supplies today -- would have discarded the connector's whole curated spec:
+// every label, every section, every picker, silently, with a green build. The
+// dangerous state was never an unmigrated provider, which returns false and
+// changes nothing; it was a half-migrated one.
+//
+// So it merges, and the merge rules are in mergeSpec below.
+func specFor(c Connector) (FormSpec, bool) {
+	generated, hasGenerated := providerFormSpec(c)
+	curated, hasCurated := formSpecs[c.Name]
+	switch {
+	case hasGenerated && hasCurated:
+		return mergeSpec(generated, curated), true
+	case hasCurated:
+		return curated, true
+	case hasGenerated:
+		return generated, true
+	}
+	return FormSpec{}, false
+}
+
+// mergeSpec lays a curated spec over a generated one.
+//
+// The direction is fixed and is the point: generated data fills what nobody has
+// said anything about, and never overrules what someone has. A disagreement
+// between the two is either a generator bug or a deliberate correction, and
+// both of those are resolved by a person reading them -- not by whichever
+// source happened to run last.
+//
+// Three of the fields are not symmetric, and each asymmetry is a safety
+// property rather than a style choice:
+//
+//   - Secret is unioned rather than overridden. Marking a flag secret keeps its
+//     value off the command line, so the two sources agreeing to mark more is
+//     always the safe resolution.
+//   - NotSecret is taken from the curated spec only. It is the one field that
+//     moves a value *onto* the command line, where `ps auxww` reads it, and a
+//     provider is not allowed to assert that about itself. datadog --app-key,
+//     stackit --service-account-key and okta --private-key are corrections a
+//     person made after checking; a generated NotSecret would be a
+//     classification nobody checked.
+//   - Ordered lists (Positional, Target, Credential) replace rather than
+//     concatenate. Each is a complete statement about order, and appending one
+//     to the other produces an order neither source asked for.
+func mergeSpec(generated, curated FormSpec) FormSpec {
+	out := generated
+
+	// Positional is the one field where a curated spec's silence is an
+	// assertion rather than an absence, so generated slots are dropped whenever
+	// a curated spec exists at all.
+	//
+	// applySpec reads "no Positional, and the connector requires no argument"
+	// as "the derived slots are not worth showing", and that is a decision
+	// someone made. aws is the case that proves it: the artifact records `ec2`
+	// at argument 0 and `instance-connect|ssm|ebs` at argument 1, so a
+	// generated Positional adds two pickers and a value box above --profile and
+	// --region. The words are real, but a vocabulary carries no label and no
+	// emit table, so what it renders is a box titled "argument 1" offering the
+	// single choice `ec2`. That is worse than the screen it replaced, and the
+	// spec that suppressed those slots said so first.
+	//
+	// Every other field merges key by key because a curated spec that does not
+	// mention a flag is simply not talking about it. Only here does not
+	// mentioning something mean "and I want it gone".
+	out.Positional = curated.Positional
+	if len(curated.Target) > 0 {
+		out.Target = curated.Target
+	}
+	if len(curated.Credential) > 0 {
+		out.Credential = curated.Credential
+	}
+
+	out.Secret = dedupeStrings(append(append([]string{}, generated.Secret...), curated.Secret...))
+	out.Hide = dedupeStrings(append(append([]string{}, generated.Hide...), curated.Hide...))
+	// Curated only; see the note above.
+	out.NotSecret = curated.NotSecret
+
+	out.Labels = mergeStringMap(generated.Labels, curated.Labels)
+	out.Sources = mergeStringMap(generated.Sources, curated.Sources)
+	out.LiveSources = mergeStringMap(generated.LiveSources, curated.LiveSources)
+	out.Env = mergeStringMap(generated.Env, curated.Env)
+	out.Choices = mergeListMap(generated.Choices, curated.Choices)
+	out.ShowFlagsIf = mergeListMap(generated.ShowFlagsIf, curated.ShowFlagsIf)
+	return out
+}
+
+// mergeStringMap overlays over onto base, key by key, without mutating either.
+func mergeStringMap(base, over map[string]string) map[string]string {
+	if len(base) == 0 {
+		return over
+	}
+	if len(over) == 0 {
+		return base
+	}
+	out := make(map[string]string, len(base)+len(over))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range over {
+		out[k] = v
+	}
+	return out
+}
+
+func mergeListMap(base, over map[string][]string) map[string][]string {
+	if len(base) == 0 {
+		return over
+	}
+	if len(over) == 0 {
+		return base
+	}
+	out := make(map[string][]string, len(base)+len(over))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range over {
+		out[k] = v
+	}
+	return out
+}
+
+// applySpec rewrites the generic form in place. Every lookup is guarded, so a
+// flag a spec names but the installed provider does not declare simply has no
+// effect -- a spec that goes stale degrades to the generic screen rather than
+// emitting a flag that no longer exists.
+func applySpec(f *form, c Connector, o FormSpec) {
+	// A spec that declares no positional fields, for a connector that does not
+	// require any, is saying the derived slots are not worth showing: they
+	// exist only for sub-command forms the spec chose not to model.
+	if len(o.Positional) == 0 && c.MinArgs == 0 {
+		var kept []field
+		for _, fd := range f.Fields() {
+			if fd.Flag != "" {
+				kept = append(kept, fd)
+			}
+		}
+		f.SetFields(kept)
+	}
+
+	if len(o.Positional) > 0 {
+		var kept []field
+		for _, fd := range f.Fields() {
+			if fd.Flag != "" {
+				kept = append(kept, fd)
+			}
+		}
+		pos := make([]field, len(o.Positional))
+		// prev is the last field the connector itself owns, so a launcher-owned
+		// field declared in the middle of the list does not break the chain
+		// behind it: `docker context` sits between `kind` and `reference`
+		// because it decides what the reference can be, and `reference` still
+		// takes its SourceBy from `kind`.
+		prev := -1
+		for i, spec := range o.Positional {
+			dependsOn := prev
+			if spec.Special != "" {
+				// A launcher-owned field steers nothing, and what steers it is
+				// the leading selector -- the same convention ShowFlagsIf uses
+				// for a flag.
+				dependsOn = 0
+			} else {
+				prev = i
+			}
+			d := tuiform.Decl{
+				Label:        spec.Label,
+				Desc:         spec.Desc,
+				Required:     spec.Required,
+				Options:      spec.Options,
+				SourceBy:     spec.SourceBy,
+				LiveSourceBy: spec.LiveSourceBy,
+				ShowIf:       spec.ShowIf,
+				DiscoverBy:   spec.DiscoverBy,
+				Special:      spec.Special,
+				DependsOn:    dependsOn,
+				Pos:          i,
+				Section:      sectionTarget,
+				Kind:         fieldText,
+			}
+			fd := tuiform.NewField(d)
+			attachSource(&fd, spec.Source)
+			if spec.Emit != nil {
+				// A declared table wins over whatever the picker says, and the
+				// two never meet: a table names the options a spec wrote down,
+				// and a picker's values are not knowable when the spec is.
+				fd.SetEmit(emitTable(spec.Emit))
+			}
+			if len(spec.Options) > 0 || spec.Source != "" || spec.SourceBy != nil {
+				fd.Kind = fieldChoice
+				// A declared option list is the whole set of valid values; a
+				// picker only suggests.
+				fd.Strict = len(spec.Options) > 0 && spec.Source == "" && spec.SourceBy == nil
+			}
+			pos[i] = fd
+		}
+		f.SetFields(append(pos, kept...))
+	}
+
+	byFlag := map[string]int{}
+	for i, fd := range f.Fields() {
+		if fd.Flag != "" {
+			byFlag[fd.Flag] = i
+		}
+	}
+	at := func(flag string) *field {
+		if i, ok := byFlag[flag]; ok {
+			return &f.Fields()[i]
+		}
+		return nil
+	}
+
+	// The classification overrides run first, because everything below sorts
+	// and sections fields by what they are, and a Target entry deliberately
+	// refuses to move a secret.
+	for _, flag := range o.Secret {
+		if fd := at(flag); fd != nil {
+			fd.Secret = true
+			fd.Section = sectionCredential
+		}
+	}
+	for _, flag := range o.NotSecret {
+		if fd := at(flag); fd != nil && fd.Secret {
+			fd.Secret = false
+			// It was in CREDENTIAL only because it was read as a secret; put
+			// it back where an ordinary flag starts and let Target or
+			// Credential below place it deliberately.
+			fd.Section = sectionOptions
+		}
+	}
+
+	for _, flag := range o.Hide {
+		if fd := at(flag); fd != nil {
+			fd.Section = ""
+		}
+	}
+	for flag, label := range o.Labels {
+		if fd := at(flag); fd != nil {
+			fd.Label = label
+		}
+	}
+	for flag, src := range o.Sources {
+		if fd := at(flag); fd != nil {
+			attachSource(fd, src)
+			fd.PromoteToChoice()
+		}
+	}
+	for flag, src := range o.LiveSources {
+		if fd := at(flag); fd != nil {
+			fd.LiveSource = src
+			fd.PromoteToChoice()
+		}
+	}
+	for flag, opts := range o.Choices {
+		if fd := at(flag); fd != nil {
+			fd.Options = opts
+			fd.PromoteToChoice()
+		}
+	}
+	for _, flag := range o.Target {
+		// A secret never leaves the credential section, whatever a spec says.
+		if fd := at(flag); fd != nil && !fd.Secret {
+			fd.Section = sectionTarget
+		}
+	}
+	for _, flag := range o.Credential {
+		if fd := at(flag); fd != nil {
+			fd.Section = sectionCredential
+		}
+	}
+	for flag, when := range o.ShowFlagsIf {
+		if fd := at(flag); fd != nil {
+			fd.ShowIf = when
+			fd.DependsOn = 0 // the leading selector
+		}
+	}
+	// Env is keyed by field identity rather than by flag, because the value
+	// that has no flag to travel in is often a positional -- the whole reason
+	// the environment is being used at all.
+	for want, envVar := range o.Env {
+		for i := range f.Fields() {
+			if tuiform.MatchesIdentity(f.Fields()[i], want) {
+				f.Fields()[i].Env = envVar
+			}
+		}
+	}
+
+	rank := map[string]int{}
+	for i, flag := range append(append([]string{}, o.Target...), o.Credential...) {
+		rank[flag] = i
+	}
+	var kept []field
+	for _, fd := range f.Fields() {
+		if fd.Section != "" {
+			kept = append(kept, fd)
+		}
+	}
+	f.SetFields(kept)
+	tuiform.SortFields(f.Fields(), rank)
+}

--- a/apps/cnspec/cmd/interactive/forms_ai_test.go
+++ b/apps/cnspec/cmd/interactive/forms_ai_test.go
@@ -1,0 +1,533 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The AI family is nine connectors whose whole credential is an API key, so
+// every test below injects the environment rather than reading it. Those are
+// exactly the variables a developer running this suite is most likely to have
+// exported, and a test that consulted the real environment would be reading
+// that developer's actual keys to decide whether it passes.
+//
+// withAmbientEnv, in source_ambient_test.go, is the seam.
+
+// aiConnectors are the nine this file curates.
+var aiConnectors = filedHere(
+	"anthropic", "claude", "huggingface", "mcp", "mistral",
+	"ollama", "openai", "together", "vllm",
+)
+
+// aiKey is a stand-in credential. Nothing that renders, and nothing that
+// reaches a command line, may ever contain it.
+const aiKey = "<PLACEHOLDER-not-a-real-secret>"
+
+// Every one of the nine is claimed by this file. Without this, dropping a
+// registerSpec call leaves that connector on the generic flag-derived screen,
+// which looks like a form and says nothing about being uncurated.
+func TestEveryAIConnectorIsCurated(t *testing.T) {
+	for _, name := range aiConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+	}
+}
+
+// aiCredentialCase is one connector's credential: the flag that carries it, the
+// variable a value typed into that flag must travel in, and the variables the
+// readout watches, in the order the provider reads them.
+type aiCredentialCase struct {
+	connector string
+	flag      string
+	env       string
+	ambient   []string
+	// fill supplies whatever else the form needs before it can be launched.
+	fill func(t *testing.T, f *form)
+}
+
+func aiCredentialCases() []aiCredentialCase {
+	return []aiCredentialCase{
+		{connector: "anthropic", flag: "token", env: "ANTHROPIC_API_KEY",
+			ambient: []string{"ANTHROPIC_API_KEY"}},
+		{connector: "anthropic", flag: "admin-token", env: "ANTHROPIC_ADMIN_API_KEY"},
+		{connector: "claude", flag: "token", env: "ANTHROPIC_API_KEY",
+			ambient: []string{"ANTHROPIC_API_KEY"}},
+		{connector: "claude", flag: "admin-token", env: "ANTHROPIC_ADMIN_API_KEY"},
+		{connector: "huggingface", flag: "token", env: "HF_TOKEN",
+			ambient: []string{"HF_TOKEN"}},
+		{connector: "mcp", flag: "token", env: "MCP_TOKEN", fill: fillMCP},
+		{connector: "mistral", flag: "token", env: "MISTRAL_API_KEY",
+			ambient: []string{"MISTRAL_API_KEY", "MISTRAL_KEY"}},
+		{connector: "ollama", flag: "token", env: "OLLAMA_API_TOKEN",
+			ambient: []string{"OLLAMA_API_TOKEN"}},
+		{connector: "openai", flag: "token", env: "OPENAI_API_KEY",
+			ambient: []string{"OPENAI_API_KEY"}},
+		{connector: "together", flag: "token", env: "TOGETHER_API_KEY",
+			ambient: []string{"TOGETHER_API_KEY"}},
+		{connector: "vllm", flag: "api-key", env: "VLLM_API_KEY",
+			ambient: []string{"VLLM_API_KEY"}, fill: fillVLLM},
+	}
+}
+
+func fillMCP(t *testing.T, f *form) {
+	t.Helper()
+	fieldByLabel(t, *f, "transport").SetValue("https")
+	fieldByLabel(t, *f, "server").SetValue("https://mcp.example.com/mcp")
+}
+
+func fillVLLM(t *testing.T, f *form) {
+	t.Helper()
+	fieldByLabel(t, *f, "endpoint").SetValue("http://localhost:8000")
+}
+
+// The whole point of the delivery machinery: a key the user types reaches the
+// provider, and never becomes a word on a command line, where `ps auxww` would
+// hand it to every other user on the machine.
+//
+// This used to also assert which environment variable each key travelled in,
+// because the launcher had to name one and the name was a fact about the
+// provider that a person had checked. The names are still recorded on the cases
+// below, but as what the *readout* watches -- what the provider reads when the
+// launcher supplies nothing -- which is a different claim and the only one they
+// were ever safe to make.
+func TestEveryAIKeyReachesTheProviderAndNotArgv(t *testing.T) {
+	for _, tc := range aiCredentialCases() {
+		t.Run(tc.connector+"/"+tc.flag, func(t *testing.T) {
+			withAmbientEnv(t, nil)
+			c, f := formFor(t, tc.connector)
+			if tc.fill != nil {
+				tc.fill(t, &f)
+			}
+
+			i := f.IndexOfFlag(tc.flag)
+			if i < 0 {
+				t.Fatalf("no --%s field on the form: %v", tc.flag, fieldLabels(f))
+			}
+			if !f.Fields()[i].Secret {
+				t.Fatalf("--%s is not marked secret, so its value could reach argv", tc.flag)
+			}
+			if f.Fields()[i].Section != sectionCredential {
+				t.Errorf("--%s sits in %q, want CREDENTIAL", tc.flag, f.Fields()[i].Section)
+			}
+			f.Fields()[i].SetValue(aiKey)
+
+			assertCredentialReachesTheProvider(t, c, f, tc.flag, aiKey)
+
+			// The command bar is what a user checks this against, so it has to
+			// agree with what launch really does.
+			if preview := (launchRequest{form: f}).preview(c, scanAction()); strings.Contains(preview, aiKey) {
+				t.Fatalf("the command preview showed the key: %q", preview)
+			}
+		})
+	}
+}
+
+// The readout's one job is to say where a credential came from. Its one
+// prohibition is saying what it is.
+func TestAIReadoutsNameTheVariableNeverTheKey(t *testing.T) {
+	for _, tc := range aiCredentialCases() {
+		if len(tc.ambient) == 0 {
+			continue
+		}
+		t.Run(tc.connector, func(t *testing.T) {
+			withAmbientEnv(t, map[string]string{tc.ambient[0]: aiKey})
+			_, f := formFor(t, tc.connector)
+
+			fd := fieldByLabel(t, f, "credential")
+			if fd.Kind != fieldCredentialState {
+				t.Fatalf("the readout is a %v, want a credential-state field", fd.Kind)
+			}
+			if fd.Value() != tc.ambient[0] {
+				t.Errorf("readout = %q, want %q", fd.Value(), tc.ambient[0])
+			}
+			if strings.Contains(fd.Display(), aiKey) {
+				t.Fatalf("the readout displayed the key: %q", fd.Display())
+			}
+			for _, g := range f.Fields() {
+				if strings.Contains(g.Value(), aiKey) {
+					t.Fatalf("%q holds the key itself", g.Label)
+				}
+			}
+			// And it is launcher-owned, so it has no flag to be emitted under
+			// and must not be mistaken for a positional argument either.
+			for _, a := range f.Args() {
+				if strings.Contains(a, tc.ambient[0]) || strings.Contains(a, aiKey) {
+					t.Fatalf("the credential reached the command line: %v", f.Args())
+				}
+			}
+		})
+	}
+}
+
+// An empty row and a row with nothing to fill in look identical, which is the
+// failure the readout exists to end: every one of them has to name the variable
+// to export when it finds nothing.
+func TestEveryAIReadoutSaysWhatToExportWhenNothingIsSet(t *testing.T) {
+	for _, tc := range aiCredentialCases() {
+		if len(tc.ambient) == 0 {
+			continue
+		}
+		t.Run(tc.connector, func(t *testing.T) {
+			withAmbientEnv(t, nil)
+			_, f := formFor(t, tc.connector)
+
+			fd := fieldByLabel(t, f, "credential")
+			if fd.IsSet() {
+				t.Fatalf("nothing is exported but the readout says %q", fd.Value())
+			}
+			if hint := credentialHint(*fd); !strings.Contains(hint, tc.ambient[0]) {
+				t.Errorf("the hint should name %s, got %q", tc.ambient[0], hint)
+			}
+		})
+	}
+}
+
+// mistral reads MISTRAL_API_KEY and falls back to MISTRAL_KEY, so the readout
+// has to name whichever the provider will actually reach for. Both were
+// confirmed against the shipped provider: with neither set it refuses and names
+// MISTRAL_API_KEY, and MISTRAL_KEY alone gets past that check.
+func TestMistralReadoutFollowsTheProvidersPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"both", map[string]string{"MISTRAL_API_KEY": aiKey, "MISTRAL_KEY": aiKey}, "MISTRAL_API_KEY"},
+		{"only the fallback", map[string]string{"MISTRAL_KEY": aiKey}, "MISTRAL_KEY"},
+		{"only the first", map[string]string{"MISTRAL_API_KEY": aiKey}, "MISTRAL_API_KEY"},
+		{"neither", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withAmbientEnv(t, tc.env)
+			_, f := formFor(t, "mistral")
+			if got := fieldByLabel(t, f, "credential").Value(); got != tc.want {
+				t.Errorf("readout = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A pasted key wins over the environment, because that is the precedence every
+// one of these providers implements. A row naming a variable while a typed key
+// was about to be used would be confidently wrong about the one fact it states.
+func TestAITypedKeyBeatsTheEnvironment(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"OPENAI_API_KEY": aiKey})
+	_, f := formFor(t, "openai")
+
+	if got := fieldByLabel(t, f, "credential").Value(); got != "OPENAI_API_KEY" {
+		t.Fatalf("readout = %q, want the variable", got)
+	}
+	paste := fieldByLabel(t, f, "API key")
+	if paste.Kind != fieldPaste {
+		t.Fatalf("the token flag is a %v, want a paste box", paste.Kind)
+	}
+	paste.SetValue("typed-" + aiKey)
+
+	resolveSources(&f)
+	readout := fieldByLabel(t, f, "credential")
+	if readout.Value() != "pasted" {
+		t.Errorf("readout = %q, want it to follow the typed key", readout.Value())
+	}
+	if strings.Contains(readout.Display(), aiKey) {
+		t.Fatal("the readout displayed the typed key")
+	}
+}
+
+// ollama is normally a server on this machine with no authentication at all, so
+// the generic hint -- "export OLLAMA_API_TOKEN, or paste one below" -- would
+// send a local user looking for a credential that does not exist.
+func TestOllamaSaysALocalServerNeedsNoToken(t *testing.T) {
+	withAmbientEnv(t, nil)
+	_, f := formFor(t, "ollama")
+
+	hint := credentialHint(*fieldByLabel(t, f, "credential"))
+	if !strings.Contains(hint, "local server does not need one") {
+		t.Errorf("the hint should say a local server needs no token, got %q", hint)
+	}
+	if !strings.Contains(hint, "OLLAMA_API_TOKEN") {
+		t.Errorf("the hint should still name the variable, got %q", hint)
+	}
+}
+
+// The two locally-hosted connectors are addressed by URL, not by credential, so
+// the address is what their TARGET has to ask for.
+func TestLocallyHostedAIConnectorsAskForAnAddress(t *testing.T) {
+	withAmbientEnv(t, nil)
+
+	_, ollama := formFor(t, "ollama")
+	host := fieldByLabel(t, ollama, "server")
+	if host.Section != sectionTarget {
+		t.Errorf("ollama's server sits in %q, want TARGET", host.Section)
+	}
+	if !containsString(host.Options, "http://localhost:11434") {
+		t.Errorf("the default address is not offered: %v", host.Options)
+	}
+	if host.Strict {
+		// A suggestion, not a validation list: a server on another host or
+		// port has to stay typeable.
+		t.Error("ollama's server field refuses anything but the suggestion")
+	}
+
+	_, vllm := formFor(t, "vllm")
+	endpoint := fieldByLabel(t, vllm, "endpoint")
+	if endpoint.Flag != "" {
+		t.Errorf("vllm's endpoint is --%s, want the positional argument", endpoint.Flag)
+	}
+	if !endpoint.Required {
+		t.Error("vllm cannot be scanned without an endpoint, so it must be required")
+	}
+	fieldByLabel(t, vllm, "endpoint").SetValue("http://localhost:8000")
+	if !containsString(vllm.Args(), "http://localhost:8000") {
+		t.Errorf("the endpoint did not reach the command: %v", vllm.Args())
+	}
+}
+
+// vllm's credential flag is --api-key rather than --token, so the readout
+// cannot redraw it as a paste box; the flag keeps its own field. The readout
+// still has to appear, and has to say that the usual unauthenticated server
+// needs nothing at all.
+func TestVLLMReportsItsKeyWithoutClaimingOne(t *testing.T) {
+	withAmbientEnv(t, nil)
+	_, f := formFor(t, "vllm")
+
+	readout := fieldByLabel(t, f, "credential")
+	if readout.Kind != fieldCredentialState {
+		t.Fatalf("vllm has no credential readout, only %v", fieldLabels(f))
+	}
+	hint := credentialHint(*readout)
+	if !strings.Contains(hint, "needs neither") {
+		t.Errorf("the hint should say an open server needs no key, got %q", hint)
+	}
+	// A readout with no flag to sit above is appended, so it renders after the
+	// field it describes and must not point downward at it.
+	if strings.Contains(hint, "below") {
+		t.Errorf("the hint points below at a field that is above it: %q", hint)
+	}
+	if key := fieldByLabel(t, f, "API key"); key.Kind == fieldPaste {
+		t.Error("--api-key was redrawn as a paste box, which only --token can be")
+	}
+}
+
+// ollama and openai read values from the environment that are not credentials,
+// and the provider will use them whether or not the user knows. Mirroring them
+// into an editable field is how the user gets to notice.
+func TestAIFieldsPrefilledFromTheEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		connector string
+		env       map[string]string
+		label     string
+		want      string
+	}{
+		{"ollama", map[string]string{"OLLAMA_HOST": "http://ollama.internal:11434"},
+			"server", "http://ollama.internal:11434"},
+		{"openai", map[string]string{"OPENAI_ORG_ID": "org-123"}, "organization", "org-123"},
+		{"openai", map[string]string{"OPENAI_PROJECT_ID": "proj-123"}, "project", "proj-123"},
+		{"openai", map[string]string{"OPENAI_BASE_URL": "https://gw.example.com/v1"},
+			"API base URL", "https://gw.example.com/v1"},
+	} {
+		t.Run(tc.connector+"/"+tc.label, func(t *testing.T) {
+			withAmbientEnv(t, tc.env)
+			_, f := formFor(t, tc.connector)
+
+			fd := fieldByLabel(t, f, tc.label)
+			if fd.Value() != tc.want {
+				t.Fatalf("%s = %q, want %q", tc.label, fd.Value(), tc.want)
+			}
+			if fd.Prefilled() == "" {
+				t.Error("a value the user did not type must say where it came from")
+			}
+			if fd.Secret {
+				t.Fatal("a secret must never be prefilled from anywhere")
+			}
+			// It is an ordinary flag, so it does travel on the command line --
+			// which is correct here, and is why nothing secret is prefilled.
+			if !containsString(f.Args(), "--"+fd.Flag) {
+				t.Errorf("the prefilled value did not reach the command: %v", f.Args())
+			}
+		})
+	}
+}
+
+// A value the user typed is never replaced by one from the environment.
+func TestAIPrefillDoesNotOverwriteTheUser(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"OLLAMA_HOST": "http://ollama.internal:11434"})
+	_, f := formFor(t, "ollama")
+	fieldByLabel(t, f, "server").SetValue("http://chosen:11434")
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "server").Value(); got != "http://chosen:11434" {
+		t.Fatalf("server = %q, want what the user typed", got)
+	}
+}
+
+// claude is the only connector in the family with anything to enumerate, and
+// the picker for it is a remote call: it needs a credential and a round trip,
+// so it must be attached as a live source that runs when the field is opened
+// rather than one that runs when the form is built.
+func TestClaudeWorkspacesAreAPickerThatWaitsToBeAsked(t *testing.T) {
+	withAmbientEnv(t, nil)
+	_, f := formFor(t, "claude")
+
+	fd := fieldByLabel(t, f, "workspace")
+	if fd.LiveSource != srcDiscoverClaudeWorkspaces {
+		t.Fatalf("workspace liveSource = %q, want %q", fd.LiveSource, srcDiscoverClaudeWorkspaces)
+	}
+	s, ok := sourceByID(srcDiscoverClaudeWorkspaces)
+	if !ok {
+		t.Fatal("the workspace source is not registered")
+	}
+	if s.Cost != CostRemote {
+		t.Errorf("workspace discovery costs a round trip, Cost = %v", s.Cost)
+	}
+	if fd.Kind != fieldChoice {
+		t.Errorf("workspace is a %v, want a picker", fd.Kind)
+	}
+	// The discovery targets the connector declares must still be offered.
+	discover := fieldByLabel(t, f, "discover")
+	for _, want := range []string{"organization", "workspaces"} {
+		if !containsString(discover.Options, want) {
+			t.Errorf("--discover does not offer %q: %v", want, discover.Options)
+		}
+	}
+}
+
+// mcp is the one connector here whose target is not a credential: it takes a
+// transport and then either a URL or the command that starts a server, and
+// which of its flags mean anything depends on the first answer.
+func TestMCPAsksForATransportThenWhatItNeeds(t *testing.T) {
+	withAmbientEnv(t, nil)
+	_, f := formFor(t, "mcp")
+
+	transport := fieldByLabel(t, f, "transport")
+	if !transport.Strict {
+		t.Error("the transport is a closed set, so the field must not accept anything else")
+	}
+	for _, want := range []string{"http", "https", "stdio"} {
+		if !containsString(transport.Options, want) {
+			t.Errorf("transport does not offer %q: %v", want, transport.Options)
+		}
+	}
+
+	visibleLabels := func() []string {
+		var out []string
+		for _, i := range f.VisibleIndices() {
+			out = append(out, f.Fields()[i].Label)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	fieldByLabel(t, f, "transport").SetValue("stdio")
+	fieldByLabel(t, f, "server").SetValue("npx -y @modelcontextprotocol/server-github")
+	if got := visibleLabels(); containsString(got, "bearer token") {
+		t.Errorf("a stdio server was asked for a bearer token: %v", got)
+	}
+	if got := visibleLabels(); !containsString(got, "working directory") {
+		t.Errorf("a stdio server was not offered a working directory: %v", got)
+	}
+	if got := f.Args(); !containsString(got, "stdio") {
+		t.Errorf("the transport did not reach the command: %v", got)
+	}
+
+	fieldByLabel(t, f, "transport").SetValue("https")
+	fieldByLabel(t, f, "server").SetValue("https://mcp.example.com/mcp")
+	if got := visibleLabels(); !containsString(got, "bearer token") {
+		t.Errorf("an HTTPS server was not offered a bearer token: %v", got)
+	}
+	if got := visibleLabels(); containsString(got, "working directory") {
+		t.Errorf("an HTTPS server was asked for a working directory: %v", got)
+	}
+}
+
+// huggingface's --namespace-type is rejected by the provider unless it is
+// "user" or "org", so those two are the whole set rather than a suggestion.
+func TestHuggingFaceOffersTheNamespaceKindsTheProviderAccepts(t *testing.T) {
+	withAmbientEnv(t, nil)
+	_, f := formFor(t, "huggingface")
+
+	fd := fieldByLabel(t, f, "namespace kind")
+	sorted := append([]string(nil), fd.Options...)
+	sort.Strings(sorted)
+	if strings.Join(sorted, ",") != "org,user" {
+		t.Errorf("namespace kind offers %v, want user and org", fd.Options)
+	}
+}
+
+// The failure this whole redesign started from: a picker with nothing in it and
+// no explanation. A field drawn as a choice has to have somewhere for its
+// values to come from -- a declared list, a source, or a live source -- or it is
+// an empty box the user cannot fill and cannot escape.
+func TestNoAIFormOffersAPickerWithNothingBehindIt(t *testing.T) {
+	withAmbientEnv(t, nil)
+	for _, name := range aiConnectors {
+		t.Run(name, func(t *testing.T) {
+			_, f := formFor(t, name)
+			for _, fd := range f.Fields() {
+				if fd.Kind != fieldChoice && fd.Kind != fieldMultiChoice {
+					continue
+				}
+				if len(fd.Options) > 0 || fd.Source() != "" || fd.LiveSource != "" ||
+					fd.SourceBy != nil || fd.LiveSourceBy != nil {
+					continue
+				}
+				t.Errorf("%q is a picker with no values and no source", fd.Label)
+			}
+		})
+	}
+}
+
+// Both Anthropic keys typed into one form travel together.
+//
+// This was a refusal once, and then it was two environment variables. Both were
+// artifacts of the launcher having to name a route: a variable carries one
+// flag, so two credentials needed two names, and neither name was the
+// launcher's to know. One ParseCLI call carries the whole form, so "how many
+// secrets does this route carry" stopped being a question.
+func TestAnthropicCarriesBothKeysAtOnce(t *testing.T) {
+	for _, name := range []string{"anthropic", "claude"} {
+		t.Run(name, func(t *testing.T) {
+			withAmbientEnv(t, nil)
+			c, f := formFor(t, name)
+			fieldByLabel(t, f, "API key").SetValue(aiKey)
+			fieldByLabel(t, f, "admin API key").SetValue(aiKey + "-admin")
+
+			p := withParser(t, &fakeParser{secretFlag: "token"})
+			plan, err := launchRequest{form: f}.plan(c, scanAction())
+			if plan.cleanup != nil {
+				defer plan.cleanup()
+			}
+			if err != nil {
+				t.Fatalf("two credentials on one form were refused: %v", err)
+			}
+
+			for flag, want := range map[string]string{
+				"token":       aiKey,
+				"admin-token": aiKey + "-admin",
+			} {
+				got, ok := p.sentValue(flag)
+				if !ok {
+					t.Errorf("--%s never reached the provider; it was sent %v", flag, sortedKeys(p.flags))
+					continue
+				}
+				if got != want {
+					t.Errorf("--%s reached the provider as %q, want %q", flag, got, want)
+				}
+			}
+
+			preview := (launchRequest{form: f}).preview(c, scanAction())
+			if strings.Contains(preview, aiKey) {
+				t.Fatalf("the preview showed a key: %q", preview)
+			}
+			if strings.Contains(strings.Join(plan.args, " "), aiKey) {
+				t.Fatalf("a key reached argv: %v", plan.args)
+			}
+			if strings.Contains(strings.Join(plan.env, " "), aiKey) {
+				t.Fatalf("a key reached the child's environment: %v", plan.env)
+			}
+		})
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_cloud_test.go
+++ b/apps/cnspec/cmd/interactive/forms_cloud_test.go
@@ -1,0 +1,783 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The curated Cloud & Virtualization forms, and what a screen for one has to
+// get right.
+//
+// TestEverySpecNamesRealFlags already proves generically, over the whole
+// registry, that every flag these specs name exists. What it cannot prove is
+// the half that decides whether a curated credential section produces a usable
+// screen: that the secret reaches the provider and reaches nothing else. That
+// is caught here, at authoring time, rather than in a demo.
+//
+// Every test below drives the real form -- newForm over the connector rebuilt
+// from internal/connectors/connectors.json -- rather than inspecting the
+// FormSpec literal, because a spec that names a flag the connector does not
+// declare is silently dropped by applySpec. Reading the spec back would agree
+// with itself; building the form is what proves the flag survived.
+//
+// The two connector lists below are what used to be two files, split where one
+// contributor's work ended and the next began. They stay two lists because each
+// test names the list it iterates, and merging them would have been a rewrite
+// of every assertion in both. Both are declared through filedHere, so the thing
+// the letters used to hide -- a connector from another category quietly added
+// to whichever list its author had open -- fails in
+// TestEveryTestedConnectorIsFiledUnderItsCategory with the name of the file it
+// belongs in.
+
+// The gate over this file's six connectors.
+//
+// TestEverySpecNamesRealFlags already proves that every flag named here exists,
+// generically over the whole registry. What it cannot prove is the half that
+// decides whether a curated credential section produces a usable screen: that
+// the secret reaches the provider and reaches nothing else. That is caught
+// here, at authoring time, rather than in a demo.
+
+// cloudAConnectors are the six this file curates.
+var cloudAConnectors = filedHere(
+	"alicloud", "digitalocean", "equinix", "hcp", "hetzner", "nutanix",
+)
+
+func TestCloudASpecsAreRegistered(t *testing.T) {
+	for _, name := range cloudAConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+	}
+}
+
+// Every secret a curated credential section offers reaches the provider, and
+// none of them reaches the command line. One secret is filled at a time,
+// because that is how a form is actually used.
+func TestCloudACredentialsReachTheProvider(t *testing.T) {
+	const secret = "<PLACEHOLDER-not-a-real-secret>"
+
+	for _, name := range cloudAConnectors {
+		spec := formSpecs[name]
+		c, base := formFor(t, name)
+
+		for _, flag := range spec.Credential {
+			i := base.IndexOfFlag(flag)
+			if i < 0 {
+				t.Errorf("%s: --%s is in Credential but built no field", name, flag)
+				continue
+			}
+			if !base.Fields()[i].Secret {
+				// A non-secret in CREDENTIAL is deliberate -- an AccessKey id
+				// belongs beside the secret it pairs with -- and carries no
+				// delivery question.
+				continue
+			}
+
+			f := base
+			f.SetFields(append([]field(nil), base.Fields()...))
+			f.Fields()[i].SetValue(secret)
+
+			assertCredentialReachesTheProvider(t, c, f, flag, secret)
+			if strings.Contains(strings.Join(f.Args(), " "), secret) {
+				t.Errorf("%s: --%s reached argv: %v", name, flag, f.Args())
+			}
+		}
+	}
+}
+
+// nutanix's two credentials both travel, and a typed password is no longer
+// swapped for a prompt.
+//
+// It used to be: --ask-pass is declared, so a typed password took the prompt
+// route, the typed value was dropped and the child asked for it again. The
+// toggle is still on the form -- ticking it is the best route there is, because
+// the value never exists outside the process that uses it -- but it is now the
+// user's choice rather than a substitution made on their behalf.
+func TestNutanixCarriesEitherCredentialAndStillOffersThePrompt(t *testing.T) {
+	c, base := formFor(t, "nutanix")
+
+	fill := func(flag string) form {
+		f := base
+		f.SetFields(append([]field(nil), base.Fields()...))
+		i := f.IndexOfFlag(flag)
+		if i < 0 {
+			t.Fatalf("nutanix built no --%s field", flag)
+		}
+		f.Fields()[i].SetValue("<PLACEHOLDER-not-a-real-secret>")
+		return f
+	}
+
+	for _, flag := range []string{"password", "api-key"} {
+		f := fill(flag)
+		if got := deliveryFor(f); got != deliverInventory {
+			t.Errorf("--%s routes as %v, want the inventory", flag, got)
+		}
+		assertCredentialReachesTheProvider(t, c, f, flag, "<PLACEHOLDER-not-a-real-secret>")
+	}
+
+	// Ticked with nothing typed: an ordinary flag on an ordinary command line.
+	ask := base
+	ask.SetFields(append([]field(nil), base.Fields()...))
+	i := ask.IndexOfFlag("ask-pass")
+	if i < 0 {
+		t.Fatal("nutanix lost its --ask-pass toggle")
+	}
+	ask.Fields()[i].SetOn(true)
+	if got := deliveryFor(ask); got != deliverPlain {
+		t.Errorf("--ask-pass on its own routes as %v, want the command line", got)
+	}
+	if !strings.Contains(strings.Join(ask.Args(), " "), "--ask-pass") {
+		t.Errorf("--ask-pass did not reach the command line: %v", ask.Args())
+	}
+}
+
+// nutanix's --endpoint is the connector's one required flag. A required field
+// left in sectionOptions sits behind the "more" fold, where focusFirstMissing
+// parks a cursor that moveFocus cannot reach.
+func TestCloudARequiredFieldsAreReachable(t *testing.T) {
+	for _, name := range cloudAConnectors {
+		_, f := formFor(t, name)
+		for _, fd := range f.Fields() {
+			if fd.Required && fd.Section == sectionOptions {
+				t.Errorf("%s: %q is required but sits behind the options fold",
+					name, fd.Label)
+			}
+		}
+	}
+}
+
+// equinix takes `org <id>` or `project <id>`: two positional arguments, which
+// the usage string only hints at and MinArgs=2 records. The words are the
+// connector's own, and both have to reach the command line in order.
+func TestEquinixEmitsItsSubcommandPair(t *testing.T) {
+	_, f := formFor(t, "equinix")
+
+	kind := fieldByLabel(t, f, "kind")
+	if kind.Kind != fieldChoice || !kind.Strict {
+		t.Errorf("the kind field is %v (strict=%v), want a closed choice",
+			kind.Kind, kind.Strict)
+	}
+	kind.SetValue("project")
+	fieldByLabel(t, f, "id").SetValue("proj-123")
+
+	got := strings.Join(f.Args(), " ")
+	if got != "project proj-123" {
+		t.Errorf("args = %q, want %q", got, "project proj-123")
+	}
+}
+
+// The connectors whose account *is* the target lead with --discover, because
+// otherwise TARGET is empty and the one question worth asking sits behind the
+// "more" fold.
+func TestAccountWideConnectorsLeadWithDiscovery(t *testing.T) {
+	for _, name := range []string{"digitalocean", "hetzner"} {
+		_, f := formFor(t, name)
+		i := f.IndexOfFlag("discover")
+		if i < 0 {
+			t.Errorf("%s built no --discover field", name)
+			continue
+		}
+		if f.Fields()[i].Section != sectionTarget {
+			t.Errorf("%s: --discover sits in %q, want TARGET",
+				name, f.Fields()[i].Section)
+		}
+	}
+}
+
+// The ambient credential widgets belong to source_ambient.go, and this file
+// curates around them rather than duplicating them. What a spec is allowed to
+// change is the label and the section; what it must not do is turn the paste
+// box back into an ordinary text field or take the readout away.
+func TestAmbientWidgetsSurviveTheseSpecs(t *testing.T) {
+	withAmbientEnv(t, nil)
+	for _, name := range []string{"digitalocean", "hetzner"} {
+		_, f := formFor(t, name)
+
+		i := f.IndexOfFlag("token")
+		if i < 0 {
+			t.Errorf("%s built no --token field", name)
+			continue
+		}
+		if f.Fields()[i].Kind != fieldPaste {
+			t.Errorf("%s: --token is a %v, want the paste box", name, f.Fields()[i].Kind)
+		}
+		if f.Fields()[i].Section != sectionCredential {
+			t.Errorf("%s: --token sits in %q", name, f.Fields()[i].Section)
+		}
+		if f.IndexOfSpecial(specialCredentialState) < 0 {
+			t.Errorf("%s: the credential readout is gone", name)
+		}
+	}
+
+	// digitalocean's second, report-only readout is part of the same
+	// arrangement and must not have picked up a flag from this file.
+	_, f := formFor(t, "digitalocean")
+	if i := f.IndexOfSpecial(specialCredentialState + ".spaces"); i < 0 {
+		t.Error("the digitalocean spaces readout is gone")
+	} else if f.Fields()[i].Flag != "" {
+		t.Errorf("the spaces readout acquired --%s", f.Fields()[i].Flag)
+	}
+}
+
+// The command each curated form assembles, spelled out.
+//
+// Every case that carries a credential now reads the same, because there is one
+// route and the bar names the file it will write rather than a command with a
+// variable in front of it. What is still worth asserting is which cases those
+// are: a connector that grew a credential, or lost one, changes a line here.
+//
+// The old expectations were transcripts -- each was run against the installed
+// provider while writing this file and got past its credential gate -- and what
+// they were checking was that the launcher had picked the right one of four
+// routes. There is no choice left to get wrong.
+func TestCloudAAssemblesTheVerifiedCommands(t *testing.T) {
+	withAmbientEnv(t, nil)
+
+	cases := []struct {
+		connector string
+		fill      map[string]string
+		positions []string
+		want      string
+	}{{
+		connector: "alicloud",
+		fill: map[string]string{
+			"region": "cn-hangzhou", "access-key-id": "AK", "access-key-secret": "SK",
+		},
+		want: "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		connector: "digitalocean",
+		fill:      map[string]string{"token": "dop_v1_x"},
+		want:      "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		connector: "equinix",
+		fill:      map[string]string{"token": "eq-token"},
+		positions: []string{"org", "org-123"},
+		want:      "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		connector: "hcp",
+		fill:      map[string]string{"client-id": "cid", "client-secret": "csec"},
+		want:      "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		connector: "hetzner",
+		fill:      map[string]string{"token": "hz-token"},
+		want:      "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		// Basic auth: the child prompts, so nothing is carried at all.
+		connector: "nutanix",
+		fill: map[string]string{
+			"endpoint": "pc.example.com", "user": "admin", "password": "pw",
+		},
+		want: "cnspec scan --inventory-file <generated, 0600>",
+	}, {
+		// Both nutanix credentials go in the file, as every credential does.
+		connector: "nutanix",
+		fill:      map[string]string{"endpoint": "pc.example.com", "api-key": "key"},
+		want:      "cnspec scan --inventory-file <generated, 0600>",
+	}}
+
+	for _, tc := range cases {
+		c, f := formFor(t, tc.connector)
+		for flag, v := range tc.fill {
+			i := f.IndexOfFlag(flag)
+			if i < 0 {
+				t.Errorf("%s built no --%s field", tc.connector, flag)
+				continue
+			}
+			f.Fields()[i].SetValue(v)
+		}
+		for _, fd := range positionalFields(&f) {
+			if fd.Pos < len(tc.positions) {
+				fd.SetValue(tc.positions[fd.Pos])
+			}
+		}
+
+		if got := (launchRequest{form: f}).preview(c, scanAction()); got != tc.want {
+			t.Errorf("%s preview:\n got %q\nwant %q", tc.connector, got, tc.want)
+		}
+		// Whatever the route, none of it may be on the command line.
+		for _, fd := range f.Secrets() {
+			if strings.Contains(strings.Join(f.Args(), " "), fd.Value()) {
+				t.Errorf("%s: the secret reached argv: %v", tc.connector, f.Args())
+			}
+		}
+	}
+}
+
+// alicloud declares MinArgs=0 and MaxArgs=0, so anything this form emitted as a
+// bare argument would make the command unrunnable -- `cnspec shell alicloud
+// staging` answers `unknown command "staging"`.
+//
+// The profile is attached now, and this is the assertion that says how: it is a
+// launcher-owned field, it contributes ALIBABA_CLOUD_PROFILE, and it puts
+// nothing on the command line. The earlier version of this test locked the
+// workaround -- "the spec declares no positional fields at all" -- because
+// there was no way to have one without the other. There is now; see
+// PositionalSpec.Special, and the note at the bottom of cli/launcher/forms/forms_cloud.go for
+// what was tried before it.
+func TestAlicloudProfileTravelsWithoutABareArgument(t *testing.T) {
+	snap, ok := snapshotByName(t)["alicloud"]
+	if !ok {
+		t.Fatal("alicloud is not in the connector snapshot")
+	}
+	if snap.MaxArgs != 0 {
+		t.Fatalf("alicloud now takes %d arguments; the profile could travel in one",
+			snap.MaxArgs)
+	}
+
+	c := snap.connector()
+	f := newForm(c)
+	profile := fieldByLabel(t, f, "profile")
+	if profile.Special != specialAlicloudProfile {
+		t.Fatalf("the profile field is %q, want the launcher-owned marker %q",
+			profile.Special, specialAlicloudProfile)
+	}
+	if profile.Source() != srcAlicloudProfile {
+		t.Errorf("the profile field has source %q, want %q", profile.Source(), srcAlicloudProfile)
+	}
+
+	// Nothing on this form is a plain positional, and filling everything in
+	// still emits no bare argument.
+	for _, fd := range positionalFields(&f) {
+		t.Errorf("alicloud built a positional field %q", fd.Label)
+	}
+	for i := range f.Fields() {
+		f.Fields()[i].SetValue("filled")
+	}
+	for _, a := range f.Args() {
+		if !strings.HasPrefix(a, "-") && !isFlagValue(f, a) {
+			t.Errorf("alicloud emitted the bare argument %q", a)
+		}
+	}
+
+	// And the profile does reach the child, as a variable with a value -- the
+	// other half of the trap, since an Emit map suppressing the argument would
+	// have produced ALIBABA_CLOUD_PROFILE= instead.
+	f = newForm(c)
+	fieldByLabel(t, f, "profile").SetValue("staging")
+	r := launchRequest{form: f}
+	env, cleanup, err := r.environment()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(env, alicloudProfileEnv+"=staging") {
+		t.Errorf("the chosen profile did not reach the child: %v", env)
+	}
+
+	// An unset profile contributes nothing at all, rather than an empty
+	// variable the SDK would read as an explicit empty profile.
+	r = launchRequest{form: newForm(c)}
+	if env, _, _ := r.environment(); len(env) != 0 {
+		t.Errorf("an untouched form contributed %v", env)
+	}
+}
+
+// isFlagValue reports whether an emitted word is the value following a flag
+// rather than a positional argument. args() emits "--flag value" pairs, so the
+// check is simply whether any flag field holds it.
+func isFlagValue(f form, word string) bool {
+	for _, fd := range f.Fields() {
+		if fd.Flag != "" && fd.Emitted() == word {
+			return true
+		}
+	}
+	return false
+}
+
+// cloudBConnectors are the six cloud connectors that were curated second: three cloud APIs and three hypervisors.
+var cloudBConnectors = filedHere(
+	"oci", "openstack", "proxmox", "stackit", "vcd", "vsphere",
+)
+
+// All six are registered, and by this file rather than by accident: a spec that
+// silently failed to register leaves the connector on the generic screen, which
+// looks fine and is not what was curated.
+func TestCloudBRegistersItsConnectors(t *testing.T) {
+	for _, name := range cloudBConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered form spec", name)
+		}
+	}
+}
+
+// The heart of it: a credential section that cannot deliver produces a form
+// that refuses to launch at the end of filling it in. Every secret field these
+// specs put in front of a user is filled here and the delivery checked.
+//
+// oci --key-secret is the deliberate exception and is asserted separately
+// below, so that removing its exclusion without finding it a route fails here
+// rather than in a demo.
+func TestCloudBCredentialsCanBeDelivered(t *testing.T) {
+	for _, name := range cloudBConnectors {
+		c, f := formFor(t, name)
+
+		var secretFlags []string
+		for _, fd := range f.Fields() {
+			if fd.Secret {
+				secretFlags = append(secretFlags, fd.Flag)
+			}
+		}
+		sort.Strings(secretFlags)
+
+		for _, flag := range secretFlags {
+			if name == "oci" && flag == "key-secret" {
+				continue
+			}
+			// One secret at a time: the routes that carry exactly one are the
+			// ones that exist, and a form with two credentials filled in is not
+			// something any of these connectors asks for.
+			_, filled := formFor(t, name)
+			i := filled.IndexOfFlag(flag)
+			if i < 0 {
+				t.Errorf("%s: --%s vanished between two builds of the same form", name, flag)
+				continue
+			}
+			filled.Fields()[i].SetValue("<PLACEHOLDER-not-a-real-secret>")
+
+			if deliveryFor(filled) == deliverPlain {
+				t.Errorf("%s: --%s is not being treated as a secret at all", name, flag)
+				continue
+			}
+			assertCredentialReachesTheProvider(t, c, filled, flag, "<PLACEHOLDER-not-a-real-secret>")
+			if strings.Contains(strings.Join(filled.Args(), " "), "<PLACEHOLDER-not-a-real-secret>") {
+				t.Errorf("%s: --%s reached argv: %v", name, flag, filled.Args())
+			}
+		}
+
+		if len(secretFlags) == 0 {
+			t.Errorf("%s: no secret field was built, so this proved nothing", name)
+		}
+	}
+}
+
+// oci's --key-secret is a private key passphrase and travels like every other
+// credential.
+//
+// Its history is the argument for this whole change. It was first a refusal --
+// oci declares no --ask-key-secret, reads no environment variable of its own,
+// and the launcher's own inventory builder could not produce the private_key
+// credential carrying key and passphrase together that NewOciConnection
+// requires. Then it was MONDOO_KEY_SECRET, a variable derived from the flag
+// name that works only because mql fills any flag with no config mapping from
+// one. Both were the launcher reasoning about a provider it could have asked:
+// oci's own ParseCLI builds exactly the private_key credential it wants, which
+// is what the round trip now finds there.
+func TestOCIKeySecretIsCarriedAsACredential(t *testing.T) {
+	c, f := formFor(t, "oci")
+	i := f.IndexOfFlag("key-secret")
+	if i < 0 {
+		t.Fatal("oci no longer declares --key-secret")
+	}
+	if !f.Fields()[i].Secret {
+		t.Error("oci --key-secret is a private key passphrase and must be classified as a secret")
+	}
+	f.Fields()[i].SetValue("<PLACEHOLDER-not-a-real-secret>")
+
+	assertCredentialReachesTheProvider(t, c, f, "key-secret", "<PLACEHOLDER-not-a-real-secret>")
+}
+
+// stackit --service-account-key is a JSON key blob whose name the shared
+// classifier does not read as a credential: it ends in "-key", which is neither
+// a strong secret word nor a reference. Without the spec's Secret override the
+// whole key goes on the command line.
+func TestStackitServiceAccountKeyIsASecret(t *testing.T) {
+	c, f := formFor(t, "stackit")
+
+	i := f.IndexOfFlag("service-account-key")
+	if i < 0 {
+		t.Fatal("stackit no longer declares --service-account-key")
+	}
+	if !f.Fields()[i].Secret {
+		t.Fatal("--service-account-key is not marked secret; the spec's Secret override is not taking effect")
+	}
+	if f.Fields()[i].Section != sectionCredential {
+		t.Errorf("--service-account-key is in %q, want %q", f.Fields()[i].Section, sectionCredential)
+	}
+
+	f.Fields()[i].SetValue(`{"client_id":"x","privateKey":"y"}`)
+	assertCredentialReachesTheProvider(t, c, f, "service-account-key",
+		`{"client_id":"x","privateKey":"y"}`)
+
+	// The two path flags name where a key lives rather than holding one, and
+	// have to stay on the command line: that is how the provider receives them.
+	for _, flag := range []string{"service-account-key-path", "private-key-path"} {
+		j := f.IndexOfFlag(flag)
+		if j < 0 {
+			t.Errorf("stackit no longer declares --%s", flag)
+			continue
+		}
+		if f.Fields()[j].Secret {
+			t.Errorf("--%s names a file and must not be treated as a secret", flag)
+		}
+	}
+}
+
+// proxmox's token reaches the provider, and the inventory the launcher writes
+// is the provider's own reading of the form rather than the launcher's guess at
+// it.
+//
+// The guess happened to be right here -- Connect reads conf.Options["host"] and
+// conf.Options["token"], which is what a secret with no accompanying --user
+// produced -- and that is exactly why it is worth replacing: being right was
+// something a person had checked once, in a comment, against a provider free to
+// change.
+func TestProxmoxInventoryIsTheProvidersOwnReading(t *testing.T) {
+	c, f := formFor(t, "proxmox")
+
+	set := func(flag, value string) {
+		i := f.IndexOfFlag(flag)
+		if i < 0 {
+			t.Fatalf("proxmox no longer declares --%s", flag)
+		}
+		f.Fields()[i].SetValue(value)
+	}
+	set("host", "https://pve.example.com:8006")
+	set("token", "PVEAPIToken=root@pam!ui=<PLACEHOLDER-not-a-real-secret>")
+
+	if got := deliveryFor(f); got != deliverInventory {
+		t.Fatalf("delivery = %v, want deliverInventory", got)
+	}
+	p := withParser(t, &fakeParser{secretFlag: "token"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatalf("the launch was refused: %v", err)
+	}
+	if got, _ := p.sentValue("host"); got != "https://pve.example.com:8006" {
+		t.Errorf("the host reached the provider as %q", got)
+	}
+	if got, _ := p.sentValue("token"); got != "PVEAPIToken=root@pam!ui=<PLACEHOLDER-not-a-real-secret>" {
+		t.Errorf("the token reached the provider as %q", got)
+	}
+	if strings.Contains(strings.Join(plan.args, " "), "<PLACEHOLDER-not-a-real-secret>") {
+		t.Errorf("the token reached argv: %v", plan.args)
+	}
+}
+
+// vsphere is addressed by one positional argument in the user@realm@host shape,
+// not by a flag. ParseCLI prepends a scheme and hands it to url.Parse, so the
+// user half is everything before the last @ -- there is nowhere else for the
+// realm to go, and no flag a spec could map it onto.
+func TestVsphereTargetIsOnePositional(t *testing.T) {
+	c, f := formFor(t, "vsphere")
+	if c.MinArgs != 1 || c.MaxArgs != 1 {
+		t.Fatalf("vsphere declares %d..%d args, expected exactly one", c.MinArgs, c.MaxArgs)
+	}
+
+	var positional []field
+	for _, fd := range f.Fields() {
+		if fd.Flag == "" {
+			positional = append(positional, fd)
+		}
+	}
+	if len(positional) != 1 {
+		t.Fatalf("expected one positional field, got %d", len(positional))
+	}
+	p := positional[0]
+	if !p.Required {
+		t.Error("the vsphere target is required; MinArgs is 1")
+	}
+	if p.Section != sectionTarget {
+		t.Errorf("the target field is in %q, want %q", p.Section, sectionTarget)
+	}
+	if !strings.Contains(p.Label, "@") {
+		t.Errorf("label %q does not say the value is a user@realm@host pair", p.Label)
+	}
+
+	// The realm is part of the user half and must not have been invented as a
+	// flag of its own.
+	if i := f.IndexOfFlag("realm"); i >= 0 {
+		t.Error("vsphere declares no --realm; the realm belongs in the positional argument")
+	}
+
+	// Filling it in has to produce the argument verbatim, ahead of any flag.
+	f.Fields()[0].SetValue("chris@vsphere.local@vcenter.example.com")
+	args := f.Args()
+	if len(args) == 0 || args[0] != "chris@vsphere.local@vcenter.example.com" {
+		t.Errorf("args = %v, want the target as the leading argument", args)
+	}
+}
+
+// vcd marks --user and --host required, and a required field left in OPTIONS
+// sits behind the "more" fold, where the cursor focusFirstMissing parks cannot
+// be reached. Both have to be in TARGET.
+func TestVCDRequiredFieldsAreReachable(t *testing.T) {
+	_, f := formFor(t, "vcd")
+	for _, fd := range f.Fields() {
+		if fd.Required && fd.Section == sectionOptions {
+			t.Errorf("--%s is required but sits in %q", fd.Flag, sectionOptions)
+		}
+	}
+	for _, flag := range []string{"host", "user"} {
+		section, ok := sectionOf(f, flag)
+		if !ok {
+			t.Errorf("vcd no longer declares --%s", flag)
+			continue
+		}
+		if section != sectionTarget {
+			t.Errorf("--%s is in %q, want %q", flag, section, sectionTarget)
+		}
+	}
+}
+
+// The two hypervisors declare an --ask-pass partner, and it stays a toggle
+// rather than a substitution.
+//
+// It used to be the route: a typed password was dropped, --ask-pass went on the
+// command line in its place, and the child asked for the password the user had
+// already given it. Prompting is still the strongest thing available -- the
+// value never exists outside the process that uses it -- and it is still one
+// keystroke away.
+func TestAskPassStaysAToggleForVCDAndVsphere(t *testing.T) {
+	for _, name := range []string{"vcd", "vsphere"} {
+		c, f := formFor(t, name)
+		i := f.IndexOfFlag("password")
+		if i < 0 {
+			t.Errorf("%s no longer declares --password", name)
+			continue
+		}
+		f.Fields()[i].SetValue("<PLACEHOLDER-not-a-real-secret>")
+
+		if got := deliveryFor(f); got != deliverInventory {
+			t.Errorf("%s: a typed password routes as %v, want the inventory", name, got)
+		}
+		assertCredentialReachesTheProvider(t, c, f, "password", "<PLACEHOLDER-not-a-real-secret>")
+
+		// Ticked with nothing typed: an ordinary flag on an ordinary command
+		// line.
+		_, ask := formFor(t, name)
+		j := ask.IndexOfFlag("ask-pass")
+		if j < 0 {
+			t.Errorf("%s no longer offers --ask-pass", name)
+			continue
+		}
+		ask.Fields()[j].SetOn(true)
+		if got := deliveryFor(ask); got != deliverPlain {
+			t.Errorf("%s: --ask-pass on its own routes as %v, want the command line", name, got)
+		}
+		if !strings.Contains(strings.Join(ask.Args(), " "), "--ask-pass") {
+			t.Errorf("%s: --ask-pass did not reach the command line: %v", name, ask.Args())
+		}
+	}
+}
+
+// oci's --profile is the one picker in this file. The default section in
+// ~/.oci/config is the literal DEFAULT rather than the lowercase spelling the
+// AWS convention would suggest, which is what srcOCIProfile knows and a
+// hand-written option list would get wrong.
+func TestOCIProfileHasThePicker(t *testing.T) {
+	_, f := formFor(t, "oci")
+	i := f.IndexOfFlag("profile")
+	if i < 0 {
+		t.Fatal("oci no longer declares --profile")
+	}
+	if f.Fields()[i].Source() != srcOCIProfile {
+		t.Errorf("--profile source = %q, want %q", f.Fields()[i].Source(), srcOCIProfile)
+	}
+	if f.Fields()[i].Kind != fieldChoice {
+		t.Errorf("--profile is kind %v, want a picker", f.Fields()[i].Kind)
+	}
+
+	// --tenancy is scope, not a discovery output: oci has no way to list
+	// tenancies before it is authenticated to one, and --filters takes regions,
+	// compartments and tags rather than an account. Nothing may quietly attach
+	// a picker to it.
+	if j := f.IndexOfFlag("tenancy"); j >= 0 {
+		if f.Fields()[j].Source() != "" || f.Fields()[j].LiveSource != "" {
+			t.Errorf("--tenancy has a picker attached (%q/%q); it is required input, not a discovery result",
+				f.Fields()[j].Source(), f.Fields()[j].LiveSource)
+		}
+	}
+	// The same holds for stackit's project id.
+	_, sf := formFor(t, "stackit")
+	if j := sf.IndexOfFlag("project-id"); j >= 0 {
+		if sf.Fields()[j].Source() != "" || sf.Fields()[j].LiveSource != "" {
+			t.Errorf("stackit --project-id has a picker attached (%q/%q); it is required input",
+				sf.Fields()[j].Source(), sf.Fields()[j].LiveSource)
+		}
+	}
+}
+
+// Every option list offered has to be one the provider accepts. auth-method is
+// the strict one -- oci's ParseCLI rejects anything outside its own
+// SupportedAuthMethods before the scan starts -- so a stale entry here is a
+// hard error rather than a bad suggestion.
+func TestOCIChoicesAreAccepted(t *testing.T) {
+	_, f := formFor(t, "oci")
+
+	i := f.IndexOfFlag("auth-method")
+	if i < 0 {
+		t.Fatal("oci no longer declares --auth-method")
+	}
+	want := map[string]bool{
+		"api-key": true, "instance-principal": true, "resource-principal": true,
+		"workload-identity": true, "security-token": true,
+	}
+	if len(f.Fields()[i].Options) != len(want) {
+		t.Errorf("auth-method offers %v, want %d entries", f.Fields()[i].Options, len(want))
+	}
+	for _, opt := range f.Fields()[i].Options {
+		if !want[opt] {
+			t.Errorf("auth-method offers %q, which the provider rejects", opt)
+		}
+	}
+
+	// Regions are a suggestion list, not a validation list: a region newer than
+	// this binary still has to be typeable.
+	j := f.IndexOfFlag("region")
+	if j < 0 {
+		t.Fatal("oci no longer declares --region")
+	}
+	if len(f.Fields()[j].Options) == 0 {
+		t.Error("no regions are offered")
+	}
+	if f.Fields()[j].Strict {
+		t.Error("the region list is strict, so a region newer than this binary cannot be entered")
+	}
+	for _, r := range f.Fields()[j].Options {
+		if !strings.Contains(r, "-") {
+			t.Errorf("%q does not look like an OCI region identifier", r)
+		}
+	}
+}
+
+// openstack's scope and its credentials are two different things and the form
+// has to keep them apart: the username and the domain that qualifies it belong
+// with the password, the project and the region are the target.
+func TestOpenstackSectionsSplitScopeFromCredentials(t *testing.T) {
+	_, f := formFor(t, "openstack")
+
+	inTarget := []string{"cloud", "auth-url", "region", "project-name", "project-id"}
+	inCredential := []string{"username", "password", "application-credential-secret"}
+
+	for _, flag := range inTarget {
+		if section, ok := sectionOf(f, flag); !ok || section != sectionTarget {
+			t.Errorf("--%s is in %q, want %q", flag, section, sectionTarget)
+		}
+	}
+	for _, flag := range inCredential {
+		if section, ok := sectionOf(f, flag); !ok || section != sectionCredential {
+			t.Errorf("--%s is in %q, want %q", flag, section, sectionCredential)
+		}
+	}
+
+	// --cloud leads, because choosing a clouds.yaml entry answers the auth URL,
+	// the project and the region at once.
+	for _, fd := range f.Fields() {
+		if fd.Section != sectionTarget {
+			continue
+		}
+		if fd.Flag != "cloud" {
+			t.Errorf("the first TARGET field is --%s, want --cloud", fd.Flag)
+		}
+		break
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_container_test.go
+++ b/apps/cnspec/cmd/interactive/forms_container_test.go
@@ -1,0 +1,207 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The curated Containers & Kubernetes forms.
+//
+// These three arrived in forms_misc_test.go, a file whose list held twelve
+// connectors from five different categories -- helm beside ansible beside
+// device beside sbom -- because "miscellaneous" was a statement about the
+// contributor's queue rather than about the launcher. They are filed by what
+// the launcher shows now; see forms_filing_test.go.
+//
+// docker, container and k8s are curated in cli/launcher/forms/forms_container.go
+// and are exercised elsewhere in this package: the docker context is a
+// launcher-owned field with its own tests in source_ambient_test.go, and k8s
+// has kubeconfig_test.go.
+
+// containerConnectors are the Containers & Kubernetes connectors this file
+// covers. filedHere is what proves the category claim rather than restating it.
+var containerConnectors = filedHere("helm", "kustomize", "portainer")
+
+// Every connector this file claims has a spec, and exactly one.
+func TestContainerSpecsAreRegisteredExactlyOnce(t *testing.T) {
+	for _, name := range containerConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+		if containsString(duplicateSpecs, name) {
+			t.Errorf("%s was registered twice, so two files claim it", name)
+		}
+	}
+}
+
+// kustomize's whole input is a path, and a curated form owes it an argument
+// slot that says what the argument is. See assertPathShapedConnector.
+func TestKustomizeNamesItsOverlayPath(t *testing.T) {
+	assertPathShapedConnector(t, "kustomize")
+}
+
+// helm's argument is two different things, and the questions worth asking
+// differ between them. A chart on disk has no repository, no version to pull
+// and no registry credential; a chart fetched by name has nothing else.
+func TestHelmAsksOnlyWhatTheChosenShapeNeeds(t *testing.T) {
+	_, f := formFor(t, "helm")
+
+	if f.Fields()[0].Label != "chart source" {
+		t.Fatalf("the selector is not leading the form: %v", fieldLabels(f))
+	}
+	if f.Fields()[0].Kind != fieldChoice {
+		t.Errorf("the selector is not a picker")
+	}
+
+	remoteOnly := []string{"repo", "version", "username", "password"}
+	for _, flag := range remoteOnly {
+		if !hasFlagField(f, flag) {
+			t.Fatalf("--%s is not on the form at all: %v", flag, fieldLabels(f))
+		}
+	}
+
+	visibleFlags := func() map[string]bool {
+		out := map[string]bool{}
+		for _, i := range f.VisibleIndices() {
+			if fd := f.Fields()[i]; fd.Flag != "" {
+				out[fd.Flag] = true
+			}
+		}
+		return out
+	}
+
+	// A local chart: the repository half is not asked.
+	f.Fields()[0].SetValue("local chart")
+	shown := visibleFlags()
+	for _, flag := range remoteOnly {
+		if shown[flag] {
+			t.Errorf("a local chart was asked for --%s", flag)
+		}
+	}
+	f.Fields()[1].SetValue("./charts/api")
+	if got := f.Args(); len(got) != 1 || got[0] != "./charts/api" {
+		t.Errorf("a local chart produced %v, want just the path", got)
+	}
+
+	// A remote chart: the repository half is asked, and the selector still
+	// contributes nothing to the command line.
+	f.Fields()[0].SetValue("chart repository")
+	shown = visibleFlags()
+	for _, flag := range remoteOnly {
+		if !shown[flag] {
+			t.Errorf("a remote chart was not asked for --%s", flag)
+		}
+	}
+	f.Fields()[1].SetValue("ingress-nginx")
+	fieldByLabel(t, f, "repository URL").SetValue("https://kubernetes.github.io/ingress-nginx")
+	got := strings.Join(f.Args(), " ")
+	if got != "ingress-nginx --repo https://kubernetes.github.io/ingress-nginx" {
+		t.Errorf("a remote chart produced %q", got)
+	}
+	if strings.Contains(got, "chart repository") {
+		t.Error("the selector reached the command line")
+	}
+}
+
+// helm's list flags, and which of them the form shows now that a list with
+// nothing to pick from can be typed into.
+//
+// The predecessor of this test asserted that all six were hidden, and said in
+// its own comment that if the field engine ever grew a way to type into a list
+// the right response was to unhide them rather than to loosen the test. It did,
+// so --values is shown. The other five are hidden for reasons of their own --
+// helm's per-key escaping for --set, cluster-specific render fidelity for
+// --api-versions -- which is why this enumerates them rather than deriving the
+// answer from the flag type.
+func TestHelmShowsTheValuesFilesAndHidesThePerKeyOverrides(t *testing.T) {
+	c, f := formFor(t, "helm")
+
+	shown := map[string]bool{"values": true}
+	for _, fl := range c.Flags {
+		if fl.Type != plugin.FlagType_List {
+			continue
+		}
+		if got := hasFlagField(f, fl.Long); got != shown[fl.Long] {
+			t.Errorf("--%s on the form = %v, want %v", fl.Long, got, shown[fl.Long])
+		}
+	}
+
+	// And the one that is shown can actually be filled in and emitted, which is
+	// the whole difference: a multi-choice with no options is a row no
+	// keystroke reaches, because openModal declines to open an empty picker and
+	// storeCursorField refuses to write the input back into one.
+	values := fieldByFlag(t, f, "values")
+	if values.Kind != fieldText {
+		t.Fatalf("--values is a %v, want a typed field", values.Kind)
+	}
+	f.Fields()[0].SetValue("local chart")
+	f.Fields()[1].SetValue("./chart")
+	values.SetValue("prod.yaml,secrets.yaml")
+	if got := strings.Join(f.Args(), " "); got != "./chart --values prod.yaml,secrets.yaml" {
+		t.Errorf("args = %q, want the comma-separated list pflag's StringSlice splits", got)
+	}
+
+	// The premise for the five that stay hidden, asserted rather than assumed.
+	empty := tuiform.NewField(tuiform.Decl{Kind: fieldMultiChoice})
+	m := Model{detail: detailState{form: tuiform.New("helm", []field{empty})}}
+	if _, _ = m.openModal(); m.picker.modal.open {
+		t.Error("an empty multi-choice opened a picker after all")
+	}
+}
+
+// helm's repository password reaches the provider like any other credential.
+//
+// Its history is worth keeping. It was first refused outright, because no HELM_*
+// variable exists to register and the launcher would not put a password on a
+// command line `ps auxww` reads. Then it travelled in MONDOO_PASSWORD, a name
+// derived from the flag rather than known to the provider, which worked only
+// because mql resolves any flag with no config mapping from one. Neither was a
+// fact about helm; both were the launcher working around not being able to ask.
+func TestHelmRepositoryPasswordReachesTheProvider(t *testing.T) {
+	c, f := formFor(t, "helm")
+	f.Fields()[0].SetValue("chart repository")
+	f.Fields()[1].SetValue("ingress-nginx")
+	fieldByLabel(t, f, "repository password").SetValue(sentinel)
+
+	assertCredentialReachesTheProvider(t, c, f, "password", sentinel)
+}
+
+// portainer's address is a positional and --address at once, and its token
+// must reach the provider without becoming a word on the command line.
+func TestPortainerAsksTheAddressOnceAndKeepsTheTokenOffArgv(t *testing.T) {
+	c, f := formFor(t, "portainer")
+
+	pos := positionalFields(&f)
+	if len(pos) != 1 || pos[0].Label != "instance address" {
+		t.Fatalf("portainer does not ask for its address: %v", fieldLabels(f))
+	}
+	if !pos[0].Required {
+		t.Error("the address is optional, so a scan can launch with nothing to connect to")
+	}
+	if hasFlagField(f, "address") {
+		t.Error("--address is offered as well as the positional; the address is asked twice")
+	}
+
+	token := fieldByLabel(t, f, "access token")
+	if !token.Secret {
+		t.Fatal("the access token is not classified as a secret")
+	}
+	if token.Section != sectionCredential {
+		t.Errorf("the access token sits in %q", token.Section)
+	}
+
+	f.Fields()[0].SetValue("https://portainer.example.com")
+	token.SetValue(sentinel)
+
+	p := assertCredentialReachesTheProvider(t, c, f, "access-token", sentinel)
+	if len(p.args) != 1 || p.args[0] != "https://portainer.example.com" {
+		t.Errorf("the address did not reach the provider as its argument: %v", p.args)
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_dev_test.go
+++ b/apps/cnspec/cmd/interactive/forms_dev_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import "testing"
+
+// The Developer & Supply Chain forms.
+//
+// Three connectors, and no two of them have the same shape: sbom is a path,
+// depsdev is a path that is genuinely optional, and artifactory is the one
+// connector here with a credential and no spec at all. They arrived in
+// forms_misc_test.go, whose list spanned five categories at once; see
+// forms_filing_test.go for the rule that keeps them here.
+
+// devConnectors are the Developer & Supply Chain connectors this file covers.
+var devConnectors = filedHere("artifactory", "depsdev", "sbom")
+
+// sbom's whole input is a path, and a curated form owes it an argument slot
+// that says what the argument is. sbom is the case that makes the point: its
+// usage string is not in the recorded metadata, so the derived slot asks for
+// "argument 1".
+func TestSbomNamesItsFile(t *testing.T) {
+	assertPathShapedConnector(t, "sbom")
+}
+
+// depsdev is the only connector here whose target is genuinely optional, and
+// the form has to keep it that way: with no go.mod it answers questions about
+// individual packages.
+func TestDepsdevTargetStaysOptionalAndIsAskedOnce(t *testing.T) {
+	_, f := formFor(t, "depsdev")
+
+	pos := positionalFields(&f)
+	if len(pos) != 1 {
+		t.Fatalf("depsdev has %d argument slots, want one: %v", len(pos), fieldLabels(f))
+	}
+	if pos[0].Required {
+		t.Error("the go.mod path is required, but depsdev runs without one")
+	}
+	if hasFlagField(f, "path") {
+		t.Error("--path is offered as well as the positional; the same file is asked for twice")
+	}
+	if err := f.Validate(); err != nil {
+		t.Errorf("depsdev refused to launch with no target: %v", err)
+	}
+	if got := f.Args(); len(got) != 0 {
+		t.Errorf("an empty depsdev form produced %v", got)
+	}
+	f.Fields()[0].SetValue("./go.mod")
+	if got := f.Args(); len(got) != 1 || got[0] != "./go.mod" {
+		t.Errorf("args = %v, want just the path", got)
+	}
+}
+
+// artifactory: no spec, but its credential still has to be deliverable, or a
+// user who installs the provider gets a form that refuses to launch. The shape
+// checked is what the generic layer builds from the connector's own flags, with
+// nothing curated over it.
+//
+// This used to build the connector by hand from artifactory 13.1.0's flag list,
+// because the recorded artifact did not carry it -- which was the reason it had
+// no spec. The artifact carries it now, so the connector is read from there
+// like every other one, and the flag names are the provider's rather than the
+// test author's.
+func TestArtifactoryCredentialsHaveARoute(t *testing.T) {
+	if _, curated := formSpecs["artifactory"]; curated {
+		t.Fatal("artifactory grew a spec; drop its registerUncurated call and let " +
+			"TestEverySpecNamesRealFlags check it")
+	}
+
+	c := connectorFor(t, "artifactory")
+	for _, flag := range []string{"token", "api-key"} {
+		t.Run(flag, func(t *testing.T) {
+			f := newForm(c)
+			fd := fieldByLabel(t, f, flag)
+			if !fd.Secret {
+				t.Fatalf("--%s is not classified as a secret", flag)
+			}
+			fd.SetValue(sentinel)
+			assertCredentialReachesTheProvider(t, c, f, flag, sentinel)
+		})
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_filing_test.go
+++ b/apps/cnspec/cmd/interactive/forms_filing_test.go
@@ -1,0 +1,234 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Where a connector's tests belong, and the rule that keeps it true.
+//
+// cli/launcher/forms files each spec under the category the launcher shows its
+// connector in, and TestEverySpecIsFiledUnderItsCategory over there refuses a
+// spec written anywhere else. The tests were the half that had not caught up:
+// forms_saas_a_test.go, forms_saas_b_test.go, forms_saas_c_test.go and
+// forms_misc_test.go recorded which contributor wrote them, and each iterated a
+// package-level list spanning several categories -- saasAConnectors held six
+// SaaS connectors and two Identity ones -- so no rule could have been stated
+// about where any of them belonged.
+//
+// The lists are one category each now, and this is what reads that back.
+//
+// # What this can and cannot enforce
+//
+// It enforces placement for every connector named in a list built by filedHere,
+// which is every list a category file iterates. It cannot enforce placement for
+// a connector named only inside a test body -- TestDatadogSiteIsASuggestion
+// hard-codes "datadog" and nothing here sees it -- because there is no call for
+// runtime.Caller to attribute. That is a real gap and it is worth saying so
+// rather than papering over: what the rule guarantees is that a file's *list*
+// cannot drift from its name, which is the failure that actually happened.
+
+// categoryTestFile is where a category's tests belong. It is the mirror of
+// categoryFile in cli/launcher/forms/forms_test.go: the same eleven categories,
+// the same one-file-per-category rule, with _test on the end.
+//
+// Two of these name files that do not exist yet. That is the same arrangement
+// the spec side has for forms_other.go, and it is deliberate: naming the file
+// before it exists is what stops the first Databases test from being appended
+// to whichever file its author had open.
+var categoryTestFile = map[string]string{
+	catHosts:     "forms_hosts_test.go",
+	catContainer: "forms_container_test.go",
+	catCloud:     "forms_cloud_test.go",
+	catIaC:       "forms_iac_test.go",
+	catIdentity:  "forms_identity_test.go",
+	catSaaS:      "forms_saas_test.go",
+	catNetwork:   "forms_network_test.go",
+	catDatabase:  "forms_database_test.go",
+	catAI:        "forms_ai_test.go",
+	catDev:       "forms_dev_test.go",
+	catOther:     "forms_other_test.go",
+}
+
+// packageWideTestFiles are the forms_*_test.go files that are not named for a
+// category because they are not about one. Each holds a gate that runs over the
+// whole registry, so filing it under a category would be filing it under the
+// wrong one ten times.
+var packageWideTestFiles = map[string]string{
+	"forms_test.go":           "the gates over every registered spec",
+	"forms_generated_test.go": "the provider-declared vocabulary, over every connector",
+	"forms_filing_test.go":    "this rule",
+}
+
+// connectorTestFile records which test file claimed each connector, taken from
+// the call stack rather than declared.
+//
+// Declared would defeat the purpose: the failure this exists to catch is a
+// block of tests pasted into the wrong file, and a pasted block brings its
+// declared file name with it. The stack cannot be pasted.
+var connectorTestFile = map[string]string{}
+
+// filedHere records that the calling file owns these connectors, and returns
+// them so it reads as the list it is:
+//
+//	var saasConnectors = filedHere("atlassian", "cloudflare", ...)
+//
+// It is called from a package-level var, so the frame above it is the
+// declaration, which is exactly the file the connector's tests live in.
+func filedHere(names ...string) []string {
+	file := ""
+	if _, f, _, ok := runtime.Caller(1); ok {
+		file = filepath.Base(f)
+	}
+	for _, name := range names {
+		connectorTestFile[name] = file
+	}
+	return names
+}
+
+// A category the catalog groups connectors under, with nowhere here to put its
+// tests, is how the taxonomy drifts back apart: the first test for it lands in
+// whichever file its author had open.
+func TestEveryCatalogCategoryHasATestFile(t *testing.T) {
+	for _, cat := range categoryOrder {
+		if categoryTestFile[cat] == "" {
+			t.Errorf("the catalog groups connectors under %q and no test file is "+
+				"named for it; add one to categoryTestFile", cat)
+		}
+	}
+	if len(categoryTestFile) != len(categoryOrder) {
+		t.Errorf("categoryTestFile has %d entries, the catalog has %d categories",
+			len(categoryTestFile), len(categoryOrder))
+	}
+
+	seen := map[string]string{}
+	for cat, file := range categoryTestFile {
+		if other, taken := seen[file]; taken {
+			t.Errorf("%s is named for both %q and %q; one file per category",
+				file, other, cat)
+		}
+		seen[file] = cat
+	}
+}
+
+// The rule itself: a connector's tests live in the file named for the category
+// the launcher shows it under.
+//
+// The category is resolved through categorize(), which is the launcher's own
+// answer and the same one cli/launcher/forms checks its specs against. Writing
+// a second connector-to-category table here would put the rule and the thing it
+// checks in the same hand, and the table is what went stale last time:
+// forms_misc_test.go filed iru under a comment reading "Other" while the
+// launcher had been showing it under SaaS since jamf and iru were grouped.
+func TestEveryTestedConnectorIsFiledUnderItsCategory(t *testing.T) {
+	byName := snapshotByName(t)
+
+	names := make([]string, 0, len(connectorTestFile))
+	for name := range connectorTestFile {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	checked := 0
+	for _, name := range names {
+		// The provider decides the category and is not always the connector's
+		// own name: ciscocatalyst and nd-ssh are served by networkdevices, host
+		// by network, mcp by ai.
+		snap, ok := byName[name]
+		if !ok {
+			t.Errorf("%s is claimed by %s but is not in %s, so its category cannot "+
+				"be resolved and its filing cannot be checked",
+				name, connectorTestFile[name], connectorSnapshotPath)
+			continue
+		}
+		cat := categorize(snap.Provider, name)
+		want := categoryTestFile[cat]
+		if want == "" {
+			t.Errorf("%s is categorized as %q, which no test file is named for", name, cat)
+			continue
+		}
+		checked++
+		if got := connectorTestFile[name]; got != want {
+			t.Errorf("%s is tested in %s but the launcher files it under %q, "+
+				"so its tests belong in %s", name, got, cat, want)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no connector was checked against its category, so this test proves nothing")
+	}
+	t.Logf("checked %d connector list entries against the catalog", checked)
+}
+
+// The other half of the rule: a forms_*_test.go that is not named for a
+// category is a place a connector's tests can hide from the check above.
+//
+// forms_saas_d_test.go is the failure this exists for. It would compile, it
+// would run, every assertion in it would pass -- and the split by category
+// would be back to a split by author with the first test somebody appended to
+// it.
+func TestNoFormsTestFileIsNamedForSomethingElse(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{}
+	for _, f := range categoryTestFile {
+		allowed[f] = true
+	}
+	for f := range packageWideTestFiles {
+		allowed[f] = true
+	}
+
+	found := 0
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasPrefix(n, "forms_") || !strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		found++
+		if !allowed[n] {
+			t.Errorf("%s is not named for a catalog category and is not one of the "+
+				"package-wide gates. The form tests are split by what the launcher "+
+				"shows, not by who wrote them; move each test to the file for its "+
+				"connector's category", n)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no form test file was found, so this test proves nothing")
+	}
+	t.Logf("checked %d form test files", found)
+}
+
+// No connector is claimed by two files. filedHere would silently let the second
+// win, and the two lists would then disagree about who runs the sweep over it.
+func TestNoConnectorIsClaimedByTwoTestFiles(t *testing.T) {
+	// Rebuilding the claims from the lists is the only way to see a collision:
+	// connectorTestFile keeps the last writer, so the map alone cannot show it.
+	counts := map[string]int{}
+	for _, list := range [][]string{
+		aiConnectors, cloudAConnectors, cloudBConnectors, containerConnectors,
+		devConnectors, hostsConnectors, iacConnectors, identityConnectors,
+		networkAConnectors, networkBConnectors, saasConnectors,
+	} {
+		for _, name := range list {
+			counts[name]++
+		}
+	}
+	for name, n := range counts {
+		if n > 1 {
+			t.Errorf("%s appears in %d connector lists; one file owns a connector", name, n)
+		}
+	}
+	if len(counts) != len(connectorTestFile) {
+		t.Errorf("%d connectors across the lists, %d recorded by filedHere; "+
+			"a list was declared without it", len(counts), len(connectorTestFile))
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_generated_test.go
+++ b/apps/cnspec/cmd/interactive/forms_generated_test.go
@@ -1,0 +1,293 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/internal/connectors"
+)
+
+// What the generated half of a form is for, and what it is not.
+//
+// providerFormSpec reads internal/connectors, the artifact internal/connectorgen
+// derives from mql provider source. The tempting summary is "the provider now
+// declares its form", and that is not what happened. A Connector arriving from
+// an installed provider already carries flags, argument counts, discovery
+// targets and help text, and genericFields has always read them. The artifact
+// adds exactly two facts on top: the environment variables behind each flag,
+// and the sub-command vocabulary.
+//
+// The environment routes are not returned -- see providerFormSpec -- so the
+// vocabulary is the whole of the generated contribution, and the tests below
+// are about what that is worth. The answer turns out to be "as a gate, more
+// than as a data source": every connector whose vocabulary the artifact records
+// already has a curated spec that names those words with labels and an emit
+// table, so the generated copy supplies nothing new today. What it can do is
+// notice when a provider grows a word that nobody curated.
+
+// vocabularyNotOffered names provider words the form deliberately does not
+// offer, keyed "<connector>/<argument index>/<word>".
+//
+// The gate below reports a provider word with no option behind it, because
+// that is what a provider growing a sub-command looks like. It cannot tell that
+// case apart from a synonym of a word already offered, so the synonyms are
+// written down here with the reason rather than the check being softened into
+// something that would also miss the real thing.
+var vocabularyNotOffered = map[string]string{
+	// gcp accepts both, and its own help text uses `org` throughout --
+	// `cnspec shell gcp org <ORGANIZATION-ID>`. The form offers one row
+	// labelled "organization" that emits `org`; a second row for the spelling
+	// would do the same thing twice.
+	"gcp/0/organization": "an alias for `org`, which the form already emits",
+}
+
+// TestGeneratedVocabularyMatchesCuration is the gate.
+//
+// A provider adding a sub-command word is invisible to this package: the
+// curated Options list is a Go literal, applySpec drops nothing that goes
+// stale, and the new word simply never appears in the picker. Nothing failed,
+// nothing was logged, and the launcher quietly stopped being able to reach part
+// of the connector. This is the only thing that notices.
+//
+// It compares membership rather than order or spelling, because the two lists
+// are answering different questions. The artifact records the literal words the
+// provider compares against, in source order; a curated list is what a person
+// reads on a screen, in a chosen order, and may add a display-only option that
+// emits nothing at all -- nmap's "network range" is one, and there is no
+// provider word behind it because there is not meant to be.
+//
+// So a curated word absent from the provider is a finding, and a provider word
+// absent from curation is a finding, and each is reported separately with the
+// side it came from.
+func TestGeneratedVocabularyMatchesCuration(t *testing.T) {
+	checked, skipped := 0, 0
+	for _, rec := range connectors.All() {
+		if len(rec.Positional) == 0 {
+			continue
+		}
+		spec, ok := formSpecs[rec.Name]
+		if !ok || len(spec.Positional) == 0 {
+			skipped++
+			continue
+		}
+		for _, p := range rec.Positional {
+			if p.Index >= len(spec.Positional) {
+				continue
+			}
+			curatedField := spec.Positional[p.Index]
+			if len(curatedField.Options) == 0 {
+				continue
+			}
+			checked++
+
+			// What a curated option contributes on the command line is its
+			// Emit entry when it has one, and its own text otherwise. That is
+			// the value the provider will actually see, so it is the one to
+			// compare.
+			emitted := map[string]string{}
+			for _, opt := range curatedField.Options {
+				word := opt
+				if curatedField.Emit != nil {
+					word = curatedField.Emit[opt]
+				}
+				if word == "" {
+					// A display-only option, steering the screen and adding no
+					// argument. There is no provider word to match it against.
+					continue
+				}
+				emitted[word] = opt
+			}
+
+			provider := map[string]bool{}
+			for _, v := range p.Values {
+				provider[v] = true
+			}
+
+			var unknown, uncovered []string
+			for word, opt := range emitted {
+				if !provider[word] {
+					unknown = append(unknown, word+" (shown as "+opt+")")
+				}
+			}
+			for _, v := range p.Values {
+				if _, ok := emitted[v]; ok {
+					continue
+				}
+				if _, allowed := vocabularyNotOffered[rec.Name+"/"+strconv.Itoa(p.Index)+"/"+v]; allowed {
+					continue
+				}
+				uncovered = append(uncovered, v)
+			}
+			sort.Strings(unknown)
+			sort.Strings(uncovered)
+
+			if len(unknown) > 0 {
+				t.Errorf("%s argument %d: the form offers %s, which the provider's own source never compares against. "+
+					"Either the word changed or the option is a typo; a typo here is invisible at runtime because the "+
+					"provider just rejects the argument.",
+					rec.Name, p.Index, strings.Join(unknown, ", "))
+			}
+			if len(uncovered) > 0 {
+				t.Errorf("%s argument %d: the provider accepts %s, which the form does not offer. "+
+					"If the provider grew a sub-command, the launcher cannot reach it; if the omission is deliberate, "+
+					"say so in the spec's comment.",
+					rec.Name, p.Index, strings.Join(uncovered, ", "))
+			}
+		}
+	}
+	// Counts, because this reads generated data rather than installed
+	// providers: it cannot silently check nothing the way a metadata test can,
+	// but a future change to the artifact could empty it, and a green run that
+	// checked zero things should say so.
+	t.Logf("compared %d curated vocabularies against the provider source; %d recorded vocabularies had no curated positional to compare",
+		checked, skipped)
+	if checked == 0 {
+		t.Error("compared no vocabularies at all; the artifact or the specs stopped lining up")
+	}
+}
+
+// TestGeneratedSpecReachesAnUncuratedConnector proves providerFormSpec is
+// wired rather than merely present.
+//
+// Everything the artifact records a vocabulary for happens to be curated today,
+// so the generated path contributes nothing to any shipping form -- which is
+// exactly the shape of a function that is quietly dead. This drives it with a
+// connector that has no spec, which is the case it exists for: the next
+// connector to arrive with a sub-command shape and nobody to curate it.
+func TestGeneratedSpecReachesAnUncuratedConnector(t *testing.T) {
+	// github is recorded with `org|user|repo` at argument 0.
+	rec, ok := connectors.ByName("github")
+	if !ok || len(rec.Positional) == 0 {
+		t.Fatal("the artifact no longer records a positional vocabulary for github")
+	}
+
+	c := Connector{Provider: "github", Name: "github", Use: "github", Installed: true, MaxArgs: 2}
+	spec, ok := providerFormSpec(c)
+	if !ok {
+		t.Fatal("providerFormSpec returned nothing for a connector the artifact describes")
+	}
+	if len(spec.Positional) == 0 {
+		t.Fatal("the generated spec declares no positional fields")
+	}
+	got := spec.Positional[0].Options
+	if len(got) != len(rec.Positional[0].Values) {
+		t.Fatalf("generated options %v, artifact records %v", got, rec.Positional[0].Values)
+	}
+
+	// And the whole way through, not only out of the constructor: a connector
+	// with no registered spec must reach applySpec with these fields.
+	if _, curated := formSpecs["definitely-not-a-connector"]; curated {
+		t.Fatal("test connector name is taken")
+	}
+	c2 := c
+	c2.Name = "definitely-not-a-connector"
+	if _, ok := specFor(c2); ok {
+		t.Fatal("specFor invented a spec for a connector the artifact does not describe")
+	}
+}
+
+// TestMergeKeepsCurationWhenTheProviderIsPartial is the regression this phase
+// exists to prevent.
+//
+// specFor used to return the provider's declaration outright whenever there was
+// one. That is safe only while providers declare nothing or everything, and the
+// artifact declares a sliver -- a vocabulary and no labels, sections or
+// pickers. Under the old rule a connector gaining a recorded vocabulary would
+// have lost its entire curated form the same day, with no test failing and no
+// message anywhere.
+func TestMergeKeepsCurationWhenTheProviderIsPartial(t *testing.T) {
+	generated := FormSpec{
+		Positional: []PositionalSpec{{Label: "argument 1", Options: []string{"org", "repo"}}},
+		Secret:     []string{"provider-said-secret"},
+	}
+	curated := FormSpec{
+		Target:     []string{"host", "port"},
+		Credential: []string{"ask-pass", "password"},
+		Labels:     map[string]string{"port": "SSH port"},
+		Secret:     []string{"curator-said-secret"},
+		NotSecret:  []string{"key-path"},
+		Choices:    map[string][]string{"port": {"22"}},
+	}
+
+	got := mergeSpec(generated, curated)
+
+	if len(got.Target) != 2 || got.Target[0] != "host" {
+		t.Errorf("Target came out %v; a partial provider spec discarded the curated grouping", got.Target)
+	}
+	if got.Labels["port"] != "SSH port" {
+		t.Errorf("Labels came out %v; the curated labels were lost", got.Labels)
+	}
+	if len(got.Choices["port"]) != 1 {
+		t.Errorf("Choices came out %v; the curated choice list was lost", got.Choices)
+	}
+	// Secret unions: both sides marking a flag secret keeps more values off the
+	// command line, which is the safe resolution in both directions.
+	if !containsString(got.Secret, "provider-said-secret") || !containsString(got.Secret, "curator-said-secret") {
+		t.Errorf("Secret came out %v; both sides' entries must survive", got.Secret)
+	}
+	// NotSecret does not: it is the direction that puts a value onto the
+	// command line, and only a person may assert it.
+	if len(got.NotSecret) != 1 || got.NotSecret[0] != "key-path" {
+		t.Errorf("NotSecret came out %v; it must be the curated list exactly", got.NotSecret)
+	}
+}
+
+// TestProviderNotSecretIsNeverHonoured states the safety property on its own,
+// because it is the one that puts a credential in the process table if it ever
+// stops holding.
+func TestProviderNotSecretIsNeverHonoured(t *testing.T) {
+	generated := FormSpec{NotSecret: []string{"password", "token"}}
+	got := mergeSpec(generated, FormSpec{})
+	if len(got.NotSecret) != 0 {
+		t.Fatalf("a generated NotSecret survived the merge as %v. That moves a value onto the command line, "+
+			"where `ps auxww` reads it, on the strength of a classification nobody checked.", got.NotSecret)
+	}
+}
+
+// TestTheThreeCorrectionsSurvive pins the per-connector secret corrections that
+// the shared name-based classifier reads the wrong way.
+//
+// Each is a case where the flag's name or description misleads the classifier
+// and a person checked the provider instead. They are the specific thing a
+// generated spec must not be allowed to overrule, so this asserts the outcome
+// rather than the mechanism: whatever specFor does, these three flags end up in
+// CREDENTIAL and masked.
+func TestTheThreeCorrectionsSurvive(t *testing.T) {
+	corrections := []struct {
+		connector, flag, why string
+	}{
+		{"datadog", "app-key", "an application key is a credential; the classifier reads '-key' as a reference"},
+		{"stackit", "service-account-key", "the key JSON itself, not a path to it"},
+		{"okta", "private-key", "the description says 'or a path to it', so the path detector matched first"},
+	}
+	byName := snapshotByName(t)
+	for _, c := range corrections {
+		snap, ok := byName[c.connector]
+		if !ok {
+			t.Errorf("%s is no longer in the artifact, so its correction is unverified", c.connector)
+			continue
+		}
+		f := newForm(snap.connector())
+		var found bool
+		for _, fd := range f.Fields() {
+			if fd.Flag != c.flag {
+				continue
+			}
+			found = true
+			if !fd.Secret {
+				t.Errorf("%s --%s is not classified as a secret: %s", c.connector, c.flag, c.why)
+			}
+			if fd.Section != sectionCredential {
+				t.Errorf("%s --%s sits in %q rather than CREDENTIAL", c.connector, c.flag, fd.Section)
+			}
+		}
+		if !found {
+			t.Errorf("%s declares no --%s any more; the correction may be stale", c.connector, c.flag)
+		}
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_hosts_test.go
+++ b/apps/cnspec/cmd/interactive/forms_hosts_test.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The Hosts & Devices forms that are not a login.
+//
+// local, ssh, winrm and filesystem are curated in
+// cli/launcher/forms/forms_hosts.go and are exercised where the thing they are
+// about lives: ssh in source_ambient_test.go for the known-hosts picker,
+// filesystem and local in prefill_test.go. What is here is the pair that
+// arrived in forms_misc_test.go -- a file whose list spanned five categories --
+// and had nowhere else to be.
+
+// hostsConnectors are the Hosts & Devices connectors this file covers.
+var hostsConnectors = filedHere("device", "vagrant")
+
+// vagrant is host-shaped but takes a machine name, not user@host, and carries
+// no credential of its own.
+func TestVagrantAsksForItsMachine(t *testing.T) {
+	_, f := formFor(t, "vagrant")
+
+	pos := positionalFields(&f)
+	if len(pos) != 1 || !pos[0].Required {
+		t.Fatalf("vagrant does not require a machine: %v", fieldLabels(f))
+	}
+	if pos[0].Label == "host" {
+		t.Error(`the slot is still labelled "host", which reads as user@host`)
+	}
+	if !hasFlagField(f, "sudo") {
+		t.Errorf("--sudo is declared but not offered: %v", fieldLabels(f))
+	}
+
+	pos[0].SetValue("default")
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Errorf("vagrant declares no credential but delivery is %v", got)
+	}
+}
+
+// device: the reason it is not curated, asserted rather than remembered.
+//
+// Every flag it declares is Hidden or Deprecated, so genericFields builds no
+// field for any of them and applySpec's at() would return nil for every flag a
+// spec could name -- silently, and while still satisfying the snapshot gate,
+// which reads the recorded flag list including the hidden ones.
+//
+// If the os provider ever unhides them, this fails and device becomes worth a
+// spec. That is the point of asserting it.
+//
+// That device is recorded as deliberately uncurated at all, rather than simply
+// forgotten, is TestEveryConnectorIsCuratedOrExcused's business: it names the
+// three exclusions over the whole catalog, so a fourth appearing silently is
+// caught there rather than in whichever file its author had open.
+func TestDeviceHasNoFlagLeftForASpecToName(t *testing.T) {
+	c, f := formFor(t, "device")
+
+	if len(c.Flags) == 0 {
+		t.Fatal("device declares no flags at all; the snapshot is not what this reasoned about")
+	}
+	var visible []string
+	for _, fl := range c.Flags {
+		if fl.Option&plugin.FlagOption_Hidden == 0 && fl.Option&plugin.FlagOption_Deprecated == 0 {
+			visible = append(visible, fl.Long)
+		}
+	}
+	if len(visible) > 0 {
+		t.Errorf("device now shows %v; curate it in cli/launcher/forms/forms_hosts.go instead of skipping it", visible)
+	}
+	if len(f.Fields()) > 0 {
+		t.Errorf("device's form has %d fields, so there is something to curate: %v",
+			len(f.Fields()), fieldLabels(f))
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_iac_test.go
+++ b/apps/cnspec/cmd/interactive/forms_iac_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import "testing"
+
+// The curated Infrastructure as Code forms.
+//
+// All three are path-shaped: the whole input is a file or a directory, there is
+// no credential, and what a curated form owes them is an argument slot that
+// says what the argument is. They arrived in forms_misc_test.go, whose list
+// spanned five categories at once; see forms_filing_test.go for the rule that
+// keeps them here.
+//
+// terraform is curated in cli/launcher/forms/forms_iac.go and is exercised in
+// parsecli_test.go, where its three sub-command shapes are the point.
+
+// iacConnectors are the Infrastructure as Code connectors this file covers.
+var iacConnectors = filedHere("ansible", "bicep", "cloudformation")
+
+// Every connector this file claims has a spec, and exactly one.
+func TestIaCSpecsAreRegisteredExactlyOnce(t *testing.T) {
+	for _, name := range iacConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+		if containsString(duplicateSpecs, name) {
+			t.Errorf("%s was registered twice, so two files claim it", name)
+		}
+	}
+}
+
+// Each of these asks for one path, and says what the path should point at. See
+// assertPathShapedConnector for what "says" means and why the derived slot is
+// not enough.
+func TestIaCConnectorsNameTheirPath(t *testing.T) {
+	for _, name := range iacConnectors {
+		t.Run(name, func(t *testing.T) {
+			assertPathShapedConnector(t, name)
+		})
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_identity_test.go
+++ b/apps/cnspec/cmd/interactive/forms_identity_test.go
@@ -1,0 +1,526 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// The curated Identity & Access forms: the systems that decide who can sign in,
+// and where credentials live.
+//
+// These eight were scattered across the three files named for whoever wrote
+// them -- activedirectory and google-workspace in forms_saas_a_test.go, ms365
+// and okta in _b, auth0, bitwarden, jumpcloud and keycloak in _c -- because
+// each contributor curated a slice of the catalog rather than a category. The
+// launcher has shown them under Identity & Access all along, and ms365 and
+// google-workspace belong here rather than under SaaS despite being
+// productivity suites: what a scan of either inspects is the tenant's
+// directory, its sign-in policy and its admin roles.
+//
+// Every test below drives the real form -- newForm over the connector rebuilt
+// from internal/connectors/connectors.json -- rather than inspecting the
+// FormSpec literal, because a spec that names a flag the connector does not
+// declare is silently dropped by applySpec. Reading the spec back would agree
+// with itself; building the form is what proves the flag survived.
+
+// identityConnectors is every connector the launcher files under Identity &
+// Access. filedHere is what proves that claim rather than restating it; see
+// forms_filing_test.go.
+var identityConnectors = filedHere(
+	"activedirectory", "auth0", "bitwarden", "google-workspace",
+	"jumpcloud", "keycloak", "ms365", "okta",
+)
+
+// Every connector this file claims has a spec, and exactly one.
+//
+// registerSpec is first-wins: a sibling file that also registered one of these
+// would take it, and the only visible sign would be an entry in duplicateSpecs.
+// The other half is a connector named here that never got registered at all
+// because an init was removed, which leaves it on the generic flag-derived
+// screen -- a screen that looks like a form and says nothing about being
+// uncurated.
+func TestIdentitySpecsAreRegisteredExactlyOnce(t *testing.T) {
+	for _, name := range identityConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+		if containsString(duplicateSpecs, name) {
+			t.Errorf("%s was registered twice, so two files claim it", name)
+		}
+	}
+}
+
+// identityTargetLeads is what each form's TARGET section leads with, by the
+// label the spec gives it.
+//
+// None of these is obvious from the flag list: keycloak leads with the server
+// rather than the realm, bitwarden with a URL that only self-hosted
+// installations need, jumpcloud with an organization id that only multi-tenant
+// keys use. Every one is a decision about what the connector is addressed by,
+// which is what the first section of the pane tells the reader.
+var identityTargetLeads = map[string]string{
+	"activedirectory":  "domain controller",
+	"auth0":            "tenant domain",
+	"bitwarden":        "API base URL (self-hosted only)",
+	"google-workspace": "customer id",
+	"jumpcloud":        "organization ID (multi-tenant keys only)",
+	"keycloak":         "server URL",
+	"ms365":            "tenant id",
+	"okta":             "organization",
+}
+
+// The field the connector cannot run without has to be on the screen, in
+// TARGET, and visible before anything else is chosen. A curated form that
+// buries it -- or gates it behind a selector value that is not the default --
+// is worse than the generic screen it replaced.
+func TestIdentityTargetsLeadTheirForms(t *testing.T) {
+	for _, name := range identityConnectors {
+		label, declared := identityTargetLeads[name]
+		if !declared {
+			t.Errorf("%s is curated here but identityTargetLeads does not say what "+
+				"its form is addressed by; add the label, or \"\" if it has no target", name)
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			_, f := hermeticFormFor(t, name)
+
+			if label == "" {
+				for _, fd := range f.Fields() {
+					if fd.Section == sectionTarget {
+						t.Errorf("%q is in TARGET, but %s has nothing to target",
+							fd.Label, name)
+					}
+				}
+				return
+			}
+
+			at := -1
+			for i := range f.Fields() {
+				if f.Fields()[i].Label == label {
+					at = i
+				}
+			}
+			if at < 0 {
+				t.Fatalf("no field labelled %q; the form asks %v", label, fieldLabels(f))
+			}
+			if got := f.Fields()[at].Section; got != sectionTarget {
+				t.Errorf("%q is in %s, want %s", label, got, sectionTarget)
+			}
+			if !f.Visible(at) {
+				t.Errorf("%q is hidden on a form nobody has touched yet", label)
+			}
+			// It leads its section: nothing else in TARGET comes before it.
+			for i, fd := range f.Fields() {
+				if fd.Section == sectionTarget && i < at {
+					t.Errorf("%q comes before the target %q", fd.Label, label)
+				}
+			}
+			// And TARGET is the first section, so the target is the first thing
+			// the user meets rather than something below a credential.
+			if at != 0 {
+				t.Errorf("the form leads with %q, want the target %q",
+					f.Fields()[0].Label, label)
+			}
+		})
+	}
+}
+
+// The target flags that are not the lead. ms365 can be scoped three ways and
+// all three say what is being scanned rather than who is scanning it -- a
+// target left in OPTIONS is below the credential, which reverses the order
+// these connectors are actually used in.
+func TestIdentitySecondaryTargetsStayInTheTargetSection(t *testing.T) {
+	targets := map[string][]string{
+		"ms365": {"tenant-id", "organization", "sharepoint-url"},
+		"okta":  {"organization"},
+	}
+	for name, flags := range targets {
+		t.Run(name, func(t *testing.T) {
+			_, f := hermeticFormFor(t, name)
+			for _, flag := range flags {
+				i := f.IndexOfFlag(flag)
+				if i < 0 {
+					t.Errorf("--%s is not on the form; fields are %v", flag, fieldLabels(f))
+					continue
+				}
+				if got := f.Fields()[i].Section; got != sectionTarget {
+					t.Errorf("--%s is in %s, want %s", flag, got, sectionTarget)
+				}
+			}
+		})
+	}
+}
+
+// Every credential a curated form offers reaches the provider, and the target
+// it was filled in beside survives being separated from it.
+//
+// Filled "on its own" is deliberate. okta declares two alternative credentials
+// at once, only one of which is ever used, so the shapes are listed as the user
+// would fill them rather than all at once -- not because the route could only
+// carry one, which it no longer is, but because several providers pick a
+// different authentication path when they see the second and legitimately drop
+// the first.
+//
+// The route each one used to be pinned to is gone with the registry that held
+// it. okta's key is the case that made the point: it wants a private_key
+// credential rather than a password, and pinning a variable name never checked
+// that.
+func TestIdentityCredentialsReachTheProvider(t *testing.T) {
+	cases := []struct {
+		name      string
+		connector string
+		// fill is flag -> value; flag gets the sentinel.
+		flag string
+		fill map[string]string
+	}{
+		{
+			// Registered in cli/launcher/forms/forms_identity.go, and checked
+			// here anyway: the okta spec puts --token in CREDENTIAL, and a
+			// section entry whose flag has no route is what produces a form
+			// that refuses.
+			name: "okta API token", connector: "okta", flag: "token",
+			fill: map[string]string{"organization": "dev-123.okta.com"},
+		},
+		{
+			name: "okta service app", connector: "okta", flag: "private-key",
+			fill: map[string]string{
+				"organization":   "dev-123.okta.com",
+				"client-id":      "0oa1",
+				"private-key-id": "kid-1",
+				"scopes":         "okta.users.read",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, f := hermeticFormFor(t, tc.connector)
+			for flag, value := range tc.fill {
+				setFlag(t, &f, flag, value)
+			}
+			fd := setFlag(t, &f, tc.flag, sentinel)
+			if !fd.Secret {
+				t.Fatalf("--%s carries a credential but is not classified as a secret", tc.flag)
+			}
+			if fd.Section != sectionCredential {
+				t.Errorf("--%s is in %s, want %s", tc.flag, fd.Section, sectionCredential)
+			}
+			if err := f.Validate(); err != nil {
+				t.Fatalf("the filled form does not validate: %v", err)
+			}
+
+			p := assertCredentialReachesTheProvider(t, c, f, tc.flag, sentinel)
+
+			// The target has to survive being separated from the credential.
+			for flag, value := range tc.fill {
+				if got, _ := p.sentValue(flag); got != value {
+					t.Errorf("--%s reached the provider as %q, want %q", flag, got, value)
+				}
+			}
+		})
+	}
+}
+
+// The blanket rule, over every Identity connector: fill every box and check
+// that nothing a user typed into a credential comes back out on a command line
+// every account on the machine can read.
+//
+// This was two sweeps in two files that had drifted apart. One filled a picker
+// with its first option and the other with the word "placeholder"; one resolved
+// the value sources afterwards and the other did not; one checked f.Args()
+// before planning and the other only checked the plan; one failed a connector
+// whose form offered no secret at all and the other returned quietly. Every one
+// of those differences was an accident of which file the author had open, and
+// the strict side of each is the one that is kept here.
+func TestNoIdentitySecretReachesArgv(t *testing.T) {
+	// google-workspace is the one form here with no credential to fill:
+	// --credentials-path names a file rather than holding a secret, so the
+	// whole form travels on the command line the way the provider expects.
+	// Every other connector here must offer one, because a curated CREDENTIAL
+	// section that built no field is a screen that cannot be completed.
+	noCredential := map[string]bool{"google-workspace": true}
+
+	for _, name := range identityConnectors {
+		t.Run(name, func(t *testing.T) {
+			c, f := hermeticFormFor(t, name)
+			secrets := fillEveryField(&f, sentinel)
+			resolveSources(&f)
+
+			if secrets == 0 && !noCredential[name] {
+				t.Fatalf("no field on the %s form is marked secret", name)
+			}
+			if secrets > 0 && noCredential[name] {
+				t.Fatalf("%s now offers a credential; it is listed as having none", name)
+			}
+
+			for _, a := range f.Args() {
+				if strings.Contains(a, sentinel) {
+					t.Fatalf("a secret reached the command line: %v", f.Args())
+				}
+			}
+
+			r := launchRequest{form: f}
+			plan, err := r.plan(c, scanAction())
+			if plan.cleanup != nil {
+				defer plan.cleanup()
+			}
+			if err != nil {
+				// A refusal is a correct outcome only when the provider kept
+				// the credential nowhere -- which is what a form holding two
+				// alternative credentials at once produces, since several
+				// providers pick one method and legitimately drop the other --
+				// and only when the message says which flag.
+				if !strings.Contains(err.Error(), "did not keep") {
+					t.Fatalf("unexpected launch failure: %v", err)
+				}
+				return
+			}
+			if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+				t.Fatalf("a secret reached argv: %v", plan.args)
+			}
+			// The preview is what tells the user the secret is not on the
+			// command line, so it must not contradict itself.
+			if preview := (launchRequest{form: f}).preview(c, scanAction()); strings.Contains(preview, sentinel) {
+				t.Fatalf("the command preview shows a secret: %q", preview)
+			}
+		})
+	}
+}
+
+// A form is navigated by label and args() tracks visibility by label, so two
+// fields sharing one would make a hidden field visible.
+func TestIdentityLabelsAreUnique(t *testing.T) {
+	for _, name := range identityConnectors {
+		_, f := hermeticFormFor(t, name)
+		seen := map[string]int{}
+		for _, fd := range f.Fields() {
+			seen[fd.Label]++
+		}
+		for label, n := range seen {
+			if n > 1 {
+				t.Errorf("%s: %d fields labelled %q", name, n, label)
+			}
+		}
+	}
+}
+
+// The credential fields have to be in CREDENTIAL, which is not automatic for
+// the ones that are not secrets: a client id, a user name and the realm a token
+// is requested from are all read as ordinary flags and would sit in the
+// collapsed OPTIONS row, away from the secret they only mean anything beside.
+func TestIdentityPairsIdentifiersWithTheirSecrets(t *testing.T) {
+	want := map[string][]string{
+		"auth0":     {"client-id"},
+		"bitwarden": {"client-id"},
+		"keycloak":  {"username", "client-id", "auth-realm"},
+	}
+
+	for name, flags := range want {
+		f := newForm(connectorFor(t, name))
+		for _, flag := range flags {
+			i := f.IndexOfFlag(flag)
+			if i < 0 {
+				t.Errorf("%s: --%s is not on the form", name, flag)
+				continue
+			}
+			if got := f.Fields()[i].Section; got != sectionCredential {
+				t.Errorf("%s: --%s is in %s, want %s", name, flag, got, sectionCredential)
+			}
+			// These are identifiers, not secrets. Marking one secret would
+			// take it off the command line where the provider expects to be
+			// shown it, and would put a value that needs no protection into the
+			// OS keychain.
+			if f.Fields()[i].Secret {
+				t.Errorf("%s: --%s is classified as a secret, which it is not", name, flag)
+			}
+		}
+	}
+}
+
+// keycloak declares two secrets for two alternative authentication methods,
+// reads an untagged password as the *client* secret, and needs cred.User to
+// mean the admin one. A user fills one; which one they filled is keycloak's to
+// work out, and it does, in its own ParseCLI. Both have to be able to launch.
+func TestKeycloakCarriesEitherAuthenticationMethod(t *testing.T) {
+	c := connectorFor(t, "keycloak")
+	for _, flag := range []string{"password", "client-secret"} {
+		t.Run(flag, func(t *testing.T) {
+			f := newForm(c)
+			value := "<PLACEHOLDER-not-a-real-secret>-" + flag
+			setFlag(t, &f, flag, value)
+			assertCredentialReachesTheProvider(t, c, f, flag, value)
+			if args := strings.Join(f.Args(), " "); strings.Contains(args, value) {
+				t.Errorf("--%s reached argv: %s", flag, args)
+			}
+		})
+	}
+}
+
+// ms365's two secrets reach the provider, and the history of this one test is
+// the argument for the whole change.
+//
+// It was first a refusal, reasoned from the provider: "its ParseCLI reads
+// req.GetFlags() and calls os.Getenv for nothing, so no variable carries
+// --client-secret or --certificate-secret to it". Every clause was true and the
+// conclusion did not follow. Then it was MONDOO_CLIENT_SECRET and
+// MONDOO_CERTIFICATE_SECRET, names derived from the flags rather than known to
+// ms365, working only because mql fills a flag with no config mapping from one
+// before ParseCLI runs.
+//
+// Reading req.GetFlags() was never the obstacle. It is the destination: the
+// launcher fills it directly now, over gRPC, and ms365's own ParseCLI builds
+// the pkcs12 credential for the certificate passphrase that no inventory this
+// package could write would have produced.
+func TestMs365SecretsReachTheProvider(t *testing.T) {
+	for _, flag := range []string{"client-secret", "certificate-secret"} {
+		t.Run(flag, func(t *testing.T) {
+			c, f := hermeticFormFor(t, "ms365")
+			setFlag(t, &f, "tenant-id", "3d8c")
+			setFlag(t, &f, flag, sentinel)
+
+			assertCredentialReachesTheProvider(t, c, f, flag, sentinel)
+		})
+	}
+}
+
+// The keyless sign-in shapes are what ms365's own help recommends, and they are
+// what the launcher can run: no secret in the form means the plain command
+// line, with the certificate path -- which names a file rather than holding a
+// credential -- on it, because that is how the provider expects to receive it.
+func TestMs365KeylessSignInLaunchesPlainly(t *testing.T) {
+	c, f := hermeticFormFor(t, "ms365")
+	setFlag(t, &f, "tenant-id", "3d8c")
+	setFlag(t, &f, "client-id", "9b21")
+	setFlag(t, &f, "certificate-path", "/keys/ms365.pem")
+	method := setFlag(t, &f, "auth-method", "cli")
+	if method.Kind != fieldChoice {
+		t.Errorf("--auth-method is a %v, want a picker over the declared methods", method.Kind)
+	}
+	if !containsString(method.Options, "workload-identity") {
+		t.Errorf("--auth-method options = %v, want the four declared methods", method.Options)
+	}
+
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Fatalf("delivery = %v, want the plain command line for a form with no secret", got)
+	}
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	line := strings.Join(plan.args, " ")
+	for _, want := range []string{"--tenant-id 3d8c", "--certificate-path /keys/ms365.pem", "--auth-method cli"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("launch = %q, missing %q", line, want)
+		}
+	}
+}
+
+// okta --private-key is the one flag in this file whose classification the
+// shared word lists get wrong, and this is the test that keeps the correction
+// honest: it asserts both that the classifier alone says "not a secret" -- so
+// the override is doing real work rather than restating the default -- and that
+// the form ends up treating it as one.
+//
+// The classifier is right about the general case. isSecretReference matches
+// "path to" in a description, which is exactly what makes github's
+// --app-private-key safe on the command line. okta's takes either the PEM
+// itself or a path to it, so the same description covers a value that must
+// never be an argument.
+func TestOktaPrivateKeyIsCorrectedToASecret(t *testing.T) {
+	c, f := hermeticFormFor(t, "okta")
+
+	var declared bool
+	for _, fl := range c.Flags {
+		if fl.Long != "private-key" {
+			continue
+		}
+		declared = true
+		if tuiform.IsSecretFlag(fl) {
+			t.Error("the shared classifier now marks okta --private-key itself; " +
+				"the FormSpec.Secret override for okta is redundant and should go")
+		}
+	}
+	if !declared {
+		t.Fatal("okta no longer declares --private-key")
+	}
+
+	i := f.IndexOfFlag("private-key")
+	if i < 0 {
+		t.Fatalf("--private-key is not on the form; fields are %v", fieldLabels(f))
+	}
+	if !f.Fields()[i].Secret {
+		t.Fatal("okta --private-key can hold a PEM and must never reach argv")
+	}
+
+	// A secret is masked on screen as well as kept off the command line: the
+	// form is drawn in a terminal somebody else can be looking at.
+	f.Fields()[i].SetValue(sentinel)
+	if strings.Contains(f.Fields()[i].Display(), sentinel) {
+		t.Fatalf("the private key is rendered in the clear: %q", f.Fields()[i].Display())
+	}
+}
+
+// activedirectory's --password reaches the provider.
+//
+// Its history is the whole argument in one connector. It was refused, because
+// its ParseCLI reads no variable for --password and there was no name to
+// register. Then it travelled in MONDOO_PASSWORD, a name derived from the flag
+// that works only because mql fills any flag with no config mapping from one --
+// confirmed against the shipped binary at the time, which is exactly the kind of
+// evidence that decays. Neither was a fact about activedirectory. The value now
+// goes into req.Flags, which is where that provider reads it from and always
+// did.
+func TestActiveDirectoryPasswordReachesTheProvider(t *testing.T) {
+	c, f := hermeticFormFor(t, "activedirectory")
+	fieldByLabel(t, f, "domain controller").SetValue("dc1.example.com")
+	fieldByLabel(t, f, "bind user").SetValue("svc@example.com")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+
+	assertCredentialReachesTheProvider(t, c, f, "password", sentinel)
+}
+
+// The Kerberos paths need no secret at all -- --keytab and --ccache name files
+// -- so they launch, and they are what makes the activedirectory form useful
+// today.
+func TestActiveDirectoryKerberosLaunchesOnTheCommandLine(t *testing.T) {
+	_, f := hermeticFormFor(t, "activedirectory")
+	fieldByLabel(t, f, "domain controller").SetValue("dc1.example.com")
+	fieldByLabel(t, f, "bind user").SetValue("svc@EXAMPLE.COM")
+	fieldByLabel(t, f, "use Kerberos (GSSAPI)").SetOn(true)
+	fieldByLabel(t, f, "Kerberos keytab").SetValue("/etc/krb5.keytab")
+
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Fatalf("delivery = %v, want the plain command line", got)
+	}
+	args := strings.Join(f.Args(), " ")
+	for _, want := range []string{"--dc dc1.example.com", "--kerberos", "--keytab /etc/krb5.keytab"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args %q missing %q", args, want)
+		}
+	}
+	// --backend is hidden: it declares two values and the connection rejects
+	// one of them outright, so it can only do nothing or fail.
+	if strings.Contains(args, "--backend") {
+		t.Errorf("--backend reached the command line: %q", args)
+	}
+}
+
+// google-workspace carries no secret at all: --credentials-path names a file,
+// so the whole form travels on the command line the way the provider expects.
+func TestGoogleWorkspaceLaunchesOnThePlainCommandLine(t *testing.T) {
+	_, f := hermeticFormFor(t, "google-workspace")
+	resolveSources(&f)
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Fatalf("delivery = %v, want the plain command line", got)
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_network_test.go
+++ b/apps/cnspec/cmd/interactive/forms_network_test.go
@@ -1,0 +1,716 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+)
+
+// The curated Network & Security Devices forms.
+//
+// Every test below drives the real form -- newForm over the connector rebuilt
+// from internal/connectors/connectors.json -- rather than inspecting the
+// FormSpec literal, because a spec that names a flag the connector does not
+// declare is silently dropped by applySpec. Reading the spec back would agree
+// with itself; building the form is what proves the flag survived.
+//
+// The two connector lists below are what used to be two files, split where one
+// contributor's work ended and the next began. They stay two lists because each
+// test names the list it iterates, and merging them would have been a rewrite
+// of every assertion in both. Both are declared through filedHere, so the thing
+// the letters used to hide -- a connector from another category quietly added
+// to whichever list its author had open -- fails in
+// TestEveryTestedConnectorIsFiledUnderItsCategory with the name of the file it
+// belongs in.
+
+// The nine appliance connectors that address a device as a positional or through a --hostname flag.
+//
+// Every test below drives the real form -- newForm over the connector rebuilt
+// from internal/connectors/connectors.json -- rather than inspecting the FormSpec literal,
+// because a spec that names a flag the connector does not declare is silently
+// dropped by applySpec. Reading the spec back would agree with itself; building
+// the form is what proves the flag survived.
+var networkAConnectors = filedHere(
+	"arista", "bigip", "checkpoint", "ciscocatalyst", "fortios",
+	"host", "ipmi", "junos", "mikrotik",
+)
+
+// All nine are registered, and each one registered here and nowhere else. Nine
+// agents were curating disjoint slices of the catalog at the same time, so a
+// connector this file believes it owns being absent means the registration was
+// lost, and registerSpec keeping someone else's is a collision this catches
+// before it reaches a user.
+func TestNetworkAConnectorsAreRegistered(t *testing.T) {
+	for _, name := range networkAConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+	}
+}
+
+// A connector that requires an argument must ask for it somewhere the user can
+// actually get to. A required field that lands in OPTIONS sits behind the fold,
+// where focusFirstMissing parks a cursor the user cannot move to -- so the
+// launcher would refuse to scan while showing nothing that needed filling in.
+//
+// This is the assertion for "the required field is present and reachable": it
+// exists, it is required, it is in TARGET, and the form considers it visible.
+func TestNetworkARequiredFieldsAreReachable(t *testing.T) {
+	// The five connectors whose target is an argument, and the label each one
+	// gives it. The labels are asserted rather than derived because the
+	// snapshot cannot carry a usage string -- connectorSnapshot.connector()
+	// sets Use to the connector name -- so without an explicit Positional in
+	// the spec every one of these would render as "argument 1".
+	want := map[string]string{
+		"arista":        "user@host",
+		"ciscocatalyst": "hostname",
+		"host":          "host",
+		"ipmi":          "user@host",
+		"mikrotik":      "user@host",
+	}
+
+	for _, name := range networkAConnectors {
+		c, f := formFor(t, name)
+		label, needsArg := want[name]
+
+		if !needsArg {
+			if c.MinArgs > 0 {
+				t.Errorf("%s: expected no required argument, but the connector declares MinArgs=%d",
+					name, c.MinArgs)
+			}
+			continue
+		}
+		if c.MinArgs == 0 {
+			t.Errorf("%s: expected a required argument, but the connector declares MinArgs=0", name)
+			continue
+		}
+
+		fd := fieldByLabel(t, f, label)
+		if !fd.Required {
+			t.Errorf("%s: %q is the connector's argument but is not marked required", name, label)
+		}
+		if fd.Section != sectionTarget {
+			t.Errorf("%s: %q is required but sits in %s, where the cursor cannot reach it",
+				name, label, fd.Section)
+		}
+		if fd.Flag != "" {
+			t.Errorf("%s: %q should be the positional argument, not --%s", name, label, fd.Flag)
+		}
+
+		// Reachable means the form is willing to show it right now, with
+		// nothing else filled in.
+		visible := false
+		for _, i := range f.VisibleIndices() {
+			if f.Fields()[i].Label == label {
+				visible = true
+			}
+		}
+		if !visible {
+			t.Errorf("%s: %q is required but hidden", name, label)
+		}
+	}
+}
+
+// A typed password reaches the provider, and the connector's own --ask-pass is
+// still on the form for a user who would rather be prompted.
+//
+// These seven all declare --ask-pass, and that used to mean a typed password
+// was thrown away: the launcher took the prompt route, put --ask-pass on the
+// command line in place of the value, and the child asked for the password the
+// user had already given it. Verified before the change --
+// `cnspec scan ssh chris@10.0.0.5 --ask-pass` was the entire command for a form
+// with a password in it. Prompting is still the strongest route there is and it
+// is still one keystroke away; it is no longer substituted for what was typed.
+func TestNetworkAPasswordReachesTheProvider(t *testing.T) {
+	// connector -> the positional to fill, if it has one.
+	arg := map[string]string{
+		"arista":        "user@host",
+		"ciscocatalyst": "hostname",
+		"ipmi":          "user@host",
+		"mikrotik":      "user@host",
+	}
+	// bigip, checkpoint and junos take the device as --hostname instead.
+	hostFlag := map[string]bool{"bigip": true, "checkpoint": true, "junos": true}
+
+	for _, name := range []string{
+		"arista", "bigip", "checkpoint", "ciscocatalyst", "ipmi", "junos", "mikrotik",
+	} {
+		c, f := formFor(t, name)
+
+		if label, ok := arg[name]; ok {
+			fieldByLabel(t, f, label).SetValue("admin@10.0.0.4")
+		}
+		if hostFlag[name] {
+			fieldByFlag(t, f, "hostname").SetValue("10.0.0.4")
+		}
+		pw := fieldByFlag(t, f, "password")
+		if !pw.Secret {
+			t.Errorf("%s: --password is not classified as a secret", name)
+		}
+		if pw.Section != sectionCredential {
+			t.Errorf("%s: --password is in %s, not CREDENTIAL", name, pw.Section)
+		}
+		pw.SetValue(sentinel)
+
+		if got := deliveryFor(f); got != deliverInventory {
+			t.Errorf("%s: a typed password routes as %v, want the inventory", name, got)
+			continue
+		}
+		assertCredentialReachesTheProvider(t, c, f, "password", sentinel)
+
+		// The toggle is still there, and ticking it with nothing typed is still
+		// an ordinary flag on an ordinary command line.
+		ask := f.IndexOfFlag("ask-pass")
+		if ask < 0 {
+			t.Errorf("%s: lost its --ask-pass toggle", name)
+			continue
+		}
+		prompt := newForm(c)
+		prompt.Fields()[prompt.IndexOfFlag("ask-pass")].SetOn(true)
+		if got := deliveryFor(prompt); got != deliverPlain {
+			t.Errorf("%s: --ask-pass on its own routes as %v, want the command line", name, got)
+		}
+		if !containsString(prompt.Args(), "--ask-pass") {
+			t.Errorf("%s: the child would never be asked to prompt: %v", name, prompt.Args())
+		}
+	}
+}
+
+// host declares no credential flag at all, so it must stay on the plain command
+// line. Routing a scan with no secret through an inventory file would be a
+// pointless regression, and it is also the check that this connector was
+// curated as the scanning target it is rather than as a login.
+func TestHostIsAScanTargetNotALogin(t *testing.T) {
+	c, f := formFor(t, "host")
+
+	for _, fd := range f.Fields() {
+		if fd.Secret {
+			t.Errorf("host: --%s is classified as a secret; this connector takes no credential", fd.Flag)
+		}
+		if fd.Section == sectionCredential {
+			t.Errorf("host: %q is in CREDENTIAL; this connector takes no credential", fd.Label)
+		}
+	}
+
+	fieldByLabel(t, f, "host").SetValue("https://mondoo.com")
+
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Errorf("host: delivery = %v, want deliverPlain", got)
+	}
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsString(plan.args, "--inventory-file") {
+		t.Errorf("host: expected a plain command line, got %v", plan.args)
+	}
+	if !containsString(plan.args, "https://mondoo.com") {
+		t.Errorf("host: the target did not reach the command line: %v", plan.args)
+	}
+}
+
+// fortios and checkpoint were the two connectors this file recorded as
+// unroutable, and neither is any more.
+//
+// fortios --token was refused because the variable derived from its name,
+// MONDOO_TOKEN, is the platform service account's own -- handing it to the child
+// would have replaced the credential the scan authenticates and uploads with.
+// checkpoint --api-key was allowed only because MONDOO_API_KEY happened not to
+// be taken. Both facts were about a name the launcher invented; neither was
+// about fortios or checkpoint. There is no derived name now, so there is nothing
+// to collide.
+func TestNetworkACredentialsReachTheProvider(t *testing.T) {
+	for _, tc := range []struct{ connector, flag string }{
+		{connector: "fortios", flag: "token"},
+		{connector: "checkpoint", flag: "api-key"},
+	} {
+		c, f := formFor(t, tc.connector)
+		fieldByFlag(t, f, "hostname").SetValue("10.0.0.4")
+
+		fd := fieldByFlag(t, f, tc.flag)
+		if !fd.Secret {
+			t.Errorf("%s: --%s is not classified as a secret", tc.connector, tc.flag)
+			continue
+		}
+		// A credential belongs in CREDENTIAL: the classifier puts it there,
+		// which is why leaving it out of the spec's Credential list hides
+		// nothing.
+		if fd.Section != sectionCredential {
+			t.Errorf("%s: --%s is in %s, not CREDENTIAL", tc.connector, tc.flag, fd.Section)
+		}
+		fd.SetValue(sentinel)
+
+		assertCredentialReachesTheProvider(t, c, f, tc.flag, sentinel)
+	}
+}
+
+// checkpoint takes a password or an API key, and handling one must not cost the
+// other. The target has to survive both.
+func TestCheckpointPasswordCarriesItsTargetToo(t *testing.T) {
+	c, f := formFor(t, "checkpoint")
+	fieldByFlag(t, f, "hostname").SetValue("mgmt.example.com")
+	fieldByFlag(t, f, "username").SetValue("admin")
+	fieldByFlag(t, f, "password").SetValue(sentinel)
+
+	p := withParser(t, &fakeParser{secretFlag: "password"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+		t.Fatalf("secret reached the command line: %v", plan.args)
+	}
+	// The target now travels in the inventory rather than on argv, so this is
+	// a question about what the provider was told rather than about the words
+	// the child was given.
+	if got, _ := p.sentValue("hostname"); got != "mgmt.example.com" {
+		t.Fatalf("the target did not survive the credential handling: hostname = %q", got)
+	}
+}
+
+// junos --identity-file names a key rather than holding one, so it has to stay
+// on the command line -- that is how the provider expects to receive it -- while
+// still being presented as part of the credential. ssh gets this right and
+// junos is the same shape; this pins it.
+func TestJunosIdentityFileIsAPathNotASecret(t *testing.T) {
+	_, f := formFor(t, "junos")
+	fd := fieldByFlag(t, f, "identity-file")
+
+	if fd.Secret {
+		t.Error("junos: --identity-file is a path and must not be masked or diverted off argv")
+	}
+	if !fd.Reference {
+		t.Error("junos: --identity-file should be classified as a reference to a credential")
+	}
+	if fd.Section != sectionCredential {
+		t.Errorf("junos: --identity-file should be shown with the credential, got %s", fd.Section)
+	}
+}
+
+// The target of each flag-addressed connector is promoted to TARGET, so the
+// first thing on the pane is the device rather than a TLS toggle.
+func TestNetworkAFlagAddressedTargetsArePromoted(t *testing.T) {
+	for _, name := range []string{"bigip", "checkpoint", "fortios", "junos"} {
+		_, f := formFor(t, name)
+		fd := fieldByFlag(t, f, "hostname")
+		if fd.Section != sectionTarget {
+			t.Errorf("%s: --hostname is in %s, want TARGET", name, fd.Section)
+		}
+		if f.Fields()[0].Flag != "hostname" {
+			t.Errorf("%s: the first field is --%s, want --hostname", name, f.Fields()[0].Flag)
+		}
+	}
+}
+
+// A picker is a promise that its values work. srcSSHHost lists ~/.ssh/config
+// aliases, which only mean anything to a client that reads that file -- and
+// none of these nine was shown to. Six of them are not SSH clients at all
+// (arista is goeapi over HTTPS, ipmi is RMCP to a BMC, mikrotik is the RouterOS
+// API, bigip/checkpoint/fortios are REST APIs), host is not a login, and
+// ciscocatalyst addresses a Catalyst Center appliance through its API.
+//
+// This is a test about honesty rather than mechanics, so it is written to fail
+// loudly if someone attaches the picker without revisiting the reasoning
+// recorded in the header of cli/launcher/forms/forms_network.go.
+func TestNetworkAOffersNoSSHConfigHosts(t *testing.T) {
+	for _, name := range networkAConnectors {
+		_, f := formFor(t, name)
+		for _, fd := range f.Fields() {
+			if fd.Source() == srcSSHHost || fd.LiveSource == srcSSHHost {
+				t.Errorf("%s: %q offers ~/.ssh/config hosts, but this connector does not "+
+					"resolve ssh_config aliases; see the reasoning in cli/launcher/forms/forms_network.go",
+					name, fd.Label)
+			}
+		}
+	}
+}
+
+// fortios --enable-forti-sdk-logs is an SDK debugging switch. Hiding it is the
+// only thing the spec does to that connector's options, so it is worth pinning:
+// a Hide that stops matching is silent.
+func TestFortiosHidesTheSDKLogSwitch(t *testing.T) {
+	_, f := formFor(t, "fortios")
+	if fd := findFieldByFlag(f, "enable-forti-sdk-logs"); fd != nil {
+		t.Errorf("fortios: --enable-forti-sdk-logs is still shown, in %s", fd.Section)
+	}
+	// The rest of the connector survived the hiding.
+	for _, flag := range []string{"hostname", "token", "insecure"} {
+		if findFieldByFlag(f, flag) == nil {
+			t.Errorf("fortios: --%s disappeared", flag)
+		}
+	}
+}
+
+// mikrotik's two ports are suggestions, not a validation list: RouterOS listens
+// on 8728 plain and 8729 with --tls, and a device on a non-default port must
+// still be reachable by typing it. Choices on a flag leaves the field free
+// text, and this is what says so.
+func TestMikrotikPortsAreSuggestionsNotAWhitelist(t *testing.T) {
+	_, f := formFor(t, "mikrotik")
+	fd := fieldByFlag(t, f, "port")
+
+	if fd.Kind != fieldChoice {
+		t.Errorf("mikrotik: --port kind = %v, want a picker", fd.Kind)
+	}
+	if fd.Strict {
+		t.Error("mikrotik: --port is strict, so a device on a non-default port could not be reached")
+	}
+	if len(fd.Options) != 2 || fd.Options[0] != "8728" || fd.Options[1] != "8729" {
+		t.Errorf("mikrotik: --port options = %v, want the API and API-SSL ports", fd.Options)
+	}
+}
+
+// networkBConnectors are the connectors this file curates. ipinfo is on the
+// list this file was written from and is deliberately not here; see
+// TestIPInfoHasNothingToCurate.
+var networkBConnectors = filedHere(
+	"nd-ssh", "networkdiscovery", "nmap", "opcua",
+	"panos", "redfish", "shodan", "unifi",
+)
+
+func TestNetworkBEveryConnectorHasASpec(t *testing.T) {
+	for _, name := range networkBConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+	}
+}
+
+// The assertion that catches a broken credential section at authoring time
+// rather than in a demo: a credential the user can fill in reaches the
+// provider, and reaches nothing that publishes it.
+//
+// Each case used to name the route as well -- the prompt for four of them, an
+// environment variable for the other two -- and every one of those was a claim
+// about the connector that a person had checked. There is one route now, and
+// what it carries is the provider's business.
+func TestNetworkBCredentialsCanLaunch(t *testing.T) {
+	cases := []struct {
+		connector string
+		// selector is the value of the leading positional, for the forms whose
+		// credential is behind one.
+		selectorLabel string
+		selector      string
+		flag          string
+	}{
+		{connector: "nd-ssh", flag: "password"},
+		{connector: "panos", flag: "password"},
+		{connector: "redfish", flag: "password"},
+		{connector: "shodan", flag: "token"},
+		{
+			connector: "unifi", selectorLabel: "sign in with", selector: "username and password",
+			flag: "password",
+		},
+		{
+			connector: "unifi", selectorLabel: "sign in with", selector: "API key",
+			flag: "api-key",
+		},
+	}
+
+	const secret = "<PLACEHOLDER-not-a-real-secret>"
+	for _, tc := range cases {
+		c, f := formFor(t, tc.connector)
+		if tc.selectorLabel != "" {
+			setLabelled(t, &f, tc.selectorLabel, tc.selector)
+		}
+		i := f.IndexOfFlag(tc.flag)
+		if i < 0 {
+			t.Errorf("%s: no --%s field to fill in", tc.connector, tc.flag)
+			continue
+		}
+		if !f.Fields()[i].Secret {
+			t.Errorf("%s: --%s is not classified as a secret, so it would reach argv",
+				tc.connector, tc.flag)
+			continue
+		}
+		f.Fields()[i].SetValue(secret)
+
+		t.Run(tc.connector+"/"+tc.flag, func(t *testing.T) {
+			assertCredentialReachesTheProvider(t, c, f, tc.flag, secret)
+		})
+	}
+}
+
+// nd-ssh declares three secret-carrying flags, and the spec leaves exactly one
+// of them fillable and promotes the two prompts that do the same job more
+// safely. The prompts are what make that a simplification rather than a loss:
+// the child asks and sets the flag itself, so the enable password never exists
+// in the launcher at all.
+//
+// The route no longer forces this -- one ParseCLI call carries as many secrets
+// as the form holds -- but the screen is still the better one, because a
+// prompted secret is stronger than a stored one and a Cisco login password and
+// enable password are two boxes nobody wants to fill twice.
+func TestNdSSHPromptsForWhatItCannotCarry(t *testing.T) {
+	c, f := formFor(t, "nd-ssh")
+
+	for _, flag := range []string{"enable-password", "private-key-passphrase"} {
+		if f.IndexOfFlag(flag) >= 0 {
+			t.Errorf("--%s is still fillable; a second secret has nowhere to travel", flag)
+		}
+	}
+	for _, flag := range []string{"ask-pass", "ask-enable-password"} {
+		if f.IndexOfFlag(flag) < 0 {
+			t.Errorf("--%s is not offered, so its credential cannot be collected at all", flag)
+		}
+	}
+
+	// Only one secret field survives.
+	var secretFlags []string
+	for _, fd := range f.Fields() {
+		if fd.Secret {
+			secretFlags = append(secretFlags, fd.Flag)
+		}
+	}
+	if len(secretFlags) != 1 || secretFlags[0] != "password" {
+		t.Fatalf("nd-ssh offers %v as secrets, want only --password", secretFlags)
+	}
+
+	// The realistic Cisco case: a login password and an enable password. The
+	// first travels as a prompt, the second as its own prompt flag.
+	setLabelled(t, &f, "user@host", "admin@switch1.example.com")
+	f.Fields()[f.IndexOfFlag("password")].SetValue("<PLACEHOLDER-not-a-real-secret>")
+	f.Fields()[f.IndexOfFlag("ask-enable-password")].SetOn(true)
+
+	p := assertCredentialReachesTheProvider(t, c, f, "password", "<PLACEHOLDER-not-a-real-secret>")
+
+	// The target and the second prompt both reach the provider. They used to be
+	// checked on argv, which is where they travelled while the credential went
+	// by environment variable; the inventory carries the whole invocation now,
+	// so the question is what the provider was told.
+	if len(p.args) != 1 || p.args[0] != "admin@switch1.example.com" {
+		t.Errorf("the target did not reach the provider: %v", p.args)
+	}
+	if _, ok := p.sentValue("ask-enable-password"); !ok {
+		t.Errorf("the enable-password prompt was not requested: %v", sortedKeys(p.flags))
+	}
+	if _, ok := p.sentValue("store-commands"); ok {
+		t.Errorf("the debugging flag was handed to the provider: %v", sortedKeys(p.flags))
+	}
+}
+
+// nmap and shodan reach their sub-commands through a selector, and the words
+// it emits are the provider's own: anything else is rejected by ParseCLI with
+// "invalid sub-command". A range emits no word at all, because it travels as
+// --networks.
+func TestNetworkBSelectorsEmitTheProviderSubcommands(t *testing.T) {
+	cases := []struct {
+		connector string
+		label     string
+		choice    string
+		target    string
+		wantArgs  []string
+	}{
+		{"nmap", "what to scan", "host", "192.168.1.1", []string{"host", "192.168.1.1"}},
+		{"nmap", "what to scan", "domain", "example.com", []string{"domain", "example.com"}},
+		{"nmap", "what to scan", "network range", "", nil},
+		{"shodan", "what to query", "host", "192.168.1.1", []string{"host", "192.168.1.1"}},
+		{"shodan", "what to query", "domain", "example.com", []string{"domain", "example.com"}},
+		{"shodan", "what to query", "account", "", nil},
+		{"shodan", "what to query", "network range", "", nil},
+	}
+
+	for _, tc := range cases {
+		_, f := formFor(t, tc.connector)
+		setLabelled(t, &f, tc.label, tc.choice)
+		if tc.target != "" {
+			setLabelled(t, &f, "target", tc.target)
+		}
+		got := f.Args()
+		if strings.Join(got, " ") != strings.Join(tc.wantArgs, " ") {
+			t.Errorf("%s %q emitted %v, want %v", tc.connector, tc.choice, got, tc.wantArgs)
+		}
+		if err := f.Validate(); err != nil {
+			t.Errorf("%s %q does not validate: %v", tc.connector, tc.choice, err)
+		}
+	}
+}
+
+// --networks is what a scan is pointed at, not a place to put something
+// discovery found. A picker on it would offer the answer as the question, and
+// it is shown only for the shape that uses it.
+func TestNetworkRangesAreInputNotDiscovered(t *testing.T) {
+	for _, name := range []string{"nmap", "shodan"} {
+		_, f := formFor(t, name)
+		i := f.IndexOfFlag("networks")
+		if i < 0 {
+			t.Errorf("%s: no --networks field", name)
+			continue
+		}
+		if f.Fields()[i].Source() != "" || f.Fields()[i].LiveSource != "" {
+			t.Errorf("%s: --networks has a picker attached (%q/%q)",
+				name, f.Fields()[i].Source(), f.Fields()[i].LiveSource)
+		}
+		if len(f.Fields()[i].ShowIf) == 0 {
+			t.Errorf("%s: --networks is shown for every shape, including the ones that ignore it", name)
+		}
+	}
+
+	// And the single-target shapes do not carry it.
+	_, f := formFor(t, "nmap")
+	setLabelled(t, &f, "what to scan", "host")
+	setLabelled(t, &f, "target", "192.168.1.1")
+	f.Fields()[f.IndexOfFlag("networks")].SetPicks(map[string]bool{"10.0.0.0/8": true})
+	if strings.Contains(strings.Join(f.Args(), " "), "10.0.0.0/8") {
+		t.Errorf("a leftover range travelled with a single-host scan: %v", f.Args())
+	}
+}
+
+// A required field left in OPTIONS sits behind the "more" fold, where
+// focusFirstMissing parks a cursor the user cannot see. opcua's --endpoint is
+// the case: it is the only thing the connector takes and it carries
+// FlagOption_Required.
+func TestNetworkBRequiredFieldsAreReachable(t *testing.T) {
+	for _, name := range networkBConnectors {
+		_, f := formFor(t, name)
+		for _, fd := range f.Fields() {
+			if fd.Required && fd.Section == sectionOptions {
+				t.Errorf("%s: %q is required but sits behind the fold in %s",
+					name, fd.Label, fd.Section)
+			}
+		}
+	}
+
+	_, f := formFor(t, "opcua")
+	i := f.IndexOfFlag("endpoint")
+	if i < 0 {
+		t.Fatal("opcua has no --endpoint field")
+	}
+	if !f.Fields()[i].Required {
+		t.Error("opcua --endpoint lost its required marking")
+	}
+	if f.Fields()[i].Section != sectionTarget {
+		t.Errorf("opcua --endpoint is in %s, want %s", f.Fields()[i].Section, sectionTarget)
+	}
+}
+
+// A credential typed into a row that a later choice hid is not part of the
+// command, and must not decide how the command is delivered.
+//
+// This is the unifi sequence: type a password, notice the controller wants an
+// API key instead, switch the selector, type the key. The password row is gone
+// from the screen and its --password is already absent from args() -- but
+// secrets() used to walk every field regardless of visibility, so delivery saw
+// two credentials on a form displaying one, and the launcher refused to run a
+// screen with nothing wrong on it. Nothing named the stale value, because
+// nothing could: it was not being shown.
+func TestAHiddenCredentialDoesNotDecideTheRoute(t *testing.T) {
+	c, f := formFor(t, "unifi")
+	setLabelled(t, &f, "sign in with", "username and password")
+	setLabelled(t, &f, "controller", "10.0.0.9")
+	f.Fields()[f.IndexOfFlag("password")].SetValue("<PLACEHOLDER-typed-then-abandoned>")
+
+	// The user changes their mind.
+	setLabelled(t, &f, "sign in with", "API key")
+	f.Fields()[f.IndexOfFlag("api-key")].SetValue("<PLACEHOLDER-the-kept-one>")
+
+	if got := f.Secrets(); len(got) != 1 || got[0].Flag != "api-key" {
+		var names []string
+		for _, s := range got {
+			names = append(names, s.Flag)
+		}
+		t.Fatalf("the form carries %v, want only the api-key the screen is showing", names)
+	}
+
+	p := withParser(t, &fakeParser{secretFlag: "api-key"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatalf("a form showing one credential was refused: %v", err)
+	}
+	if got, _ := p.sentValue("api-key"); got != "<PLACEHOLDER-the-kept-one>" {
+		t.Errorf("the key reached the provider as %q", got)
+	}
+	if _, sent := p.sentValue("password"); sent {
+		t.Error("the abandoned password was handed to the provider anyway")
+	}
+	// And the abandoned password goes nowhere at all -- not to argv, and not
+	// to the child's environment either.
+	for _, s := range append(append([]string{}, plan.args...), plan.env...) {
+		if strings.Contains(s, "<PLACEHOLDER-typed-then-abandoned>") {
+			t.Errorf("the hidden password was carried anyway: %q", s)
+		}
+	}
+}
+
+// unifi's two ways in are alternatives, and each choice shows exactly one
+// credential.
+func TestUnifiOffersOneCredentialAtATime(t *testing.T) {
+	cases := map[string][]string{
+		"username and password": {"username", "password", "ask-pass"},
+		"API key":               {"api-key"},
+	}
+	all := []string{"username", "password", "ask-pass", "api-key"}
+
+	for choice, want := range cases {
+		_, f := formFor(t, "unifi")
+		setLabelled(t, &f, "sign in with", choice)
+
+		visible := map[string]bool{}
+		for _, i := range f.VisibleIndices() {
+			visible[f.Fields()[i].Flag] = true
+		}
+		shown := map[string]bool{}
+		for _, flag := range want {
+			shown[flag] = true
+			if !visible[flag] {
+				t.Errorf("unifi %q hides --%s, which that choice needs", choice, flag)
+			}
+		}
+		for _, flag := range all {
+			if !shown[flag] && visible[flag] {
+				t.Errorf("unifi %q also shows --%s, which belongs to the other way in", choice, flag)
+			}
+		}
+		// The controller is asked for either way.
+		if !visible["hostname"] {
+			t.Errorf("unifi %q does not ask for the controller", choice)
+		}
+	}
+}
+
+// ipinfo is on the list this file was written from and carries nothing to
+// curate: no flags, no positional arguments, no discovery targets. A spec
+// would name flags that do not exist, and applySpec would drop every one of
+// them in silence -- which is the exact failure the spec tests exist to catch.
+//
+// Its credential is env-only and flagless too: the connection reads
+// IPINFO_TOKEN directly and nothing on the command line carries it, so there is
+// nothing for a form to collect and nothing for ParseCLI to be handed. The
+// launcher passes its own environment through, so the variable works as the
+// provider documents it.
+//
+// This is a drift guard rather than a formality: the day ipinfo declares a
+// flag, HasFormData turns true, it appears in the snapshot, and this says so.
+func TestIPInfoHasNothingToCurate(t *testing.T) {
+	if _, ok := formSpecs["ipinfo"]; ok {
+		t.Error("ipinfo has a spec, but declares no flags for one to name")
+	}
+	if _, ok := snapshotByName(t)["ipinfo"]; ok {
+		t.Error("ipinfo now carries form metadata and should be curated")
+	}
+
+	// And where it is installed, confirm that is a property of the connector
+	// rather than of the snapshot being stale.
+	for _, c := range BuildCatalog() {
+		if c.Name != "ipinfo" || !c.Installed {
+			continue
+		}
+		if c.HasFormData() {
+			t.Errorf("ipinfo declares form metadata locally (%d flags, MaxArgs=%d, discovery=%v); curate it",
+				len(c.Flags), c.MaxArgs, c.Discovery)
+		}
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_saas_test.go
+++ b/apps/cnspec/cmd/interactive/forms_saas_test.go
@@ -1,0 +1,855 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+)
+
+// The curated SaaS forms: the accounts an organisation holds with someone else.
+//
+// This file used to be three -- forms_saas_a_test.go, _b and _c -- and the
+// letter recorded which contributor wrote which third rather than anything
+// about the connectors. Two of those three also carried Identity connectors,
+// because the person who curated atlassian also curated activedirectory, so
+// "the SaaS tests" and "the tests one person wrote" were the same list and only
+// one of them was a category. They are filed by what the launcher shows now;
+// see forms_filing_test.go for the rule and what it can and cannot enforce.
+//
+// Every test below drives the real form -- newForm over the connector rebuilt
+// from internal/connectors/connectors.json -- rather than inspecting the
+// FormSpec literal, because a spec that names a flag the connector does not
+// declare is silently dropped by applySpec. Reading the spec back would agree
+// with itself; building the form is what proves the flag survived. That is also
+// why they build from the recorded artifact rather than from the machine: CI
+// runs with an empty provider set, and a check that skipped itself there would
+// prove nothing exactly where the proof is needed.
+
+// saasConnectors is every connector the launcher files under SaaS that this
+// file curates.
+//
+// The package-wide gates check the specs that exist. What they cannot check is
+// a connector nobody registered, which looks exactly like a connector nobody
+// was assigned -- so the list is written down, and filedHere is what proves
+// every name on it really is a SaaS connector rather than one that drifted in.
+var saasConnectors = filedHere(
+	"atlassian", "cloudflare", "databricks", "datadog", "dropbox", "gitlab",
+	"grafana", "iru", "jamf", "mondoo", "mongodbatlas", "netlify", "nextdns",
+	"slack", "snowflake", "tailscale", "vercel", "zoom",
+)
+
+// Every connector this file claims has a spec, and exactly one.
+//
+// Both halves matter and they fail differently. registerSpec is first-wins, so
+// a sibling file that also registered one of these would take it and the only
+// visible sign would be an entry in duplicateSpecs; that is the second check.
+// The first is the opposite failure -- a connector named here whose init was
+// removed, which leaves it on the generic flag-derived screen. That screen
+// looks like a form and says nothing about being uncurated.
+//
+// The environment routes this used to pin as well -- JAMF_CLIENT_SECRET,
+// MONGODB_ATLAS_PRIVATE_KEY, TAILSCALE_API_KEY and a dozen more -- are gone
+// with the registry that held them. Three of them were the interesting ones:
+// jamf routes its credential on cred.User carrying the client id, mongodbatlas
+// on the labels "private-key" and "client-secret", and okta's key wants a
+// private_key credential rather than a password. Pinning a variable name never
+// checked any of that.
+func TestSaaSSpecsAreRegisteredExactlyOnce(t *testing.T) {
+	for _, name := range saasConnectors {
+		if _, ok := formSpecs[name]; !ok {
+			t.Errorf("%s has no registered spec", name)
+		}
+		if containsString(duplicateSpecs, name) {
+			t.Errorf("%s was registered twice, so two files claim it", name)
+		}
+	}
+}
+
+// saasTargetLeads is what each SaaS form's TARGET section leads with, by the
+// label the spec gives it, and "" for the connectors whose whole form is the
+// credential.
+//
+// This was three tables in three files asking three different questions of
+// three thirds of the list: one checked a label was in TARGET and visible, one
+// checked the first field carried a particular flag, one checked which label
+// led TARGET. They are the same claim -- TARGET is the first section on the
+// pane, so what leads it is what the launcher says this connector is addressed
+// by -- and none of the three covered the whole category. One table does, and
+// every entry is a decision that is not obvious from the flag list: snowflake
+// leads with the account rather than the user, tailscale with a positional the
+// usage string does not even name, atlassian with a selector that is not a flag
+// at all.
+var saasTargetLeads = map[string]string{
+	"atlassian":    "product",
+	"databricks":   "connect to",
+	"datadog":      "site",
+	"gitlab":       "group",
+	"grafana":      "instance URL",
+	"iru":          "tenant subdomain",
+	"jamf":         "Jamf Pro URL",
+	"mongodbatlas": "organization id",
+	"netlify":      "account (optional)",
+	"slack":        "team ID",
+	"snowflake":    "account identifier",
+	"tailscale":    "tailnet",
+	"vercel":       "team (slug or ID)",
+	"zoom":         "account ID",
+
+	// The four with nothing to target. A TARGET section that holds an API key
+	// is a lie about what the field is, so nothing may be promoted into it to
+	// fill the space: cloudflare and dropbox declare one flag each and it is
+	// the credential, nextdns the same, and mondoo reads neither a flag nor an
+	// argument -- its ParseCLI builds a config from the connector name and
+	// returns.
+	"cloudflare": "",
+	"dropbox":    "",
+	"nextdns":    "",
+	"mondoo":     "",
+}
+
+// The field the connector cannot run without has to be on the screen, in
+// TARGET, and visible before anything else is chosen. A curated form that
+// buries it -- or gates it behind a selector value that is not the default --
+// is worse than the generic screen it replaced.
+func TestSaaSTargetsLeadTheirForms(t *testing.T) {
+	for _, name := range saasConnectors {
+		label, declared := saasTargetLeads[name]
+		if !declared {
+			t.Errorf("%s is curated here but saasTargetLeads does not say what its "+
+				"form is addressed by; add the label, or \"\" if it has no target", name)
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			_, f := hermeticFormFor(t, name)
+
+			if label == "" {
+				for _, fd := range f.Fields() {
+					if fd.Section == sectionTarget {
+						t.Errorf("%q is in TARGET, but %s has nothing to target",
+							fd.Label, name)
+					}
+				}
+				return
+			}
+
+			at := -1
+			for i := range f.Fields() {
+				if f.Fields()[i].Label == label {
+					at = i
+				}
+			}
+			if at < 0 {
+				t.Fatalf("no field labelled %q; the form asks %v", label, fieldLabels(f))
+			}
+			if got := f.Fields()[at].Section; got != sectionTarget {
+				t.Errorf("%q is in %s, want %s", label, got, sectionTarget)
+			}
+			if !f.Visible(at) {
+				t.Errorf("%q is hidden on a form nobody has touched yet", label)
+			}
+			// It leads its section: nothing else in TARGET comes before it.
+			for i, fd := range f.Fields() {
+				if fd.Section == sectionTarget && i < at {
+					t.Errorf("%q comes before the target %q", fd.Label, label)
+				}
+			}
+			// And TARGET is the first section, so the target is the first thing
+			// the user meets rather than something below a credential.
+			if at != 0 {
+				t.Errorf("the form leads with %q, want the target %q",
+					f.Fields()[0].Label, label)
+			}
+		})
+	}
+}
+
+// The target flags, named as flags rather than as the labels the lead table
+// uses. mongodbatlas asks for a project inside the organization and neither is
+// the lead; jamf and netlify are named here because the flag behind the label
+// is the part that has to survive -- a spec that relabelled --instance-domain
+// onto a different flag would still lead with "Jamf Pro URL".
+//
+// All of these are what is being scanned rather than who is scanning it, and a
+// target left in OPTIONS is below the credential, which reverses the order the
+// connector is actually used in.
+func TestSaaSSecondaryTargetsStayInTheTargetSection(t *testing.T) {
+	targets := map[string][]string{
+		"jamf":         {"instance-domain"},
+		"mongodbatlas": {"org-id", "project-id"},
+		"netlify":      {"account"},
+	}
+	for name, flags := range targets {
+		t.Run(name, func(t *testing.T) {
+			_, f := hermeticFormFor(t, name)
+			for _, flag := range flags {
+				i := f.IndexOfFlag(flag)
+				if i < 0 {
+					t.Errorf("--%s is not on the form; fields are %v", flag, fieldLabels(f))
+					continue
+				}
+				if got := f.Fields()[i].Section; got != sectionTarget {
+					t.Errorf("--%s is in %s, want %s", flag, got, sectionTarget)
+				}
+			}
+		})
+	}
+}
+
+// A credential a user can fill in has to reach the provider, and must not reach
+// a command line every account on the machine can read. The target it was
+// filled in beside has to survive being separated from it.
+//
+// This used to name the environment variable each one travelled in, and the
+// list was long: ATLASSIAN_USER_TOKEN, DATABRICKS_TOKEN, DD_APP_KEY, nine in
+// all. Every one was a claim about a provider that a person had checked by
+// running it, and every one could go stale in silence. There is one route now
+// and the provider decides what it carries.
+//
+// Each secret is filled on its own form rather than all at once. Both
+// mongodbatlas and atlassian declare alternative credentials only one of which
+// is ever used, so the shapes are listed as a user would fill them -- not
+// because the route could only carry one, which it no longer is, but because
+// several providers pick a different authentication path when they see the
+// second and legitimately drop the first.
+func TestSaaSCredentialsReachTheProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		connector string
+		// flag is the credential field to fill; fill names the fields that have
+		// to be filled beside it for the form to make sense, and is checked
+		// afterwards to prove the target survived.
+		flag string
+		fill map[string]string
+		// byLabel fills a field the connector has no flag for -- a selector, or
+		// a positional the spec named.
+		byLabel map[string]string
+		// validates marks the shapes that are complete as listed, so the form
+		// must accept them. It is not every row: several of these fill one
+		// credential onto a form that still has a required target empty, which
+		// is how a user meets it rather than how they leave it.
+		validates bool
+	}{
+		{name: "atlassian jira", connector: "atlassian", flag: "user-token",
+			byLabel: map[string]string{"product": "jira"}},
+		{name: "atlassian admin", connector: "atlassian", flag: "admin-token",
+			byLabel: map[string]string{"product": "admin"}},
+		{name: "atlassian scim", connector: "atlassian", flag: "scim-token",
+			byLabel: map[string]string{"product": "scim"}},
+		{name: "databricks workspace", connector: "databricks", flag: "token",
+			byLabel: map[string]string{"connect to": "workspace"}},
+		{name: "databricks account console", connector: "databricks", flag: "client-secret",
+			byLabel: map[string]string{"connect to": "account console"}},
+		{name: "datadog API key", connector: "datadog", flag: "api-key"},
+		{name: "datadog application key", connector: "datadog", flag: "app-key"},
+		{name: "grafana token", connector: "grafana", flag: "token"},
+		{name: "cloudflare token", connector: "cloudflare", flag: "token"},
+		{name: "gitlab token", connector: "gitlab", flag: "token"},
+		{name: "jamf API client", connector: "jamf", flag: "client-secret", validates: true,
+			fill: map[string]string{"instance-domain": "https://acme.jamfcloud.com", "client-id": "abc"}},
+		{name: "atlas programmatic API key", connector: "mongodbatlas", flag: "private-key", validates: true,
+			fill: map[string]string{"org-id": "5f1", "public-key": "pub"}},
+		{name: "atlas service account", connector: "mongodbatlas", flag: "client-secret", validates: true,
+			fill: map[string]string{"org-id": "5f1", "client-id": "mdb_sa_id"}},
+		{name: "netlify personal access token", connector: "netlify", flag: "token", validates: true,
+			fill: map[string]string{"account": "acme"}},
+		{name: "nextdns API key", connector: "nextdns", flag: "api-key", validates: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, f := hermeticFormFor(t, tc.connector)
+			for label, value := range tc.byLabel {
+				fieldByLabel(t, f, label).SetValue(value)
+			}
+			for flag, value := range tc.fill {
+				setFlag(t, &f, flag, value)
+			}
+
+			i := f.IndexOfFlag(tc.flag)
+			if i < 0 {
+				t.Fatalf("no --%s field; the form asks %v", tc.flag, fieldLabels(f))
+			}
+			if !f.Fields()[i].Secret {
+				t.Fatalf("--%s is not marked secret, so its value would reach argv", tc.flag)
+			}
+			if got := f.Fields()[i].Section; got != sectionCredential {
+				t.Errorf("--%s is in %s, want %s", tc.flag, got, sectionCredential)
+			}
+			f.Fields()[i].SetValue(sentinel)
+			resolveSources(&f)
+			if tc.validates {
+				if err := f.Validate(); err != nil {
+					t.Fatalf("the filled form does not validate: %v", err)
+				}
+			}
+
+			p := assertCredentialReachesTheProvider(t, c, f, tc.flag, sentinel)
+
+			// The target has to survive being separated from the credential.
+			for flag, value := range tc.fill {
+				if got, _ := p.sentValue(flag); got != value {
+					t.Errorf("--%s reached the provider as %q, want %q", flag, got, value)
+				}
+			}
+		})
+	}
+}
+
+// The one that matters most, over every SaaS connector: fill every box and
+// check that nothing a user typed into a credential comes back out on a command
+// line every account on the machine can read.
+//
+// This was two sweeps in two files that had drifted apart. One filled a picker
+// with its first option and the other with the word "placeholder"; one resolved
+// the value sources afterwards and the other did not; one checked f.Args()
+// before planning and the other only checked the plan; one failed a connector
+// whose form offered no secret at all and the other returned quietly. Every one
+// of those differences was an accident of which file the author had open, and
+// the strict side of each is the one that is kept here.
+func TestNoSaaSSecretReachesArgv(t *testing.T) {
+	// mondoo is the one SaaS form with no credential to fill, and it is not an
+	// omission: its ParseCLI reads neither a flag nor an argument and the
+	// credential comes from the workstation's own registration. Every other
+	// connector here must offer one, because a curated CREDENTIAL section that
+	// built no field is a screen that cannot be completed.
+	noCredential := map[string]bool{"mondoo": true}
+
+	for _, name := range saasConnectors {
+		t.Run(name, func(t *testing.T) {
+			c, f := hermeticFormFor(t, name)
+			secrets := fillEveryField(&f, sentinel)
+			resolveSources(&f)
+
+			if secrets == 0 && !noCredential[name] {
+				t.Fatalf("no field on the %s form is marked secret", name)
+			}
+			if secrets > 0 && noCredential[name] {
+				t.Fatalf("%s now offers a credential; it is listed as having none", name)
+			}
+
+			for _, a := range f.Args() {
+				if strings.Contains(a, sentinel) {
+					t.Fatalf("a secret reached the command line: %v", f.Args())
+				}
+			}
+
+			r := launchRequest{form: f}
+			plan, err := r.plan(c, scanAction())
+			if plan.cleanup != nil {
+				defer plan.cleanup()
+			}
+			if err != nil {
+				// A refusal is a correct outcome only when the provider kept
+				// the credential nowhere -- which is what a form holding two
+				// alternative credentials at once produces, since several
+				// providers pick one method and legitimately drop the other --
+				// and only when the message says which flag.
+				if !strings.Contains(err.Error(), "did not keep") {
+					t.Fatalf("unexpected launch failure: %v", err)
+				}
+				return
+			}
+			if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+				t.Fatalf("a secret reached argv: %v", plan.args)
+			}
+			// The preview is what tells the user the secret is not on the
+			// command line, so it must not contradict itself.
+			if preview := (launchRequest{form: f}).preview(c, scanAction()); strings.Contains(preview, sentinel) {
+				t.Fatalf("the command preview shows a secret: %q", preview)
+			}
+		})
+	}
+}
+
+// A form is navigated by label and args() tracks visibility by label, so two
+// fields sharing one would make a hidden field visible.
+func TestSaaSLabelsAreUnique(t *testing.T) {
+	for _, name := range saasConnectors {
+		_, f := hermeticFormFor(t, name)
+		seen := map[string]int{}
+		for _, fd := range f.Fields() {
+			seen[fd.Label]++
+		}
+		for label, n := range seen {
+			if n > 1 {
+				t.Errorf("%s: %d fields labelled %q", name, n, label)
+			}
+		}
+	}
+}
+
+// The credential fields have to be in CREDENTIAL, which is not automatic for
+// the ones that are not secrets: a client id, a user name and the identity file
+// a key is read from are all read as ordinary flags and would sit in the
+// collapsed OPTIONS row, away from the secret they only mean anything beside.
+func TestSaaSPairsIdentifiersWithTheirSecrets(t *testing.T) {
+	want := map[string][]string{
+		"snowflake": {"user", "identity-file"},
+		"tailscale": {"client-id"},
+		"zoom":      {"client-id"},
+	}
+
+	for name, flags := range want {
+		f := newForm(connectorFor(t, name))
+		for _, flag := range flags {
+			i := f.IndexOfFlag(flag)
+			if i < 0 {
+				t.Errorf("%s: --%s is not on the form", name, flag)
+				continue
+			}
+			if got := f.Fields()[i].Section; got != sectionCredential {
+				t.Errorf("%s: --%s is in %s, want %s", name, flag, got, sectionCredential)
+			}
+			// These are identifiers, not secrets. Marking one secret would
+			// take it off the command line where the provider expects to be
+			// shown it, and would put a value that needs no protection into the
+			// OS keychain.
+			if f.Fields()[i].Secret {
+				t.Errorf("%s: --%s is classified as a secret, which it is not", name, flag)
+			}
+		}
+	}
+}
+
+// mondoo reads neither a flag nor an argument: its ParseCLI builds a config
+// from the connector name and returns, and the credential comes from the
+// workstation's registration. The empty spec exists to suppress the box that
+// MaxArgs=4 would otherwise produce, so the form has to be empty and the
+// launch has to be the bare command.
+func TestMondooAsksForNothing(t *testing.T) {
+	c, f := hermeticFormFor(t, "mondoo")
+	if len(f.Fields()) != 0 {
+		t.Fatalf("mondoo asks for %v, but the connector reads nothing", fieldLabels(f))
+	}
+	if err := f.Validate(); err != nil {
+		t.Fatalf("an empty form should be launchable: %v", err)
+	}
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if got := strings.Join(plan.args, " "); got != "scan mondoo" {
+		t.Fatalf("mondoo launch = %q, want %q", got, "scan mondoo")
+	}
+}
+
+// atlassian's four products need four different credentials, and the flat
+// screen offered all five flags at once -- four of them always wrong. The
+// product chosen has to decide what is asked, and the word it emits has to be
+// the one the connector's own ParseCLI accepts.
+func TestAtlassianAsksOnlyForTheChosenProduct(t *testing.T) {
+	for _, tc := range []struct {
+		product string
+		want    []string // credential labels that must be visible
+		gone    []string // and those that must not
+		args    []string
+	}{
+		{product: "jira", want: []string{"site URL", "account email", "API token"},
+			gone: []string{"admin API token", "SCIM API token", "directory id"},
+			args: []string{"jira"}},
+		{product: "confluence", want: []string{"site URL", "account email", "API token"},
+			gone: []string{"admin API token", "SCIM API token"},
+			args: []string{"confluence"}},
+		{product: "admin", want: []string{"admin API token"},
+			gone: []string{"API token", "SCIM API token", "site URL", "directory id"},
+			args: []string{"admin"}},
+		{product: "scim", want: []string{"SCIM API token", "directory id"},
+			gone: []string{"API token", "admin API token", "site URL"},
+			args: []string{"scim", "dir-1"}},
+	} {
+		t.Run(tc.product, func(t *testing.T) {
+			_, f := hermeticFormFor(t, "atlassian")
+			fieldByLabel(t, f, "product").SetValue(tc.product)
+			resolveSources(&f)
+
+			visible := map[string]bool{}
+			for _, i := range f.VisibleIndices() {
+				visible[f.Fields()[i].Label] = true
+			}
+			for _, label := range tc.want {
+				if !visible[label] {
+					t.Errorf("%q is hidden for %s", label, tc.product)
+				}
+			}
+			for _, label := range tc.gone {
+				if visible[label] {
+					t.Errorf("%q is offered for %s, which does not use it", label, tc.product)
+				}
+			}
+
+			if tc.product == "scim" {
+				fieldByLabel(t, f, "directory id").SetValue("dir-1")
+			}
+			got := f.Args()
+			if len(got) != len(tc.args) {
+				t.Fatalf("args = %v, want %v", got, tc.args)
+			}
+			for i := range got {
+				if got[i] != tc.args[i] {
+					t.Fatalf("args = %v, want %v", got, tc.args)
+				}
+			}
+		})
+	}
+}
+
+// scim is the one product whose second argument the connector insists on --
+// "scim requires a directory id" -- and the only one where the field appears.
+func TestAtlassianScimRequiresItsDirectory(t *testing.T) {
+	_, f := hermeticFormFor(t, "atlassian")
+	fieldByLabel(t, f, "product").SetValue("scim")
+	resolveSources(&f)
+	if err := f.Validate(); err == nil {
+		t.Fatal("scim with no directory id validated")
+	}
+	fieldByLabel(t, f, "directory id").SetValue("dir-1")
+	if err := f.Validate(); err != nil {
+		t.Fatalf("scim with a directory id did not validate: %v", err)
+	}
+}
+
+// databricks declares MaxArgs=0, so the plane selector is a UI distinction and
+// nothing more: a stray word on the command line would be rejected by cnspec
+// before the connector ever saw it.
+func TestDatabricksPlaneSelectorPutsNoWordOnTheCommandLine(t *testing.T) {
+	c := connectorFor(t, "databricks")
+	if c.MaxArgs != 0 {
+		t.Fatalf("databricks now declares MaxArgs=%d; the selector may need to emit a word", c.MaxArgs)
+	}
+
+	for _, plane := range []string{"account console", "workspace"} {
+		_, f := hermeticFormFor(t, "databricks")
+		fieldByLabel(t, f, "connect to").SetValue(plane)
+		fieldByLabel(t, f, "host").SetValue("example.cloud.databricks.com")
+		resolveSources(&f)
+		for _, a := range f.Args() {
+			if a == plane {
+				t.Errorf("%q reached the command line: %v", plane, f.Args())
+			}
+		}
+	}
+}
+
+// The account id routes to the account console and a personal access token is
+// documented as workspace-only, so neither is offered where it does nothing.
+func TestDatabricksAsksWhatThePlaneNeeds(t *testing.T) {
+	for _, tc := range []struct{ plane, want, gone string }{
+		{plane: "account console", want: "account id", gone: "personal access token"},
+		{plane: "workspace", want: "personal access token", gone: "account id"},
+	} {
+		t.Run(tc.plane, func(t *testing.T) {
+			_, f := hermeticFormFor(t, "databricks")
+			fieldByLabel(t, f, "connect to").SetValue(tc.plane)
+			resolveSources(&f)
+
+			visible := map[string]bool{}
+			for _, i := range f.VisibleIndices() {
+				visible[f.Fields()[i].Label] = true
+			}
+			if !visible[tc.want] {
+				t.Errorf("%q is hidden for a %s connection", tc.want, tc.plane)
+			}
+			if visible[tc.gone] {
+				t.Errorf("%q is offered for a %s connection", tc.gone, tc.plane)
+			}
+			// OAuth M2M works on both planes, so it is never gated.
+			if !visible["OAuth client secret"] {
+				t.Errorf("OAuth is hidden for a %s connection", tc.plane)
+			}
+		})
+	}
+}
+
+// The shared classifier reads --api-key as a secret and --app-key as ordinary
+// text, because "app-key" ends in no strong secret word. A Datadog application
+// key is a credential, so the spec says so for this one flag rather than
+// widening a word list every other connector shares.
+func TestDatadogApplicationKeyIsASecret(t *testing.T) {
+	_, f := hermeticFormFor(t, "datadog")
+	for _, flag := range []string{"api-key", "app-key"} {
+		i := f.IndexOfFlag(flag)
+		if i < 0 {
+			t.Fatalf("no --%s field", flag)
+		}
+		if !f.Fields()[i].Secret {
+			t.Errorf("--%s is not marked secret, so its value would reach argv", flag)
+		}
+		if got := f.Fields()[i].Section; got != sectionCredential {
+			t.Errorf("--%s is in %s, want %s", flag, got, sectionCredential)
+		}
+	}
+
+	// Both filled is the normal case for datadog rather than an impossible one:
+	// the API key says which account, the application key says which user, and
+	// the API refuses most endpoints without the pair. This was a refusal once,
+	// because delivery resolved one route for the whole form, and then it was
+	// two variables. It is one call now, and how many secrets it carries is not
+	// a question the launcher has to answer.
+	f.Fields()[f.IndexOfFlag("api-key")].SetValue(sentinel)
+	f.Fields()[f.IndexOfFlag("app-key")].SetValue(sentinel + "-app")
+	c := connectorFor(t, "datadog")
+
+	p := withParser(t, &fakeParser{secretFlag: "api-key"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatalf("both keys were refused: %v", err)
+	}
+	if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+		t.Fatalf("a key reached argv: %v", plan.args)
+	}
+	for flag, want := range map[string]string{
+		"api-key": sentinel,
+		"app-key": sentinel + "-app",
+	} {
+		if got, _ := p.sentValue(flag); got != want {
+			t.Errorf("--%s reached the provider as %q, want %q", flag, got, want)
+		}
+	}
+}
+
+// The site list suggests without constraining: a Datadog region newer than
+// this binary still has to be typeable.
+func TestDatadogSiteIsASuggestion(t *testing.T) {
+	_, f := hermeticFormFor(t, "datadog")
+	fd := fieldByLabel(t, f, "site")
+	if fd.Kind != fieldChoice {
+		t.Fatalf("site is a %v, want a picker", fd.Kind)
+	}
+	if fd.Strict {
+		t.Error("the site list is strict, so a new Datadog region could not be typed")
+	}
+	if len(fd.Options) == 0 {
+		t.Error("the site picker offers nothing")
+	}
+}
+
+// gitlab's group and project are enumerable, but only through cnspec's own
+// discovery, which needs the token first -- so they are live pickers rather
+// than lists fetched while the screen is being drawn.
+func TestGitLabTargetsUseDiscovery(t *testing.T) {
+	_, f := hermeticFormFor(t, "gitlab")
+	for _, tc := range []struct{ label, source string }{
+		{"group", srcDiscoverGitLabGroups},
+		{"project", srcDiscoverGitLabProjects},
+	} {
+		fd := fieldByLabel(t, f, tc.label)
+		if fd.LiveSource != tc.source {
+			t.Errorf("%s live source = %q, want %q", tc.label, fd.LiveSource, tc.source)
+		}
+		if fd.Kind != fieldChoice {
+			t.Errorf("%s is a %v, want a picker", tc.label, fd.Kind)
+		}
+		if _, ok := sourceByID(tc.source); !ok {
+			t.Errorf("%s names %q, which is not a registered source", tc.label, tc.source)
+		}
+	}
+
+	// The ambient widgets stay whatever source_ambient.go made them: this file
+	// curates the target around the credential, never over it.
+	if got := fieldByLabel(t, f, "token").Kind; got != fieldPaste {
+		t.Errorf("the token field is a %v, want the ambient paste box", got)
+	}
+}
+
+// cloudflare declares one flag and it is the credential, so there is no target
+// to curate -- only where the token belongs and what to call it.
+func TestCloudflareIsCredentialOnly(t *testing.T) {
+	_, f := hermeticFormFor(t, "cloudflare")
+	token := fieldByLabel(t, f, "API token")
+	if token.Flag != "token" || !token.Secret {
+		t.Errorf("the API token row is %+v, want the secret --token flag", token)
+	}
+	if token.Kind != fieldPaste {
+		t.Errorf("the token field is a %v, want the ambient paste box", token.Kind)
+	}
+}
+
+// A value picker that names a source nobody registered leaves the field an
+// empty box with no explanation, which is the failure the source registry
+// exists to prevent. TestEverySourceNamedByASpecExists covers every spec at
+// once; this one names the pickers this file attaches and the flag each belongs
+// to, so a source retargeted at a different flag is visible here.
+func TestSaaSPickersNameRegisteredSources(t *testing.T) {
+	cases := []struct{ connector, flag, source string }{
+		{"mongodbatlas", "project-id", srcDiscoverAtlasProjects},
+		{"netlify", "account", discoverSourceID("netlify", "accounts")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.connector+" --"+tc.flag, func(t *testing.T) {
+			s, ok := sourceByID(tc.source)
+			if !ok {
+				t.Fatalf("%q is not a registered source", tc.source)
+			}
+			// Both are cnspec's own discovery, which connects into every asset
+			// it finds. That has to stay deferred: running it when the form
+			// opens would spend a round trip on a field nobody looked at.
+			if s.Cost != CostRemote {
+				t.Errorf("%s runs at cost %v, want CostRemote", tc.source, s.Cost)
+			}
+
+			_, f := hermeticFormFor(t, tc.connector)
+			i := f.IndexOfFlag(tc.flag)
+			if i < 0 {
+				t.Fatalf("--%s is not on the form; fields are %v", tc.flag, fieldLabels(f))
+			}
+			if f.Fields()[i].Source() != tc.source {
+				t.Fatalf("--%s draws from %q, want %q", tc.flag, f.Fields()[i].Source(), tc.source)
+			}
+			// applySources only merges a live source into a base source's
+			// values, so a picker attached through LiveSources alone would
+			// never show anything. This one has to be the base.
+			if f.Fields()[i].Kind != fieldChoice {
+				t.Errorf("--%s is a %v, want a picker", tc.flag, f.Fields()[i].Kind)
+			}
+		})
+	}
+}
+
+// vercel's team picker has to be reachable.
+//
+// applySources only fills a field whose `source` is set, so a field carrying
+// nothing but a liveSource loads its values and never shows them -- it spins,
+// answers, and the picker stays empty. That is why the discovery source is
+// attached through Sources here, and this is the assertion that keeps someone
+// from "fixing" it into LiveSources later.
+func TestVercelTeamPickerIsAttachedSoItsValuesLand(t *testing.T) {
+	f := newForm(connectorFor(t, "vercel"))
+	i := f.IndexOfFlag("team")
+	if i < 0 {
+		t.Fatal("vercel has no --team field")
+	}
+	fd := f.Fields()[i]
+
+	if fd.Source() != discoverSourceID("vercel", "teams") {
+		t.Errorf("--team source = %q, want the registered vercel teams discovery", fd.Source())
+	}
+	if fd.LiveSource != "" && fd.Source() == "" {
+		t.Error("--team carries only a live source, whose values applySources never applies")
+	}
+	if fd.Kind != fieldChoice {
+		t.Errorf("--team kind = %v, want a picker", fd.Kind)
+	}
+	if !deferredSource(fd.Source()) {
+		t.Error("the vercel teams picker is not deferred, so it would run for every form the user passes through")
+	}
+}
+
+// snowflake's --token was the launcher's last standing refusal, and it is not
+// one any more.
+//
+// The refusal was sound about the provider and wrong about the conclusion.
+// snowflake declares --token and --password with ConfigEntry "-", which tells
+// mql to read them from cobra alone and consult no variable -- confirmed
+// against the shipped binary, `MONDOO_TOKEN=... MONDOO_PASSWORD=... cnspec shell
+// snowflake --account ... --user ...` still answered "missing credentials for
+// snowflake connection". Every word of that is about how a *flag value* gets
+// into the process. It is not how the value gets in any more: it goes into
+// req.Flags, which is the same place cobra would have put it.
+func TestSnowflakeTokenTravels(t *testing.T) {
+	c := connectorFor(t, "snowflake")
+	f := newForm(c)
+	i := f.IndexOfFlag("token")
+	if i < 0 {
+		t.Fatal("snowflake no longer declares --token")
+	}
+	f.Fields()[i].SetValue("<PLACEHOLDER-not-a-real-secret>")
+
+	assertCredentialReachesTheProvider(t, c, f, "token", "<PLACEHOLDER-not-a-real-secret>")
+
+	// --ask-pass is still declared and still the strongest route for the
+	// password, and it is still a toggle the user can tick.
+	if j := f.IndexOfFlag("ask-pass"); j < 0 {
+		t.Error("snowflake no longer offers --ask-pass, so nothing can prompt for its password")
+	}
+}
+
+// snowflake's account picker offers the account identifiers from
+// connections.toml, which is the only thing in that file the connector can use:
+// no flag and no variable takes a connection name. Attaching it anywhere but
+// --account would put a connection name on the command line as an account.
+func TestSnowflakeAccountPickerIsOnTheAccountFlag(t *testing.T) {
+	f := newForm(connectorFor(t, "snowflake"))
+	i := f.IndexOfFlag("account")
+	if i < 0 {
+		t.Fatal("snowflake has no --account field")
+	}
+	if got := f.Fields()[i].Source(); got != srcSnowflakeConnection {
+		t.Errorf("--account source = %q, want %q", got, srcSnowflakeConnection)
+	}
+	for _, fd := range f.Fields() {
+		if fd.Flag != "account" && fd.Source() == srcSnowflakeConnection {
+			t.Errorf("the connections.toml picker is also on --%s, which does not take an account identifier", fd.Flag)
+		}
+	}
+}
+
+// tailscale's tailnet is a positional argument the usage string does not name,
+// so without the spec it renders as "argument 1". It reaches the provider as
+// req.Args[0] and needs no environment route of its own.
+//
+// tailscale is also the credential that could never have been written down as a
+// variable name: it reads the same secret as the API token or as the OAuth
+// client secret depending on whether --client-id is set.
+func TestTailscaleNamesItsTailnet(t *testing.T) {
+	f := newForm(connectorFor(t, "tailscale"))
+	if len(f.Fields()) == 0 {
+		t.Fatal("tailscale built an empty form")
+	}
+	lead := f.Fields()[0]
+	if lead.Flag != "" {
+		t.Fatalf("tailscale leads with --%s, not with its positional argument", lead.Flag)
+	}
+	if lead.Label != "tailnet" {
+		t.Errorf("the positional is labelled %q, want %q", lead.Label, "tailnet")
+	}
+	if lead.Required {
+		t.Error("the tailnet is optional -- the provider defaults to the token's own tailnet")
+	}
+
+	// It travels as an argument, so nothing should have given it a variable.
+	if lead.Env != "" {
+		t.Errorf("the tailnet carries env %q, but it reaches the provider as req.Args[0]", lead.Env)
+	}
+}
+
+// iru takes no argument: the tenant is a flag and the token is a flag the
+// provider marks as a password. Iru is Kandji renamed, and the launcher files
+// it beside jamf because they are the same job -- which is why it is here and
+// not under the "Other" heading a stale comment in forms_misc_test.go gave it.
+func TestIruAsksForItsTenantAndKeepsTheTokenOffArgv(t *testing.T) {
+	c, f := formFor(t, "iru")
+
+	if pos := positionalFields(&f); len(pos) != 0 {
+		t.Errorf("iru takes no argument but the form asks for %d: %v",
+			len(pos), fieldLabels(f))
+	}
+
+	subdomain := fieldByLabel(t, f, "tenant subdomain")
+	if subdomain.Section != sectionTarget {
+		t.Errorf("the tenant sits in %q rather than TARGET", subdomain.Section)
+	}
+	if subdomain.Secret {
+		t.Error("the tenant subdomain is not a secret and must stay on the command line")
+	}
+
+	token := fieldByLabel(t, f, "API token")
+	if !token.Secret || token.Section != sectionCredential {
+		t.Fatalf("the API token is secret=%v in %q", token.Secret, token.Section)
+	}
+
+	subdomain.SetValue("mondoo")
+	token.SetValue(sentinel)
+
+	p := assertCredentialReachesTheProvider(t, c, f, "token", sentinel)
+	if got, ok := p.sentValue("subdomain"); !ok || got != "mondoo" {
+		t.Errorf("the tenant reached the provider as %q (present=%v)", got, ok)
+	}
+}

--- a/apps/cnspec/cmd/interactive/forms_test.go
+++ b/apps/cnspec/cmd/interactive/forms_test.go
@@ -1,0 +1,279 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// updateSnapshot rewrites internal/connectors/connectors.json from the installed provider
+// set. It lives here rather than in snapshot_test.go only because a package can
+// register a flag once.
+var updateSnapshot = flag.Bool("update", false, "rewrite internal/connectors/connectors.json from the installed providers")
+
+// The gate over the curated overlays.
+//
+// applySpec drops any flag the connector does not declare, which is deliberate:
+// an overlay that goes stale degrades to the generic screen rather than
+// emitting a flag that no longer exists. The cost of that graceful degradation
+// is that a typo is completely silent -- the field just never appears, with
+// nothing anywhere saying why -- and inventing a plausible flag is the
+// documented failure mode on this branch, caught last time only by a human
+// reading it.
+//
+// This is checked against the recorded snapshot rather than the machine,
+// because the machine has no providers on it in CI. See snapshot_test.go.
+//
+// A flag is checked against every connector that shares the spec naming it, not
+// against each one separately, and that distinction is the whole difficulty of
+// this test. databaseSpec is registered for fifteen connectors and is
+// deliberately the union of the family's vocabulary -- postgresdb has no --sid,
+// oracledb has no --auth-db -- so a per-connector rule would report a hundred
+// failures for a spec that is doing exactly what its comment says. A flag that
+// *no* connector sharing the spec declares is a different thing entirely: it
+// cannot ever appear on a screen, which is what a typo looks like. For a spec
+// registered for one connector -- every spec written from here on -- the two
+// rules are the same rule.
+func TestEverySpecNamesRealFlags(t *testing.T) {
+	byName := snapshotByName(t)
+	var missing []string
+	checked, groups := 0, 0
+
+	for _, group := range specGroups() {
+		// The flags declared by any connector in the group, plus --discover,
+		// which the CLI synthesizes for every connector with discovery targets
+		// and which therefore never appears in Flags.
+		declared := map[string]bool{}
+		var known []string
+		for _, name := range group.connectors {
+			snap, ok := byName[name]
+			if !ok {
+				continue
+			}
+			known = append(known, name)
+			for _, fl := range snap.Flags {
+				declared[fl.Long] = true
+			}
+			if len(snap.Discovery) > 0 {
+				declared["discover"] = true
+			}
+		}
+		if len(known) == 0 {
+			// No connector in the group is in the snapshot, so there is nothing
+			// to check it against. Worth seeing, not worth failing: a provider
+			// may simply not have been installed when the snapshot was taken.
+			t.Logf("%s: no snapshot entry, so its flags were not checked",
+				group.connectors[0])
+			continue
+		}
+		groups++
+		checked += len(known)
+
+		label := group.connectors[0]
+		if len(group.connectors) > 1 {
+			label = group.connectors[0] + " (shared by " + strconv.Itoa(len(group.connectors)) + " connectors)"
+		}
+		report := func(section, flag string) {
+			if flag == "" || declared[flag] {
+				return
+			}
+			missing = append(missing, label+" "+section+" names --"+flag+
+				", which no connector using this spec declares")
+		}
+
+		spec := group.spec
+		for _, f := range spec.Target {
+			report("Target", f)
+		}
+		for _, f := range spec.Credential {
+			report("Credential", f)
+		}
+		for _, f := range spec.Secret {
+			report("Secret", f)
+		}
+		for _, f := range spec.NotSecret {
+			report("NotSecret", f)
+		}
+		for _, f := range spec.Hide {
+			report("Hide", f)
+		}
+		for f := range spec.Labels {
+			report("Labels", f)
+		}
+		for f := range spec.Sources {
+			report("Sources", f)
+		}
+		for f := range spec.LiveSources {
+			report("LiveSources", f)
+		}
+		for f := range spec.Choices {
+			report("Choices", f)
+		}
+		for f := range spec.ShowFlagsIf {
+			report("ShowFlagsIf", f)
+		}
+	}
+
+	sort.Strings(missing)
+	for _, m := range missing {
+		t.Error(m)
+	}
+	if checked == 0 {
+		t.Fatal("no spec was checked against the snapshot, so this test proves nothing")
+	}
+	t.Logf("checked %d of %d registered connectors, in %d spec groups",
+		checked, len(formSpecs), groups)
+}
+
+// specGroup is one spec and every connector registered with it.
+type specGroup struct {
+	spec       FormSpec
+	connectors []string
+}
+
+// specGroups collects the registered specs, folding connectors that share an
+// identical spec into one group. Sharing is by value because that is all the
+// registry keeps -- registerSpec takes a FormSpec, not a pointer to one.
+func specGroups() []specGroup {
+	names := make([]string, 0, len(formSpecs))
+	for name := range formSpecs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var out []specGroup
+	for _, name := range names {
+		spec := formSpecs[name]
+		placed := false
+		for i := range out {
+			if reflect.DeepEqual(out[i].spec, spec) {
+				out[i].connectors = append(out[i].connectors, name)
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			out = append(out, specGroup{spec: spec, connectors: []string{name}})
+		}
+	}
+	return out
+}
+
+// A connector that requires positional arguments needs somewhere to put them.
+// A spec that replaces the derived slots with fewer than the connector demands
+// produces a form that cannot assemble a valid command, and says nothing about
+// why.
+func TestEverySpecHasRoomForItsArguments(t *testing.T) {
+	byName := snapshotByName(t)
+	for name, spec := range formSpecs {
+		snap, ok := byName[name]
+		if !ok || len(spec.Positional) == 0 {
+			continue
+		}
+		if uint(len(spec.Positional)) < snap.MinArgs {
+			t.Errorf("%s declares %d positional fields but the connector requires %d",
+				name, len(spec.Positional), snap.MinArgs)
+		}
+	}
+}
+
+// Two registrations for one connector mean two people each believed they owned
+// it, and init order decides which one the user gets. registerSpec keeps the
+// first and records the collision here rather than letting the second win in
+// silence.
+func TestNoConnectorHasTwoSpecs(t *testing.T) {
+	for _, name := range duplicateSpecs {
+		t.Errorf("%s has more than one registered spec", name)
+	}
+}
+
+// Every environment contributor has to name a connector, a field and something
+// to do, or it silently contributes nothing and the target it was written for
+// is scanned as though it had never been chosen.
+func TestEveryEnvSpecIsComplete(t *testing.T) {
+	for connector, specs := range envSpecs {
+		for _, s := range specs {
+			if s.Connector != connector {
+				t.Errorf("%s: registered under %q but declares connector %q",
+					connector, connector, s.Connector)
+			}
+			if s.Field == "" {
+				t.Errorf("%s: an EnvSpec with no Field matches nothing", connector)
+			}
+			if s.Apply == nil {
+				t.Errorf("%s: an EnvSpec with no Apply contributes nothing", connector)
+			}
+		}
+	}
+}
+
+// A positional declares either a value table or a value picker, never both.
+//
+// The two are alternative answers to "what does this field's display mean on a
+// command line", and field.emit holds one of them. A picker's answer arrives
+// with the picker -- attachSource takes them together, because a source
+// assigned without its mapping emits an annotated AWS profile verbatim -- so a
+// selector that switched pickers would drop a table declared beside it. Nothing
+// declares both today; this is what keeps that true, since the alternative is a
+// spec whose Emit entries stop applying the moment the selector above it moves.
+func TestNoPositionalDeclaresBothATableAndAPicker(t *testing.T) {
+	for name, spec := range formSpecs {
+		for _, p := range spec.Positional {
+			if p.Emit == nil {
+				continue
+			}
+			if p.Source != "" || p.SourceBy != nil {
+				t.Errorf("%s: %q declares an Emit table and a value picker; "+
+					"a picker brings its own mapping and would replace the table",
+					name, p.Label)
+			}
+		}
+	}
+}
+
+// Every registered spec has a snapshot entry, so TestEverySpecNamesRealFlags
+// above skipped none of them.
+//
+// That gate logs and continues when a spec's connector is absent from the
+// recorded artifact, which is the right behaviour -- a provider may simply not
+// have been installed when the artifact was generated -- and is also the shape
+// that turns a green run into a claim about nothing. A spec whose connector is
+// missing has its Target, Credential, Secret, Hide and picker flags checked by
+// nothing at all, and looks identical to one that passed.
+//
+// forms_misc_test.go used to say this for the twelve connectors one contributor
+// had been assigned, and forms_saas_c_test.go worked around it for six others
+// by re-checking their flags against a hand-written fixture. Both were
+// per-file answers to a question about the whole registry. This is the
+// question: how many of the registered specs did the gate actually see.
+func TestEverySpecIsCoveredByTheSnapshotGate(t *testing.T) {
+	byName := snapshotByName(t)
+
+	var unchecked []string
+	checked := 0
+	for name := range formSpecs {
+		if _, ok := byName[name]; !ok {
+			unchecked = append(unchecked, name)
+			continue
+		}
+		checked++
+	}
+	sort.Strings(unchecked)
+
+	if checked == 0 {
+		t.Fatal("no registered spec has a snapshot entry, so the flag gate above " +
+			"checked nothing and passed")
+	}
+	for _, name := range unchecked {
+		t.Errorf("%s has a spec but no entry in %s, so nothing checks the flags it "+
+			"names. Refresh the artifact with `make connectors/generate`, or say here "+
+			"why it is absent", name, connectorSnapshotPath)
+	}
+	t.Logf("%d of %d registered specs are covered by the snapshot gate",
+		checked, len(formSpecs))
+}

--- a/apps/cnspec/cmd/interactive/install.go
+++ b/apps/cnspec/cmd/interactive/install.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/mql/providers"
+)
+
+// A connector's input form is built from metadata that only an installed
+// provider carries: providers.DefaultProviders names every connector cnspec
+// supports but strips the flags, arg counts and discovery targets. So the
+// launcher installs a provider on demand the moment a user opens its form,
+// rather than degrading to a bare text box for anything not already on disk.
+//
+// The install is the same one a scan would trigger on first use, so this only
+// moves the download earlier -- to the point where the user is choosing what to
+// run rather than in the middle of running it.
+
+// providerInstalledMsg reports the outcome of an on-demand install.
+type providerInstalledMsg struct {
+	provider string
+	// conns are the provider's connectors rebuilt from the freshly loaded
+	// metadata, ready to replace the catalog's placeholder entries.
+	conns []Connector
+	err   error
+}
+
+// installProviderCmd downloads and installs a provider in the background.
+//
+// EnsureProvider does network I/O and can take seconds, so this must only ever
+// run as a tea.Cmd. It also writes the package-level provider cache without a
+// lock, so the caller is responsible for keeping a single install in flight.
+func installProviderCmd(provider string) tea.Cmd {
+	return func() tea.Msg {
+		p, err := providers.EnsureProvider(
+			providers.ProviderLookup{ProviderName: provider}, true, nil)
+		if err != nil {
+			return providerInstalledMsg{provider: provider, err: err}
+		}
+		// EnsureProvider loads the provider's JSON on install, so p carries the
+		// full connector metadata the form needs.
+		return providerInstalledMsg{
+			provider: provider,
+			conns:    connectorsOf(provider, p.Provider, true),
+		}
+	}
+}
+
+// What the launcher does with the answer is listState.applyInstalled: the
+// catalog is what an install replaces, and the catalog is the list's.

--- a/apps/cnspec/cmd/interactive/inventory_test.go
+++ b/apps/cnspec/cmd/interactive/inventory_test.go
@@ -1,0 +1,221 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// Writing the inventory lives in cli/launcher/delivery, and the properties of
+// the file itself -- 0600 in a 0700 directory, removed on every exit, a vault
+// reference carrying no inline secret -- are tested there against an asset
+// written by hand.
+//
+// What is tested here is the join, end to end and against a real provider: that
+// the launcher's *curated* ssh form, handed to the os provider's own ParseCLI,
+// produces an asset that cnspec's inventory loader accepts and that the
+// keychain can protect. A field renamed or re-sectioned in a spec breaks this
+// and nothing in the delivery package would notice.
+//
+// ssh is the right connector to spend a subprocess on. It is the one whose
+// inventory shape cnspec's own documentation and testdata demonstrate, so a
+// disagreement here is a disagreement with something written down.
+
+func sshFormWithPassword(t *testing.T) (Connector, form) {
+	t.Helper()
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue("<PLACEHOLDER-not-a-real-secret>")
+	fieldByLabel(t, f, "sudo").SetOn(true)
+	return c, f
+}
+
+// sshAssetFromProvider asks the os provider what the curated ssh form means.
+//
+// It skips rather than fails when the provider is not installed, and says so:
+// CI points PROVIDERS_PATH at an empty directory, so a test in this shape that
+// stayed silent would be green having checked nothing.
+func sshAssetFromProvider(t *testing.T, f form) (Connector, *inventory.Asset) {
+	t.Helper()
+	c := sshConnector()
+	if !installedProviders()[c.Provider] {
+		t.Skipf("the %s provider is not installed here, so the ssh join was not checked", c.Provider)
+	}
+	req := deliverypkg.RequestFor(f, c.Flags)
+	asset, err := deliverypkg.Parser.ParseCLI(c.Provider, c.Name, req.Args, req.Flags)
+	if err != nil {
+		t.Fatalf("the os provider refused the curated ssh form: %v", err)
+	}
+	return c, asset
+}
+
+// The generated inventory must load through the same code path `cnspec scan`
+// uses, or the launcher is writing files only it can read.
+func TestGeneratedInventoryRoundTrips(t *testing.T) {
+	_, f := sshFormWithPassword(t)
+	c, asset := sshAssetFromProvider(t, f)
+
+	data, err := deliverypkg.InventoryFor(c.Name, asset, nil, "").ToYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := inventory.InventoryFromYAML(data)
+	if err != nil {
+		t.Fatalf("cnspec cannot read the inventory we generated: %v\n%s", err, data)
+	}
+	if err := loaded.PreProcess(); err != nil {
+		t.Fatalf("PreProcess rejected it: %v\n%s", err, data)
+	}
+	if err := loaded.Validate(); err != nil {
+		t.Fatalf("Validate rejected it: %v\n%s", err, data)
+	}
+}
+
+// The curated ssh form maps onto the shape the os provider reads: a host, a
+// user carried by the credential rather than by the target string, and sudo.
+func TestInventoryShapesTheSSHAsset(t *testing.T) {
+	_, f := sshFormWithPassword(t)
+	_, asset := sshAssetFromProvider(t, f)
+	conn := asset.Connections[0]
+
+	if conn.Type != "ssh" {
+		t.Errorf("connection type = %q, want ssh", conn.Type)
+	}
+	// The deprecated `backend` field triggers a fallback path and a warning.
+	if conn.Backend != 0 {
+		t.Errorf("backend should be left unset, got %v", conn.Backend)
+	}
+	if conn.Host != "10.0.0.4" {
+		t.Errorf("host = %q, want 10.0.0.4", conn.Host)
+	}
+	if conn.Sudo == nil || !conn.Sudo.Active {
+		t.Error("sudo should be active")
+	}
+	// Two credentials, and that is the provider's decision rather than the
+	// launcher's: a password for what was typed and an ssh_agent fallback for
+	// the same user, so a wrong password does not cost you the agent. The
+	// launcher's own builder produced one or the other and never both.
+	t.Logf("the os provider built %d credentials: %s",
+		len(conn.Credentials), describeCreds(conn.Credentials))
+
+	var password *vault.Credential
+	for _, cred := range conn.Credentials {
+		if cred.Type == vault.CredentialType_password {
+			password = cred
+		}
+	}
+	if password == nil {
+		t.Fatalf("no password credential among %s", describeCreds(conn.Credentials))
+	}
+	if password.User != "chris" {
+		t.Errorf("credential user = %q, want chris", password.User)
+	}
+	// Which field of the credential holds it is the provider's business -- ssh
+	// puts it in Secret rather than Password -- and Locate is what knows how to
+	// look, which is why the launcher never has to.
+	placed := deliverypkg.Locate(f, asset)
+	if len(placed) != 1 || placed[0].Placement != deliverypkg.PlacedCredential {
+		t.Fatalf("the typed password was located as %+v, want a credential", placed)
+	}
+}
+
+func describeCreds(creds []*vault.Credential) string {
+	var out []string
+	for _, c := range creds {
+		out = append(out, c.Type.String()+"/user="+c.User)
+	}
+	return strings.Join(out, ", ")
+}
+
+// With no credential in the form, a host connector still carries its user so
+// ssh can fall back to the agent for that account.
+//
+// This used to be something the launcher arranged, in a branch of its own
+// inventory builder. It is the provider's own behaviour, which is why it is
+// worth asserting here rather than there: if the os provider ever stopped doing
+// it, the launcher would silently stop offering agent authentication.
+func TestInventoryFallsBackToSSHAgent(t *testing.T) {
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("deploy@host.example")
+
+	_, asset := sshAssetFromProvider(t, f)
+	creds := asset.Connections[0].Credentials
+	if len(creds) != 1 || creds[0].Type != vault.CredentialType_ssh_agent || creds[0].User != "deploy" {
+		t.Fatalf("want a single ssh_agent credential for deploy, got %+v", creds)
+	}
+}
+
+// A vault-backed launch references the secret by id, and the password the user
+// typed into the launcher's own form must not reach the file.
+func TestInventoryReferencesAVaultSecret(t *testing.T) {
+	_, f := sshFormWithPassword(t)
+	c, asset := sshAssetFromProvider(t, f)
+
+	saved := deliverypkg.Keychainable(deliverypkg.Locate(f, asset))
+	if saved == nil {
+		t.Fatal("the os provider kept the password nowhere the keychain can hold")
+	}
+	inv := deliverypkg.InventoryFor(c.Name, asset, saved, "cnspec-ui-ssh-chris-20260818T120000")
+
+	creds := inv.Spec.Assets[0].Connections[0].Credentials
+	refs := 0
+	for _, cred := range creds {
+		if cred.SecretId != "" {
+			refs++
+			if cred.SecretId != "cnspec-ui-ssh-chris-20260818T120000" {
+				t.Errorf("secret id = %q", cred.SecretId)
+			}
+		}
+	}
+	// Exactly one, whatever else the provider built alongside it: the reference
+	// stands in for the credential that was saved and for no other.
+	if refs != 1 {
+		t.Fatalf("want exactly one credential reference, got %d of %s",
+			refs, describeCreds(creds))
+	}
+	if inv.Spec.Vault == nil || inv.Spec.Vault.Type != vault.VaultType_KeyRing {
+		t.Fatalf("want the keyring vault named in the inventory, got %+v", inv.Spec.Vault)
+	}
+
+	// The whole point: the password must not be in the file.
+	data, err := inv.ToYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "<PLACEHOLDER-not-a-real-secret>") {
+		t.Fatalf("the secret was written into the inventory despite the vault:\n%s", data)
+	}
+}
+
+// The generated inventory is removed on every exit the launcher can observe,
+// including the ones that are not a finished scan.
+func TestTheGeneratedInventoryIsTracked(t *testing.T) {
+	_, f := sshFormWithPassword(t)
+	c, asset := sshAssetFromProvider(t, f)
+
+	path, cleanup, err := writeInventory(deliverypkg.InventoryFor(c.Name, asset, nil, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the inventory was not written: %v", err)
+	}
+	// Not through the returned cleanup: through the exit hook, which is the
+	// path a quit or a signal takes.
+	cleanupTempFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the generated inventory outlived the exit hook: %v", err)
+	}
+}

--- a/apps/cnspec/cmd/interactive/kubeconfig_test.go
+++ b/apps/cnspec/cmd/interactive/kubeconfig_test.go
@@ -1,0 +1,68 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Writing the kubeconfig copy that targets a cluster now lives in
+// cli/launcher/delivery, and is tested there. What stays here is the launcher
+// end of the same story: the picker that lists a cluster's namespaces has to
+// answer for the cluster the form is pointed at, and no other.
+
+// Namespaces are cached per cluster: serving one cluster's list for another is
+// exactly the confidently-wrong answer worth avoiding.
+func TestNamespaceValuesAreCachedPerCluster(t *testing.T) {
+	a := sourceKey(srcK8sNamespace, []string{"KUBECONFIG=/tmp/a"})
+	b := sourceKey(srcK8sNamespace, []string{"KUBECONFIG=/tmp/b"})
+	if a == b {
+		t.Fatal("two clusters share a cache key")
+	}
+	if !strings.HasPrefix(a, srcK8sNamespace) {
+		t.Errorf("key %q should name its source", a)
+	}
+}
+
+// A picker's cache key has to be stable, or a load and its lookup never match.
+// Keying on the generated kubeconfig path did exactly that: every lookup minted
+// a new path, so a field showed nothing while holding a complete answer.
+func TestSourceKeyIsStableAcrossLookups(t *testing.T) {
+	m := NewModel([]Connector{{
+		Provider: "k8s", Name: "k8s", Use: "k8s", Category: catContainer, Installed: true,
+		MaxArgs: 1,
+		Flags: []plugin.Flag{
+			{Long: "context", Type: plugin.FlagType_String},
+			{Long: "namespaces", Type: plugin.FlagType_String},
+		},
+	}})
+	m.syncSelection()
+	for i := range m.detail.form.Fields() {
+		if m.detail.form.Fields()[i].Flag == "context" {
+			m.detail.form.Fields()[i].SetValue("prod-cluster")
+		}
+	}
+
+	first := sourceKeyFor(m.detail.form, srcK8sNamespace)
+	second := sourceKeyFor(m.detail.form, srcK8sNamespace)
+	if first != second {
+		t.Fatalf("key is not stable: %q then %q", first, second)
+	}
+	if !strings.Contains(first, "prod-cluster") {
+		t.Errorf("key %q should identify the cluster it answers for", first)
+	}
+
+	// A different cluster must not read the first one's namespaces.
+	for i := range m.detail.form.Fields() {
+		if m.detail.form.Fields()[i].Flag == "context" {
+			m.detail.form.Fields()[i].SetValue("staging-cluster")
+		}
+	}
+	if sourceKeyFor(m.detail.form, srcK8sNamespace) == first {
+		t.Fatal("two clusters share a cache key")
+	}
+}

--- a/apps/cnspec/cmd/interactive/launch.go
+++ b/apps/cnspec/cmd/interactive/launch.go
@@ -1,0 +1,485 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"time"
+
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// launchPlan is everything needed to run one command: what to exec, what
+// environment it needs, how to clean up after it, and anything the user should
+// be told before it starts.
+type launchPlan struct {
+	args    []string
+	env     []string
+	cleanup func()
+	// warn is shown to the user and printed above the command. It is not an
+	// error -- the scan still runs -- but it describes a weaker guarantee than
+	// the one normally offered.
+	warn string
+}
+
+// launchState is the command being assembled, and what the last one left on
+// disk.
+//
+// The two are one lifecycle: preparing covers the window between the button
+// being pressed and a plan coming back, and cleanup is what that plan wrote.
+// They are not part of scanState because they are about a *command* -- `shell`
+// takes this path and never becomes a scan at all.
+type launchState struct {
+	// preparing is true while the plan for a scan is being assembled off the
+	// event loop. See prepareLaunchCmd: the keychain write in there can sit on
+	// an OS authentication dialog for as long as the user takes to answer it.
+	preparing bool
+	// cleanup removes the generated inventory once the command it fed has
+	// finished. Only the tea.Exec path holds one; a background scan hands its
+	// cleanup to the session instead.
+	cleanup func()
+}
+
+// begin claims the launch, reporting false when one is already being prepared.
+// Enter twice must not write the credential twice, nor start two scans.
+func (l *launchState) begin() bool {
+	if l.preparing {
+		return false
+	}
+	l.preparing = true
+	return true
+}
+
+// prepared marks the assembly over, whether or not it produced a plan.
+func (l *launchState) prepared() { l.preparing = false }
+
+// release runs the cleanup and forgets it, which is what a command that owned
+// one finishing means.
+func (l *launchState) release() {
+	if l.cleanup != nil {
+		l.cleanup()
+	}
+	l.cleanup = nil
+}
+
+// disown drops the cleanup without running it, for when something else has
+// taken over what it would remove -- a scan session, or the process-wide
+// temp-file registry on the way out. Releasing the inventory twice is harmless;
+// releasing it early is not, which is why this is a second method rather than
+// an argument to the first.
+func (l *launchState) disown() { l.cleanup = nil }
+
+// launchRequest is the whole of what deciding a command depends on: the form
+// the user filled in, and whether they chose to keep the results here.
+//
+// It is a type of its own because assembling a command is not a property of the
+// screen it was assembled from. Model has thirty-six fields and this reads two
+// of them, which the tests were paying for: forty-three of them built a whole
+// Model to ask what one form emits, and every field added to the launcher's UI
+// state was a field they were implicitly constructing.
+type launchRequest struct {
+	form form
+	// incognito is the user's choice to keep the results on this machine,
+	// already resolved against whether there is a choice to make at all. See
+	// verb: with no credentials there is no choice, and the flag would then be
+	// a word on the command line the user did not ask for.
+	incognito bool
+}
+
+// launchRequestFrom is the launcher's current answer to what would be run.
+func (m Model) launchRequestFrom() launchRequest {
+	return launchRequest{
+		form:      m.detail.form,
+		incognito: m.upstream.canToggle() && m.upstream.incognito,
+	}
+}
+
+// launchArgs assembles the plan for the launcher's current form.
+func (m Model) launchArgs(c Connector, a Action) (launchPlan, error) {
+	return m.launchRequestFrom().plan(c, a)
+}
+
+// commandPreview is what the command bar shows, read from the same request the
+// button would launch. It is on Model rather than on the pane that draws it
+// because the incognito choice is not the pane's to know.
+func (m Model) commandPreview(c Connector) string {
+	return m.launchRequestFrom().preview(c, scanAction())
+}
+
+// verb is the command words every plan starts with: the action, the connector,
+// and --incognito when the user has chosen to keep the results on this machine.
+//
+// The flag expresses a *choice*, not a state. With no credentials there is no
+// choice to express -- scan switches to incognito on its own, and the header
+// badge already says so -- and passing a redundant flag would put a word on
+// every command line that the user did not ask for and cannot turn off.
+func (r launchRequest) verb(c Connector, a Action) []string {
+	out := []string{a.Name, c.Name}
+	if r.incognito {
+		out = append(out, "--incognito")
+	}
+	return out
+}
+
+// preview is what the command bar shows, and it is deliberately a method on
+// the request rather than on the pane that draws it.
+//
+// The bar promises "this is what will run", and for one release it was not:
+// plan() prepends --incognito through verb() when the user has asked to keep
+// the results on this machine, while the preview built its own prefix out of
+// []string{"cnspec", a.Name, c.Name} and had no way to know. A user who toggled
+// incognito saw a command missing the flag that the launch would add. Sharing
+// verb() is the whole fix, and it is why the preview cannot live somewhere that
+// has the form but not the choice.
+//
+// One difference is real and stays: the inventory route names a file that does
+// not exist yet, because writing it is what plan() does -- and the provider has
+// not been asked yet either, so there is nothing more specific to say. The bar
+// says so rather than showing a path that would be a lie by the time it was
+// read.
+//
+// This runs on every keystroke, which is why it decides the route from the form
+// alone. Asking the provider costs a subprocess and a gRPC round trip; doing
+// that per keystroke to redraw one line would be a redraw nobody could type
+// through.
+func (r launchRequest) preview(c Connector, a Action) string {
+	if deliveryFor(r.form) == deliverInventory {
+		return "cnspec " + strings.Join(r.inventoryVerb(a, "<generated, 0600>"), " ")
+	}
+	return strings.Join(append([]string{"cnspec", strings.Join(r.verb(c, a), " ")},
+		r.form.Args()...), " ")
+}
+
+// inventoryVerb is the command for a scan driven by a generated inventory.
+//
+// The connector's name is absent on purpose: the inventory carries the
+// connection type, and `cnspec scan --inventory-file` reads the file instead of
+// a target. Naming a connector as well would make cnspec parse a target it then
+// discards -- verified live, `cnspec scan local --inventory-file <ssh asset>`
+// scans the ssh asset and never touches this machine.
+//
+// The user's incognito choice is carried here rather than by verb() for that
+// same reason, and leaving it out is what this function was extracted to stop.
+// The inventory route built its own argument list and dropped the flag, so a
+// user who had asked to keep the results on this machine got a scan that
+// reported upstream -- the one route where the choice matters most, since it is
+// the route a credential travels.
+func (r launchRequest) inventoryVerb(a Action, path string) []string {
+	out := []string{a.Name}
+	if r.incognito {
+		out = append(out, "--incognito")
+	}
+	return append(out, "--inventory-file", path)
+}
+
+// plan picks how the command is delivered, and returns any environment the
+// child needs along with it.
+//
+// There are two outcomes and one of them is a refusal. A form with no
+// credential becomes a command line. A form with one is handed to the
+// connector's own ParseCLI, and what comes back decides the rest: the asset the
+// provider built is written as an inventory, the credential it built is put in
+// the OS keychain and referenced by id, and if the provider turns out not to
+// have kept the secret at all the launch is refused rather than run
+// unauthenticated.
+func (r launchRequest) plan(c Connector, a Action) (launchPlan, error) {
+	// Some of what the user chose reaches the scan through the environment
+	// rather than the command line, because the connector has no flag that
+	// carries it -- a chosen Kubernetes cluster is the original case. See
+	// environment.
+	fieldEnv, envCleanup, err := r.environment()
+	if err != nil {
+		return launchPlan{}, err
+	}
+
+	if deliveryFor(r.form) == deliverPlain {
+		return launchPlan{
+			args:    append(r.verb(c, a), r.form.Args()...),
+			env:     fieldEnv,
+			cleanup: envCleanup,
+		}, nil
+	}
+
+	plan, err := r.inventoryPlan(c, a)
+	if err != nil {
+		if envCleanup != nil {
+			envCleanup()
+		}
+		return launchPlan{}, err
+	}
+	// The environment a *target* needs travels with the inventory too. Nothing
+	// declares both today -- no connector with an EnvSpec also has a credential
+	// field -- and the branch this replaces dropped it on the floor rather than
+	// pass it on, which would have been a scan of the wrong cluster the first
+	// time one did.
+	plan.env = fieldEnv
+	if envCleanup != nil {
+		inner := plan.cleanup
+		plan.cleanup = func() {
+			envCleanup()
+			if inner != nil {
+				inner()
+			}
+		}
+	}
+	return plan, nil
+}
+
+// parsedForm is the connector's own reading of a filled-in form: the asset its
+// provider would connect to, and where each secret the user typed ended up
+// inside it.
+//
+// The two travel together because the second is only meaningful about the
+// first. Locate matches by value against this asset, so a placement carried
+// beside a different asset would be a claim about a credential that is not
+// there -- and the placements are what decide whether the keychain can hold the
+// secret and what the user has to be told about the file.
+type parsedForm struct {
+	asset  *inventory.Asset
+	placed []deliverypkg.Located
+}
+
+// parseForm asks the connector's provider what the form means, and refuses when
+// the provider kept a secret nowhere at all.
+//
+// It touches nothing outside the process. That is what makes it the right thing
+// to run on a key press that has not yet been confirmed -- the export modal
+// opens on it -- and it is the same ordering inventoryPlan has always relied
+// on: asking is what says whether there is a credential the keychain can hold
+// at all, and saving first would put a secret in the OS store on behalf of an
+// action that then gets refused.
+func (r launchRequest) parseForm(c Connector) (parsedForm, error) {
+	req := deliverypkg.RequestFor(r.form, c.Flags)
+	asset, err := parseCLI(c.Provider, c.Name, req.Args, req.Flags)
+	if err != nil {
+		return parsedForm{}, errors.Wrap(err, "cnspec ui could not prepare a scan for "+c.Name)
+	}
+
+	placed := deliverypkg.Locate(r.form, asset)
+	if lost := placementsWith(placed, deliverypkg.PlacedNowhere); len(lost) > 0 {
+		// The provider was handed the value and did not keep it. Running anyway
+		// scans unauthenticated at best; databricks is the case that makes this
+		// a refusal rather than a warning, because its credential switch has no
+		// default arm and the SDK then resolves DATABRICKS_TOKEN out of the
+		// ambient environment -- which does not error, it scans whatever account
+		// that variable names.
+		return parsedForm{}, errors.New("the " + c.Name + " provider did not keep " +
+			flagList(lost) + " from these settings, so the scan would run without it")
+	}
+	return parsedForm{asset: asset, placed: placed}, nil
+}
+
+// plaintextFlags names the flags whose value this provider keeps somewhere no
+// vault reference is read from, so that whatever file is written carries them
+// in the clear.
+//
+// It answers from what the provider did rather than from a list of connector
+// names, which is the only reason the answer is right: the list everything here
+// used to name -- openai, ollama, huggingface, claude -- is measurably eleven
+// connectors and thirteen fields, and four of them keep a *different*
+// credential on the same form in a place the keychain can hold. See
+// deliverypkg.PlacedOption for the measured set and the test that prints it.
+func (p parsedForm) plaintextFlags() []string {
+	return placementsWith(p.placed, deliverypkg.PlacedOption)
+}
+
+// inventoryPlan saves the credential the provider built and writes the result
+// as the temporary inventory a scan reads.
+func (r launchRequest) inventoryPlan(c Connector, a Action) (launchPlan, error) {
+	parsed, err := r.parseForm(c)
+	if err != nil {
+		return launchPlan{}, err
+	}
+
+	secretID, saved, keychainErr := r.saveCredential(c, parsed.placed)
+	var warn string
+	if keychainErr != nil {
+		// Not fatal, and not silent. The scan still runs and the secret still
+		// stays off the command line, but it is now written to a file rather
+		// than held by the operating system, and the user should know that.
+		//
+		// The export path answers the same failure with a refusal, because the
+		// file it would fall back to is one the user chose a path for and keeps.
+		// See exportInventory.
+		warn = "could not use the OS keychain (" + keychainErr.Error() +
+			") — the credential is written into a temporary 0600 inventory file instead, " +
+			"and removed after the scan"
+	}
+	if plain := parsed.plaintextFlags(); len(plain) > 0 {
+		// Not a refusal. The alternatives are no better -- an environment
+		// variable sits in /proc/<pid>/environ for the whole run, where this
+		// file is 0600 inside a 0700 directory and is removed after it -- but
+		// the user is told, by name, which value is in the clear.
+		warn = joinWarnings(warn, "the "+c.Name+" provider reads "+flagList(plain)+
+			" as a connection option rather than as a credential, so the OS keychain "+
+			"cannot hold it: it is written in plain text into a temporary 0600 "+
+			"inventory file, removed after the scan")
+	}
+
+	path, cleanup, err := writeInventory(deliverypkg.InventoryFor(c.Name, parsed.asset, saved, secretID))
+	if err != nil {
+		return launchPlan{}, err
+	}
+	return launchPlan{
+		args:    r.inventoryVerb(a, path),
+		cleanup: cleanup,
+		warn:    warn,
+	}, nil
+}
+
+// placementsWith names the form's flags whose value the provider put in one
+// particular place.
+func placementsWith(placed []deliverypkg.Located, want deliverypkg.Placement) []string {
+	var out []string
+	for _, p := range placed {
+		if p.Placement == want {
+			out = append(out, p.Flag)
+		}
+	}
+	return out
+}
+
+// flagList spells a set of flags the way the user typed them, for a sentence.
+func flagList(flags []string) string {
+	out := make([]string, len(flags))
+	for i, f := range flags {
+		out[i] = "--" + f
+	}
+	return strings.Join(out, " and ")
+}
+
+func joinWarnings(a, b string) string {
+	if a == "" {
+		return b
+	}
+	return a + "; " + b
+}
+
+// saveCredential puts the credential the provider built in the OS keychain and
+// returns the id the inventory should reference.
+//
+// This is not offered as a choice. Where a credential can be kept somewhere the
+// operating system protects, that is simply where it goes -- asking first only
+// invites the worse answer, and the toggle that used to be here appeared even
+// for connectors whose credential the launcher cannot carry at all.
+//
+// What gets saved is the provider's own credential rather than one assembled
+// here, and that is the difference this change makes: artifactory's token is a
+// bearer credential, azure's certificate is a pkcs12 bundle, okta's key is a
+// private_key, and hcp routes on cred.User carrying the label "client-secret".
+// Every one of those used to be flattened into a password with no user, and a
+// provider whose credential switch did not recognise the result dropped the
+// credential without a word.
+//
+// An empty id and a nil error mean there was nothing for the keychain to hold:
+// the form carried no credential, or the provider kept it somewhere a vault
+// reference is never read from. A non-nil error means the keychain refused, and
+// what to do about that is the caller's to decide -- the scan falls back to the
+// temporary 0600 inventory with a warning, and an export refuses outright. That
+// fallback is deliberately not an encrypted file, because the encrypted-file
+// vault takes its password from Options["password"] in the same inventory that
+// references it, which protects nothing while looking like it does.
+func (r launchRequest) saveCredential(c Connector, placed []deliverypkg.Located) (secretID string, saved *deliverypkg.Located, err error) {
+	saved = deliverypkg.Keychainable(placed)
+	if saved == nil {
+		return "", nil, nil
+	}
+	cred := saved.Credential()
+	if cred == nil {
+		return "", nil, nil
+	}
+	id := newSecretID(c.Name, cred.User, time.Now())
+	if err := storeCredentialWithin(keychainTimeout, id, cred); err != nil {
+		log.Debug().Err(err).Msg("keychain unavailable")
+		// Nothing is returned to reference: the caller must not build an
+		// inventory pointing at a keychain entry that was never written.
+		return "", nil, err
+	}
+	if err := recordSaved(savedEntry{
+		ID:        id,
+		Connector: c.Name,
+		Label:     cred.User,
+		SavedAt:   time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		log.Debug().Err(err).Msg("could not record the saved credential")
+	}
+	return id, saved, nil
+}
+
+// environment is the environment the form's own values contribute to the child,
+// and the cleanup for anything written on their behalf.
+//
+// Not every value the user picks has a flag to travel in, and that is a
+// property of the connector rather than an accident. k8s --context is parsed
+// and then never reaches the client config; alicloud declares no --profile;
+// snowflake takes no connection name; docker and container take no --context.
+// For all of them the value has to reach the child process through its
+// environment instead.
+//
+// This used to be one function that opened `if m.form.connector != "k8s"`,
+// called from one place. Four more connectors needing the same thing would have
+// meant four more special cases in it, which is exactly the shape the declared
+// Source and FormSpec contracts were written to end -- so the declaration moved
+// onto the field, and this walks whatever the form declares.
+func (r launchRequest) environment() ([]string, func(), error) {
+	var env []string
+	var cleanups []func()
+	// The caller gets one cleanup whatever happened, including the partial
+	// work of a contributor that failed after an earlier one succeeded.
+	runCleanups := func() {
+		for _, c := range cleanups {
+			c()
+		}
+	}
+	fail := func(err error) ([]string, func(), error) {
+		runCleanups()
+		return nil, nil, err
+	}
+
+	for _, fd := range r.form.Fields() {
+		if !fd.IsSet() {
+			continue
+		}
+		if v := fieldEnvVar(fd); v != "" {
+			env = append(env, v+"="+fd.Emitted())
+		}
+		env = append(env, neutralisedBy(fieldEnvVar(fd), fd.Emitted())...)
+		for _, spec := range envSpecsFor(r.form.Subject()) {
+			if !tuiform.MatchesIdentity(fd, spec.Field) {
+				continue
+			}
+			more, cleanup, err := spec.Apply(fd.Emitted())
+			if cleanup != nil {
+				cleanups = append(cleanups, cleanup)
+			}
+			if err != nil {
+				return fail(err)
+			}
+			env = append(env, more...)
+		}
+	}
+
+	if len(cleanups) == 0 {
+		return env, nil, nil
+	}
+	return env, runCleanups, nil
+}
+
+// fieldEnvVar names the environment variable a field's value travels in: what
+// the spec said, or failing that what the source attached to it declares --
+// a docker context is DOCKER_CONTEXT wherever it is offered.
+func fieldEnvVar(fd field) string {
+	if fd.Env != "" {
+		return fd.Env
+	}
+	if s, ok := sourceByID(fd.Source()); ok && s.Env != "" {
+		return s.Env
+	}
+	return ""
+}

--- a/apps/cnspec/cmd/interactive/layout.go
+++ b/apps/cnspec/cmd/interactive/layout.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import "go.mondoo.com/cnspec/cli/tui"
+
+// The launcher's geometry is computed in exactly one place: computeLayout. It
+// renders nothing and mutates nothing, and both View (to draw) and Update (to
+// hit-test mouse clicks) derive from it. Because they share the same numbers, a
+// drawn element and the region that responds to it cannot drift apart.
+//
+// The invariant that makes this work: every row the launcher draws is exactly
+// one terminal line. No style in view.go carries a margin, because a margin adds
+// a line that the arithmetic here cannot see -- which is how a list that
+// "obviously" fits ends up scrolling the screen.
+//
+// The pane arithmetic itself lives in package tui, shared with the report
+// viewer. Only the parts that need the Model are here.
+
+// layout is the launcher's handle on the shared geometry. It exists so that
+// offsetRow and detailOffsetOf can stay methods: both need the Model, and Go
+// does not allow a method on a type declared in another package.
+type layout struct{ tui.Layout }
+
+// computeLayout derives every rect and clickable zone from the model.
+func computeLayout(m Model) layout {
+	l := layout{tui.Dims(m.width, m.height)}
+
+	// The reporting badge is clickable. Its position comes from the same
+	// function the renderer uses, and headerRightX answers -1 when the header
+	// is too narrow to draw the badge -- so a click can never land on a badge
+	// that is not on screen.
+	if x := m.headerRightX(l.Width); x >= 0 {
+		if bw := m.upstream.badgeWidth(); bw > 0 {
+			l.Zones = append(l.Zones, tui.Zone{
+				Rect: tui.Rect{X: x, Y: 0, W: bw, H: 1},
+				Kind: tui.ZoneUpstream,
+			})
+		}
+	}
+
+	showList := l.TwoPane || m.focus == focusList
+	showDetail := l.TwoPane || m.focus != focusList
+
+	if showList {
+		for i := l.offsetRow(m.list); i < len(m.list.rows) && i < l.offsetRow(m.list)+l.ListH; i++ {
+			r := m.list.rows[i]
+			if r.kind != rowEntry {
+				continue
+			}
+			y := l.ListTop + (i - l.offsetRow(m.list))
+			l.Zones = append(l.Zones, tui.Zone{
+				Rect: tui.Rect{X: tui.InnerX, Y: y, W: tui.InnerWidth(l.LeftW), H: 1},
+				Kind: tui.ZoneEntry,
+				Idx:  r.sel,
+			})
+		}
+	}
+
+	if showDetail {
+		// The detail pane's geometry is not computed in parallel with the
+		// renderer -- both walk the same plan, one line per item, so a zone
+		// cannot land on a row the renderer put something else on.
+		plan, _ := splitPlan(m.detailPlan())
+		cx := l.RightX + tui.InnerX
+		cw := tui.InnerWidth(l.RightW)
+		off := l.detailOffsetOf(m, len(plan))
+		visible := tui.InnerHeight(l.BodyH) - 1 // the pinned command bar
+
+		for i, item := range plan {
+			row := i - off
+			if row < 0 || row >= visible {
+				continue
+			}
+			y := l.BodyTop + 1 + row
+			switch item.kind {
+			case diField:
+				l.Zones = append(l.Zones, tui.Zone{Rect: tui.Rect{X: cx, Y: y, W: cw, H: 1}, Kind: tui.ZoneField, Idx: item.idx})
+			case diMore:
+				l.Zones = append(l.Zones, tui.Zone{Rect: tui.Rect{X: cx, Y: y, W: cw, H: 1}, Kind: tui.ZoneMore})
+			case diButton:
+				l.Zones = append(l.Zones, tui.Zone{Rect: tui.Rect{X: cx, Y: y, W: cw, H: 1}, Kind: tui.ZoneRun})
+			}
+		}
+	}
+
+	return l
+}
+
+// offsetRow clamps the model's scroll offset into the current layout, so a
+// resize that grows the terminal cannot leave the list scrolled past its end.
+func (l layout) offsetRow(s listState) int {
+	return s.offset.Clamp(len(s.rows), l.ListH)
+}
+
+// detailOffsetOf clamps the detail pane's scroll offset to the plan it is
+// showing, so a resize cannot leave it scrolled past the end.
+func (l layout) detailOffsetOf(m Model, planLen int) int {
+	return m.detail.offset.Clamp(planLen, tui.InnerHeight(l.BodyH)-1)
+}

--- a/apps/cnspec/cmd/interactive/layout_test.go
+++ b/apps/cnspec/cmd/interactive/layout_test.go
@@ -1,0 +1,241 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// termSizes covers the sizes that actually break things: the 80x24 default, a
+// narrow window that has to drop to one pane, and a tall one where the list is
+// long enough to need scrolling.
+var termSizes = []struct{ w, h int }{
+	{80, 24}, {100, 30}, {120, 40}, {200, 60}, {70, 24}, {60, 15}, {40, 10},
+}
+
+func sized(m Model, w, h int) Model {
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	return nm.(Model)
+}
+
+func viewLines(m Model) []string {
+	return strings.Split(m.View(), "\n")
+}
+
+// TestViewNeverOverflows is the test that keeps the launcher inside the
+// terminal. A view taller than the screen scrolls the alt-screen buffer, which
+// pushes the header off and leaves the cursor pointing at rows nobody can see.
+func TestViewNeverOverflows(t *testing.T) {
+	for _, focus := range []focusArea{focusList, focusForm} {
+		for _, s := range termSizes {
+			m := sized(newTestModel(), s.w, s.h)
+			m.focus = focus
+			lines := viewLines(m)
+			if len(lines) != s.h {
+				t.Errorf("focus=%d %dx%d: rendered %d lines, want exactly %d",
+					focus, s.w, s.h, len(lines), s.h)
+			}
+			for i, ln := range lines {
+				if w := tui.Width(ln); w > s.w {
+					t.Errorf("focus=%d %dx%d: line %d is %d cells wide, want <= %d",
+						focus, s.w, s.h, i, w, s.w)
+				}
+			}
+		}
+	}
+}
+
+// The full catalog is the real stress case: many categories, many rows.
+func TestViewNeverOverflowsWithFullCatalog(t *testing.T) {
+	base := NewModel(BuildCatalog())
+	for _, s := range termSizes {
+		m := sized(base, s.w, s.h)
+		if lines := viewLines(m); len(lines) != s.h {
+			t.Errorf("%dx%d: rendered %d lines, want exactly %d", s.w, s.h, len(lines), s.h)
+		}
+		// Scroll to the very bottom and re-check: the last page is where an
+		// off-by-one in the offset clamp shows up.
+		m.list.cursor = len(m.list.selectable) - 1
+		m.list.ensureVisible(m.listH())
+		if lines := viewLines(m); len(lines) != s.h {
+			t.Errorf("%dx%d at end of list: rendered %d lines, want exactly %d", s.w, s.h, len(lines), s.h)
+		}
+	}
+}
+
+// TestZonesMatchRender asserts that a click zone lands on the thing the
+// renderer drew at that line. Both come from computeLayout, and this is what
+// proves they have not drifted.
+func TestZonesMatchRender(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+	m.focus = focusForm
+	m.detail.loadCursorField()
+	l := computeLayout(m)
+	lines := viewLines(m)
+
+	lineAt := func(y int) string {
+		if y < 0 || y >= len(lines) {
+			t.Fatalf("y=%d outside the rendered view (%d lines)", y, len(lines))
+		}
+		return ansi.Strip(lines[y])
+	}
+
+	var sawEntry, sawField, sawRun bool
+	for _, z := range l.Zones {
+		switch z.Kind {
+		case tui.ZoneEntry:
+			want := m.list.filtered[m.list.rows[m.list.selectable[z.Idx]].idx].Name
+			if got := lineAt(z.Rect.Y); !strings.Contains(got, want) {
+				t.Errorf("entry zone at y=%d should be %q, line is %q", z.Rect.Y, want, got)
+			}
+			sawEntry = true
+		case tui.ZoneField:
+			want := m.detail.form.Fields()[z.Idx].Label
+			if got := lineAt(z.Rect.Y); !strings.Contains(got, want) {
+				t.Errorf("field zone at y=%d should be %q, line is %q", z.Rect.Y, want, got)
+			}
+			sawField = true
+		case tui.ZoneRun:
+			if got := lineAt(z.Rect.Y); !strings.Contains(got, "Scan") {
+				t.Errorf("run zone at y=%d should hold the scan button, line is %q", z.Rect.Y, got)
+			}
+			sawRun = true
+		}
+	}
+	if !sawEntry || !sawField || !sawRun {
+		t.Fatalf("missing zones: entry=%v field=%v run=%v", sawEntry, sawField, sawRun)
+	}
+}
+
+func TestClickSelectsListEntry(t *testing.T) {
+	m := sized(newTestModel(), 120, 40)
+	l := computeLayout(m)
+
+	var target tui.Zone
+	for _, z := range l.Zones {
+		if z.Kind == tui.ZoneEntry && z.Idx == 2 {
+			target = z
+		}
+	}
+	if target.Kind != tui.ZoneEntry {
+		t.Fatal("no entry zone for selectable index 2")
+	}
+	nm, _ := m.Update(tea.MouseMsg{
+		X: tui.InnerX, Y: target.Rect.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	if got := nm.(Model).list.cursor; got != 2 {
+		t.Fatalf("expected the click to select entry 2, got %d", got)
+	}
+}
+
+// Below minTwoPaneWidth the launcher shows one pane, following focus, rather
+// than squeezing two unreadable columns into the window.
+func TestNarrowTerminalUsesOnePane(t *testing.T) {
+	m := sized(newTestModel(), 60, 20)
+	if computeLayout(m).TwoPane {
+		t.Fatal("expected a single pane at width 60")
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "local") {
+		t.Fatal("expected the list pane while focus is on the list")
+	}
+
+	m = selectEntry(t, m, "aws")
+	m.focus = focusForm
+	out := ansi.Strip(m.View())
+	if !strings.Contains(out, "an AWS account") {
+		t.Fatal("expected the detail pane once focus moves off the list")
+	}
+}
+
+// The scroll offset must survive a resize that grows the terminal past the end
+// of the list.
+func TestOffsetClampsOnResize(t *testing.T) {
+	m := sized(NewModel(BuildCatalog()), 120, 20)
+	m.list.cursor = len(m.list.selectable) - 1
+	m.list.ensureVisible(m.listH())
+	if m.list.offset.Off == 0 {
+		t.Skip("catalog too short to scroll at this size")
+	}
+	m = sized(m, 120, 200)
+	l := computeLayout(m)
+	// Everything now fits, so the list must be scrolled back to the top rather
+	// than left showing a window past the end of the rows.
+	if off := l.offsetRow(m.list); off != 0 {
+		t.Fatalf("offset %d after growing past the list (rows=%d listH=%d), want 0", off, len(m.list.rows), l.ListH)
+	}
+	if lines := viewLines(m); len(lines) != 200 {
+		t.Fatalf("rendered %d lines after resize, want 200", len(lines))
+	}
+}
+
+// A notice with a newline in it must not make the view taller than the
+// terminal. This is a bug that shipped: the launcher assigned err.Error()
+// straight into lastErr at five call sites and drew it through ansi.Truncate,
+// which cuts a line to a width and leaves every newline in it -- so a
+// three-line provider error rendered a 24-row terminal as 26 rows and pushed
+// the footer, the one row that says how to get out, off the bottom of the
+// screen.
+//
+// The fixture is deliberately the shape that broke it: a wrapped error chain
+// with embedded newlines, of the kind an exec failure or a cloud SDK produces.
+// A single-line fixture asserts nothing here.
+func TestMultiLineNoticeKeepsTheViewInsideTheTerminal(t *testing.T) {
+	notices := []string{
+		"could not install the aws provider:\nGet \"https://releases.mondoo.com\": dial tcp: lookup failed\nno such host",
+		"exit status 1\r\nprovider crashed\r\n",
+		"one\n\n\nfour",
+		strings.Repeat("wrapped: ", 40) + "\nand a second line",
+	}
+	for _, notice := range notices {
+		for _, s := range termSizes {
+			for _, field := range []string{"lastErr", "lastWarn"} {
+				m := sized(newTestModel(), s.w, s.h)
+				if field == "lastErr" {
+					m.lastErr = notice
+				} else {
+					m.lastWarn = notice
+				}
+				lines := viewLines(m)
+				if len(lines) != s.h {
+					t.Errorf("%s %dx%d: rendered %d lines, want exactly %d",
+						field, s.w, s.h, len(lines), s.h)
+				}
+				for i, ln := range lines {
+					if w := ansi.StringWidth(ln); w > s.w {
+						t.Errorf("%s %dx%d: line %d is %d cells wide, want <= %d",
+							field, s.w, s.h, i, w, s.w)
+					}
+				}
+			}
+		}
+	}
+}
+
+// The same rule for the other string the launcher does not write: the reason a
+// value picker came back empty, which is rendered into a panel line rather than
+// into the footer. A newline there makes the panel taller than the number of
+// lines the layout measured it for, which is the same failure one pane over.
+func TestMultiLineSourceErrorKeepsTheViewInsideTheTerminal(t *testing.T) {
+	for _, s := range termSizes {
+		m := selectEntry(t, sized(newTestModel(), s.w, s.h), "aws")
+		m.focus = focusForm
+		for _, fd := range m.detail.form.Fields() {
+			if fd.Source() == "" {
+				continue
+			}
+			setSourceErr(&m, fd.Source(), errors.New(
+				"cannot read ~/.aws/config:\npermission denied\nrun aws configure"))
+		}
+		if lines := viewLines(m); len(lines) != s.h {
+			t.Errorf("%dx%d: rendered %d lines, want exactly %d", s.w, s.h, len(lines), s.h)
+		}
+	}
+}

--- a/apps/cnspec/cmd/interactive/list.go
+++ b/apps/cnspec/cmd/interactive/list.go
@@ -1,0 +1,243 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+type rowKind int
+
+const (
+	rowBlank rowKind = iota
+	rowHeader
+	rowEntry
+)
+
+// row is one line of the left list. Blank separators are rows rather than style
+// margins so the line count stays exact; see layout.go.
+type row struct {
+	kind rowKind
+	text string // category name, for rowHeader
+	idx  int    // index into listState.filtered, for rowEntry
+	sel  int    // index into listState.selectable, for rowEntry; -1 otherwise
+}
+
+// listState is the catalog and the way through it: the search over it, the
+// rows that search renders to, and where the cursor and the viewport are.
+//
+// Everything below entries is derived from entries and the search text, and
+// refilter is the only thing that derives it. They are one type because they
+// were seven fields that had to be recomputed together and nothing but
+// convention said so -- setting the search text without calling refilter left
+// the rows describing a filter that was no longer in force, and the cursor
+// indexing a list that had changed under it.
+//
+// installing is here rather than beside the pickers because what it names is a
+// catalog entry. providers.DefaultProviders strips the flags, argument counts
+// and discovery targets a form is built from, so a connector whose provider is
+// not on disk is a placeholder; finishing the download replaces it in entries,
+// and applyInstalled is the only thing that writes entries after construction.
+type listState struct {
+	entries []Connector
+	search  textinput.Model
+
+	// derived list state
+	filtered   []Connector
+	rows       []row
+	selectable []int
+	cursor     int
+	// offset scrolls the connector list. See ensureVisible for the one thing
+	// the shared type does not do.
+	offset tui.Scroll
+
+	// installing names the provider currently being downloaded. Only one runs
+	// at a time: the provider cache it writes is not guarded by a lock.
+	installing string
+}
+
+func newListState(catalog []Connector, height int) listState {
+	s := textinput.New()
+	s.Placeholder = "filter connectors"
+	s.Prompt = "⌕ "
+	s.CharLimit = 64
+	s.Focus()
+
+	l := listState{entries: catalog, search: s}
+	l.refilter(height)
+	return l
+}
+
+// count is how many connectors the catalog holds, which the header reports.
+func (s listState) count() int { return len(s.entries) }
+
+// refilter recomputes the filtered entries and the display rows from the search
+// text. Every row it emits is exactly one line.
+func (s *listState) refilter(height int) {
+	tokens := strings.Fields(strings.ToLower(strings.TrimSpace(s.search.Value())))
+
+	s.filtered = s.filtered[:0]
+	for _, e := range s.entries {
+		if matchesTokens(e.SearchText(), tokens) {
+			s.filtered = append(s.filtered, e)
+		}
+	}
+
+	s.rows = s.rows[:0]
+	s.selectable = s.selectable[:0]
+	for _, cat := range categoryOrder {
+		var idxs []int
+		for i, e := range s.filtered {
+			if e.Category == cat {
+				idxs = append(idxs, i)
+			}
+		}
+		if len(idxs) == 0 {
+			continue
+		}
+		if len(s.rows) > 0 {
+			s.rows = append(s.rows, row{kind: rowBlank, sel: -1})
+		}
+		s.rows = append(s.rows, row{kind: rowHeader, text: cat, sel: -1})
+		for _, i := range idxs {
+			s.selectable = append(s.selectable, len(s.rows))
+			s.rows = append(s.rows, row{kind: rowEntry, idx: i, sel: len(s.selectable) - 1})
+		}
+	}
+
+	if s.cursor >= len(s.selectable) {
+		s.cursor = len(s.selectable) - 1
+	}
+	if s.cursor < 0 {
+		s.cursor = 0
+	}
+	s.ensureVisible(height)
+}
+
+// clearSearch drops the filter and reports whether there was one to drop. The
+// answer decides what esc means in the list: emptying the search, or leaving.
+func (s *listState) clearSearch(height int) bool {
+	if s.search.Value() == "" {
+		return false
+	}
+	s.search.SetValue("")
+	s.refilter(height)
+	return true
+}
+
+// typed hands a key to the search box and refilters behind it.
+func (s *listState) typed(msg tea.KeyMsg, height int) tea.Cmd {
+	var cmd tea.Cmd
+	s.search, cmd = s.search.Update(msg)
+	s.refilter(height)
+	return cmd
+}
+
+// current returns the connector under the cursor.
+func (s listState) current() (Connector, bool) {
+	if len(s.selectable) == 0 || s.cursor < 0 || s.cursor >= len(s.selectable) {
+		return Connector{}, false
+	}
+	return s.filtered[s.rows[s.selectable[s.cursor]].idx], true
+}
+
+// move walks the cursor and scrolls to keep it visible. It reports whether
+// there was anything to move to, so a caller does not resynchronise a detail
+// pane against a selection that did not change.
+func (s *listState) move(delta, height int) bool {
+	if len(s.selectable) == 0 {
+		return false
+	}
+	s.cursor = tui.ClampIndex(s.cursor+delta, len(s.selectable))
+	s.ensureVisible(height)
+	return true
+}
+
+// selectRow puts the cursor on a selectable index, reporting whether that index
+// exists. A click is hit-tested against a layout computed for an earlier frame,
+// so the index it carries is not assumed to still be there.
+func (s *listState) selectRow(idx, height int) bool {
+	if idx < 0 || idx >= len(s.selectable) {
+		return false
+	}
+	s.cursor = idx
+	s.ensureVisible(height)
+	return true
+}
+
+// ensureVisible scrolls the list so the cursor's row is on screen, pulling in
+// the category header above it when there is room.
+//
+// The clamp is tui.Scroll's, but the walk-back is not and stays here. A row
+// scrolled to the very top of the pane is a row that has lost the "☁ CLOUD"
+// heading it belongs under, so the offset is nudged up over the header and its
+// spacer -- at most two rows, and only while they are not entries themselves.
+// tui.Scroll has no idea what a row is and should not learn: this is the
+// launcher's list, with the launcher's row kinds, and a shared type carrying a
+// special case for one caller is how the duplication this package is being
+// pulled out of started.
+func (s *listState) ensureVisible(height int) {
+	if len(s.selectable) == 0 {
+		s.offset.Off = 0
+		return
+	}
+	sel := s.selectable[s.cursor]
+
+	if sel < s.offset.Off {
+		s.offset.Off = sel
+		// Show the header (and its spacer) above a row scrolled to the top.
+		for back := 1; back <= 2 && s.offset.Off > 0 && s.rows[s.offset.Off-1].kind != rowEntry; back++ {
+			s.offset.Off--
+		}
+	}
+	if sel >= s.offset.Off+height {
+		s.offset.Off = sel - height + 1
+	}
+	s.offset.Apply(len(s.rows), height)
+}
+
+// ensureProvider starts an on-demand install when the selected connector's
+// provider is not present. Only one install runs at a time.
+func (s *listState) ensureProvider() tea.Cmd {
+	c, ok := s.current()
+	if !ok || c.Installed || s.installing != "" {
+		return nil
+	}
+	s.installing = c.Provider
+	return installProviderCmd(c.Provider)
+}
+
+// downloading reports whether a connector's provider is being fetched now.
+func (s listState) downloading(c Connector) bool { return s.installing == c.Provider }
+
+// applyInstalled swaps freshly installed connector metadata into the catalog,
+// leaving the list and the cursor where the user left them. It reports whether
+// the catalog changed, so a caller does not rebuild a detail pane over entries
+// that are the ones it already drew.
+func (s *listState) applyInstalled(msg providerInstalledMsg, height int) bool {
+	if len(msg.conns) == 0 {
+		return false
+	}
+	updated := make(map[string]Connector, len(msg.conns))
+	for _, c := range msg.conns {
+		updated[c.Name] = c
+	}
+	for i, e := range s.entries {
+		if e.Provider != msg.provider {
+			continue
+		}
+		if c, ok := updated[e.Name]; ok {
+			// Keep the category the catalog assigned: it is the launcher's own
+			// grouping, not something the provider declares.
+			c.Category = e.Category
+			s.entries[i] = c
+		}
+	}
+	s.refilter(height)
+	return true
+}

--- a/apps/cnspec/cmd/interactive/modal.go
+++ b/apps/cnspec/cmd/interactive/modal.go
@@ -1,0 +1,335 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Picking a value happens in a modal that takes over the body, rather than by
+// expanding the field in place.
+//
+// Expanding in place made two things ambiguous at once: the arrow keys drove
+// either the field list or the values depending on invisible state, and the
+// fields below jumped down the screen as a list opened. In a modal the arrows
+// only ever mean one thing, nothing moves behind it, and the title says what is
+// being chosen.
+
+const (
+	modalMaxWidth = 72
+	// modalPadX is the horizontal padding in modalBox. lipgloss counts padding
+	// inside the width it is given, so the usable content is that width minus
+	// twice this -- getting it wrong is what wrapped every row by exactly six
+	// columns and split long values across two lines.
+	modalPadX = 3
+	// modalBorder is one column each side.
+	modalBorder = 1
+)
+
+// modalRows is how many values a picker shows before it scrolls.
+const modalRows = 10
+
+var modalBox = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(tui.ColAccent).
+	Padding(1, modalPadX)
+
+// modalGeom returns the width handed to the box style and the content width
+// inside it, from the total the modal may occupy.
+func modalGeom(total int) (boxW, contentW int) {
+	boxW = modalWidth(total) - 2*modalBorder
+	contentW = boxW - 2*modalPadX
+	if contentW < 8 {
+		contentW = 8
+	}
+	return boxW, contentW
+}
+
+// modalState is the picker currently open, if any.
+type modalState struct {
+	open bool
+	// field is the index of the field being chosen for.
+	field  int
+	cursor int
+	filter string
+}
+
+// move walks the cursor within a list of n values, refusing to leave it. The
+// clamp lives with the cursor so that every key that moves it agrees about
+// where the ends are.
+func (s *modalState) move(delta, n int) {
+	next := s.cursor + delta
+	if next < 0 || next >= n {
+		return
+	}
+	s.cursor = next
+}
+
+// typed extends the filter. The cursor returns to the top because the list
+// under it has just changed, and leaving it where it was would select a value
+// the user never looked at.
+func (s *modalState) typed(runes []rune) {
+	s.filter += string(runes)
+	s.cursor = 0
+}
+
+// backspace shortens the filter, for the same reason typed lengthens it.
+func (s *modalState) backspace() {
+	if s.filter == "" {
+		return
+	}
+	s.filter = trimLastRune(s.filter)
+	s.cursor = 0
+}
+
+// trimLastRune drops the last character of a string, which is not the same as
+// dropping its last byte.
+//
+// typed() appends whatever runes the terminal delivered, and a Kubernetes
+// context, a container name or a file name is free to hold a multi-byte one.
+// Slicing a byte off the end of that leaves a partial encoding: the filter then
+// renders as a replacement glyph and matches nothing, and a file name typed
+// into the export box would be a path with an invalid byte in it. Shared with
+// the export box so both kinds of typing agree about what one backspace means.
+func trimLastRune(s string) string {
+	if s == "" {
+		return ""
+	}
+	_, size := utf8.DecodeLastRuneInString(s)
+	return s[:len(s)-size]
+}
+
+// options are the values the picker is offering for a field, after its filter.
+func (s modalState) options(fd field) []string {
+	if s.filter == "" {
+		return fd.Options
+	}
+	needle := strings.ToLower(s.filter)
+	out := make([]string, 0, len(fd.Options))
+	for _, o := range fd.Options {
+		if strings.Contains(strings.ToLower(o), needle) {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// valid reports whether the picker still points at a field that exists.
+// Rebuilding the form is what can break this, and rebuildForm closes the picker
+// itself. The check exists as well because the cost of being wrong is a panic
+// in View, which takes the terminal down with it.
+func (s modalState) valid(fields []field) bool {
+	return s.field >= 0 && s.field < len(fields)
+}
+
+// modalWidth fits the box to the terminal, leaving a margin on narrow ones.
+func modalWidth(total int) int {
+	w := modalMaxWidth
+	if fit := total - 8; fit > 24 && fit < w {
+		w = fit
+	}
+	return w
+}
+
+// viewModal renders the open picker as a centered box occupying exactly bodyH
+// lines, so the footer stays where it is.
+func (m Model) viewModal(l layout) string {
+	md := m.picker.modal
+	fd := m.detail.form.Fields()[md.field]
+	opts := md.options(fd)
+	boxW, contentW := modalGeom(l.Width)
+
+	var b strings.Builder
+	b.WriteString(tui.StyleAccent.Render(tui.Truncate(fd.Label, contentW)))
+	if fd.Desc != "" {
+		b.WriteString("\n" + tui.StyleDim.Render(tui.Truncate(fd.Desc, contentW)))
+	}
+	b.WriteString("\n\n")
+
+	switch {
+	case len(fd.Options) == 0 && m.picker.waitingFor(m.detail.form, fd) != "":
+		b.WriteString(m.spinner.View() + " " +
+			tui.StyleDim.Render(tui.Truncate(m.picker.waitingFor(m.detail.form, fd)+"…", contentW-2)))
+	case len(fd.Options) == 0:
+		b.WriteString(tui.StyleFaint.Render(tui.Truncate(m.picker.choiceHint(m.detail.form, fd), contentW)))
+	case len(opts) == 0:
+		b.WriteString(tui.StyleFaint.Render("nothing matches " + strconv.Quote(md.filter)))
+	default:
+		start, end := tui.Window(md.cursor, len(opts), modalRows)
+
+		// The cursor occupies two cells ahead of the value.
+		valueW := max(contentW-2, 8)
+		for i := start; i < end; i++ {
+			text := opts[i]
+			if fd.Kind == fieldMultiChoice {
+				mark := "○ "
+				if fd.Picked(text) {
+					mark = "● "
+				}
+				text = mark + text
+			}
+			line := truncateTail(text, valueW)
+			if i == md.cursor {
+				b.WriteString(tui.Bar("▸ "+line, contentW, tui.BandSelected) + "\n")
+				continue
+			}
+			b.WriteString("  " + tui.StyleText.Render(line) + "\n")
+		}
+		if more := tui.MoreRow(len(opts) - (end - start)); more != "" {
+			b.WriteString(more + "\n")
+		}
+	}
+
+	// A live refresh that failed has to say so even when the cheap read
+	// succeeded: the list is showing, it is just incomplete, and the reason is
+	// the only actionable thing on screen.
+	if busy := m.picker.waitingFor(m.detail.form, fd); busy != "" && len(fd.Options) > 0 {
+		b.WriteString(m.spinner.View() + " " +
+			tui.StyleDim.Render(tui.Truncate(busy+"…", contentW-2)) + "\n")
+	}
+	if warn := m.picker.liveError(m.detail.form, fd); warn != "" {
+		b.WriteString(tui.StyleWarn.Render(tui.Truncate("! "+warn, contentW)) + "\n")
+	}
+
+	b.WriteString("\n")
+	if md.filter != "" {
+		b.WriteString(tui.Truncate(tui.StyleAccent.Render("⌕ "+md.filter)+
+			tui.StyleFaint.Render(fmt.Sprintf("   %d of %d", len(opts), len(fd.Options))), contentW) + "\n")
+	}
+	help := "↑/↓ choose · type to filter · enter select · esc cancel"
+	if fd.Kind == fieldMultiChoice {
+		help = "↑/↓ move · space toggle · type to filter · enter done · esc cancel"
+	}
+	b.WriteString(tui.StyleFaint.Render(tui.Truncate(help, contentW)))
+
+	box := modalBox.Width(boxW).Render(b.String())
+	return lipgloss.Place(l.Width, l.BodyH, lipgloss.Center, lipgloss.Center, box)
+}
+
+// truncateTail keeps the end of an over-long value rather than the start. The
+// identifying part of a Kubernetes context lives at the end -- the cluster name
+// in an EKS ARN, the account in an OpenShift URL -- so cutting the head leaves
+// the reader something they can tell apart.
+func truncateTail(s string, w int) string {
+	width := tui.Width(s)
+	if width <= w {
+		return s
+	}
+	return ansi.TruncateLeft(s, width-w+1, "…")
+}
+
+// openModal starts choosing a value for the field under the cursor.
+func (m Model) openModal() (tea.Model, tea.Cmd) {
+	if m.detail.form.Cursor() < 0 || m.detail.form.Cursor() >= len(m.detail.form.Fields()) {
+		return m, nil
+	}
+	fd := m.detail.form.Fields()[m.detail.form.Cursor()]
+	// Only the two picker kinds have anything to choose from. The launcher's
+	// own kinds -- a credential readout, a paste box -- deliberately fall out
+	// here: neither has a list, and opening an empty modal over one would hide
+	// the thing that does work.
+	if fd.Kind != fieldChoice && fd.Kind != fieldMultiChoice {
+		return m, nil
+	}
+	// Nothing to choose from and nowhere to get anything: this is a text field
+	// wearing a picker's clothes, and opening an empty box over it only hides
+	// the one thing that works, which is typing.
+	if len(fd.Options) == 0 && fd.Source() == "" && fd.LiveSource == "" {
+		return m, nil
+	}
+	md := modalState{open: true, field: m.detail.form.Cursor()}
+	// Start on the current value so reopening a picker does not lose the place.
+	for i, o := range fd.Options {
+		if o == fd.Value() {
+			md.cursor = i
+		}
+	}
+	m.picker.modal = md
+	return m, m.openPickerCmd(fd)
+}
+
+// keyModal drives the open picker. Nothing here can launch a scan.
+func (m Model) keyModal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// md points into the copy this method returns, so what it moves is what the
+	// caller ends up with.
+	md := &m.picker.modal
+
+	// A modal is only ever opened over a picker (see openModal), but the field
+	// it points at can be replaced underneath it by a rebuild. Closing rather
+	// than editing is the safe answer for a kind that has no options: a paste
+	// box or a credential readout has nothing this key handling can mean.
+	//
+	// The out-of-range index closes too, rather than being tested and then
+	// indexed anyway. Only rebuildForm and syncSelection shrink the field
+	// slice and both close the picker, so nothing today gets here with a stale
+	// index -- but the guard used to prove the index was in range and then let
+	// the line below index with it regardless, which is a panic that takes the
+	// terminal down with it. View() has always closed this hole; this is the
+	// same close, on the key path.
+	if !md.valid(m.detail.form.Fields()) {
+		m.picker.close()
+		return m, nil
+	}
+	if k := m.detail.form.Fields()[md.field].Kind; k != fieldChoice && k != fieldMultiChoice {
+		m.picker.close()
+		return m, nil
+	}
+
+	opts := md.options(m.detail.form.Fields()[md.field])
+
+	switch msg.String() {
+	case "esc":
+		m.picker.close()
+		return m, nil
+	case "up", "ctrl+p":
+		md.move(-1, len(opts))
+		return m, nil
+	case "down", "ctrl+n":
+		md.move(1, len(opts))
+		return m, nil
+	case " ":
+		// Space toggles a multi-select and leaves the picker open, because
+		// choosing several is the whole point of one.
+		fd := &m.detail.form.Fields()[md.field]
+		if fd.Kind == fieldMultiChoice && md.cursor < len(opts) {
+			fd.TogglePick(opts[md.cursor])
+		}
+		return m, nil
+
+	case "enter":
+		fd := &m.detail.form.Fields()[md.field]
+		if fd.Kind == fieldMultiChoice {
+			// Enter closes; the toggling was done with space.
+			m.picker.close()
+			return m, nil
+		}
+		if md.cursor >= 0 && md.cursor < len(opts) {
+			fd.SetValue(opts[md.cursor])
+			fd.SetPrefilled("")
+			if m.detail.form.Cursor() == md.field {
+				m.detail.input.SetValue(fd.Value())
+				m.detail.input.CursorEnd()
+			}
+		}
+		m.picker.close()
+		resolveSources(&m.detail.form)
+		return m, tea.Batch(m.picker.pendingCmds(m.detail.form)...)
+	case "backspace":
+		md.backspace()
+		return m, nil
+	}
+
+	if msg.Type == tea.KeyRunes {
+		md.typed(msg.Runes)
+	}
+	return m, nil
+}

--- a/apps/cnspec/cmd/interactive/model.go
+++ b/apps/cnspec/cmd/interactive/model.go
@@ -1,0 +1,809 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/reportview"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// focusArea is which part of the launcher the keyboard drives. The list and the
+// detail pane are always both on screen, so focus -- not a wizard step -- is
+// what decides where a key lands.
+type focusArea int
+
+const (
+	focusList focusArea = iota
+	focusForm
+)
+
+// Model is the launcher. What it holds is the bubbletea surface -- Init, Update
+// and View -- plus the states the screens are made of, each of which owns the
+// facts that change together and the methods that change them.
+//
+// Nothing below is a lone fact that belongs to one of those states. What is
+// left over is the chrome, and each field says why it is chrome.
+type Model struct {
+	// list is the catalog, the search over it, and the cursor in it. See
+	// list.go.
+	list listState
+	// detail is the pane on the right: the form for the connector under the
+	// cursor, the box editing it, where in the pane the keys are, and how far
+	// it is scrolled. See detail.go.
+	detail detailState
+	// picker is the value pickers: the one that is open, and what each of them
+	// has found for the parameters it was asked about. See picker.go.
+	//
+	// It is a sibling of detail rather than a part of it because it is the only
+	// state here with a life of its own: a load outlives the form that started
+	// it, and answers to a key rather than to a field. What joins the two is
+	// sourceKeyFor, which turns a field into the key it asks under.
+	picker pickerState
+	// upstream is where a scan's results would go, whether that is the user's
+	// choice, and the chooser that makes it. Read once at startup: it is a
+	// config file read, and the answer does not change under us.
+	upstream upstreamState
+	// scan is the background scan being watched, if any. See scan.go.
+	scan scanState
+	// viewer holds the report of the most recent scan and the embedded model
+	// that draws it. See viewer.go.
+	viewer viewerState
+	// launching is the command being assembled and what the last one left on
+	// disk. See launch.go.
+	launching launchState
+	// export is the box that writes the configured target out as a reusable
+	// inventory file. See export.go.
+	//
+	// It is a sibling of launching rather than part of it because the two go to
+	// different places with the same material: launching writes a private file
+	// for a child process and removes it, export writes one the user keeps. It
+	// outlives a keypress the same way launching does, and for the same reason
+	// -- the OS keychain dialog.
+	export exportState
+
+	// --- the launcher's own chrome ------------------------------------------
+
+	// focus is which of the two panes the keyboard drives. It stays here for
+	// the same reason phase does: the list asks it whether to draw itself
+	// active, the detail pane asks it the same question, and the layout asks it
+	// which pane to show when the terminal is too narrow for both. A pane that
+	// owned it would be answering for its sibling.
+	//
+	// Where the keys are *inside* the detail pane is that pane's own business
+	// and lives there, as detailState.spot.
+	focus focusArea
+
+	width  int
+	height int
+
+	// spinner animates a wait. A gcloud call can take tens of seconds, and a
+	// still screen is indistinguishable from a hung one.
+	//
+	// It is chrome rather than the pickers' because the scanning screen borrows
+	// its current frame, and a scan reaching into the pickers to find out what
+	// a spinner looks like would be the coupling this split removed. One
+	// animation clock, like width and height.
+	spinner spinner.Model
+
+	// lastErr is shown in the footer until the next key; lastRun is the command
+	// that most recently ran, so returning from it says what just happened.
+	lastErr string
+	// lastWarn describes a weaker guarantee than usual -- a credential that
+	// could not reach the keychain, say. The command still ran.
+	lastWarn string
+	// lastNote is something that simply worked and is worth saying: a file that
+	// was written, and the command that reads it.
+	//
+	// It exists because there were two footer channels and three kinds of
+	// message. A completed export went out through lastWarn, so the launcher
+	// announced a file it had just written correctly in the warning color,
+	// behind a "!". Three channels is the smaller lie.
+	lastNote string
+	lastRun  string
+
+	// phase is what the launcher is doing with the terminal: showing the
+	// fields, watching a background scan, or handing the screen to the report
+	// viewer. See phases.go.
+	//
+	// It stays on Model rather than inside scan: two of the three phases are
+	// not the scan's, and a viewer that had to read the scan's state to know
+	// whether it is on screen would be the coupling this split removed.
+	phase phase
+}
+
+// NewModel builds a launcher model over the given catalog.
+func NewModel(catalog []Connector) Model {
+	a := textinput.New()
+	a.Prompt = ""
+	a.CharLimit = 256
+
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = tui.StyleAccent
+
+	const width, height = 100, 30
+	m := Model{
+		list:     newListState(catalog, tui.Dims(width, height).ListH),
+		upstream: readUpstreamFn(),
+		detail:   detailState{input: a},
+		picker:   newPickerState(),
+		spinner:  sp,
+		width:    width,
+		height:   height,
+	}
+	m.syncSelection()
+	return m
+}
+
+func (m Model) Init() tea.Cmd { return tea.Batch(textinput.Blink, m.spinner.Tick) }
+
+// listH is how many rows of the connector list fit on screen. Everything the
+// list does to its own scroll offset needs it, and it is the launcher's
+// geometry rather than the list's.
+func (m Model) listH() int { return tui.Dims(m.width, m.height).ListH }
+
+// syncSelection refreshes everything derived from the cursor: the action list
+// and the argument field's placeholder.
+func (m *Model) syncSelection() {
+	c, ok := m.list.current()
+	if !ok {
+		m.detail.form = form{}
+		return
+	}
+
+	// Rebuilding on every cursor move would throw away half-typed input, so
+	// the form is only rebuilt when the selection actually changed connector.
+	if m.detail.form.Subject() != c.Name {
+		m.detail.form = newForm(c)
+		m.picker.fill(&m.detail.form)
+	}
+}
+
+// rebuildForm rebuilds the current form from scratch, keeping what the user
+// typed and leaving no stale references behind.
+//
+// This is the path taken when a provider finishes installing: the connector
+// gains the metadata the form is built from, so the form has to be rebuilt --
+// but it is rebuilt underneath whatever the user is doing at that moment.
+func (m *Model) rebuildForm() {
+	c, ok := m.list.current()
+	if !ok {
+		m.detail.form = form{}
+		m.picker.close()
+		return
+	}
+	old := m.detail.form
+	m.detail.form = newForm(c)
+	carryOver(&m.detail.form, old)
+	m.picker.fill(&m.detail.form)
+	// An open picker indexes the field list it was opened against. The list
+	// just changed, so the picker is closed rather than left pointing into it.
+	if m.picker.modal.open {
+		m.picker.close()
+	}
+}
+
+// readyToRun reports whether the form has everything the command needs, which
+// decides whether enter scans or opens the fields.
+func (m Model) readyToRun() bool {
+	if _, ok := m.list.current(); !ok {
+		return false
+	}
+	return m.detail.form.Validate() == nil
+}
+
+// openPickerCmd starts the loads a field being opened needs, and restarts the
+// animation clock for them.
+//
+// The loads are pickerState.openCmds; the clock is the launcher's one spinner.
+// This is the seam between them and is all that is left on Model of what used
+// to be the whole method: the pickers have no spinner to tick, and giving them
+// one would be a second animation clock nothing would keep in step with the
+// first.
+func (m Model) openPickerCmd(fd field) tea.Cmd {
+	cmds := m.picker.openCmds(m.detail.form, fd)
+	if len(cmds) == 0 {
+		return nil
+	}
+	// The spinner is only ticking while something is loading, so restart it.
+	return tea.Batch(append(cmds, m.spinner.Tick)...)
+}
+
+// moveCursor walks the list and rebuilds the form under it.
+//
+// The two halves stay together on Model because they belong to different
+// clusters: the list owns where the cursor is, and syncSelection owns what the
+// detail pane shows for it. A list that rebuilt the form would be the list
+// knowing what a form is.
+func (m *Model) moveCursor(delta int) {
+	if !m.list.move(delta, m.listH()) {
+		return
+	}
+	m.syncSelection()
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// A background scan reports in wherever the launcher happens to be, so its
+	// messages are handled before the phase is consulted. Each handler checks
+	// that the session is still the current one: an event from a scan the user
+	// cancelled is dropped, and the session releases itself.
+	switch msg := msg.(type) {
+	case scanRunningMsg:
+		return m, m.scan.running(msg)
+	case scanProgressMsg:
+		return m, m.scan.progressed(msg)
+	case scanExitedMsg:
+		return m, m.scan.exited(msg)
+	case scanReportMsg:
+		return m.scanReport(msg)
+	case reportview.ExportDoneMsg:
+		// A write can outlive the view that started it: close the report while
+		// a large json-full is still being written and the result arrives here,
+		// with the viewer gone. Say it in the footer rather than dropping a
+		// confirmation the user is waiting for.
+		if m.phase == phaseViewing {
+			break // the viewer is up and says it itself
+		}
+		if msg.Err != nil {
+			m.lastErr = reportview.ExportNotice(msg)
+		} else {
+			m.lastNote = reportview.ExportNotice(msg)
+		}
+		return m, nil
+
+	case exportParsedMsg:
+		// The two halves of an export answer from off the event loop and both
+		// can outlive the box that asked, so they are handled before the phase
+		// is consulted -- a scan started in the meantime must not swallow the
+		// word that a file was written. Each checks for itself whether it is
+		// still wanted; see exportParsed and exportWrote.
+		return m.exportParsed(msg)
+	case exportWroteMsg:
+		return m.exportWrote(msg)
+
+	case viewerClosedMsg:
+		return m.closeViewer()
+	}
+
+	switch m.phase {
+	case phaseScanning:
+		return m.updateScanning(msg)
+	case phaseViewing:
+		return m.updateViewing(msg)
+	}
+
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		// Only animate while something is actually being fetched; a spinner
+		// ticking over a settled screen is noise. The export box waits on a
+		// provider and then on the OS keychain, so it is a second thing that
+		// can be waiting -- an animation clock that only knew about the pickers
+		// would leave the box still while it was the only thing on screen.
+		if !m.picker.busy() && !m.export.busy() {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.list.ensureVisible(m.listH())
+		return m, nil
+
+	case launchPreparedMsg:
+		m.launching.prepared()
+		if msg.err != nil {
+			m.lastErr = msg.err.Error()
+			return m, nil
+		}
+		m.lastWarn = msg.plan.warn
+		m.lastRun = "cnspec " + strings.Join(msg.plan.args, " ")
+		if interactiveAction(msg.action) {
+			// A shell has no report and is genuinely interactive, so it still
+			// gets the terminal handed to it. Everything else runs in the
+			// background and comes back as a report.
+			m.launching.cleanup = msg.plan.cleanup
+			return m, launchCmd(msg.plan.args, msg.plan.env, msg.plan.warn)
+		}
+		return m.startScan(msg.plan)
+
+	case launchDoneMsg:
+		m.launching.release()
+		if msg.err != nil {
+			m.lastErr = msg.err.Error()
+		}
+		return m, textinput.Blink
+
+	case sourceValuesMsg:
+		m.picker.answer(msg)
+		if msg.cancelled {
+			// The picker that asked has been closed, and answer files nothing
+			// for it: caching an empty list would leave a key a later picker
+			// would then trust.
+			return m, nil
+		}
+		if msg.err != nil && len(msg.values) == 0 {
+			// Say it where there is room to say it. A picker that quietly
+			// offers less than it should is the failure mode worth avoiding.
+			m.lastWarn = msg.err.Error()
+		}
+		m.picker.fill(&m.detail.form)
+		m.detail.applyPrefill(msg.source, msg.values, m.focus == focusForm)
+		return m, nil
+
+	case providerInstalledMsg:
+		if m.list.installing == msg.provider {
+			m.list.installing = ""
+		}
+		if msg.err != nil {
+			m.lastErr = "could not install the " + msg.provider + " provider: " + msg.err.Error()
+			return m, nil
+		}
+		if m.list.applyInstalled(msg, m.listH()) {
+			m.syncSelection()
+		}
+		// The catalog entry now carries the metadata the form is built from,
+		// so rebuild it and start any pickers it asks for.
+		m.rebuildForm()
+		return m, tea.Batch(m.picker.pendingCmds(m.detail.form)...)
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
+	}
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		return m.quit()
+	}
+	// any key dismisses what is showing
+	m.lastErr, m.lastWarn, m.lastNote = "", "", ""
+
+	// Reporting is global: it decides where the results of anything launched
+	// from here end up, so it is reachable from every pane. It is a control key
+	// because the list treats bare letters as filter input.
+	if m.upstream.modal.open {
+		m.lastWarn = m.upstream.keyModal(msg)
+		return m, nil
+	}
+	if msg.String() == "ctrl+r" {
+		m.upstream.openModal()
+		return m, nil
+	}
+
+	// The export box takes every key while it is up, for the same reason the
+	// pickers do: what a key means there is what the box says it means.
+	if m.export.open {
+		return m.exportKey(msg)
+	}
+
+	if m.picker.modal.open {
+		return m.keyModal(msg)
+	}
+
+	// Reachable from both panes, like reporting and the report: what would be
+	// exported is the form the launcher is showing, whichever side the keys are
+	// on. Not reachable from an open picker, which owns the screen while it is
+	// up and must not be left standing behind another box.
+	if msg.String() == "ctrl+e" {
+		return m.openExport()
+	}
+
+	// The report of the last scan is still in memory, so leaving the viewer is
+	// not the same as losing it. Reachable from both panes for the same reason
+	// reporting is -- it is about the session, not about the field under the
+	// cursor -- but not from an open picker, which owns the screen while it is
+	// up and must not be left standing behind a report.
+	if msg.String() == "ctrl+o" {
+		return m.reopenViewer()
+	}
+	switch m.focus {
+	case focusForm:
+		return m.keyForm(msg)
+	default:
+		return m.keyList(msg)
+	}
+}
+
+// quit leaves, removing what the launcher wrote on the way out.
+//
+// The generated inventory holds a plaintext credential whenever the keychain
+// was unavailable, and it used to be removed on exactly one event -- the
+// command it fed finishing. Quitting between assembling a plan and running it,
+// or quitting at all after a scan that never happened, left that file in the
+// system temp directory. See cleanupTempFiles for the rest of the story.
+func (m Model) quit() (tea.Model, tea.Cmd) {
+	m.scan.cancel()
+	cleanupTempFiles()
+	// Dropped rather than run: cleanupTempFiles has just removed what it would
+	// remove, because trackTemp registered it when the plan was assembled.
+	m.launching.disown()
+	return m, tea.Quit
+}
+
+func (m Model) keyList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		if m.list.clearSearch(m.listH()) {
+			m.syncSelection()
+			return m, nil
+		}
+		return m.quit()
+	case "up", "ctrl+p":
+		m.moveCursor(-1)
+		return m, nil
+	case "down", "ctrl+n":
+		m.moveCursor(1)
+		return m, nil
+	case "pgup":
+		m.moveCursor(-m.listH())
+		return m, nil
+	case "pgdown":
+		m.moveCursor(m.listH())
+		return m, nil
+	case "home":
+		m.moveCursor(-len(m.list.selectable))
+		return m, nil
+	case "end":
+		m.moveCursor(len(m.list.selectable))
+		return m, nil
+	case "tab", "right", "enter", "shift+tab":
+		// Enter never scans from here. Configuring a target and starting a scan
+		// are separate acts, and a key that did both meant choosing a connector
+		// could launch one by accident.
+		return m.focusRight()
+	}
+
+	cmd := m.list.typed(msg, m.listH())
+	m.syncSelection()
+	return m, cmd
+}
+
+// focusRight moves focus into the fields.
+func (m Model) focusRight() (tea.Model, tea.Cmd) {
+	// Opening the detail pane is the first point where the user has committed
+	// to a connector, so it is when the provider gets installed if it is
+	// missing -- the form is built from metadata only an installed provider
+	// carries. The download would happen on the first scan anyway.
+	install := m.list.ensureProvider()
+	model, cmd := m.enterForm()
+	return model, tea.Batch(install, cmd)
+}
+
+// enterForm moves focus onto the input fields and kicks off any value pickers
+// the form needs.
+func (m Model) enterForm() (tea.Model, tea.Cmd) {
+	m.focus = focusForm
+
+	// A connector with nothing to configure -- local is the whole point of the
+	// launcher's short path -- still needs somewhere for the keys to land, and
+	// that is the scan button.
+	if len(m.detail.focusableFields()) == 0 {
+		m.detail.spot = spotButton
+		m.list.search.Blur()
+		m.detail.input.Blur()
+		return m, nil
+	}
+
+	m.detail.leaveButton()
+	m.list.search.Blur()
+	if visible := m.detail.focusableFields(); len(visible) > 0 {
+		m.detail.form.SetCursor(visible[0])
+	}
+	m.ensureFieldVisible()
+	m.detail.loadCursorField()
+	return m, tea.Batch(append(m.picker.pendingCmds(m.detail.form), textinput.Blink)...)
+}
+
+// focusFirstMissing puts the cursor on the first required field still empty,
+// so opening the fields lands on the thing standing between here and a scan.
+func (m *Model) focusFirstMissing() {
+	for i, fd := range m.detail.form.Fields() {
+		if fd.Required && !fd.IsSet() {
+			m.detail.form.SetCursor(i)
+			m.ensureFieldVisible()
+			m.detail.loadCursorField()
+			return
+		}
+	}
+}
+
+func (m Model) keyForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	visible := m.detail.focusableFields()
+	// With nothing reachable to type into, the keys cannot be on a field, so
+	// they go to the button. The reveal row is a position in its own right and
+	// is left alone -- a form whose every field is a folded option has no
+	// reachable field and still has that row, and clobbering it here is what
+	// stopped `up` from walking off the top of such a pane back to the list.
+	if len(visible) == 0 && m.detail.onField() {
+		m.detail.spot = spotButton
+	}
+
+	switch msg.String() {
+	case "esc":
+		m.detail.storeCursorField()
+		m.focus = focusList
+		// The button is released on the way out, so returning to the pane does
+		// not land on it: the fields are what the user came back for.
+		m.detail.leaveButton()
+		m.detail.input.Blur()
+		m.list.search.Focus()
+		return m, textinput.Blink
+
+	case "shift+tab", "up", "ctrl+p":
+		if !m.moveFocus(-1) {
+			// Off the top of the pane: hand the keys back to the list.
+			m.detail.storeCursorField()
+			m.focus = focusList
+			m.detail.input.Blur()
+			m.list.search.Focus()
+		}
+		return m, textinput.Blink
+
+	case "tab", "down", "ctrl+n":
+		m.moveFocus(1)
+		return m, textinput.Blink
+
+	case "enter":
+		// The scan button is the only thing that scans.
+		if m.detail.onButton() {
+			return m.launch()
+		}
+		if m.detail.onMore() {
+			m.detail.showOptions = true
+			// The row the keys were on has just stopped existing, so they go
+			// back to a field and moveFocus(0) settles them on a real one.
+			m.detail.leaveMore()
+			m.moveFocus(0)
+			return m, textinput.Blink
+		}
+		return m.activateField()
+	}
+
+	if !m.detail.onField() || m.detail.form.Cursor() >= len(m.detail.form.Fields()) {
+		return m, nil
+	}
+
+	fd := &m.detail.form.Fields()[m.detail.form.Cursor()]
+	switch fd.Kind {
+	case fieldBool:
+		if msg.String() == " " {
+			fd.Toggle()
+		}
+		return m, nil
+	case fieldChoice, fieldMultiChoice:
+		if msg.String() == " " {
+			return m.openModal()
+		}
+		// A picker still accepts a value it has not heard of, so typing falls
+		// through to the text input below.
+	case fieldCredentialState:
+		// Stub. There is nothing to type into a readout, so keys are swallowed
+		// rather than falling through to the shared input and being written
+		// back over the state. Navigation was handled above and still works.
+		return m, nil
+	case fieldPaste:
+		// Stub. A paste field is a secret text field, so typing and pasting
+		// fall through to the shared input below.
+	}
+
+	var cmd tea.Cmd
+	m.detail.input, cmd = m.detail.input.Update(msg)
+	m.detail.storeCursorField()
+	resolveSources(&m.detail.form)
+	return m, tea.Batch(append(m.picker.pendingCmds(m.detail.form), cmd)...)
+}
+
+// activateField does whatever the focused field needs: open a picker, flip a
+// switch, or step past a text field, which is edited in place.
+func (m Model) activateField() (tea.Model, tea.Cmd) {
+	fd := &m.detail.form.Fields()[m.detail.form.Cursor()]
+	switch fd.Kind {
+	case fieldChoice, fieldMultiChoice:
+		return m.openModal()
+	case fieldBool:
+		fd.Toggle()
+		return m, nil
+	case fieldCredentialState:
+		// Stub. Enter on a readout will eventually re-check the environment;
+		// stepping past it is the honest thing to do until it does, because
+		// doing nothing at all reads as a key the launcher swallowed.
+		m.moveFocus(1)
+		return m, textinput.Blink
+	}
+	m.moveFocus(1)
+	return m, textinput.Blink
+}
+
+// moveFocus walks the visible fields and then the scan button, which sits after
+// the last field. It reports whether the focus stayed in the pane, so moving
+// off the top can fall back to the list.
+func (m *Model) moveFocus(delta int) bool {
+	visible := m.detail.focusableFields()
+	more := m.detail.hasMoreRow()
+
+	// Positions: one per field, then the reveal row if there is one, then the
+	// scan button.
+	last := len(visible)
+	if more {
+		last++
+	}
+
+	pos := last // the button
+	switch m.detail.spot {
+	case spotMore:
+		pos = len(visible)
+	case spotField:
+		pos = 0
+		for i, idx := range visible {
+			if idx == m.detail.form.Cursor() {
+				pos = i
+			}
+		}
+	}
+
+	next := pos + delta
+	if next < 0 {
+		return false
+	}
+	if next > last {
+		next = last
+	}
+
+	m.detail.storeCursorField()
+	switch {
+	case next == last:
+		m.detail.spot = spotButton
+		m.detail.input.Blur()
+	case more && next == len(visible):
+		m.detail.spot = spotMore
+		m.detail.input.Blur()
+	default:
+		m.detail.spot = spotField
+		m.detail.form.SetCursor(visible[next])
+		m.ensureFieldVisible()
+		m.detail.loadCursorField()
+	}
+	return true
+}
+
+// launch assembles the command and runs it. A form that is missing something
+// required does not launch: focus moves to the field instead, because the
+// alternative is tearing the screen down to show a usage error the launcher
+// already knew was coming.
+func (m Model) launch() (tea.Model, tea.Cmd) {
+	c, ok := m.list.current()
+	if !ok {
+		return m, nil
+	}
+	if err := m.detail.form.Validate(); err != nil {
+		m.lastErr = err.Error()
+		m.focus = focusForm
+		m.focusFirstMissing()
+		return m, textinput.Blink
+	}
+
+	// The button says what is happening in the meantime; see the diButton arm
+	// of renderDetailItem.
+	if !m.launching.begin() {
+		return m, nil
+	}
+	// Nothing else is batched in: the button says "Preparing…" and does not
+	// animate, so the one repaint this Update already causes is all it needs.
+	return m, prepareLaunchCmd(m, c, scanAction())
+}
+
+// launchPreparedMsg carries an assembled plan back to the event loop.
+type launchPreparedMsg struct {
+	// action is the verb the plan runs, which decides how it runs: a shell
+	// takes the terminal, everything else goes to the background.
+	action string
+	plan   launchPlan
+	err    error
+}
+
+// prepareLaunchCmd assembles the plan off the event loop.
+//
+// Everything launchArgs does is quick except one step, and that one has no
+// bound at all: writing the credential to the OS keychain raises an
+// authentication dialog when the keychain is locked, and the call does not
+// return until the dialog is answered. Doing that from Update froze the whole
+// TUI behind a dialog the launcher was not drawing -- alt screen, spinner and
+// all -- so the launcher looked hung at exactly the moment it was asking for
+// permission.
+//
+// m is a copy and launchArgs only reads it, so this is safe to run from a
+// command. What it writes -- the inventory, a kubeconfig copy -- is returned in
+// the plan rather than stored on the model.
+func prepareLaunchCmd(m Model, c Connector, a Action) tea.Cmd {
+	return func() tea.Msg {
+		plan, err := m.launchArgs(c, a)
+		return launchPreparedMsg{action: a.Name, plan: plan, err: err}
+	}
+}
+
+func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// A modal owns the body while it is up, and every zone computeLayout
+	// registers belongs to a screen that is not drawn underneath it. The keys
+	// have always respected that; the mouse did not, so a click landed on a row
+	// nobody could see -- and a click where the scan button would have been
+	// launched a scan from behind an open picker. The wheel is included: it
+	// moved the selection under the box, which then rebuilt the form the box
+	// was describing.
+	if m.upstream.modal.open || m.export.open || m.picker.modal.open {
+		return m, nil
+	}
+
+	l := computeLayout(m)
+
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		m.moveCursor(-1)
+		return m, nil
+	case tea.MouseButtonWheelDown:
+		m.moveCursor(1)
+		return m, nil
+	}
+
+	// Dispatch on press rather than release: some terminals drop the release
+	// event in cell-motion mode, which would swallow the click entirely.
+	if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+		return m, nil
+	}
+
+	switch z := l.HitZone(msg.X, msg.Y); z.Kind {
+	case tui.ZoneEntry:
+		if m.list.selectRow(z.Idx, m.listH()) {
+			m.focus = focusList
+			m.detail.input.Blur()
+			m.list.search.Focus()
+			m.syncSelection()
+		}
+		return m, textinput.Blink
+	case tui.ZoneField:
+		if z.Idx < 0 || z.Idx >= len(m.detail.form.Fields()) {
+			return m, nil
+		}
+		// Clicking a toggle flips it; clicking anything else moves the cursor
+		// there so it can be edited.
+		if m.focus == focusForm {
+			m.detail.storeCursorField()
+		}
+		m.detail.form.SetCursor(z.Idx)
+		m.detail.spot = spotField
+		if fd := &m.detail.form.Fields()[z.Idx]; fd.Kind == fieldBool {
+			fd.Toggle()
+		}
+		m.focus = focusForm
+		m.list.search.Blur()
+		m.detail.loadCursorField()
+		return m, tea.Batch(append(m.picker.pendingCmds(m.detail.form), textinput.Blink)...)
+	case tui.ZoneUpstream:
+		m.upstream.openModal()
+		return m, nil
+	case tui.ZoneMore:
+		m.detail.showOptions = true
+		// The row that was clicked has just stopped existing, so the keys
+		// cannot stay on it. They are left where they are otherwise: a click
+		// on the reveal row is not a claim about the button.
+		m.detail.leaveMore()
+		return m, nil
+	case tui.ZoneRun:
+		if m.focus == focusForm {
+			m.detail.storeCursorField()
+		}
+		return m.launch()
+	}
+	return m, nil
+}

--- a/apps/cnspec/cmd/interactive/model_test.go
+++ b/apps/cnspec/cmd/interactive/model_test.go
@@ -1,0 +1,617 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// sampleCatalog is a small hermetic catalog so model tests don't depend on the
+// installed provider set.
+func sampleCatalog() []Connector {
+	// ssh and aws carry the metadata a real installed provider would, so the
+	// model tests exercise actual forms rather than empty ones.
+	ssh := sshConnector()
+	ssh.Short = "a remote system via SSH"
+	aws := awsConnector()
+	aws.Short = "an AWS account"
+
+	return []Connector{
+		{Provider: "os", Name: "local", Use: "local", Short: "your local system", Category: catHosts, Installed: true},
+		ssh,
+		{Provider: "os", Name: "docker", Use: "docker", Short: "a running Docker container", Category: catContainer},
+		aws,
+		{Provider: "k8s", Name: "k8s", Use: "k8s", Short: "a Kubernetes cluster", Category: catContainer},
+		{Provider: "mongo", Name: "mongo", Use: "mongo [host]", Short: "a MongoDB server", Category: catDatabase},
+	}
+}
+
+// setSource seeds a picker's cached values the way a completed load would.
+func setSource(m *Model, source string, values []string) {
+	m.picker.answer(sourceValuesMsg{source: source, key: sourceKeyFor(m.detail.form, source), values: values})
+	m.picker.fill(&m.detail.form)
+}
+
+// setSourceErr records why a picker came back empty, the way a load that could
+// not reach its cluster would. It goes through the same answer path a real one
+// does, so a test cannot leave the four facts about a key in a combination the
+// launcher would never produce.
+func setSourceErr(m *Model, source string, err error) {
+	m.picker.answer(sourceValuesMsg{source: source, key: sourceKeyFor(m.detail.form, source), err: err})
+}
+
+// newTestModel builds the launcher as a machine that is connected to Mondoo
+// Platform, because otherwise every assertion about an assembled command line
+// would depend on whether the developer running the suite happens to be logged
+// in -- the same command gains --incognito on a machine with no credentials.
+// Tests that care about the other states set upstream themselves.
+func newTestModel() Model {
+	m := NewModel(sampleCatalog())
+	m.upstream = upstreamState{configured: true, scope: "test-space"}
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return nm.(Model)
+}
+
+func typeString(m Model, s string) Model {
+	for _, r := range s {
+		nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = nm.(Model)
+	}
+	return m
+}
+
+func key(m Model, t tea.KeyType) Model {
+	nm, cmd := m.Update(tea.KeyMsg{Type: t})
+	return settle(nm.(Model), cmd)
+}
+
+// settle delivers the one message a test has to see for itself, the way the
+// program's own loop would.
+//
+// The scan plan is assembled off the event loop -- see prepareLaunchCmd, which
+// is what stops a locked keychain freezing the screen -- so pressing the button
+// no longer finishes the launch inside Update. It is gated on the launch state
+// rather than run for every command, because most of what this model returns
+// is a timer: textinput.Blink and spinner.Tick both sleep when called, and a
+// test that ran them would pay half a second per keystroke.
+func settle(m Model, cmd tea.Cmd) Model {
+	if !m.launching.preparing || cmd == nil {
+		return m
+	}
+	// launchCmd comes back from this, and is deliberately dropped: tea.Exec
+	// only wraps the child, so nothing is spawned by building it.
+	nm, _ := m.Update(cmd())
+	return nm.(Model)
+}
+
+// selectEntry moves the cursor onto the named entry.
+func selectEntry(t *testing.T, m Model, name string) Model {
+	t.Helper()
+	for i := range m.list.selectable {
+		m.list.cursor = i
+		m.list.ensureVisible(m.listH())
+		m.syncSelection()
+		if e, ok := m.list.current(); ok && e.Name == name {
+			return m
+		}
+	}
+	t.Fatalf("entry %q not found", name)
+	return m
+}
+
+func TestFilterNarrowsResults(t *testing.T) {
+	m := typeString(newTestModel(), "aws")
+	if len(m.list.filtered) != 1 || m.list.filtered[0].Name != "aws" {
+		t.Fatalf("expected only aws to match, got %d results", len(m.list.filtered))
+	}
+
+	m2 := typeString(newTestModel(), "database")
+	if len(m2.list.filtered) != 1 || m2.list.filtered[0].Name != "mongo" {
+		t.Fatalf("expected category search to find mongo, got %d results", len(m2.list.filtered))
+	}
+}
+
+// The list opens populated and ready: no landing screen, no action list, and
+// the first connector's fields already built.
+func TestOpensReadyToLaunch(t *testing.T) {
+	m := newTestModel()
+	if m.focus != focusList {
+		t.Fatalf("expected list focus on open, got %d", m.focus)
+	}
+	e, ok := m.list.current()
+	if !ok || e.Name != "local" {
+		t.Fatalf("expected local selected first, got %q ok=%v", e.Name, ok)
+	}
+	// local needs nothing, so opening the launcher and pressing enter is a
+	// complete interaction.
+	if !m.readyToRun() {
+		t.Fatal("expected local to be runnable with no input")
+	}
+}
+
+// Choosing a connector never starts a scan. Configuring a target and running
+// one are separate acts; enter from the list only opens the configuration.
+func TestEnterFromTheListNeverScans(t *testing.T) {
+	for _, name := range []string{"aws", "k8s", "local"} {
+		m := selectEntry(t, newTestModel(), name)
+		m = key(m, tea.KeyEnter)
+		if m.lastRun != "" {
+			t.Errorf("%s: enter from the list launched %q", name, m.lastRun)
+		}
+		if m.focus != focusForm {
+			t.Errorf("%s: expected the fields to open, got focus %d", name, m.focus)
+		}
+	}
+}
+
+// tabToScan walks the fields to the scan button.
+func tabToScan(m Model) Model {
+	for i := 0; i < 40 && !m.detail.onButton(); i++ {
+		m = key(m, tea.KeyTab)
+	}
+	return m
+}
+
+// The scan button is the only thing that scans.
+func TestOnlyTheButtonScans(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "aws")
+	m = key(m, tea.KeyTab) // into the fields
+	if m.detail.onButton() {
+		t.Fatal("the fields should be entered on a field, not the button")
+	}
+
+	m = tabToScan(m)
+	if !m.detail.onButton() {
+		t.Fatal("tab should reach the scan button")
+	}
+	m = key(m, tea.KeyEnter)
+	if m.lastRun != "cnspec scan aws" {
+		t.Fatalf("expected the button to launch, got %q lastErr=%q", m.lastRun, m.lastErr)
+	}
+}
+
+// A required field still blocks, and says which one.
+func TestButtonRefusesWhileSomethingIsRequired(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	m = key(m, tea.KeyTab)
+	m = tabToScan(m)
+	m = key(m, tea.KeyEnter)
+
+	if m.lastRun != "" {
+		t.Fatalf("expected no launch, got %q", m.lastRun)
+	}
+	if !strings.Contains(m.lastErr, "user@host") {
+		t.Fatalf("expected the error to name the missing field, got %q", m.lastErr)
+	}
+}
+
+// Tab walks the fields and then the button; shift+tab walks back and off the
+// top returns to the list.
+func TestFocusWalksFieldsThenButton(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	m = key(m, tea.KeyTab)
+	if m.focus != focusForm || m.detail.onButton() {
+		t.Fatalf("expected the first field, got focus=%d button=%v", m.focus, m.detail.onButton())
+	}
+	first := m.detail.form.Cursor()
+
+	m = key(m, tea.KeyTab)
+	if m.detail.form.Cursor() == first && !m.detail.onButton() {
+		t.Fatal("tab should move to the next field")
+	}
+
+	m = tabToScan(m)
+	m = key(m, tea.KeyTab) // already at the end, stays put
+	if !m.detail.onButton() {
+		t.Fatal("tab past the button should stay on the button")
+	}
+
+	// Back out the way we came.
+	for i := 0; i < 40 && m.focus == focusForm; i++ {
+		m = key(m, tea.KeyShiftTab)
+	}
+	if m.focus != focusList {
+		t.Fatalf("shift+tab off the top should return to the list, got %d", m.focus)
+	}
+}
+
+// The keys are in exactly one place in the detail pane, and carrying a position
+// out of one pane must not light up two rows in the next.
+//
+// This is the bug the three-valued spot ended. moreFocused and scanFocused were
+// two bools, and leaving the pane from the reveal row left moreFocused set. Open
+// a connector whose every field is a folded option -- `local`, which has two --
+// and enterForm set scanFocused as well, because there was no reachable field
+// for the keys to land on. Both were then true, the renderer drew the selection
+// dot on the reveal row *and* on the scan button, and the two disagreed about
+// what a key meant: moveFocus read "more", enter read "button".
+//
+// Reproduced from the keyboard on the shipped catalog before the fix:
+// ssh, enter, down x4 (onto the reveal row), esc, esc, down x2, enter.
+func TestOnlyOneRowOfThePaneHasTheKeys(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	m = key(m, tea.KeyTab)
+	for i := 0; i < 40 && !m.detail.onMore(); i++ {
+		m = key(m, tea.KeyTab)
+	}
+	if !m.detail.onMore() {
+		t.Fatal("tab never reached the row that reveals the folded options")
+	}
+
+	// Out of the pane, onto a connector with nothing reachable to fill in, and
+	// back in. The position from the other pane must not survive as a second
+	// highlighted row.
+	m = key(m, tea.KeyEsc)
+	m = selectEntry(t, m, "local")
+	if len(m.detail.focusableFields()) != 0 {
+		t.Skip("local now has a reachable field; the premise no longer holds")
+	}
+	m = key(m, tea.KeyTab)
+
+	if !m.detail.onButton() {
+		t.Fatalf("a pane with nothing to fill in should open on the button, got spot=%d", m.detail.spot)
+	}
+	if m.detail.onMore() {
+		t.Fatal("the reveal row kept the keys it was given in another pane")
+	}
+}
+
+// esc clears the filter before it quits, so a typo does not drop the session.
+func TestEscClearsFilterFirst(t *testing.T) {
+	m := typeString(newTestModel(), "aws")
+	m = key(m, tea.KeyEsc)
+	if m.list.search.Value() != "" {
+		t.Fatalf("expected esc to clear the filter, got %q", m.list.search.Value())
+	}
+	if len(m.list.filtered) != len(m.list.entries) {
+		t.Fatalf("expected the full list back, got %d of %d", len(m.list.filtered), len(m.list.entries))
+	}
+}
+
+func TestActionFilteringForConnector(t *testing.T) {
+	// aws does not support sbom; ensure it is not offered.
+	for _, a := range ActionsFor("aws") {
+		if a.Name == "sbom" {
+			t.Fatal("sbom should not be offered for aws")
+		}
+	}
+	names := map[string]bool{}
+	for _, a := range ActionsFor("local") {
+		names[a.Name] = true
+	}
+	for _, want := range []string{"scan", "shell", "run", "discover", "vuln", "sbom", "aibom"} {
+		if !names[want] {
+			t.Fatalf("expected action %q for local", want)
+		}
+	}
+}
+
+func TestTokenizeQuotes(t *testing.T) {
+	got := tokenize(`-c "aws.regions.length"`)
+	if len(got) != 2 || got[0] != "-c" || got[1] != "aws.regions.length" {
+		t.Fatalf("unexpected tokenize result: %#v", got)
+	}
+}
+
+func TestRequiresArg(t *testing.T) {
+	cases := []struct {
+		use, name string
+		want      bool
+	}{
+		{"ssh user@host", "ssh", true},
+		{"ansible PATH", "ansible", true},
+		{"mongo [host]", "mongo", false},
+		{"sbom [flags]", "sbom", false},
+		{"aws", "aws", false},
+	}
+	for _, c := range cases {
+		if got := (Connector{Name: c.name, Use: c.use}).RequiresArg(); got != c.want {
+			t.Errorf("RequiresArg(%q) = %v, want %v", c.use, got, c.want)
+		}
+	}
+}
+
+// withTestSource registers a source for one test and takes it out again, so
+// the contract tests that walk the whole registry never see it.
+func withTestSource(t *testing.T, s Source) {
+	t.Helper()
+	if _, taken := sourceByID(s.ID); taken {
+		t.Fatalf("%s is already registered; pick an id no real source uses", s.ID)
+	}
+	register(s)
+	t.Cleanup(func() { delete(registry, s.ID) })
+}
+
+// A load has to be registered under the key its answer will arrive with.
+//
+// It was not. pendingSourceCmds registered m.loading[sourceKeyFor(m.detail.form, src)] -- a
+// key built from the parameters the source declared it needs -- and then
+// started the load with nil parameters, whose answer carries a key built from
+// nil. The delete in the sourceValuesMsg handler therefore matched nothing and
+// the field waited for an answer it had already been given. Only the one
+// CostRemote source had Needs when this was written, and that one skips this
+// path, which is why nothing shipped span; the enumerated and discovery
+// sources put dependent fields straight onto it.
+func TestAPendingLoadIsAnsweredUnderTheKeyItRegistered(t *testing.T) {
+	const id = "test.needs-a-cluster"
+	withTestSource(t, Source{
+		ID:       id,
+		Class:    ClassPostConnection,
+		Cost:     CostInstant,
+		Activity: "reading the test fixture",
+		Tool:     "the test fixture",
+		Needs:    []string{"context"},
+		Fetch:    func([]string) ([]string, error) { return []string{"kube-system"}, nil },
+	})
+
+	m := newTestModel()
+	m.detail.form.SetFields([]field{
+		valued(tuiform.Decl{Label: "context", Flag: "context", Kind: fieldChoice}, "prod-eu"),
+		sourced(tuiform.Decl{Label: "namespace", Flag: "namespace", Kind: fieldChoice}, id),
+	})
+
+	cmds := m.picker.pendingCmds(m.detail.form)
+	if len(cmds) != 1 {
+		t.Fatalf("expected one pending load, got %d", len(cmds))
+	}
+	waits := m.picker.inFlight()
+	if len(waits) != 1 {
+		t.Fatalf("expected one registered wait, got %v", waits)
+	}
+	registered := waits[0]
+	// The parameters are the point: a key with no cluster in it would be a
+	// different cluster's namespace list.
+	if !strings.Contains(registered, "prod-eu") {
+		t.Errorf("the wait was registered without the cluster it is for: %q", registered)
+	}
+
+	msg, ok := cmds[0]().(sourceValuesMsg)
+	if !ok {
+		t.Fatalf("expected a sourceValuesMsg, got %T", cmds[0]())
+	}
+	if msg.key != registered {
+		t.Fatalf("the answer arrived under %q but the wait was registered as %q;\n"+
+			"the spinner can never be cleared", msg.key, registered)
+	}
+
+	nm, _ := m.Update(msg)
+	if left := nm.(Model).picker.inFlight(); len(left) != 0 {
+		t.Errorf("the wait outlived its answer: %v", left)
+	}
+}
+
+// The keychain write must not happen on the event loop.
+//
+// A locked keychain does not fail, it asks: macOS raises an authentication
+// dialog and the call does not return until it is answered. Doing that inside
+// Update froze the whole TUI behind a dialog the launcher was not drawing.
+func TestTheKeychainWriteIsNotOnTheEventLoop(t *testing.T) {
+	release := make(chan struct{})
+	orig := storeCredentialFn
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		<-release
+		return errors.New("keyring unavailable")
+	}
+	defer func() { storeCredentialFn = orig }()
+
+	m := selectEntry(t, newTestModel(), "ssh")
+	m.detail.form.Fields()[fieldIndex(t, m.detail.form, "user@host")].SetValue("chris@10.0.0.4")
+	// identity-file has no --ask-* partner, so this is the inventory route --
+	// the one that puts a credential in the keychain. A password would be
+	// prompted for by the child and never reach one.
+	secret := &m.detail.form.Fields()[fieldIndex(t, m.detail.form, "identity-file")]
+	secret.Secret, secret.Reference = true, false
+	secret.SetValue("<PLACEHOLDER-not-a-real-secret>")
+	m.focus = focusForm
+	m.detail.spot = spotButton
+
+	type result struct {
+		m   Model
+		cmd tea.Cmd
+	}
+	done := make(chan result, 1)
+	go func() {
+		nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		done <- result{nm.(Model), cmd}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("Update did not return while the keychain write was outstanding")
+	}
+	if !got.m.launching.preparing {
+		t.Error("the button has nothing to say while the scan is being prepared")
+	}
+	if got.m.lastRun != "" {
+		t.Errorf("the launch finished inside Update: %q", got.m.lastRun)
+	}
+
+	// And the answer still arrives, with the existing fallback intact: the
+	// scan runs, the secret is off the command line, and the user is told the
+	// guarantee is weaker.
+	close(release)
+	msg, ok := got.cmd().(launchPreparedMsg)
+	if !ok {
+		t.Fatalf("expected a prepared plan, got %T", got.cmd())
+	}
+	if msg.err != nil {
+		t.Fatalf("a keychain failure must not stop the scan: %v", msg.err)
+	}
+	if msg.plan.cleanup != nil {
+		defer msg.plan.cleanup()
+	}
+	if !strings.Contains(msg.plan.warn, "keychain") {
+		t.Errorf("falling back to a file must warn, got %q", msg.plan.warn)
+	}
+	if strings.Contains(strings.Join(msg.plan.args, " "), "<PLACEHOLDER-not-a-real-secret>") {
+		t.Errorf("secret reached argv: %v", msg.plan.args)
+	}
+
+	nm, _ := got.m.Update(msg)
+	after := nm.(Model)
+	if after.launching.preparing {
+		t.Error("the button is still preparing after the plan arrived")
+	}
+	if after.lastRun == "" || after.lastWarn == "" {
+		t.Errorf("the launch was not reported: run=%q warn=%q", after.lastRun, after.lastWarn)
+	}
+}
+
+// A picker owns what it starts, so closing one stops it. Abandoning the result
+// and leaving `gcloud projects list` or `cnspec discover` running to
+// completion is not the same thing.
+func TestClosingAPickerStopsWhatItStarted(t *testing.T) {
+	const id = "test.blocks-until-cancelled"
+	started := make(chan struct{})
+	withTestSource(t, Source{
+		ID:       id,
+		Class:    ClassPostConnection,
+		Cost:     CostRemote,
+		Activity: "asking the test fixture for nothing",
+		Tool:     "the test fixture",
+		FetchCtx: func(ctx context.Context, _ []string) ([]string, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	// The load itself: cancelled means cancelled, and says so rather than
+	// reporting the killed child's own complaint as a failure of the cluster.
+	ctx, cancel := context.WithCancel(context.Background())
+	answers := make(chan tea.Msg, 1)
+	go func() { answers <- loadSourceCmd(ctx, id, nil)() }()
+	<-started
+	cancel()
+
+	var msg sourceValuesMsg
+	select {
+	case got := <-answers:
+		msg, _ = got.(sourceValuesMsg)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the fetch outlived its context")
+	}
+	if !msg.cancelled {
+		t.Errorf("a cancelled load reported itself as an answer: %+v", msg)
+	}
+
+	// And the model's half: opening the picker records how to stop the load,
+	// closing it runs that and clears the wait with it.
+	m := newTestModel()
+	m.detail.form.SetFields([]field{
+		sourced(tuiform.Decl{Label: "project", Flag: "project", Kind: fieldChoice}, id),
+	})
+	if cmd := m.openPickerCmd(m.detail.form.Fields()[0]); cmd == nil {
+		t.Fatal("opening the picker started nothing")
+	}
+	if len(m.picker.cancellable()) != 1 || len(m.picker.inFlight()) != 1 {
+		t.Fatalf("the picker's load was not tracked: cancels=%d loading=%d",
+			len(m.picker.cancellable()), len(m.picker.inFlight()))
+	}
+	m.picker.close()
+	if left := m.picker.cancellable(); len(left) != 0 {
+		t.Errorf("closing the picker left %d loads running", len(left))
+	}
+	if left := m.picker.inFlight(); len(left) != 0 {
+		t.Errorf("closing the picker left the field waiting: %v", left)
+	}
+}
+
+// An explicit DOCKER_HOST silently overrides the context the launcher sets, so
+// the child is cleared of it -- but only when the user actually chose a
+// context, and never for `default`, which *is* the DOCKER_HOST resolution.
+func TestDockerHostCannotOverrideTheChosenContext(t *testing.T) {
+	env := func(t *testing.T, value string) []string {
+		t.Helper()
+		fd := sourced(tuiform.Decl{Label: "context", Kind: fieldChoice}, srcDockerContext)
+		fd.SetValue(value)
+		r := launchRequest{form: tuiform.New("docker", []field{fd})}
+		got, cleanup, err := r.environment()
+		if cleanup != nil {
+			defer cleanup()
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	chosen := env(t, "colima")
+	if !containsString(chosen, dockerContextEnv+"=colima") {
+		t.Fatalf("the chosen context did not reach the child: %v", chosen)
+	}
+	if !containsString(chosen, dockerHostEnv+"=") {
+		t.Errorf("DOCKER_HOST still overrides the chosen context: %v", chosen)
+	}
+
+	// `default` is not a host of its own; it is the DOCKER_HOST-and-socket
+	// resolution, so clearing the variable there would retarget the scan.
+	fallback := env(t, dockerDefaultContext)
+	for _, e := range fallback {
+		if strings.HasPrefix(e, dockerHostEnv+"=") {
+			t.Errorf("the default context cleared DOCKER_HOST: %v", fallback)
+		}
+	}
+}
+
+// Quitting removes what the launcher wrote. The generated inventory holds a
+// plaintext credential whenever the keychain was unavailable, and it used to
+// be removed on exactly one event: the command it fed finishing.
+func TestQuittingRemovesTheGeneratedInventory(t *testing.T) {
+	inv := t.TempDir()
+	path := filepath.Join(inv, "inventory.yml")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestModel()
+	m.launching.cleanup = trackTemp(func() { _ = os.RemoveAll(inv) })
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c did not quit")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("quitting left the generated inventory behind: %v", err)
+	}
+	if nm.(Model).launching.cleanup != nil {
+		t.Error("the launcher still holds a cleanup it has already run")
+	}
+
+	// And the same from the list's own esc, which is the ordinary way out.
+	inv2 := t.TempDir()
+	m2 := newTestModel()
+	m2.launching.cleanup = trackTemp(func() { _ = os.RemoveAll(inv2) })
+	if _, cmd := m2.Update(tea.KeyMsg{Type: tea.KeyEsc}); cmd == nil {
+		t.Fatal("esc did not quit an empty search")
+	}
+	if _, err := os.Stat(inv2); !os.IsNotExist(err) {
+		t.Errorf("quitting with esc left %s behind", inv2)
+	}
+}
+
+// fieldIndex finds a field by label.
+func fieldIndex(t *testing.T, f form, label string) int {
+	t.Helper()
+	for i, fd := range f.Fields() {
+		if fd.Label == label {
+			return i
+		}
+	}
+	t.Fatalf("no field labelled %q", label)
+	return -1
+}

--- a/apps/cnspec/cmd/interactive/parsecli_test.go
+++ b/apps/cnspec/cmd/interactive/parsecli_test.go
@@ -1,0 +1,524 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	deliverypkg "go.mondoo.com/cnspec/cli/launcher/delivery"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// Two kinds of test live here and they are answering different questions.
+//
+// The per-connector tests all over this package ask what the *launcher* does
+// with a provider's answer, and they use the fake below. Spawning a plugin
+// subprocess per case would make the suite a provider integration test that
+// happens to be shaped like a unit test, and it would skip entirely wherever
+// the provider is not installed -- which on CI is everywhere, since
+// PROVIDERS_PATH points at an empty directory.
+//
+// TestEveryCredentialFieldRoundTrips asks the other question: whether the real
+// providers actually answer the way this whole approach assumes. It runs
+// against whatever is installed and reports what it could not check.
+
+// fakeParser stands in for a provider. It records what it was asked and answers
+// the way the well-behaved majority do: flags become connection options and the
+// one marked secret becomes a typed credential.
+type fakeParser struct {
+	provider  string
+	connector string
+	args      []string
+	flags     map[string]*llx.Primitive
+	// secretFlag is the flag the fake turns into a credential rather than an
+	// option. Empty means every flag becomes an option, which is how the four
+	// providers that never read conn.Credentials behave.
+	secretFlag string
+	// classify decides which flags become credentials when secretFlag names
+	// nothing in particular. See defaultTestParser.
+	classify func(flag string) bool
+	// asset overrides the answer entirely, for a test about one provider's
+	// particular shape.
+	asset *inventory.Asset
+	err   error
+}
+
+// answer is the stand-in's ParseCLI.
+func (p *fakeParser) answer(provider, connector string, args []string, flags map[string]*llx.Primitive) (*inventory.Asset, error) {
+	p.provider, p.connector, p.args, p.flags = provider, connector, args, flags
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.asset != nil {
+		return p.asset, nil
+	}
+	conn := &inventory.Config{Type: connector, Options: map[string]string{}}
+	for name, prim := range flags {
+		value := string(prim.Value)
+		credential := name == p.secretFlag
+		if p.secretFlag == "" && p.classify != nil {
+			credential = p.classify(name)
+		}
+		if credential {
+			conn.Credentials = append(conn.Credentials,
+				&vault.Credential{Type: vault.CredentialType_password, Password: value})
+			continue
+		}
+		conn.Options[name] = value
+	}
+	return &inventory.Asset{Connections: []*inventory.Config{conn}}, nil
+}
+
+// withParser points the launcher at a stand-in provider for the duration of one
+// test.
+func withParser(t *testing.T, p *fakeParser) *fakeParser {
+	t.Helper()
+	prev := parseCLI
+	t.Cleanup(func() { parseCLI = prev })
+	parseCLI = p.answer
+	return p
+}
+
+// defaultTestParser is what the package runs against unless a test says
+// otherwise: a stand-in that turns every credential-shaped flag into a
+// credential, which is what the well-behaved majority of providers do.
+//
+// It is installed from TestMain rather than left to each test to remember,
+// because forgetting means starting a plugin subprocess -- which is slow, and
+// which answers differently on a machine with no providers installed.
+func defaultTestParser() {
+	p := &fakeParser{classify: func(flag string) bool {
+		// The form layer's own classifier, so the stand-in agrees with the
+		// screen about what a secret is.
+		return tuiform.IsSecretFlag(plugin.Flag{Long: flag, Type: plugin.FlagType_String})
+	}}
+	parseCLI = p.answer
+}
+
+// sentValue is what the launcher handed the provider for one flag.
+func (p *fakeParser) sentValue(flag string) (string, bool) {
+	prim, ok := p.flags[flag]
+	if !ok {
+		return "", false
+	}
+	return string(prim.Value), true
+}
+
+// assertCredentialReachesTheProvider is the claim every curated credential
+// makes, and the only one it makes.
+//
+// It used to be a different claim per connector -- "this token travels in
+// GITHUB_TOKEN", "that one travels in DD_API_KEY" -- because the launcher had
+// to name a variable and the name was a fact about the provider that a person
+// had checked. There is no name to get wrong now. What is left is the invariant
+// the whole package exists for: the value reaches the provider, and it does not
+// reach a command line that `ps auxww` publishes.
+func assertCredentialReachesTheProvider(t *testing.T, c Connector, f form, flag, value string) *fakeParser {
+	t.Helper()
+	p := withParser(t, &fakeParser{secretFlag: flag})
+
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		t.Cleanup(plan.cleanup)
+	}
+	if err != nil {
+		t.Fatalf("a typed credential must have somewhere to go: %v", err)
+	}
+
+	if p.connector != c.Name || p.provider != c.Provider {
+		t.Errorf("asked %s/%s, want %s/%s", p.provider, p.connector, c.Provider, c.Name)
+	}
+	got, ok := p.sentValue(flag)
+	if !ok {
+		t.Fatalf("--%s never reached the provider; it was sent %v", flag, sortedKeys(p.flags))
+	}
+	if got != value {
+		t.Errorf("--%s reached the provider as %q, want %q", flag, got, value)
+	}
+	if line := strings.Join(plan.args, " "); strings.Contains(line, value) {
+		t.Fatalf("the credential reached the command line: %v", plan.args)
+	}
+	if joined := strings.Join(plan.env, " "); strings.Contains(joined, value) {
+		t.Fatalf("the credential reached the child's environment: %v", plan.env)
+	}
+	if len(plan.args) < 3 || plan.args[len(plan.args)-2] != "--inventory-file" {
+		t.Fatalf("want a scan driven by an inventory file, got %v", plan.args)
+	}
+	return p
+}
+
+func sortedKeys(m map[string]*llx.Primitive) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// A launch is refused when the provider did not keep the credential.
+//
+// This is the check no table could make, and databricks is why it is a refusal
+// rather than a warning: its credential switch has no default arm, so an
+// untagged credential leaves the token empty and the Databricks SDK then
+// resolves DATABRICKS_TOKEN out of the ambient environment on its own. That
+// does not error. It scans whatever account that variable names.
+func TestALaunchIsRefusedWhenTheProviderDropsTheCredential(t *testing.T) {
+	c := Connector{Provider: "databricks", Name: "databricks"}
+	f := tuiform.New("databricks", []tuiform.Field{secretField("token", "<PLACEHOLDER-not-a-real-secret>")})
+
+	withParser(t, &fakeParser{asset: &inventory.Asset{
+		Connections: []*inventory.Config{{
+			Type: "databricks", Options: map[string]string{"account-id": "123"},
+		}},
+	}})
+
+	_, err := (launchRequest{form: f}).plan(c, scanAction())
+	if err == nil {
+		t.Fatal("the launch went ahead with a credential the provider had dropped")
+	}
+	if !strings.Contains(err.Error(), "--token") {
+		t.Errorf("the refusal does not name the credential that was lost: %v", err)
+	}
+}
+
+// A credential the provider reads as a plain connection option cannot go to the
+// keychain, and the user is told so by name rather than left to assume it did.
+//
+// openai is one of eleven connectors this happens on -- see
+// deliverypkg.PlacedOption for the measured set, which is larger than the four
+// AI connectors it was first noticed on. Refusing them would take working
+// connectors away for an exposure no worse than the environment route they had
+// before --
+// a 0600 file in a 0700 directory, removed after the run, versus
+// /proc/<pid>/environ for the length of it. So it warns, and the warning names
+// the flag.
+func TestAPlaintextOnlyCredentialWarnsAndNamesTheFlag(t *testing.T) {
+	c := Connector{Provider: "openai", Name: "openai"}
+	f := tuiform.New("openai", []tuiform.Field{secretField("token", "<PLACEHOLDER-not-a-real-secret>")})
+
+	// secretFlag empty: every flag becomes an option, which is what these four
+	// providers do.
+	withParser(t, &fakeParser{})
+
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatalf("a plaintext-only credential is a warning, not a refusal: %v", err)
+	}
+	if !strings.Contains(plan.warn, "--token") {
+		t.Errorf("the warning does not name the flag: %q", plan.warn)
+	}
+	if !strings.Contains(plan.warn, "plain text") {
+		t.Errorf("the warning does not say what the exposure is: %q", plan.warn)
+	}
+	if strings.Contains(strings.Join(plan.args, " "), "<PLACEHOLDER-not-a-real-secret>") {
+		t.Fatalf("the key reached argv even so: %v", plan.args)
+	}
+}
+
+// The keychain is not touched for a credential that could not be referenced
+// from the file anyway.
+//
+// Saving one would leave a secret in the OS store that nothing reads, and on
+// macOS it would raise an authentication dialog behind the launcher to put it
+// there.
+func TestNoKeychainWriteForACredentialTheFileCannotReference(t *testing.T) {
+	c := Connector{Provider: "openai", Name: "openai"}
+	f := tuiform.New("openai", []tuiform.Field{secretField("token", "<PLACEHOLDER-not-a-real-secret>")})
+	withParser(t, &fakeParser{})
+
+	writes := 0
+	prev := storeCredentialFn
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		writes++
+		return nil
+	}
+	defer func() { storeCredentialFn = prev }()
+
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writes != 0 {
+		t.Errorf("the keychain was written %d times for a credential it cannot hold", writes)
+	}
+}
+
+// The provider is asked before the keychain is touched, so a launch that gets
+// refused leaves nothing behind in the OS store.
+func TestARefusedLaunchWritesNoKeychainEntry(t *testing.T) {
+	c := Connector{Provider: "databricks", Name: "databricks"}
+	f := tuiform.New("databricks", []tuiform.Field{secretField("token", "<PLACEHOLDER-not-a-real-secret>")})
+	withParser(t, &fakeParser{asset: &inventory.Asset{
+		Connections: []*inventory.Config{{Type: "databricks"}},
+	}})
+
+	writes := 0
+	prev := storeCredentialFn
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		writes++
+		return nil
+	}
+	defer func() { storeCredentialFn = prev }()
+
+	if _, err := (launchRequest{form: f}).plan(c, scanAction()); err == nil {
+		t.Fatal("want a refusal")
+	}
+	if writes != 0 {
+		t.Errorf("a refused launch wrote %d keychain entries", writes)
+	}
+}
+
+// A provider that cannot be asked is a refusal, not a scan with no credential.
+func TestAProviderThatCannotBeAskedRefusesTheLaunch(t *testing.T) {
+	c := Connector{Provider: "ssh", Name: "ssh"}
+	f := tuiform.New("ssh", []tuiform.Field{secretField("password", "<PLACEHOLDER-not-a-real-secret>")})
+	withParser(t, &fakeParser{err: errNoProvider})
+
+	_, err := (launchRequest{form: f}).plan(c, scanAction())
+	if err == nil {
+		t.Fatal("the launch went ahead without asking the provider anything")
+	}
+	if !strings.Contains(err.Error(), "ssh") {
+		t.Errorf("the refusal does not name the connector: %v", err)
+	}
+}
+
+var errNoProvider = &parseError{"cannot start the ssh provider"}
+
+type parseError struct{ msg string }
+
+func (e *parseError) Error() string { return e.msg }
+
+func secretField(flag, value string) tuiform.Field {
+	fd := tuiform.NewField(tuiform.Decl{
+		Label: flag, Flag: flag, Kind: tuiform.KindText,
+		Secret: true, Section: tuiform.SectionCredential,
+	})
+	fd.SetValue(value)
+	return fd
+}
+
+// Whether every connector actually round-trips through ParseCLI is the entire
+// basis for this approach, so it is checked against the real providers rather
+// than reasoned about.
+//
+// For each connector the catalog knows about, and for each credential field on
+// its form, the form is filled the way a user configuring one target fills it
+// -- the TARGET section plus whatever the connector marks required, plus that
+// one credential -- and the connector's own ParseCLI is asked what it means.
+// The value is then looked for in the asset that came back.
+//
+// Only one outcome is a failure: the provider keeping the value nowhere at all.
+// A credential is the good case and an option is the warned case, and both are
+// counted and logged so a change in the split is visible.
+//
+// The counts are logged rather than asserted. CI points PROVIDERS_PATH at an
+// empty directory, so this checks nothing there and says so; a total asserted
+// here would fail on one machine and pass vacuously on the other, and the
+// vacuous pass is the dangerous half.
+func TestEveryCredentialFieldRoundTrips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a provider plugin per connector")
+	}
+
+	// Each entry is a connector, a flag, and why that provider keeps the value
+	// nowhere the launcher can find it. Every one was reproduced against the
+	// installed provider, and every one is a launch the user is refused with a
+	// message naming the flag -- which is the honest answer, because the scan
+	// would otherwise run without the credential.
+	knownLost := map[string]map[string]string{
+		// Verified: alicloud's ParseCLI keeps access-key-id, region, regions,
+		// role-arn and role-session-name, and drops --sts-token entirely.
+		"alicloud": {"sts-token": "the provider's ParseCLI does not read it"},
+
+		// A passphrase with no certificate, a client secret with no client id,
+		// a key passphrase with no key: each provider correctly drops half a
+		// credential. The other half is a field on the same form.
+		"azure": {"certificate-secret": "needs --certificate-path, which this probe leaves empty"},
+		"ms365": {"certificate-secret": "needs --certificate-path, which this probe leaves empty"},
+		"jamf":  {"client-secret": "needs --client-id, which is not in TARGET"},
+		"oci":   {"key-secret": "needs --key-path, which this probe leaves empty"},
+	}
+
+	checked, skipped, lost := 0, 0, 0
+	placements := map[deliverypkg.Placement]int{}
+	connectors := map[string]bool{}
+
+	installed := installedProviders()
+	for _, c := range BuildCatalog() {
+		if !c.DeclaresMetadata() || !installed[c.Provider] {
+			skipped++
+			continue
+		}
+		base := newForm(c)
+		for i := range base.Fields() {
+			fd := base.Fields()[i]
+			if !fd.Secret || fd.Reference || fd.Flag == "" || !base.Visible(i) {
+				continue
+			}
+
+			f := fillOneCredential(c, fd.Identity())
+			req := deliverypkg.RequestFor(f, c.Flags)
+			asset, err := deliverypkg.Parser.ParseCLI(c.Provider, c.Name, req.Args, req.Flags)
+			if err != nil {
+				// The provider refused these settings, which is a fact about
+				// the probe's filling rather than about the round trip. The
+				// launcher surfaces the same message.
+				t.Logf("%s --%s: not checkable here, the provider refused the probe's settings (%v)",
+					c.Name, fd.Flag, err)
+				continue
+			}
+			checked++
+			connectors[c.Name] = true
+
+			placed := deliverypkg.Locate(f, asset)
+			if len(placed) != 1 {
+				t.Errorf("%s --%s: %d located secrets, want exactly one", c.Name, fd.Flag, len(placed))
+				continue
+			}
+			placements[placed[0].Placement]++
+
+			why, expected := knownLost[c.Name][fd.Flag]
+			if placed[0].Placement == deliverypkg.PlacedNowhere {
+				lost++
+				if !expected {
+					t.Errorf("%s --%s: the provider kept the value nowhere, so a launch "+
+						"is refused. Either the flag is not a credential, or the form is "+
+						"missing the field it belongs with; add it to knownLost with the reason.",
+						c.Name, fd.Flag)
+				}
+				continue
+			}
+			if expected {
+				t.Errorf("%s --%s now lands as %v, but is recorded as lost because %s. "+
+					"Drop it from knownLost.", c.Name, fd.Flag, placed[0].Placement, why)
+			}
+		}
+	}
+
+	t.Logf("checked %d credential fields over %d connectors: %d reached a credential the "+
+		"keychain can hold, %d reached a plaintext option, %d were kept nowhere; "+
+		"skipped %d catalog entries with no metadata installed here",
+		checked, len(connectors),
+		placements[deliverypkg.PlacedCredential], placements[deliverypkg.PlacedOption], lost,
+		skipped)
+	if checked == 0 {
+		t.Skipf("no provider is installed here, so nothing was checked (%d catalog entries skipped)", skipped)
+	}
+}
+
+// fillOneCredential fills the form the way a user configuring one target does:
+// the TARGET section, anything the connector marks required, and exactly one
+// credential.
+//
+// The rest of the CREDENTIAL section is deliberately left empty. Filling a
+// second credential makes several providers choose a different authentication
+// path and legitimately drop the one under test -- github prefers its app
+// credentials over --token, junos refuses a password beside an identity file --
+// and a probe that provoked that would be measuring its own filling.
+func fillOneCredential(c Connector, want string) form {
+	f := newForm(c)
+	for i := range f.Fields() {
+		if !f.Visible(i) {
+			continue
+		}
+		fd := &f.Fields()[i]
+		if fd.Special != "" {
+			continue
+		}
+		if fd.Secret {
+			if fd.Identity() == want {
+				fd.SetValue(probeSecretFor(fd.Flag))
+			}
+			continue
+		}
+		if !fd.Required && fd.Section != sectionTarget {
+			continue
+		}
+		// A path-shaped flag is left alone: the provider opens it, and a path
+		// that does not exist is an error about the probe.
+		if strings.Contains(fd.Flag, "-path") || strings.Contains(fd.Flag, "-file") {
+			continue
+		}
+		switch fd.Kind {
+		case fieldBool, fieldCredentialState:
+		case fieldChoice, fieldMultiChoice:
+			if len(fd.Options) == 0 {
+				if fd.Kind == fieldChoice {
+					fd.SetValue("probe")
+				}
+				continue
+			}
+			if fd.Kind == fieldMultiChoice {
+				fd.TogglePick(fd.Options[0])
+			} else {
+				fd.SetValue(fd.Options[0])
+			}
+		default:
+			switch {
+			case fd.Flag == "":
+				if c.Name == "ssh" || c.Name == "winrm" {
+					fd.SetValue("probe@10.0.0.5")
+				} else {
+					fd.SetValue("probe")
+				}
+			case strings.Contains(fd.Flag, "port"):
+				fd.SetValue("443")
+			case strings.Contains(fd.Flag, "url"), strings.Contains(fd.Flag, "endpoint"):
+				fd.SetValue("https://probe.example")
+			case strings.Contains(fd.Flag, "host"):
+				fd.SetValue("probe.example")
+			default:
+				fd.SetValue("probe")
+			}
+		}
+	}
+	return f
+}
+
+// probeSecretFor is a value distinctive enough that finding it in the asset
+// means the provider kept it, rather than that something else happened to be
+// spelled the same way.
+func probeSecretFor(flag string) string {
+	return "cnspec-ui-probe-" + strings.ReplaceAll(flag, "-", "_") +
+		"-" + time.Now().Format("150405")
+}
+
+// installedProviders is what is on this machine, read once.
+//
+// The tests that ask a real provider check this first and skip what is missing.
+// ProviderParser.ParseCLI would otherwise install it, which is right for a
+// launch -- a user who opened a form expects it to work -- and wrong for a test
+// suite: CI points PROVIDERS_PATH at an empty directory, so every one of these
+// would download a provider over the network to answer a question about the
+// launcher.
+var installedProviders = sync.OnceValue(func() map[string]bool {
+	out := map[string]bool{}
+	list, err := providers.ListActive()
+	if err != nil {
+		return out
+	}
+	for _, p := range list {
+		if p.Provider != nil {
+			out[p.Name] = true
+		}
+	}
+	return out
+})

--- a/apps/cnspec/cmd/interactive/phases.go
+++ b/apps/cnspec/cmd/interactive/phases.go
@@ -1,0 +1,166 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// The launcher owns the terminal for the whole session now, so it has three
+// things it can be doing with it rather than one.
+//
+// phaseForm is the launcher proper: the connector list and the fields. From
+// there a scan moves to phaseScanning, which watches a background child, and
+// then to phaseViewing, which delegates the whole screen to the report viewer.
+// Both of the other two lead back to phaseForm, because the point of not
+// handing the terminal to a child process is that the next scan does not need a
+// new program.
+type phase int
+
+const (
+	phaseForm phase = iota
+	phaseScanning
+	phaseViewing
+)
+
+// startScan moves the launcher onto the scanning screen and forks the child.
+func (m Model) startScan(plan launchPlan) (tea.Model, tea.Cmd) {
+	label := "scan"
+	if c, ok := m.list.current(); ok {
+		label = c.Name
+	}
+
+	cmd := m.scan.begin(plan, label)
+	m.phase = phaseScanning
+	// The plan's cleanup belongs to the session now, so the launch path must
+	// not also hold one: releasing the inventory twice is harmless, releasing
+	// it early is not.
+	m.launching.disown()
+
+	return m, tea.Batch(cmd, m.spinner.Tick)
+}
+
+// scanReport opens the viewer on what the child wrote, or explains why it
+// cannot. It stays on Model because those two outcomes are the footer and the
+// viewer, neither of which is the scan's to decide.
+func (m Model) scanReport(msg scanReportMsg) (tea.Model, tea.Cmd) {
+	out, ok := m.scan.finish(msg)
+	if !ok {
+		return m, nil
+	}
+	m.phase = phaseForm
+
+	if msg.err != nil {
+		m.lastErr = scanFailure(msg.err, out)
+		return m, textinput.Blink
+	}
+
+	cmd := m.viewer.open(msg.report, m.width, m.height)
+	m.phase = phaseViewing
+	return m, cmd
+}
+
+// scanFailure is what the user is told when a scan produced no readable report.
+//
+// The child's own output leads, because that is where the reason is: a provider
+// that could not connect, a policy that would not resolve, a credential the
+// remote end refused. The loader's error is about a file and explains nothing
+// on its own.
+func scanFailure(err error, out scanOutcome) string {
+	msg := "the scan produced no report"
+	if lines := lastLines(out.output, 1); len(lines) > 0 {
+		return msg + ": " + strings.TrimSpace(lines[0])
+	}
+	if out.err != nil {
+		return msg + ": " + out.err.Error()
+	}
+	if err != nil {
+		return msg + ": " + err.Error()
+	}
+	return msg
+}
+
+// cancelScan kills the child and returns to the fields.
+func (m Model) cancelScan() (tea.Model, tea.Cmd) {
+	m.scan.abort()
+	m.phase = phaseForm
+	m.lastWarn = "scan cancelled"
+	return m, textinput.Blink
+}
+
+// updateScanning drives the scanning screen. It handles only what that screen
+// can do: cancel, quit, resize, and animate.
+func (m Model) updateScanning(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.list.ensureVisible(m.listH())
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return m.quit()
+		case "esc", "q":
+			return m.cancelScan()
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+// updateViewing delegates to the report viewer.
+//
+// Everything except ctrl+c goes to the viewer's own model, including the keys
+// the launcher would otherwise claim: while a report is open the viewer's key
+// map is the only one, which is what keeps `cnspec report view` and this screen
+// the same program to learn.
+func (m Model) updateViewing(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok && key.String() == "ctrl+c" {
+		// Handled before delegation: ctrl+c quits from anywhere, and the
+		// interception below cannot tell the viewer's ctrl+c from its q.
+		return m.quit()
+	}
+
+	if size, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width, m.height = size.Width, size.Height
+		m.list.ensureVisible(m.listH())
+	}
+
+	return m, m.viewer.update(msg)
+}
+
+// closeViewer returns from the report to the launcher, keeping the report so
+// that leaving it is not the same as losing it.
+func (m Model) closeViewer() (tea.Model, tea.Cmd) {
+	m.phase = phaseForm
+	return m, textinput.Blink
+}
+
+// reopenViewer shows the report of the most recent scan again.
+func (m Model) reopenViewer() (tea.Model, tea.Cmd) {
+	if !m.viewer.loaded {
+		m.lastWarn = "no report yet — run a scan first"
+		return m, nil
+	}
+	m.phase = phaseViewing
+	return m, m.viewer.resize(m.width, m.height)
+}
+
+// interactiveAction reports whether an action has to own the terminal itself.
+//
+// `shell` is the whole list: it is an interactive REPL and it produces no
+// report, so there is nothing for a background child to hand back and nothing
+// for the viewer to draw. Everything else the launcher runs writes a report,
+// and running it in the background is what keeps the launcher on screen.
+func interactiveAction(name string) bool { return name == "shell" }

--- a/apps/cnspec/cmd/interactive/picker.go
+++ b/apps/cnspec/cmd/interactive/picker.go
@@ -1,0 +1,390 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/tui"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// sourceLoad is everything the launcher knows about one source key: what the
+// picker answered with, why it answered with nothing, whether a fetch is still
+// in flight, and how to stop it.
+//
+// It is one record because it used to be four maps -- sourceValues, sourceErrs,
+// loading and cancelLoad -- all keyed by the same string, and four maps are
+// four chances to key the same fact differently. One of those chances was
+// already taken: a load registered under a key scoped by the form's parameters
+// and deleted under an unscoped one left the field spinning for the rest of the
+// session, because the delete never matched the insert. Registration, the
+// answer and the release now go through begin, beginOwned and answer below, and
+// each of those takes the key exactly once.
+//
+// It does not make a mis-keyed load impossible -- a caller that computes the
+// key differently in two places still gets two entries. What it removes is the
+// second failure mode, where the four facts about one key drift apart: a
+// spinner with no load behind it, an error beside values that superseded it, a
+// cancel for a load that already answered.
+type sourceLoad struct {
+	// answered is whether a fetch has come back. It is not the same as having
+	// values: a picker that looked and found nothing has answered, and asking
+	// again would re-run the gcloud that found nothing.
+	answered bool
+	values   []string
+	// err explains an empty answer, so a field can say "cluster unreachable"
+	// rather than look like a cluster with nothing in it.
+	err error
+	// loading is whether a fetch is in flight for this key.
+	loading bool
+	// cancel stops what a picker started. It is nil for the loads a form-open
+	// read begins: those have no picker to close and nothing worth killing.
+	cancel context.CancelFunc
+}
+
+// empty reports whether an entry holds nothing worth keeping, which is what a
+// cancelled load leaves behind. Such an entry is dropped rather than kept as a
+// key that answers "no" to every question.
+func (l sourceLoad) empty() bool { return !l.answered && !l.loading && l.cancel == nil }
+
+// pickerState is the value pickers: the one that is open, what each of them has
+// found, and how to stop the ones still looking.
+//
+// The map is shared with every copy of the Model, which is what lets a value
+// receiver register a load -- see pendingSourceCmds, which is `func (m Model)`
+// and still has to be seen by the model it was called on. Nothing else in here
+// is written from a value receiver.
+type pickerState struct {
+	// loads is one entry per source key: a picker id and the parameters it is
+	// answering for. See sourceKey.
+	loads map[string]sourceLoad
+	// modal is the value picker currently open, if any.
+	modal modalState
+}
+
+func newPickerState() pickerState {
+	return pickerState{loads: map[string]sourceLoad{}}
+}
+
+// known reports whether a source key has already been answered.
+func (p pickerState) known(key string) bool { return p.loads[key].answered }
+
+// cached returns what a picker found for a key, and whether it has answered at
+// all. A picker that answered with nothing returns (nil, true), which is what
+// stops the launcher asking again.
+func (p pickerState) cached(key string) ([]string, bool) {
+	l := p.loads[key]
+	return l.values, l.answered
+}
+
+// waiting reports whether a fetch is in flight for a key.
+func (p pickerState) waiting(key string) bool { return p.loads[key].loading }
+
+// failure is why a key came back empty, if it did.
+func (p pickerState) failure(key string) error { return p.loads[key].err }
+
+// busy reports whether anything at all is being fetched, which is what decides
+// whether the spinner animates: one ticking over a settled screen is noise.
+func (p pickerState) busy() bool {
+	for _, l := range p.loads {
+		if l.loading {
+			return true
+		}
+	}
+	return false
+}
+
+// begin registers a fetch the launcher started on its own account, when a form
+// opened and its cheap file-backed pickers were read.
+//
+// Nothing is registered on a Model built as a literal rather than through
+// NewModel. The load still runs and still answers; it is simply not tracked,
+// which is where the cancellation bookkeeping already stood before these four
+// maps became one -- refusing the load outright would be a worse trade.
+func (p pickerState) begin(key string) {
+	if p.loads == nil {
+		return
+	}
+	l := p.loads[key]
+	l.loading = true
+	p.loads[key] = l
+}
+
+// beginOwned registers a fetch a picker started and the cancel that stops it.
+//
+// A picker owns what it starts: closing it cancels this context, which kills
+// the gcloud or the cnspec discover underneath rather than leaving it to finish
+// for an audience that has left.
+func (p pickerState) beginOwned(key string, cancel context.CancelFunc) {
+	if p.loads == nil {
+		return
+	}
+	l := p.loads[key]
+	if l.cancel != nil {
+		l.cancel()
+	}
+	l.loading, l.cancel = true, cancel
+	p.loads[key] = l
+}
+
+// answer records what a fetch came back with and releases its context.
+//
+// Cancelling a context that has already returned is how it is released, not an
+// abort. A cancelled answer is filed under nothing at all: the picker that
+// asked has been closed, and caching an empty list would leave a key a later
+// picker would then trust.
+func (p pickerState) answer(msg sourceValuesMsg) {
+	if p.loads == nil {
+		return
+	}
+	l := p.loads[msg.key]
+	if l.cancel != nil {
+		l.cancel()
+	}
+	l.loading, l.cancel = false, nil
+
+	if !msg.cancelled {
+		l.answered, l.values = true, msg.values
+		// An error is only kept when it is the whole story. A live refresh that
+		// failed after a cheap read succeeded has values to show, and the list
+		// is what the field says.
+		l.err = nil
+		if msg.err != nil && len(msg.values) == 0 {
+			l.err = msg.err
+		}
+	}
+
+	if l.empty() {
+		delete(p.loads, msg.key)
+		return
+	}
+	p.loads[msg.key] = l
+}
+
+// close shuts the open picker and stops whatever it started.
+//
+// This is the whole of the cancellation policy: a load belongs to the picker
+// that asked for it, and a picker that is gone is not owed an answer. Loads
+// started when the form opened carry no cancel at all, so they run on -- they
+// are file reads, and there is nothing there worth killing.
+func (p *pickerState) close() {
+	p.modal = modalState{}
+	for key, l := range p.loads {
+		if l.cancel == nil {
+			continue
+		}
+		l.cancel()
+		l.loading, l.cancel = false, nil
+		if l.empty() {
+			delete(p.loads, key)
+			continue
+		}
+		p.loads[key] = l
+	}
+}
+
+// inFlight names the keys still being fetched. Only assertions use it: the
+// launcher asks busy() whether to animate and waiting(key) about one field.
+func (p pickerState) inFlight() []string {
+	var out []string
+	for key, l := range p.loads {
+		if l.loading {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// cancellable names the keys whose load a picker owns and could stop.
+func (p pickerState) cancellable() []string {
+	var out []string
+	for key, l := range p.loads {
+		if l.cancel != nil {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// --- what a picker has to say about a field ----------------------------------
+//
+// This is the half of the picker cluster that could not move when pickerState
+// was first pulled out. A pickerState knows only keys; which key a field asks
+// under is a fact about the *form*, because a source declares what it Needs and
+// the answer is the values of those fields right now. The two are joined by
+// sourceKeyFor below, and everything under it takes the form as an argument
+// rather than reaching through a Model to find one.
+
+// sourceParamsFor identify what a picker is answering for, from the fields the
+// source declared it needs. They must be stable: keying the cache on anything
+// generated means a load and its lookup never match, and a complete answer then
+// never reaches the screen.
+func sourceParamsFor(f form, source string) []string {
+	s, ok := sourceByID(source)
+	if !ok || len(s.Needs) == 0 {
+		return nil
+	}
+	var params []string
+	for _, need := range s.Needs {
+		for _, fd := range f.Fields() {
+			// A need names a field by identity, so a source can depend on a
+			// positional. It used to compare against fd.flag, which positional
+			// fields leave empty -- so every dependency worth having was
+			// inexpressible: the gcp id, the container reference and the
+			// github name are all positional, and a source keyed off one
+			// silently answered for the whole connector instead of for the
+			// chosen target.
+			if fd.IsSet() && tuiform.MatchesIdentity(fd, need) {
+				params = append(params, need+"="+fd.Emitted())
+			}
+		}
+	}
+	return params
+}
+
+// sourceKeyFor is the key a source answers under for the form as it now stands.
+func sourceKeyFor(f form, source string) string {
+	return sourceKey(source, sourceParamsFor(f, source))
+}
+
+// fill gives every field the options its picker has already found, for the
+// parameters currently in the form. Pickers that have not run leave the field
+// as free text.
+func (p pickerState) fill(f *form) {
+	for i := range f.Fields() {
+		src := f.Fields()[i].Source()
+		if src == "" {
+			continue
+		}
+		if vals, ok := p.cached(sourceKeyFor(*f, src)); ok {
+			// A live refresh adds to what the cheap read already found rather
+			// than replacing it, so the locally configured answer never
+			// disappears because a network call was slow or refused.
+			if live := f.Fields()[i].LiveSource; live != "" {
+				if extra, ok := p.cached(sourceKeyFor(*f, live)); ok {
+					vals = sortedUnique(append(append([]string{}, vals...), extra...))
+				}
+			}
+			f.Fields()[i].Options = vals
+		} else {
+			// The parameters changed, so whatever was offered belongs to a
+			// different cluster or profile and must not be shown for this one.
+			f.Fields()[i].Options = nil
+		}
+	}
+}
+
+// pendingCmds returns the loads a form's pickers still need.
+//
+// Only the file-backed ones run here. A source that needs a live connection can
+// take seconds and can fail, so it waits until its field is actually opened
+// rather than firing for every field of every form the user passes through.
+func (p pickerState) pendingCmds(f form) []tea.Cmd {
+	var cmds []tea.Cmd
+	seen := map[string]bool{}
+	for _, fd := range f.Fields() {
+		if fd.Source() == "" || deferredSource(fd.Source()) {
+			continue
+		}
+		// The parameters are computed once and used for both halves. They used
+		// to differ: the key the wait was registered under was built from the
+		// form's parameters and the load was started with nil, so the key the
+		// answer came back under was a different string and the delete never
+		// matched. The field then span for the rest of the session. Nothing
+		// shipped hit it -- the only source with Needs was CostRemote and
+		// skipped here -- but the enumerated and discovery sources put
+		// dependent fields on this path, so the two are derived from one value
+		// now rather than written out twice.
+		params := sourceParamsFor(f, fd.Source())
+		key := sourceKey(fd.Source(), params)
+		if seen[key] || p.known(key) || p.waiting(key) {
+			continue
+		}
+		seen[key] = true
+		p.begin(key)
+		cmds = append(cmds, loadSourceCmd(context.Background(), fd.Source(), params))
+	}
+	return cmds
+}
+
+// openCmds loads the values for the field being opened, if they are not already
+// in hand for these parameters.
+//
+// It returns the loads rather than a batch of them: restarting the animation
+// clock is the launcher's job, not the pickers'. See Model.openPickerCmd.
+func (p pickerState) openCmds(f form, fd field) []tea.Cmd {
+	var cmds []tea.Cmd
+	for _, src := range []string{fd.Source(), fd.LiveSource} {
+		if src == "" {
+			continue
+		}
+		params := sourceParamsFor(f, src)
+		key := sourceKey(src, params)
+		if p.known(key) {
+			continue
+		}
+		// A picker owns what it starts. Closing it cancels this context, which
+		// kills the gcloud or the cnspec discover underneath rather than
+		// leaving it to finish for an audience that has left.
+		ctx, cancel := context.WithCancel(context.Background())
+		p.beginOwned(key, cancel)
+		cmds = append(cmds, loadSourceCmd(ctx, src, params))
+	}
+	return cmds
+}
+
+// waitingFor describes what a field is still waiting on, if anything.
+func (p pickerState) waitingFor(f form, fd field) string {
+	for _, src := range []string{fd.Source(), fd.LiveSource} {
+		if src == "" {
+			continue
+		}
+		if p.waiting(sourceKeyFor(f, src)) {
+			return activityFor(src)
+		}
+	}
+	return ""
+}
+
+// liveError reports why a field's live refresh came back with nothing.
+func (p pickerState) liveError(f form, fd field) string {
+	if fd.LiveSource == "" {
+		return ""
+	}
+	if err := p.failure(sourceKeyFor(f, fd.LiveSource)); err != nil {
+		return tui.OneLine(err.Error())
+	}
+	return ""
+}
+
+// choiceHint says why a picker is showing nothing: still working, genuinely
+// empty, or never had a source to begin with.
+func (p pickerState) choiceHint(f form, fd field) string {
+	if fd.Source() == "" {
+		return fd.Placeholder()
+	}
+	if busy := p.waitingFor(f, fd); busy != "" {
+		return busy + "…"
+	}
+	key := sourceKeyFor(f, fd.Source())
+	values, loaded := p.cached(key)
+	switch {
+	case !loaded && deferredSource(fd.Source()):
+		return "press enter to look it up"
+	case !loaded:
+		return activityFor(fd.Source()) + "…"
+	case p.failure(key) != nil:
+		// An empty list and a failed lookup look identical otherwise, and the
+		// reason is usually the only actionable thing on the screen. It is
+		// flattened for the same reason the footer flattens: this goes into a
+		// panel line, and a newline in one makes the panel taller than the
+		// number of lines the layout measured it for.
+		return tui.OneLine(p.failure(key).Error())
+	case len(values) == 0:
+		return "none found — type a value"
+	}
+	return fd.Placeholder()
+}

--- a/apps/cnspec/cmd/interactive/prefill_test.go
+++ b/apps/cnspec/cmd/interactive/prefill_test.go
@@ -1,0 +1,517 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Prefilling a guess the user has to notice and undo is worse than an empty
+// field, so a value is only chosen when the answer is unambiguous.
+func TestPreferredValueOnlyWhenUnambiguous(t *testing.T) {
+	// Exactly one candidate is unambiguous whatever the source.
+	if got, why := preferredValue(srcSSHHost, []string{"jump"}); got != "jump" || why != "only one" {
+		t.Errorf("single host = %q/%q, want jump/only one", got, why)
+	}
+	// Several, with nothing to distinguish them, is not.
+	if got, _ := preferredValue(srcSSHHost, []string{"jump", "prod-web"}); got != "" {
+		t.Errorf("two hosts prefilled %q, want nothing", got)
+	}
+	// The conventional AWS name counts, even when the picker has labelled it.
+	if got, why := preferredValue(srcAWSProfile, []string{"prod", "default  (123456789012)"}); got != "default  (123456789012)" || why != "default" {
+		t.Errorf("aws = %q/%q, want the default profile", got, why)
+	}
+	// This machine's eight profiles include no "default", so nothing is chosen.
+	if got, _ := preferredValue(srcAWSProfile, []string{"chris", "mondoo-dev", "private"}); got != "" {
+		t.Errorf("profiles with no default prefilled %q, want nothing", got)
+	}
+	if got, _ := preferredValue(srcAWSProfile, nil); got != "" {
+		t.Errorf("no values prefilled %q", got)
+	}
+}
+
+// A source that reports after the user has started typing must not move the
+// ground under them.
+func TestPrefillNeverOverwritesTypedInput(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	m.focus = focusForm
+	m.detail.form.SetCursor(0)
+	m.detail.loadCursorField()
+	m = typeString(m, "root@10.0.0.9")
+
+	m.detail.applyPrefill(srcSSHHost, []string{"jump"}, m.focus == focusForm)
+	if got := m.detail.form.Fields()[0].Value(); got != "root@10.0.0.9" {
+		t.Fatalf("a late source overwrote typed input: %q", got)
+	}
+	if m.detail.form.Fields()[0].Prefilled() != "" {
+		t.Error("a field the user typed must not be marked prefilled")
+	}
+}
+
+// A prefilled field says why, so a value nobody typed is not a small mystery.
+func TestPrefilledValueExplainsItself(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 140, 40), "ssh")
+	m.detail.applyPrefill(srcSSHHost, []string{"only-host"}, m.focus == focusForm)
+
+	fd := m.detail.form.Fields()[0]
+	if fd.Value() != "only-host" || fd.Prefilled() != "only one" {
+		t.Fatalf("field = %q/%q, want it filled and explained", fd.Value(), fd.Prefilled())
+	}
+	if out := m.View(); !strings.Contains(out, "only one") {
+		t.Error("the reason a field filled itself should be on screen")
+	}
+}
+
+// The cheap sources run when a form opens so the target is already there; the
+// ones that reach a cluster wait to be asked.
+func TestCheapSourcesLoadOnOpenAndRemoteOnesDoNot(t *testing.T) {
+	if deferredSource(srcSSHHost) || deferredSource(srcDockerContainer) {
+		t.Error("file and local-daemon sources should not be deferred")
+	}
+	if !deferredSource(srcK8sNamespace) {
+		t.Error("a source that queries a cluster should be deferred")
+	}
+
+	m := selectEntry(t, newTestModel(), "ssh")
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = nm.(Model)
+	if m.focus != focusForm {
+		t.Fatalf("expected the fields to open, got %d", m.focus)
+	}
+	if cmd == nil {
+		t.Fatal("opening the fields should start the cheap pickers")
+	}
+}
+
+// Prefilling must leave the command runnable, not merely populated.
+func TestPrefillMakesTheCommandComplete(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	if m.readyToRun() {
+		t.Fatal("ssh is not runnable before its target is known")
+	}
+	m.detail.applyPrefill(srcSSHHost, []string{"only-host"}, m.focus == focusForm)
+	if !m.readyToRun() {
+		t.Fatal("a prefilled target should leave the command runnable")
+	}
+
+	conn, _ := m.list.current()
+	if got := m.commandPreview(conn); got != "cnspec scan ssh only-host" {
+		t.Fatalf("command = %q", got)
+	}
+	if !strings.Contains(m.runButton(), "scan") {
+		t.Fatalf("affordance should now offer to scan, got %q", m.runButton())
+	}
+}
+
+// k8s asks what shape of thing is being scanned first, and then only what that
+// shape needs. A cluster screen must not ask for a manifest path, and a
+// manifest screen must not ask which cluster.
+func TestK8sFormIsGuidedByWhatToScan(t *testing.T) {
+	c := Connector{
+		Provider: "k8s", Name: "k8s", Use: "k8s", Category: catContainer,
+		Installed: true, MaxArgs: 1,
+		Flags: []plugin.Flag{
+			{Long: "context", Type: plugin.FlagType_String},
+			{Long: "namespaces", Type: plugin.FlagType_String},
+			{Long: "kubelogin", Type: plugin.FlagType_Bool},
+		},
+		Discovery: []string{"pods", "namespaces"},
+	}
+	f := newForm(c)
+
+	labels := func() []string {
+		var out []string
+		for _, i := range f.VisibleIndices() {
+			out = append(out, f.Fields()[i].Label)
+		}
+		return out
+	}
+
+	// Before anything is chosen, only the question itself is asked.
+	if got := labels(); !containsString(got, "what to scan") {
+		t.Fatalf("expected the shape question, got %v", got)
+	}
+	for _, hidden := range []string{"manifest path", "cluster", "namespaces (optional)"} {
+		if containsString(labels(), hidden) {
+			t.Errorf("%q should be hidden until a shape is chosen: %v", hidden, labels())
+		}
+	}
+
+	fieldByLabel(t, f, "what to scan").SetValue("live cluster")
+	if got := labels(); !containsString(got, "cluster") || !containsString(got, "namespaces (optional)") {
+		t.Errorf("a live cluster should ask for a cluster and namespaces, got %v", got)
+	}
+	if containsString(labels(), "manifest path") {
+		t.Errorf("a live cluster must not ask for a manifest path: %v", labels())
+	}
+
+	fieldByLabel(t, f, "what to scan").SetValue("manifest file")
+	if got := labels(); !containsString(got, "manifest path") {
+		t.Errorf("a manifest should ask for a path, got %v", got)
+	}
+	for _, hidden := range []string{"cluster", "namespaces (optional)"} {
+		if containsString(labels(), hidden) {
+			t.Errorf("a manifest must not ask for %q: %v", hidden, labels())
+		}
+	}
+}
+
+// A value left behind by an abandoned branch must not travel with the command.
+func TestHiddenFieldsDoNotReachTheCommand(t *testing.T) {
+	c := Connector{
+		Provider: "k8s", Name: "k8s", Use: "k8s", Installed: true, MaxArgs: 1,
+		Flags: []plugin.Flag{{Long: "context", Type: plugin.FlagType_String}},
+	}
+	f := newForm(c)
+	fieldByLabel(t, f, "what to scan").SetValue("manifest file")
+	fieldByLabel(t, f, "manifest path").SetValue("./deploy.yaml")
+	// Set a cluster, then switch away from the branch that asked for it.
+	fieldByLabel(t, f, "cluster").SetValue("some-cluster")
+
+	got := strings.Join(f.Args(), " ")
+	if strings.Contains(got, "some-cluster") {
+		t.Fatalf("a hidden field reached the command: %q", got)
+	}
+	if got != "./deploy.yaml" {
+		t.Fatalf("args = %q, want just the manifest path", got)
+	}
+}
+
+// A hidden required field cannot block the scan, or choosing a manifest would
+// be refused for want of a cluster.
+func TestHiddenRequiredFieldDoesNotBlock(t *testing.T) {
+	c := Connector{Provider: "k8s", Name: "k8s", Use: "k8s", Installed: true, MaxArgs: 1}
+	f := newForm(c)
+	fieldByLabel(t, f, "what to scan").SetValue("live cluster")
+	if err := f.Validate(); err != nil {
+		t.Fatalf("a live cluster should not need the manifest path: %v", err)
+	}
+}
+
+// A single-letter shortcut in a pane full of text fields steals keystrokes:
+// an "o" shortcut turned root@host into rot@host. Every letter must reach the
+// field being edited.
+func TestLettersReachTheFieldBeingEdited(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "ssh")
+	m = key(m, tea.KeyTab)
+	m = typeString(m, "root@options.example")
+
+	if got := m.detail.form.Fields()[m.detail.form.Cursor()].Value(); got != "root@options.example" {
+		t.Fatalf("typed value came out as %q", got)
+	}
+}
+
+// The long tail of provider flags folds away behind one row, which is a focus
+// stop rather than a shortcut.
+func TestOptionsFoldAwayBehindAFocusStop(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+	m = key(m, tea.KeyTab)
+
+	if !m.detail.hasMoreRow() {
+		t.Fatal("ssh declares options, so there should be a row to reveal them")
+	}
+	for _, i := range m.detail.focusableFields() {
+		if m.detail.form.Fields()[i].Section == sectionOptions {
+			t.Fatalf("%q should be folded away", m.detail.form.Fields()[i].Label)
+		}
+	}
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "more options") {
+		t.Errorf("the fold should be visible:\n%s", out)
+	}
+
+	// Tab to it and open it.
+	for i := 0; i < 20 && !m.detail.onMore(); i++ {
+		m = key(m, tea.KeyTab)
+	}
+	if !m.detail.onMore() {
+		t.Fatal("tab should reach the reveal row")
+	}
+	m = key(m, tea.KeyEnter)
+	if !m.detail.showOptions {
+		t.Fatal("enter should reveal the options")
+	}
+	found := false
+	for _, i := range m.detail.focusableFields() {
+		if m.detail.form.Fields()[i].Section == sectionOptions {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("revealed options should be reachable")
+	}
+}
+
+// A modal row must never wrap.
+//
+// The previous version of this test only checked lines against the terminal
+// width, which the box never approaches, so it passed while every row inside
+// the box wrapped by exactly the padding. This one measures the box itself: a
+// wrapped row makes the box taller than the rows it is showing.
+func TestModalRowsNeverWrap(t *testing.T) {
+	long := []string{
+		"arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster",
+		"default/api-mondoo-rosa1-49nm-p1-openshiftapps-com:6443/chris@mondoo.com",
+		"gke_coding-agents-495409_us-central1_airlock",
+		"short",
+	}
+	for _, size := range []struct{ w, h int }{{100, 30}, {80, 24}, {140, 40}} {
+		m := selectEntry(t, sized(newTestModel(), size.w, size.h), "ssh")
+		setSource(&m, srcSSHHost, long)
+		m = key(m, tea.KeyTab)
+		nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = nm.(Model)
+		if !m.picker.modal.open {
+			t.Fatalf("%dx%d: expected the picker to open", size.w, size.h)
+		}
+
+		lines := strings.Split(ansi.Strip(m.View()), "\n")
+		if len(lines) != size.h {
+			t.Fatalf("%dx%d: view is %d lines, want %d", size.w, size.h, len(lines), size.h)
+		}
+
+		// The box is every line carrying a border glyph.
+		boxW, contentW := modalGeom(size.w)
+		var box []string
+		for _, ln := range lines {
+			if strings.ContainsAny(ln, "│╭╰") {
+				box = append(box, strings.TrimSpace(ln))
+			}
+		}
+		if len(box) == 0 {
+			t.Fatalf("%dx%d: no modal box rendered", size.w, size.h)
+		}
+
+		// Every box line is the same width, and that width is what the geometry
+		// says. A wrapped row would not change this, so height is checked next.
+		for i, ln := range box {
+			if w := tui.Width(ln); w != boxW+2*modalBorder {
+				t.Errorf("%dx%d: box line %d is %d wide, want %d", size.w, size.h, i, w, boxW+2*modalBorder)
+			}
+		}
+
+		// 2 border + 2 padding + title + desc + blank + 4 rows + blank + help.
+		wantHeight := 2 + 2 + 1 + 1 + 1 + len(long) + 1 + 1
+		if len(box) != wantHeight {
+			t.Errorf("%dx%d: box is %d lines, want %d — a row wrapped",
+				size.w, size.h, len(box), wantHeight)
+		}
+
+		// Every value is on exactly one line, and the long ones keep their tail
+		// so they can be told apart.
+		joined := strings.Join(box, "\n")
+		if !strings.Contains(joined, "cluster/patrick-container-escape-demo-azql-cluster") &&
+			!strings.Contains(joined, "azql-cluster") {
+			t.Errorf("%dx%d: the identifying end of the ARN was cut:\n%s", size.w, size.h, joined)
+		}
+		_ = contentW
+	}
+}
+
+// Cutting the head of an over-long value keeps the part that identifies it.
+func TestTruncateKeepsTheTail(t *testing.T) {
+	arn := "arn:aws:eks:us-east-2:921877552404:cluster/patrick1"
+	got := truncateTail(arn, 20)
+	if tui.Width(got) != 20 {
+		t.Fatalf("width = %d, want 20 (%q)", tui.Width(got), got)
+	}
+	if !strings.HasSuffix(got, "patrick1") {
+		t.Fatalf("truncation dropped the cluster name: %q", got)
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Fatalf("a cut value should say so: %q", got)
+	}
+	if short := truncateTail("chris-dev", 20); short != "chris-dev" {
+		t.Fatalf("a value that fits should be untouched, got %q", short)
+	}
+}
+
+// gcp is guided the same way k8s is: ask what is being scanned, then only what
+// that answer needs.
+func TestGCPFormIsGuidedByWhatToScan(t *testing.T) {
+	c := Connector{
+		Provider: "gcp", Name: "gcp", Use: "gcp", Category: catCloud,
+		Installed: true, MaxArgs: 2,
+		Flags: []plugin.Flag{
+			{Long: "project-id", Type: plugin.FlagType_String},
+			{Long: "zone", Type: plugin.FlagType_String},
+			{Long: "repository", Type: plugin.FlagType_String},
+			{Long: "credentials-path", Type: plugin.FlagType_String, Desc: "The path to the service account credentials"},
+		},
+	}
+	f := newForm(c)
+	labels := func() []string {
+		var out []string
+		for _, i := range f.VisibleIndices() {
+			out = append(out, f.Fields()[i].Label)
+		}
+		return out
+	}
+
+	fieldByLabel(t, f, "what to scan").SetValue("project")
+	fieldByLabel(t, f, "id").SetValue("attack-surface-scanner")
+	if got := strings.Join(f.Args(), " "); got != "project attack-surface-scanner" {
+		t.Fatalf("args = %q, want the sub-command the connector documents", got)
+	}
+	for _, hidden := range []string{"project", "zone", "repository"} {
+		for _, l := range labels() {
+			if l == hidden && hidden != "project" {
+				t.Errorf("a project scan must not ask for %q", hidden)
+			}
+		}
+	}
+
+	// An instance is addressed by project and zone.
+	fieldByLabel(t, f, "what to scan").SetValue("compute instance")
+	if got := labels(); !containsString(got, "project") || !containsString(got, "zone") {
+		t.Errorf("an instance should ask for project and zone, got %v", got)
+	}
+	fieldByLabel(t, f, "id").SetValue("web-1")
+	fieldByLabel(t, f, "project").SetValue("attack-surface-scanner")
+	fieldByLabel(t, f, "zone").SetValue("us-central1-c")
+	got := strings.Join(f.Args(), " ")
+	if got != "instance web-1 --project-id attack-surface-scanner --zone us-central1-c" {
+		t.Fatalf("args = %q", got)
+	}
+
+	// A registry is addressed by repository, not by zone.
+	fieldByLabel(t, f, "what to scan").SetValue("container registry")
+	if got := labels(); !containsString(got, "repository") || containsString(got, "zone") {
+		t.Errorf("a registry should ask for a repository and not a zone, got %v", got)
+	}
+}
+
+// The active gcloud project is prefilled, the way the current kube context is.
+func TestGCPPrefillsTheActiveProject(t *testing.T) {
+	value, why := preferredValue(srcGCPProject, []string{"other-project", gcpActiveProject()})
+	if gcpActiveProject() == "" {
+		t.Skip("no gcloud configuration on this machine")
+	}
+	if value != gcpActiveProject() || why != "active" {
+		t.Fatalf("prefill = %q/%q, want the active project", value, why)
+	}
+	// Two projects with no active one is ambiguous, so nothing is chosen.
+	if got, _ := preferredValue(srcGCPProject, []string{"a-project", "b-project"}); got != "" {
+		t.Errorf("prefilled %q where the answer is ambiguous", got)
+	}
+}
+
+// The cheap local read and the live list are merged, so the configured project
+// never disappears because the network call was slow or refused.
+func TestLiveValuesMergeWithLocalOnes(t *testing.T) {
+	c := Connector{
+		Provider: "gcp", Name: "gcp", Use: "gcp", Category: catCloud,
+		Installed: true, MaxArgs: 2,
+		Flags: []plugin.Flag{{Long: "project-id", Type: plugin.FlagType_String}},
+	}
+	m := NewModel([]Connector{c})
+	m.syncSelection()
+	fieldByLabel(t, m.detail.form, "what to scan").SetValue("project")
+	resolveSources(&m.detail.form) // the selector decides which picker the id uses
+
+	id := fieldByLabel(t, m.detail.form, "id")
+	if id.Source() != srcGCPProject || id.LiveSource != srcGCPProjectAll {
+		t.Fatalf("id field sources = %q/%q, want the local read plus the live list", id.Source(), id.LiveSource)
+	}
+
+	setSource(&m, srcGCPProject, []string{"attack-surface-scanner"})
+	m.picker.fill(&m.detail.form)
+	if got := fieldByLabel(t, m.detail.form, "id").Options; len(got) != 1 {
+		t.Fatalf("before the live call the picker should hold the configured project, got %v", got)
+	}
+
+	setSource(&m, srcGCPProjectAll, []string{"mondoo-demo", "attack-surface-scanner"})
+	m.picker.fill(&m.detail.form)
+	got := fieldByLabel(t, m.detail.form, "id").Options
+	if len(got) != 2 || !containsString(got, "attack-surface-scanner") || !containsString(got, "mondoo-demo") {
+		t.Fatalf("merged options = %v, want both without duplicates", got)
+	}
+}
+
+// Opening the picker starts the live call; entering the form does not.
+func TestLiveListWaitsUntilThePickerOpens(t *testing.T) {
+	if !deferredSource(srcGCPProjectAll) {
+		t.Fatal("the live project list must not run on entering a form")
+	}
+	if deferredSource(srcGCPProject) {
+		t.Fatal("the configured project is a file read and should load immediately")
+	}
+}
+
+// A live list belongs to the selector that asked for it. Left attached across a
+// change of kind, an organization id would be offered a list of projects, and
+// the picker would sit there fetching them.
+func TestLiveSourceFollowsTheSelector(t *testing.T) {
+	c := Connector{
+		Provider: "gcp", Name: "gcp", Use: "gcp", Category: catCloud,
+		Installed: true, MaxArgs: 2,
+	}
+	f := newForm(c)
+	kind := fieldByLabel(t, f, "what to scan")
+
+	for _, tc := range []struct{ kind, source, live string }{
+		{"project", srcGCPProject, srcGCPProjectAll},
+		{"container registry", srcGCPProject, srcGCPProjectAll},
+		{"organization", "", ""},
+		{"folder", "", ""},
+		{"compute instance", "", ""},
+	} {
+		kind.SetValue(tc.kind)
+		resolveSources(&f)
+		id := fieldByLabel(t, f, "id")
+		if id.Source() != tc.source || id.LiveSource != tc.live {
+			t.Errorf("kind %q: sources = %q/%q, want %q/%q",
+				tc.kind, id.Source(), id.LiveSource, tc.source, tc.live)
+		}
+	}
+}
+
+// A field with nothing to offer and nowhere to get anything is a text field.
+// Opening an empty box over it hides the only thing that works: typing.
+func TestNoPickerWhenThereIsNothingToPick(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "aws")
+	m = key(m, tea.KeyTab)
+	// Find a plain text field with no source.
+	for i, fd := range m.detail.form.Fields() {
+		if fd.Kind == fieldChoice && fd.Source() == "" && fd.LiveSource == "" && len(fd.Options) == 0 {
+			m.detail.form.SetCursor(i)
+			nm, _ := m.openModal()
+			if nm.(Model).picker.modal.open {
+				t.Fatalf("%q has nothing to offer but opened a picker", fd.Label)
+			}
+		}
+	}
+}
+
+// A wait says what it is waiting for, and names the tool, so the user knows
+// which credentials matter and what to run if it goes wrong.
+func TestWaitNamesTheToolBeingAsked(t *testing.T) {
+	for src, want := range map[string]string{
+		srcGCPProjectAll: "gcloud",
+		srcK8sNamespace:  "kubectl",
+		srcKubeContext:   "kubectl",
+		srcDockerImage:   "docker",
+	} {
+		if got := activityFor(src); !strings.Contains(got, want) {
+			t.Errorf("activity for %q = %q, want it to name %q", src, got, want)
+		}
+	}
+
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+	m = key(m, tea.KeyTab)
+	fd := m.detail.form.Fields()[m.detail.form.Cursor()]
+	m.picker.begin(sourceKeyFor(m.detail.form, fd.Source()))
+	if got := m.picker.waitingFor(m.detail.form, fd); !strings.Contains(got, "ssh") {
+		t.Fatalf("waitingFor = %q, want it to name what is being read", got)
+	}
+	m.picker.modal = modalState{open: true, field: m.detail.form.Cursor()}
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "reading ~/.ssh/config") {
+		t.Errorf("the picker should say what it is waiting for:\n%s", out)
+	}
+}

--- a/apps/cnspec/cmd/interactive/preview_test.go
+++ b/apps/cnspec/cmd/interactive/preview_test.go
@@ -1,0 +1,162 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// The command bar says "$ <command>", and a user reads it to decide whether to
+// press the button. It was allowed to be wrong in two ways at once, and both
+// were the same mistake: a second place that assembled the words.
+//
+// plan() puts --incognito on the command through verb() when the user has asked
+// to keep the results on this machine. The preview built its own prefix out of
+// []string{"cnspec", a.Name, c.Name} and could not know, so the bar showed a
+// command that reported upstream while the button ran one that did not. The
+// inventory route went further and dropped the flag from the *command*: it
+// assembled []string{a.Name, "--inventory-file", path} directly, so a user who
+// chose incognito on the one route that carries a credential got a scan that
+// reported upstream anyway.
+//
+// The cases below are one per route, run with the choice both ways, because a
+// route that never carries the flag and a route that always does are both
+// wrong in a way a single-value test would miss. There are two routes now
+// rather than four, and the one that matters is still the one carrying the
+// credential.
+func TestPreviewAndLaunchAgreeOnTheIncognitoChoice(t *testing.T) {
+	// The keychain is asked for the inventory route, and a locked one blocks on
+	// an OS dialog. Failing it takes the documented fallback -- the 0600 file --
+	// which is the branch that assembles the argument list either way.
+	orig := storeCredentialFn
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		return errors.New("keyring unavailable")
+	}
+	defer func() { storeCredentialFn = orig }()
+
+	for _, tc := range []struct {
+		name   string
+		conn   Connector
+		fill   func(t *testing.T, f *form)
+		secret string
+		want   delivery
+	}{
+		{
+			name: "plain",
+			conn: awsConnector(),
+			fill: func(t *testing.T, f *form) { fieldByLabel(t, *f, "profile").SetValue("prod") },
+			want: deliverPlain,
+		},
+		{
+			name: "inventory, host connector",
+			conn: sshConnector(),
+			fill: func(t *testing.T, f *form) {
+				fieldByLabel(t, *f, "user@host").SetValue("chris@10.0.0.4")
+				fieldByLabel(t, *f, "password").SetValue(sentinel)
+			},
+			secret: "password",
+			want:   deliverInventory,
+		},
+		{
+			name:   "inventory, API token",
+			conn:   githubConnector(),
+			fill:   func(t *testing.T, f *form) { fieldByLabel(t, *f, "personal access token").SetValue(sentinel) },
+			secret: "token",
+			want:   deliverInventory,
+		},
+	} {
+		for _, incognito := range []bool{false, true} {
+			f := newForm(tc.conn)
+			tc.fill(t, &f)
+			r := launchRequest{form: f, incognito: incognito}
+			withParser(t, &fakeParser{secretFlag: tc.secret})
+
+			if got := deliveryFor(f); got != tc.want {
+				t.Fatalf("%s: route = %v, want %v -- the case no longer covers what it names", tc.name, got, tc.want)
+			}
+
+			preview := r.preview(tc.conn, scanAction())
+			plan, err := r.plan(tc.conn, scanAction())
+			if plan.cleanup != nil {
+				defer plan.cleanup()
+			}
+			if err != nil {
+				t.Fatalf("%s (incognito=%v): plan: %v", tc.name, incognito, err)
+			}
+
+			inPreview := strings.Contains(preview, "--incognito")
+			inCommand := containsString(plan.args, "--incognito")
+			if inPreview != inCommand {
+				t.Errorf("%s (incognito=%v): the bar shows --incognito=%v and the command has it=%v\n  bar: %s\n  cmd: cnspec %s",
+					tc.name, incognito, inPreview, inCommand, preview, strings.Join(plan.args, " "))
+			}
+			if inCommand != incognito {
+				t.Errorf("%s: the user chose incognito=%v and the command reads %v",
+					tc.name, incognito, strings.Join(plan.args, " "))
+			}
+			if strings.Contains(preview, sentinel) {
+				t.Errorf("%s: the bar showed the secret: %q", tc.name, preview)
+			}
+		}
+	}
+}
+
+// The route whose words are fully known before anything is written has to match
+// the command exactly, not merely agree about one flag.
+//
+// The inventory route is deliberately excluded: its path is created by plan(),
+// so the bar names "<generated, 0600>" instead. That difference is the intended
+// one -- a path shown before the file exists would be a lie by the time it was
+// read -- and everything ahead of it is checked above.
+func TestPreviewIsTheCommandWordForWord(t *testing.T) {
+	conn := awsConnector()
+	for _, incognito := range []bool{false, true} {
+		f := newForm(conn)
+		fieldByLabel(t, f, "profile").SetValue("prod")
+		r := launchRequest{form: f, incognito: incognito}
+
+		plan, err := r.plan(conn, scanAction())
+		if plan.cleanup != nil {
+			defer plan.cleanup()
+		}
+		if err != nil {
+			t.Fatalf("plan: %v", err)
+		}
+		want := "cnspec " + strings.Join(plan.args, " ")
+		if got := r.preview(conn, scanAction()); got != want {
+			t.Errorf("incognito=%v:\n bar %q\n cmd %q", incognito, got, want)
+		}
+	}
+}
+
+// The bar names the file rather than a path, because writing the file is what
+// pressing the button does.
+//
+// It also no longer says "cnspec cannot carry --x safely yet" for anything.
+// That message was the preview's way of showing a refusal it could compute from
+// the form alone; whether a credential can be carried is now the provider's
+// answer, and it arrives at launch.
+func TestTheInventoryPreviewNamesTheFileItWillWrite(t *testing.T) {
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+
+	got := (launchRequest{form: f}).preview(c, scanAction())
+	want := "cnspec scan --inventory-file <generated, 0600>"
+	if got != want {
+		t.Errorf("bar = %q, want %q", got, want)
+	}
+	// The connector's name is absent on purpose: the inventory carries the
+	// connection type, and naming a target as well makes cnspec parse one it
+	// then discards. Verified live -- `cnspec scan local --inventory-file <ssh
+	// asset>` scans the ssh asset and never touches this machine.
+	if strings.Contains(got, " ssh ") {
+		t.Errorf("the bar names a target beside the inventory file: %q", got)
+	}
+}

--- a/apps/cnspec/cmd/interactive/reach_test.go
+++ b/apps/cnspec/cmd/interactive/reach_test.go
@@ -1,0 +1,335 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// How far the launcher reaches, asserted so that the numbers cannot quietly
+// stop being true.
+//
+// Every other test in this package checks one connector, or one file's worth of
+// them, against something its author knew. This checks the opposite direction:
+// that no connector fell through the gaps between those files. A connector
+// nobody was assigned looks exactly like a connector somebody decided not to
+// curate, and the only difference is whether a reason was written down.
+//
+// # The denominator moves, so nothing here counts
+//
+// The catalog is the union of the static DefaultProviders list compiled into
+// the binary and whatever providers are installed locally: 88 providers and 94
+// connectors on the machine this was written on, 103 names in the union, and a
+// different number on a colleague's laptop. Worse, CI points PROVIDERS_PATH at
+// an empty directory, so BuildCatalog() degenerates to the flagless static
+// list.
+//
+// A test asserting a total would therefore fail on one machine and pass
+// vacuously on the other -- and the vacuous pass is the dangerous half, because
+// green is exactly what a reach test is supposed to mean. So every assertion
+// below is a property of one connector, evaluated over whatever the catalog
+// happens to hold, and anything that could not be checked is counted and named
+// in the log. A green run that skipped ninety connectors says so.
+//
+// The snapshot is what keeps that number small. internal/connectors/connectors.json is
+// checked in, so the form-shape checks run against real metadata even where no
+// provider is installed; only a connector that is in neither the snapshot nor
+// the local catalog is genuinely uncheckable.
+
+// reachEntry is one connector to check, from whichever source knew about it.
+type reachEntry struct {
+	name string
+	// c carries flags when the connector was installed here or is in the
+	// snapshot; otherwise it is the flagless static entry.
+	c Connector
+	// detailed is true when c came from real metadata rather than from the
+	// static list, and therefore whether the form checks can say anything.
+	detailed bool
+}
+
+// reachCatalog is every connector the launcher could offer, from the union of
+// the built catalog and the recorded snapshot, preferring whichever has real
+// metadata.
+//
+// The union rather than either alone: the catalog is the only place the
+// static-list connectors appear (db2 and artifactory are there and nowhere
+// else), and the snapshot is the only place any flags appear when no provider
+// is installed.
+func reachCatalog(t *testing.T) []reachEntry {
+	t.Helper()
+	byName := map[string]reachEntry{}
+
+	for _, s := range loadConnectorSnapshot(t) {
+		byName[s.Name] = reachEntry{name: s.Name, c: s.connector(), detailed: true}
+	}
+	for _, c := range BuildCatalog() {
+		if prev, ok := byName[c.Name]; ok && prev.detailed && !c.DeclaresMetadata() {
+			// The snapshot knows more about it than this machine does.
+			continue
+		}
+		byName[c.Name] = reachEntry{name: c.Name, c: c, detailed: c.DeclaresMetadata()}
+	}
+
+	out := make([]reachEntry, 0, len(byName))
+	for _, e := range byName {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
+// Every connector is either curated or recorded as deliberately not, and the
+// launcher has something to show for it either way.
+//
+// forms_misc_test.go used to run this same four-way check over the twelve
+// connectors one contributor had been assigned, which is the shape a per-file
+// copy of a catalog-wide property always takes: it proves the property for the
+// names its author happened to write down and says nothing about the rest. The
+// four cases below are that check, over every connector the launcher can offer.
+func TestEveryConnectorIsCuratedOrExcused(t *testing.T) {
+	entries := reachCatalog(t)
+	if len(entries) == 0 {
+		t.Fatal("the catalog and the snapshot are both empty; nothing was checked")
+	}
+
+	var curated, excused, uncheckable []string
+	for _, e := range entries {
+		_, hasSpec := formSpecs[e.name]
+		reason, excluded := uncuratedReason(e.name)
+
+		switch {
+		case hasSpec && excluded:
+			t.Errorf("%s has a spec and is also recorded as deliberately uncurated; "+
+				"one of the two is wrong", e.name)
+		case hasSpec:
+			curated = append(curated, e.name)
+		case excluded:
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("%s is excluded with an empty reason, which says nothing "+
+					"a future reader can act on", e.name)
+			}
+			excused = append(excused, e.name)
+		default:
+			t.Errorf("%s has no FormSpec and no recorded reason for not having one. "+
+				"Register a spec in the cli/launcher/forms file for its catalog category, or call "+
+				"registerUncurated with what stops one from being written.", e.name)
+		}
+
+		if !e.detailed {
+			uncheckable = append(uncheckable, e.name)
+		}
+	}
+
+	t.Logf("%d connectors: %d curated, %d deliberately not, %d with no metadata "+
+		"here to check the form against (%s)",
+		len(entries), len(curated), len(excused), len(uncheckable),
+		strings.Join(uncheckable, ", "))
+
+	// The exclusions are a decision, so removing one has to be a decision too.
+	// Naming them here rather than counting them is the point: a fourth
+	// exclusion appearing silently is exactly what this is for.
+	wantExcused := map[string]bool{"device": true, "ipinfo": true, "artifactory": true}
+	got := map[string]bool{}
+	for _, name := range excused {
+		got[name] = true
+	}
+	for name := range wantExcused {
+		if !got[name] {
+			t.Errorf("%s is no longer recorded as deliberately uncurated. If it grew "+
+				"a form, drop it from this list; if its registerUncurated call was lost, "+
+				"that is the bug.", name)
+		}
+	}
+	for name := range got {
+		if !wantExcused[name] {
+			t.Errorf("%s was excluded from curation without being named here. "+
+				"An exclusion is a decision -- add it with the reason, or write the spec.",
+				name)
+		}
+	}
+}
+
+// Opening any connector puts something on the screen: fields to fill in, or a
+// sentence saying why there are none. Never a blank pane.
+//
+// Two connectors reached this the hard way and from opposite directions.
+// `device` declares nine flags and every one of them is Hidden or Deprecated,
+// so genericFields builds nothing while HasFormData() -- which counted
+// len(c.Flags) -- said there was a form. `mondoo` declares no flags at all and
+// MaxArgs=4 that its ParseCLI discards, so its spec suppresses the argument box
+// and leaves the same emptiness behind. Both rendered a pane with a scan button
+// and nothing above it.
+//
+// The assertion is on the rendered plan rather than on the predicate, because
+// the predicate is not the thing that was wrong -- what was wrong is what the
+// user saw, and there is more than one way to arrive at it.
+func TestEveryConnectorPaneSaysSomething(t *testing.T) {
+	checked, skipped := 0, 0
+	for _, e := range reachCatalog(t) {
+		if !e.detailed {
+			skipped++
+			continue
+		}
+		checked++
+
+		m := newTestModel()
+		m.list.filtered = []Connector{e.c}
+		m.list.cursor = 0
+		m.detail.form = newForm(e.c)
+
+		var fields, text int
+		for _, item := range m.detailPlan() {
+			switch item.kind {
+			case diField, diMore:
+				fields++
+			case diText:
+				text++
+			}
+		}
+		if fields == 0 && text < 2 {
+			// One diText is always there: the connector's own one-line
+			// description. A pane with nothing to fill in owes the reader a
+			// second line saying so.
+			t.Errorf("%s opens on a pane with no fields and no explanation for it, "+
+				"which is a scan button under a heading", e.name)
+		}
+	}
+	t.Logf("checked %d connectors, skipped %d with no metadata available here", checked, skipped)
+	if checked == 0 {
+		t.Fatal("no connector carried metadata, so this proved nothing; " +
+			"internal/connectors/connectors.json should have supplied it")
+	}
+}
+
+// Every field on every form is reachable and answerable.
+//
+// The two failures this catches are both ones the launcher cannot show you: a
+// required field parked in OPTIONS sits behind the "more" fold, where the
+// cursor focusFirstMissing leaves cannot be moved to; and a picker with no
+// options and no source is a row no keystroke fills, because openModal declines
+// to open an empty box and storeCursorField will not write into a multi-choice.
+//
+// Both were found per-file by the agents who curated those files. Running them
+// over the whole catalog is what covers the connectors nobody curated, whose
+// forms come from genericFields and were never looked at by anyone.
+func TestEveryFieldOnEveryFormCanBeAnswered(t *testing.T) {
+	checked, skipped := 0, 0
+	for _, e := range reachCatalog(t) {
+		if !e.detailed {
+			skipped++
+			continue
+		}
+		checked++
+		f := newForm(e.c)
+		for i := range f.Fields() {
+			fd := f.Fields()[i]
+			// Required-in-OPTIONS is checked over every field rather than only
+			// the visible ones, which is the scope forms_misc_test.go used for
+			// its own copy of this check and the stricter of the two: a field
+			// that is required and folded away is a form that cannot be
+			// completed the moment whatever hides it stops hiding it.
+			if fd.Required && fd.Section == sectionOptions {
+				t.Errorf("%s: %q is required but sits behind the OPTIONS fold, "+
+					"where the cursor cannot reach it", e.name, fd.Label)
+			}
+			if !f.Visible(i) {
+				// An empty picker nobody can see is not a row a keystroke has
+				// to reach, so the check below is the visible fields only.
+				continue
+			}
+			if fd.Kind != fieldChoice && fd.Kind != fieldMultiChoice {
+				continue
+			}
+			if len(fd.Options) == 0 && fd.Source() == "" && fd.LiveSource == "" &&
+				fd.SourceBy == nil && fd.LiveSourceBy == nil {
+				t.Errorf("%s: %q is a picker with nothing to pick and no source, "+
+					"so no keystroke can fill it", e.name, fd.Label)
+			}
+		}
+	}
+	t.Logf("checked %d connectors, skipped %d with no metadata available here", checked, skipped)
+	if checked == 0 {
+		t.Fatal("no connector carried metadata, so this proved nothing")
+	}
+}
+
+// A credential the form lets you type has to reach the provider, and must not
+// reach a command line.
+//
+// This used to have a list attached: seven connector/flag pairs the launcher
+// refused, each with the reason it could not carry them. Three declared
+// ConfigEntry "-" so no derived variable reached them, two declared a prompt
+// flag the CLI does not act on, and two derived a name cnspec reads for its own
+// service account. Every one of those was a fact about how a *flag value* gets
+// from this process into a child, and none of them is true any more: the value
+// goes into a ParseCLI request over the plugin's gRPC connection, which is the
+// same place a flag would have ended up.
+//
+// The list is gone rather than emptied. An empty exception list invites the
+// next refusal to be added to it; there is no mechanism left that could produce
+// one from the form alone.
+//
+// # Why this also drives the launch
+//
+// It used to stop at "routes as an inventory", and forms_saas_c_test.go carried
+// a second test that went the rest of the way -- planning the launch and asking
+// a stand-in provider what it was handed -- over the ten connectors one
+// contributor had curated. Those are the same claim at two depths, and the
+// deeper one was the one scoped to a tenth of the catalog.
+//
+// So the deeper one is here and covers all of it. The route is not the promise;
+// the promise is that the value arrives, which is what assertCredentialReaches-
+// TheProvider checks and what the delivery check alone cannot: an inventory
+// that routes perfectly and carries the credential under a key the provider
+// never reads satisfies deliveryFor and fails the user.
+func TestEveryTypeableCredentialReachesTheProvider(t *testing.T) {
+	const sentinel = "<PLACEHOLDER-not-a-real-secret>"
+	checked, skipped := 0, 0
+
+	for _, e := range reachCatalog(t) {
+		if !e.detailed {
+			skipped++
+			continue
+		}
+		f := newForm(e.c)
+		for i := range f.Fields() {
+			fd := &f.Fields()[i]
+			// Visible only, and that is a real limit rather than an oversight:
+			// a secret behind a selector -- atlassian's four product tokens,
+			// databricks' workspace token -- is not typeable until the selector
+			// is answered, and answering it is a decision this loop has no way
+			// to make. Those are covered by name, with the selector value
+			// beside them, in the category file for their connector.
+			if !fd.Secret || fd.Flag == "" || !f.Visible(i) {
+				continue
+			}
+			checked++
+
+			// One secret at a time: several providers pick a different
+			// authentication path when they are shown a second one, and what
+			// matters here is that each has a way through at all.
+			probe := newForm(e.c)
+			probe.Fields()[i].SetValue(sentinel)
+
+			if got := deliveryFor(probe); got != deliverInventory {
+				t.Errorf("%s --%s is typeable but routes as %v, so the credential "+
+					"would travel on the command line", e.name, fd.Flag, got)
+				continue
+			}
+			if args := strings.Join(probe.Args(), " "); strings.Contains(args, sentinel) {
+				t.Errorf("%s --%s reached argv: %s", e.name, fd.Flag, args)
+			}
+			t.Run(e.name+"/"+fd.Flag, func(t *testing.T) {
+				assertCredentialReachesTheProvider(t, e.c, probe, fd.Flag, sentinel)
+			})
+		}
+	}
+	t.Logf("checked %d typeable credentials over the catalog; skipped %d connectors "+
+		"with no metadata available here", checked, skipped)
+	if checked == 0 {
+		t.Fatal("no credential field was built, so this proved nothing")
+	}
+}

--- a/apps/cnspec/cmd/interactive/rebuild_test.go
+++ b/apps/cnspec/cmd/interactive/rebuild_test.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// installed is the message a finished provider install sends, carrying the
+// connector metadata the form is rebuilt from.
+func installed(provider, connector, use string) providerInstalledMsg {
+	return providerInstalledMsg{
+		provider: provider,
+		conns:    []Connector{{Provider: provider, Name: connector, Use: use}},
+	}
+}
+
+// A provider install lands asynchronously and rebuilds the form. It can land
+// while a picker is open, at which point the picker's field index refers to a
+// field list that no longer exists.
+func TestInstallDoesNotStrandAnOpenPicker(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+	m.picker.modal.open = true
+	m.picker.modal.field = len(m.detail.form.Fields()) - 1
+	if m.picker.modal.field < 1 {
+		t.Fatal("expected the ssh form to have several fields")
+	}
+
+	nm, _ := m.Update(installed("os", "ssh", "ssh user@host"))
+	m = nm.(Model)
+
+	if m.picker.modal.open && !m.picker.modal.valid(m.detail.form.Fields()) {
+		t.Fatalf("picker left pointing at field %d of %d", m.picker.modal.field, len(m.detail.form.Fields()))
+	}
+	// The panic this guards is in the renderer, so render.
+	_ = m.View()
+}
+
+// The key path has to survive a stale index too, not only the renderer.
+//
+// keyModal used to test that the index was in range and then index with it
+// regardless: an out-of-range one fell past the kind check straight into
+// m.detail.form.Fields()[md.field]. Nothing shipped could reach it -- only
+// rebuildForm and syncSelection shrink the field slice, and both close the
+// picker -- so this drives it directly rather than through a sequence.
+func TestKeyModalSurvivesAStaleIndex(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+	m.picker.modal = modalState{open: true, field: len(m.detail.form.Fields()) + 5}
+
+	for _, k := range []tea.KeyType{tea.KeyEnter, tea.KeyDown, tea.KeyUp, tea.KeySpace, tea.KeyEsc} {
+		nm, _ := m.Update(tea.KeyMsg{Type: k})
+		got := nm.(Model)
+		if got.picker.modal.open {
+			t.Fatalf("a picker pointing past the end of the form stayed open after %v", k)
+		}
+		_ = got.View()
+	}
+}
+
+// The same rebuild must not discard what the user typed while waiting for it.
+func TestInstallKeepsTypedInput(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+
+	idx := -1
+	for i := range m.detail.form.Fields() {
+		if m.detail.form.Fields()[i].Kind == fieldText && m.detail.form.Fields()[i].Prefilled() == "" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("expected a free-text field on the ssh form")
+	}
+	m.detail.form.Fields()[idx].SetValue("root@prod-db-01")
+	want := m.detail.form.Fields()[idx].Identity()
+
+	// A real install adds metadata rather than removing it, so the rebuild is
+	// driven by the connector the catalog actually holds.
+	c, ok := m.list.current()
+	if !ok {
+		t.Fatal("no connector selected")
+	}
+	nm, _ := m.Update(providerInstalledMsg{provider: c.Provider, conns: []Connector{c}})
+	m = nm.(Model)
+
+	for _, fd := range m.detail.form.Fields() {
+		if fd.Identity() == want {
+			if fd.Value() != "root@prod-db-01" {
+				t.Errorf("typed value lost across the rebuild: got %q", fd.Value())
+			}
+			return
+		}
+	}
+	t.Errorf("field %q is gone from the rebuilt form", want)
+}
+
+// A rebuild re-derives prefilled values rather than preserving the old ones:
+// the point of rebuilding is that the provider metadata is now available.
+func TestCarryOverLeavesPrefillsToTheRebuild(t *testing.T) {
+	old := tuiform.New("k8s", []field{
+		prefilled(tuiform.Decl{Flag: "context"}, "stale-cluster", "current"),
+		valued(tuiform.Decl{Flag: "namespace"}, "typed-by-hand"),
+	})
+	fresh := tuiform.New("k8s", []field{
+		prefilled(tuiform.Decl{Flag: "context"}, "real-current", "current"),
+		tuiform.NewField(tuiform.Decl{Flag: "namespace"}),
+	})
+	carryOver(&fresh, old)
+
+	if fresh.Fields()[0].Value() != "real-current" {
+		t.Errorf("prefill was overwritten by the stale one: %q", fresh.Fields()[0].Value())
+	}
+	if fresh.Fields()[1].Value() != "typed-by-hand" {
+		t.Errorf("user input was not carried: %q", fresh.Fields()[1].Value())
+	}
+}
+
+// Carrying over is keyed on what a field asks, not where it sits: a rebuild
+// that inserts a field must not shift values onto their neighbours.
+func TestCarryOverSurvivesReordering(t *testing.T) {
+	old := tuiform.New("aws", []field{
+		valued(tuiform.Decl{Flag: "profile"}, "prod"),
+		valued(tuiform.Decl{Flag: "region"}, "eu-central-1"),
+	})
+	fresh := tuiform.New("aws", []field{
+		tuiform.NewField(tuiform.Decl{Flag: "endpoint-url"}),
+		tuiform.NewField(tuiform.Decl{Flag: "region"}),
+		tuiform.NewField(tuiform.Decl{Flag: "profile"}),
+	})
+	carryOver(&fresh, old)
+
+	if got := fresh.Fields()[2].Value(); got != "prod" {
+		t.Errorf("profile = %q, want prod", got)
+	}
+	if got := fresh.Fields()[1].Value(); got != "eu-central-1" {
+		t.Errorf("region = %q, want eu-central-1", got)
+	}
+	if got := fresh.Fields()[0].Value(); got != "" {
+		t.Errorf("endpoint-url picked up a value it never had: %q", got)
+	}
+}
+
+// A different connector's form shares nothing with this one.
+func TestCarryOverIgnoresADifferentConnector(t *testing.T) {
+	old := tuiform.New("aws", []field{valued(tuiform.Decl{Flag: "profile"}, "prod")})
+	fresh := tuiform.New("gcp", []field{tuiform.NewField(tuiform.Decl{Flag: "profile"})})
+	carryOver(&fresh, old)
+
+	if fresh.Fields()[0].Value() != "" {
+		t.Errorf("carried a value across connectors: %q", fresh.Fields()[0].Value())
+	}
+}
+
+// Pressing Scan with a required field still empty must land the cursor on that
+// field. The launcher used to report the error and leave the cursor where it
+// was, which says what is wrong without saying where.
+func TestScanFocusesTheMissingField(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 120, 40), "ssh")
+
+	want := -1
+	for i := range m.detail.form.Fields() {
+		m.detail.form.Fields()[i].SetValue("filled")
+		if m.detail.form.Fields()[i].Required && want < 0 {
+			want = i
+		}
+	}
+	if want < 0 {
+		t.Skip("no required field on this form")
+	}
+	m.detail.form.Fields()[want].SetValue("") // the one thing standing in the way
+	m.detail.form.SetCursor(len(m.detail.form.Fields()) - 1)
+
+	nm, _ := m.launch()
+	m = nm.(Model)
+
+	if m.lastErr == "" {
+		t.Fatal("expected a validation error")
+	}
+	if m.detail.form.Cursor() != want {
+		t.Errorf("cursor = %d (%q), want %d (%q)",
+			m.detail.form.Cursor(), m.detail.form.Fields()[m.detail.form.Cursor()].Label,
+			want, m.detail.form.Fields()[want].Label)
+	}
+}

--- a/apps/cnspec/cmd/interactive/run.go
+++ b/apps/cnspec/cmd/interactive/run.go
@@ -1,0 +1,205 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Run shows the interactive launcher and blocks until the user quits. Commands
+// the user picks are run from inside the launcher (see launchCmd), so a session
+// can run several of them.
+func Run() error {
+	// The last line of defence for the generated inventory, which holds a
+	// plaintext credential when the OS keychain was unavailable. This covers
+	// every way out of Run: a quit, an error, a panic unwinding through here,
+	// and -- because bubbletea turns both into a quit -- SIGINT and SIGTERM.
+	defer cleanupTempFiles()
+	stopWatching := cleanupTempFilesOnHangup()
+	defer stopWatching()
+
+	m := NewModel(BuildCatalog())
+	_, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
+	return err
+}
+
+// cleanupTempFilesOnHangup removes what the launcher wrote if the terminal goes
+// away, and returns the func that uninstalls it.
+//
+// SIGHUP is the one signal worth handling here, and the only one. bubbletea
+// already listens for SIGINT and SIGTERM and turns them into a quit
+// (Program.handleSignals), so Run returns normally and the deferred cleanup
+// above does the work with the terminal properly restored -- installing our own
+// handler for those would race with that restore for no gain. Nothing listens
+// for SIGHUP, whose default disposition is to terminate, and which is exactly
+// what arrives when a terminal window is closed on a launcher sitting at a form
+// with a credential in it.
+//
+// Exiting rather than re-raising is deliberate: SIGHUP means the terminal has
+// already gone, so there is no screen state left to hand back and nothing to
+// restore it for.
+func cleanupTempFilesOnHangup() func() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGHUP)
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case <-sig:
+			cleanupTempFiles()
+			os.Exit(1)
+		case <-done:
+		}
+	}()
+
+	return func() {
+		signal.Stop(sig)
+		close(done)
+	}
+}
+
+// launchDoneMsg reports that a launched command finished.
+type launchDoneMsg struct{ err error }
+
+// launchCmd hands the terminal to this same binary with the assembled
+// arguments. Re-executing (rather than calling into cobra directly) means the
+// chosen command goes through the exact same startup path as if the user had
+// typed it: provider auto-install, flag parsing, discovery, and all.
+//
+// This is now the exception rather than the rule. A scan runs as a background
+// child and comes back as a report the launcher renders (see scan.go); what is
+// left here is `shell`, which is a genuinely interactive REPL, produces no
+// report, and therefore has to own the terminal for as long as it runs.
+// tea.Exec hands it over and takes it back on exit.
+func launchCmd(args []string, extraEnv []string, warn string) tea.Cmd {
+	self, err := os.Executable()
+	if err != nil {
+		self = os.Args[0]
+	}
+	c := exec.Command(self, args...)
+	c.Env = append(os.Environ(), extraEnv...)
+	// The launcher is already the current binary; letting the child hand off to
+	// whatever release sits in the auto-update cache would put the user in a
+	// different version of the shell than the one they are running.
+	c.Env = append(c.Env, "MONDOO_AUTO_UPDATE=false")
+	return tea.Exec(&handoverCmd{Cmd: c, args: args, warn: warn}, func(err error) tea.Msg {
+		return launchDoneMsg{err: err}
+	})
+}
+
+// handoverCmd announces the command before running it, so the user sees what
+// they are about to be dropped into.
+//
+// It used to also read a line from the shared stdin afterwards, to stop the
+// launcher repainting over a scan report the user was still reading. That pause
+// went with the scan: a report is now rendered inside the TUI, and reading a
+// line off the terminal that bubbletea is about to take back is how type-ahead
+// gets swallowed. A shell has nothing left on screen worth pausing for.
+type handoverCmd struct {
+	*exec.Cmd
+	args []string
+	warn string
+}
+
+func (c *handoverCmd) SetStdin(r io.Reader) {
+	if c.Stdin == nil {
+		c.Stdin = r
+	}
+}
+
+func (c *handoverCmd) SetStdout(w io.Writer) {
+	if c.Stdout == nil {
+		c.Stdout = w
+	}
+}
+
+func (c *handoverCmd) SetStderr(w io.Writer) {
+	if c.Stderr == nil {
+		c.Stderr = w
+	}
+}
+
+func (c *handoverCmd) Run() error {
+	out := c.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	if c.warn != "" {
+		// Printed where the user is looking when the command starts, not only
+		// in the launcher they are about to leave.
+		fmt.Fprintf(out, "\n! %s\n", c.warn)
+	}
+	fmt.Fprintf(out, "\n$ cnspec %s\n\n", shellJoin(c.args))
+
+	err := c.Cmd.Run()
+	if err != nil {
+		fmt.Fprintf(out, "\ncommand exited with an error: %v\n", err)
+	}
+	// The exit status is the command's business, not the launcher's: a failing
+	// command is a normal outcome and must not look like the launcher broke.
+	return nil
+}
+
+// shellJoin renders args for display, quoting the ones that need it.
+func shellJoin(args []string) string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "" || strings.ContainsAny(a, " \t\"'") {
+			out = append(out, strconv.Quote(a))
+			continue
+		}
+		out = append(out, a)
+	}
+	return strings.Join(out, " ")
+}
+
+// tokenize splits a user-entered argument string into individual args,
+// honoring double and single quotes so values like -c "aws.regions" survive as
+// a single token. This is intentionally small: it is a convenience for the
+// launcher, not a full shell parser.
+func tokenize(s string) []string {
+	var out []string
+	var cur []rune
+	var quote rune
+	inToken := false
+
+	flush := func() {
+		if inToken {
+			out = append(out, string(cur))
+			cur = cur[:0]
+			inToken = false
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur = append(cur, r)
+			}
+			inToken = true
+		case r == '"' || r == '\'':
+			quote = r
+			inToken = true
+		case r == ' ' || r == '\t':
+			flush()
+		default:
+			cur = append(cur, r)
+			inToken = true
+		}
+	}
+	flush()
+	return out
+}

--- a/apps/cnspec/cmd/interactive/scan.go
+++ b/apps/cnspec/cmd/interactive/scan.go
@@ -1,0 +1,304 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"context"
+	"io"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	launcherscan "go.mondoo.com/cnspec/cli/launcher/scan"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// What a scan *is* now lives in cli/launcher/scan: the child process, the
+// NDJSON progress stream it emits, the report it writes, and the single cleanup
+// that removes all of it. What is left here is the launcher's view of one --
+// the bubbletea messages the event loop switches on, the commands that produce
+// them, and the three display-only facts (the command line as typed, the
+// weaker-guarantee warning, the target's name) that a scanning screen renders
+// and a scan has no use for.
+//
+// The split is worth stating because it is not arbitrary: the engine has no
+// tea.Msg in it and the shim forks nothing. That is what lets the engine be
+// tested against a real fork without a Model, and the screen be rendered
+// without one.
+
+// scanSession is one background scan as the launcher sees it.
+//
+// It embeds the engine's session rather than reimplementing it, and adds only
+// what the scanning screen draws. Args are held here as well as in the engine
+// because they are two different facts that happen to coincide: the engine
+// holds an argv to exec, this holds the command line to show, and the reporting
+// flags the engine appends are deliberately in the first and not the second.
+type scanSession struct {
+	*launcherscan.Session
+
+	// cancel asks the child to stop. It exists from construction, before the
+	// fork, so an esc pressed while the fork is still in flight has something
+	// to act on.
+	cancel context.CancelFunc
+
+	// args is the command line as the user sees it.
+	args []string
+	// warn is the weaker-guarantee note from the plan, shown while the scan
+	// runs rather than only in the pane the user has just left.
+	warn string
+	// label names the target, for the scanning screen's title.
+	label string
+	// prog is the live aggregate the scanning screen reads each frame.
+	prog scanProgressView
+}
+
+// scanProgressView is the renderer's handle on the engine's aggregate.
+type scanProgressView struct{ *launcherscan.Progress }
+
+func (p scanProgressView) snapshot() scanSnapshot { return p.Snapshot() }
+
+// scanSnapshot and scanAsset are the engine's types under the names the views
+// already use, so that moving the engine did not become a rename of every
+// screen that draws one.
+type (
+	scanSnapshot = launcherscan.Snapshot
+	scanAsset    = launcherscan.Asset
+)
+
+// scanOutcome is how the child ended: the error from Wait (nil for a clean
+// exit) and whatever it wrote to its output streams.
+//
+// A non-nil err is emphatically not "the scan failed". `cnspec scan` exits 1
+// when any asset errored *or* when the worst score crosses the risk threshold
+// (apps/cnspec/cmd/scan.go), so a scan that worked perfectly and found two
+// failing checks lands here with an ExitError. Only the report file decides
+// which of the two happened -- see Model.scanExited.
+type scanOutcome struct {
+	err    error
+	output string
+}
+
+// newScanSession builds the session for a prepared plan. Nothing is forked
+// here: this runs on the event loop, and the whole point of it is that the
+// cancel function exists from the moment the launcher switches screens.
+func newScanSession(plan launchPlan, label string) *scanSession {
+	// The plan's own temp files -- a generated inventory holding a credential,
+	// a rewritten kubeconfig -- are released with the rest of the session, so
+	// there is one thing that ends a scan rather than two. trackTemp is handed
+	// in rather than reached for, because it is this process's registry of what
+	// must be removed on any exit at all and the engine has no opinion on where
+	// that lives.
+	s := launcherscan.NewSession(launcherscan.Request{
+		Args:      plan.args,
+		Env:       plan.env,
+		Cleanup:   plan.cleanup,
+		TrackTemp: trackTemp,
+	})
+	return &scanSession{
+		Session: s,
+		cancel:  s.Cancel,
+		args:    plan.args,
+		warn:    plan.warn,
+		label:   label,
+		prog:    scanProgressView{s.Progress()},
+	}
+}
+
+func (s *scanSession) release()                 { s.Release() }
+func (s *scanSession) abort()                   { s.Abort() }
+func (s *scanSession) elapsed() time.Duration   { return s.Elapsed() }
+func (s *scanSession) readProgress(r io.Reader) { s.ReadProgress(r) }
+
+// scanState is the launcher's grip on the background scan it is watching.
+//
+// The three fields move together and are meaningless apart: loading says
+// something only while a session exists, and out is read exactly once, by the
+// report that session's exit produced. They were three fields on Model, and the
+// order in which each of the three endings had to clear them was written out
+// three times.
+type scanState struct {
+	// session is the background child currently running, if any. It is a
+	// pointer so that cancelling one from a copied Model still cancels the real
+	// thing.
+	session *scanSession
+	// loading is true between the child exiting and its report being read; on a
+	// large scan that parse is not instant and a still screen would look like a
+	// hang.
+	loading bool
+	// out is how the last child ended, kept only long enough to explain a scan
+	// that produced no readable report.
+	out scanOutcome
+}
+
+// active reports whether a scan is attached.
+func (s scanState) active() bool { return s.session != nil }
+
+// current reports whether an arriving message is about the scan on screen.
+//
+// Every handler asks this first, and it is the whole of the staleness rule: an
+// event from a scan the user has already cancelled must not reanimate the
+// screen they left. The cancelled session releases itself.
+func (s scanState) current(session *scanSession) bool { return session == s.session }
+
+// begin attaches a session for a prepared plan and returns the command that
+// forks it.
+//
+// The session is built here, on the event loop, rather than inside the command:
+// its cancel function has to exist before the screen that offers to cancel is
+// drawn, or an esc pressed during the fork would have nothing to act on.
+func (s *scanState) begin(plan launchPlan, label string) tea.Cmd {
+	*s = scanState{session: newScanSession(plan, label)}
+	return startScanCmd(s.session)
+}
+
+// running wires up the two streams the child now has.
+func (s scanState) running(msg scanRunningMsg) tea.Cmd {
+	if !s.current(msg.session) {
+		return nil
+	}
+	return tea.Batch(waitProgressCmd(msg.session), waitScanCmd(msg.session))
+}
+
+// progressed repaints and asks for the next event.
+func (s scanState) progressed(msg scanProgressMsg) tea.Cmd {
+	if !s.current(msg.session) || msg.done {
+		return nil
+	}
+	return waitProgressCmd(msg.session)
+}
+
+// exited turns the child's exit into the one question that matters: is there a
+// report to read?
+//
+// The exit status deliberately does not decide that. `cnspec scan` exits 1 when
+// any asset errored or when the worst score crosses the risk threshold, so the
+// ordinary outcome of a useful scan -- it found things -- is a non-zero status.
+// The launcher therefore always tries to read the artifact, and only treats the
+// run as failed when there is nothing readable there.
+func (s *scanState) exited(msg scanExitedMsg) tea.Cmd {
+	if !s.current(msg.session) {
+		return nil
+	}
+	s.loading = true
+	s.out = msg.outcome
+	return loadReportCmd(msg.session)
+}
+
+// finish releases the session and hands back how the child ended, leaving no
+// scan attached. It reports false for a message from a scan that is no longer
+// the one on screen.
+//
+// The outcome is handed over rather than kept: it is up to 16 KiB of the
+// child's log output, and there is no reason for it to live as long as the
+// session does.
+func (s *scanState) finish(msg scanReportMsg) (scanOutcome, bool) {
+	if !s.current(msg.session) {
+		return scanOutcome{}, false
+	}
+	// The artifact has been read into memory, so the file has no reason to
+	// exist any longer -- and neither has the generated inventory the child was
+	// reading, nor the child itself.
+	msg.session.release()
+	out := s.out
+	*s = scanState{}
+	return out, true
+}
+
+// abort kills the child and forgets it.
+//
+// It returns immediately rather than waiting for the process to die: the
+// session reaps it and releases what it was reading in the background, and a UI
+// that froze for five seconds on cancel would be the thing this whole phase was
+// written to avoid.
+func (s *scanState) abort() {
+	if s.session != nil {
+		s.session.abort()
+	}
+	*s = scanState{}
+}
+
+// cancel stops a scan on the way out of the program.
+//
+// A scan the user quit out of must not outlive the launcher. A started
+// session's tracked cleanup cancels it too, so cleanupTempFiles covers the
+// running case; this covers the one where the fork has not happened yet and
+// there is nothing in the registry to cancel.
+func (s *scanState) cancel() {
+	if s.session != nil {
+		s.session.cancel()
+	}
+	*s = scanState{}
+}
+
+// lastLines returns the final n non-empty lines of the child's output, which is
+// what there is room for in a footer.
+func lastLines(s string, n int) []string { return launcherscan.LastLines(s, n) }
+
+// --- messages and commands ----------------------------------------------------
+
+// scanRunningMsg reports that the child is alive and its streams are wired up.
+type scanRunningMsg struct{ session *scanSession }
+
+// scanProgressMsg reports that the aggregate moved, or -- with done set -- that
+// the progress stream has ended.
+type scanProgressMsg struct {
+	session *scanSession
+	done    bool
+}
+
+// scanExitedMsg carries the child's outcome.
+type scanExitedMsg struct {
+	session *scanSession
+	outcome scanOutcome
+}
+
+// scanReportMsg carries the artifact the child wrote, or the reason it could
+// not be read back.
+type scanReportMsg struct {
+	session *scanSession
+	report  *policy.ReportCollection
+	err     error
+}
+
+// startScanCmd forks the child off the event loop.
+//
+// A Start that fails has already ended the session -- the progress stream is
+// closed and the failure published as the outcome -- so that a session ends
+// exactly one way whatever happened. All that is left here is to say so.
+func startScanCmd(s *scanSession) tea.Cmd {
+	return func() tea.Msg {
+		if err := s.Start(); err != nil {
+			return scanExitedMsg{session: s, outcome: scanOutcome{err: err}}
+		}
+		return scanRunningMsg{session: s}
+	}
+}
+
+// waitProgressCmd blocks until the aggregate moves.
+func waitProgressCmd(s *scanSession) tea.Cmd {
+	return func() tea.Msg {
+		_, ok := <-s.Wake()
+		return scanProgressMsg{session: s, done: !ok}
+	}
+}
+
+// waitScanCmd blocks until the child exits.
+func waitScanCmd(s *scanSession) tea.Cmd {
+	return func() tea.Msg {
+		out := <-s.Exit()
+		return scanExitedMsg{session: s, outcome: scanOutcome{err: out.Err, output: out.Output}}
+	}
+}
+
+// loadReportCmd reads the artifact back off the event loop. On a real scan it
+// is a multi-megabyte JSON document, which is not something to parse between
+// two keystrokes.
+func loadReportCmd(s *scanSession) tea.Cmd {
+	return func() tea.Msg {
+		collection, err := s.LoadReport()
+		if err != nil {
+			return scanReportMsg{session: s, err: err}
+		}
+		return scanReportMsg{session: s, report: collection}
+	}
+}

--- a/apps/cnspec/cmd/interactive/scan_test.go
+++ b/apps/cnspec/cmd/interactive/scan_test.go
@@ -1,0 +1,307 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	launcherscan "go.mondoo.com/cnspec/cli/launcher/scan"
+)
+
+// These tests fork a real child and drive the whole Model over it.
+//
+// What the child process itself guarantees -- the inherited descriptor, the pin
+// to this binary, a cancel that kills something -- is proven in cli/launcher/scan,
+// against a child that binary owns. What is left here is the launcher: that a
+// scan which found things still ends in the viewer, and that one which wrote
+// nothing ends back at the form saying why. Both of those are statements about
+// phases and messages, and neither can be made without a real fork underneath.
+//
+// The child is this test binary, re-executed with -test.run pointed at
+// TestScanChild, which is the pattern os/exec's own tests use.
+// launcherscan.Binary is the seam. The fixtures under testdata are a real
+// report and a real progress stream, both recorded from `cnspec scan local
+// --incognito -f examples/example.mql.yaml -o json-full`.
+
+const (
+	childEnv     = "CNSPEC_UI_TEST_CHILD"
+	childModeEnv = "CNSPEC_UI_TEST_CHILD_MODE"
+	childExitEnv = "CNSPEC_UI_TEST_CHILD_EXIT"
+
+	// childModeReport writes the recorded report and the recorded progress
+	// stream: what a scan that worked looks like.
+	childModeReport = "report"
+	// childModeSilent writes progress but no report: a scan that fell over
+	// before it had anything to say.
+	childModeSilent = "silent"
+)
+
+// TestScanChild is the stand-in scan. It is not a test: it returns immediately
+// unless it was started as a child, and when it was, it exits the process
+// itself rather than letting the testing framework decide the status.
+func TestScanChild(t *testing.T) {
+	if os.Getenv(childEnv) != "1" {
+		return
+	}
+
+	// Always the first thing on stderr, so a parent that captured the output
+	// can see for itself which value the child was pinned to.
+	childSay("MONDOO_AUTO_UPDATE=" + os.Getenv("MONDOO_AUTO_UPDATE"))
+
+	writeChildProgress(os.Getenv("MONDOO_PROGRESS_STREAM"))
+
+	if os.Getenv(childModeEnv) == childModeReport {
+		if format := childFlag("-o"); format != launcherscan.ReportFormat {
+			childDie(96, "the child was asked for format "+strconv.Quote(format))
+		}
+		raw, err := os.ReadFile(filepath.Join("testdata", "scan_report.json"))
+		if err != nil {
+			childDie(95, err.Error())
+		}
+		if err := os.WriteFile(childFlag("--output-target"), raw, 0o600); err != nil {
+			childDie(94, err.Error())
+		}
+	}
+
+	code, _ := strconv.Atoi(os.Getenv(childExitEnv))
+	os.Exit(code)
+}
+
+func childSay(line string) { _, _ = fmt.Fprintln(os.Stderr, line) }
+
+func childDie(code int, line string) {
+	childSay(line)
+	os.Exit(code)
+}
+
+// writeChildProgress replays the recorded NDJSON stream to wherever the parent
+// asked for it, through both destination forms the real writer honors.
+func writeChildProgress(target string) {
+	if target == "" {
+		return
+	}
+
+	var out *os.File
+	if rest, ok := strings.CutPrefix(target, "fd:"); ok {
+		fd, err := strconv.Atoi(rest)
+		if err != nil {
+			childDie(93, "unreadable descriptor "+target)
+		}
+		out = os.NewFile(uintptr(fd), target)
+	} else {
+		f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			childDie(92, err.Error())
+		}
+		out = f
+	}
+	if out == nil {
+		childDie(91, "no progress stream")
+	}
+	defer func() { _ = out.Close() }()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", "scan_progress.ndjson"))
+	if err != nil {
+		childDie(90, err.Error())
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			childDie(89, err.Error())
+		}
+	}
+}
+
+// childFlag reads a flag's value off this process's own command line.
+func childFlag(name string) string {
+	for i, a := range os.Args {
+		if a == name && i+1 < len(os.Args) {
+			return os.Args[i+1]
+		}
+	}
+	return ""
+}
+
+// childPlan builds a plan that runs the stand-in child instead of cnspec.
+func childPlan(t *testing.T, mode string, exit int) launchPlan {
+	t.Helper()
+
+	real := launcherscan.Binary
+	launcherscan.Binary = func() string { return os.Args[0] }
+	t.Cleanup(func() { launcherscan.Binary = real })
+
+	return launchPlan{
+		// Everything after -- is left for the child to read off os.Args, which
+		// is also where the reporting flags the session appends land.
+		args: []string{"-test.run=TestScanChild", "--", "scan", "local"},
+		env: []string{
+			childEnv + "=1",
+			childModeEnv + "=" + mode,
+			childExitEnv + "=" + strconv.Itoa(exit),
+		},
+	}
+}
+
+// runSession forks the child and waits for it, returning its outcome.
+func runSession(t *testing.T, s *scanSession) scanOutcome {
+	t.Helper()
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	select {
+	case out := <-s.Exit():
+		return scanOutcome{err: out.Err, output: out.Output}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the child never exited")
+		return scanOutcome{}
+	}
+}
+
+// A scan that wrote nothing is the only failure. What the user is told then is
+// the child's own last word, because the loader's error is about a file and
+// explains nothing on its own.
+func TestAScanWithNoReportFailsWithTheChildsReason(t *testing.T) {
+	s := newScanSession(childPlan(t, childModeSilent, 3), "local")
+	defer s.release()
+
+	out := runSession(t, s)
+	if out.err == nil {
+		t.Fatal("the child was supposed to exit non-zero")
+	}
+
+	msg, ok := loadReportCmd(s)().(scanReportMsg)
+	if !ok {
+		t.Fatal("expected a report message")
+	}
+	if msg.err == nil {
+		t.Fatal("a scan that wrote no report must fail")
+	}
+
+	said := scanFailure(msg.err, out)
+	if !strings.Contains(said, "no report") {
+		t.Errorf("the failure does not say what went wrong: %q", said)
+	}
+	if strings.Contains(said, "exit status") {
+		t.Errorf("an exit status is not a reason and must not be the whole message: %q", said)
+	}
+}
+
+// The whole model, driven the way the program's own loop drives it: a scan
+// starts, its progress arrives, its report is read and the viewer opens on it
+// -- with the child exiting 1 throughout, because it found things.
+func TestTheLauncherEndsUpInTheViewer(t *testing.T) {
+	m := newTestModel()
+	m.width, m.height = 120, 40
+
+	model, cmd := m.startScan(childPlan(t, childModeReport, 1))
+	m = model.(Model)
+	if m.phase != phaseScanning {
+		t.Fatal("starting a scan does not show the scanning screen")
+	}
+	if !strings.Contains(m.View(), "scanning") {
+		t.Errorf("the scanning screen does not say what it is doing:\n%s", m.View())
+	}
+
+	m = pump(t, m, cmd, func(m Model) bool { return m.phase == phaseViewing })
+
+	if m.phase != phaseViewing {
+		t.Fatalf("the launcher never reached the viewer: %s", m.lastErr)
+	}
+	if !m.viewer.loaded {
+		t.Error("the report was not kept")
+	}
+	if m.scan.active() {
+		t.Error("the session outlived the scan it described")
+	}
+	if !strings.Contains(m.View(), "launcher-test-host") {
+		t.Errorf("the viewer is not showing the scanned asset:\n%s", m.View())
+	}
+}
+
+// A scan that wrote no report leaves the launcher where it started, saying why.
+func TestAFailedScanReturnsToTheLauncher(t *testing.T) {
+	m := newTestModel()
+	m.width, m.height = 120, 40
+
+	model, cmd := m.startScan(childPlan(t, childModeSilent, 2))
+	m = pump(t, model.(Model), cmd, func(m Model) bool { return m.lastErr != "" })
+
+	if m.phase != phaseForm {
+		t.Errorf("a failed scan left the launcher in phase %d", m.phase)
+	}
+	if m.viewer.loaded {
+		t.Error("a scan that wrote no report must not leave one behind")
+	}
+	if !strings.Contains(m.lastErr, "no report") {
+		t.Errorf("the launcher does not say what happened: %q", m.lastErr)
+	}
+}
+
+// pump runs commands the way bubbletea would, feeding each answer back into the
+// model, until the condition holds or the test runs out of patience.
+func pump(t *testing.T, m Model, cmd tea.Cmd, until func(Model) bool) Model {
+	t.Helper()
+
+	queue := []tea.Cmd{cmd}
+	deadline := time.Now().Add(60 * time.Second)
+
+	for len(queue) > 0 && !until(m) {
+		if time.Now().After(deadline) {
+			t.Fatal("the model never settled")
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next == nil {
+			continue
+		}
+
+		msg := runCmd(t, next)
+		if msg == nil {
+			continue
+		}
+		// A batch is a list of commands for the runtime to run, not a message
+		// the model has any use for.
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		// Timers would make this test take as long as they do.
+		if isTimer(msg) {
+			continue
+		}
+
+		model, out := m.Update(msg)
+		m = model.(Model)
+		queue = append(queue, out)
+	}
+	return m
+}
+
+// runCmd runs one command with a bound, so a command that never answers fails
+// the test rather than hanging it.
+func runCmd(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	out := make(chan tea.Msg, 1)
+	go func() { out <- cmd() }()
+	select {
+	case msg := <-out:
+		return msg
+	case <-time.After(30 * time.Second):
+		t.Fatal("a command never answered")
+		return nil
+	}
+}
+
+// isTimer reports whether a message is one of bubbletea's own animations, which
+// sleep for as long as they say and have nothing to contribute here.
+func isTimer(msg tea.Msg) bool {
+	name := strings.ToLower(fmt.Sprintf("%T", msg))
+	return strings.Contains(name, "blink") || strings.Contains(name, "tick")
+}

--- a/apps/cnspec/cmd/interactive/seams_test.go
+++ b/apps/cnspec/cmd/interactive/seams_test.go
@@ -1,0 +1,337 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The seams the launcher is extended through, tested as contracts rather than
+// through whichever connector happens to use them today. Every one of them
+// exists so that adding a source or a form is an append in a file its author
+// owns, and each was a shared table before.
+
+// A source's Needs names a field by identity, so it can depend on a positional.
+//
+// It used to compare against fd.flag, which a positional leaves empty. That
+// made every dependency worth having inexpressible: the gcp id, the container
+// reference and the github name are all positional, so a source keyed off one
+// quietly answered for the whole connector instead of for the chosen target --
+// the confidently wrong answer the parameterised cache key exists to prevent.
+func TestNeedsCanNameAPositionalField(t *testing.T) {
+	const src = "test.needs.positional"
+	register(Source{
+		ID: src, Class: ClassPostConnection, Cost: CostRemote,
+		Activity: "asking test for things", Tool: "test",
+		Needs: []string{"p:1"},
+		Fetch: func([]string) ([]string, error) { return nil, nil },
+	})
+	t.Cleanup(func() { delete(registry, src) })
+
+	f := tuiform.New("test", []field{
+		valued(tuiform.Decl{Label: "kind", Pos: 0, Kind: fieldChoice}, "repo"),
+		valued(tuiform.Decl{Label: "name", Pos: 1, Kind: fieldText}, "mondoohq/cnspec"),
+	})
+
+	params := sourceParamsFor(f, src)
+	if len(params) != 1 || params[0] != "p:1=mondoohq/cnspec" {
+		t.Fatalf("sourceParams = %v, want the positional's value", params)
+	}
+	// And the key it produces must scope to it, or two targets share a list.
+	if sourceKeyFor(f, src) == sourceKey(src, nil) {
+		t.Error("the key does not vary with the positional it depends on")
+	}
+}
+
+// The bare flag name is how Needs has always been spelled, and breaking it
+// would silently unscope the one source already relying on it.
+func TestNeedsStillAcceptsABareFlagName(t *testing.T) {
+	f := tuiform.New("k8s", []field{
+		valued(tuiform.Decl{Label: "cluster", Flag: "context", Kind: fieldChoice}, "prod"),
+	})
+	params := sourceParamsFor(f, srcK8sNamespace)
+	if len(params) != 1 || params[0] != "context=prod" {
+		t.Fatalf("sourceParams = %v, want context=prod", params)
+	}
+	// The explicit identity spelling of the same thing must resolve to it too.
+	if !tuiform.MatchesIdentity(f.Fields()[0], "f:context") {
+		t.Error(`"f:context" did not match the --context field`)
+	}
+	// A bare name is a flag shorthand only. Reading it as a positional index
+	// would make "0" mean two different fields.
+	if tuiform.MatchesIdentity(tuiform.NewField(tuiform.Decl{Pos: 0}), "0") {
+		t.Error(`"0" matched a positional; the shorthand is flags only`)
+	}
+}
+
+// A spec corrects the shared classifier for its own connector, rather than
+// widening a word list that every other connector also reads.
+func TestSpecCanOverrideTheSecretClassifier(t *testing.T) {
+	c := Connector{
+		Provider: "test", Name: "test-secret-override", Use: "test", Installed: true,
+		Flags: []plugin.Flag{
+			// Classified as a secret by the shared word list.
+			{Long: "session-token", Type: plugin.FlagType_String},
+			// Classified as harmless by it.
+			{Long: "handle", Type: plugin.FlagType_String},
+		},
+	}
+	f := tuiform.New(c.Name, genericFields(c))
+	applySpec(&f, c, FormSpec{
+		Secret:    []string{"handle"},
+		NotSecret: []string{"session-token"},
+	})
+
+	byFlag := map[string]field{}
+	for _, fd := range f.Fields() {
+		byFlag[fd.Flag] = fd
+	}
+	if !byFlag["handle"].Secret {
+		t.Error("Secret did not mark --handle")
+	}
+	if byFlag["handle"].Section != sectionCredential {
+		t.Errorf("--handle is a secret but sits in %q", byFlag["handle"].Section)
+	}
+	if byFlag["session-token"].Secret {
+		t.Error("NotSecret did not clear --session-token")
+	}
+	if byFlag["session-token"].Section == sectionCredential {
+		t.Error("--session-token is no longer a secret but stayed in CREDENTIAL")
+	}
+}
+
+// A value with no flag to carry it reaches the child through its environment.
+// alicloud declares no --profile, snowflake takes no connection name, and
+// docker and container take no --context, so this is four connectors' only
+// route rather than a special case.
+func TestSpecCanDeclareAnEnvironmentVariable(t *testing.T) {
+	c := Connector{
+		Provider: "test", Name: "test-env", Use: "test", Installed: true,
+		MinArgs: 1, MaxArgs: 1,
+		Flags: []plugin.Flag{{Long: "region", Type: plugin.FlagType_String}},
+	}
+	f := tuiform.New(c.Name, genericFields(c))
+	applySpec(&f, c, FormSpec{
+		Positional: []PositionalSpec{{Label: "profile", Required: true}},
+		Target:     []string{"region"},
+		Env:        map[string]string{"p:0": "ALIBABA_CLOUD_PROFILE"},
+	})
+	for i := range f.Fields() {
+		if f.Fields()[i].Label == "profile" {
+			f.Fields()[i].SetValue("staging")
+		}
+	}
+
+	r := launchRequest{form: f}
+	env, cleanup, err := r.environment()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 || env[0] != "ALIBABA_CLOUD_PROFILE=staging" {
+		t.Fatalf("environment = %v, want ALIBABA_CLOUD_PROFILE=staging", env)
+	}
+
+	// An unset field contributes nothing: an empty variable is not the same as
+	// an absent one, and several SDKs treat it as an explicit empty profile.
+	r.form.Fields()[0].SetValue("")
+	if env, _, _ := r.environment(); len(env) != 0 {
+		t.Errorf("an unset field contributed %v", env)
+	}
+}
+
+// A source can carry the variable instead, for a value that means the same
+// thing wherever it is offered -- a docker context is DOCKER_CONTEXT on every
+// form that lets you pick one.
+func TestSourceCanDeclareAnEnvironmentVariable(t *testing.T) {
+	const src = "test.Env.Source()"
+	register(Source{
+		ID: src, Class: ClassEnumerated, Cost: CostInstant,
+		Activity: "reading ~/.test", Tool: "~/.test", Env: "TEST_CONTEXT",
+		Fetch: func([]string) ([]string, error) { return nil, nil },
+	})
+	t.Cleanup(func() { delete(registry, src) })
+
+	fd := sourced(tuiform.Decl{Label: "context", Kind: fieldChoice}, src)
+	fd.SetValue("desktop")
+	r := launchRequest{form: tuiform.New("test", []field{fd})}
+	env, _, err := r.environment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 || env[0] != "TEST_CONTEXT=desktop" {
+		t.Fatalf("environment = %v, want TEST_CONTEXT=desktop", env)
+	}
+}
+
+// A source can also declare what its displayed values mean on a command line,
+// for a picker that annotates what it found. The engine must not know which
+// picker does that: emitted() used to open with a test for the AWS profile
+// source by name, and the second annotated picker would have added a second.
+func TestSourceCanDeclareWhatItsValuesEmit(t *testing.T) {
+	const src = "test.emit.source"
+	register(Source{
+		ID: src, Class: ClassEnumerated, Cost: CostInstant,
+		Activity: "reading ~/.test", Tool: "~/.test",
+		Emit:  func(display string) string { return strings.TrimSuffix(display, "  (annotated)") },
+		Fetch: func([]string) ([]string, error) { return nil, nil },
+	})
+	t.Cleanup(func() { delete(registry, src) })
+
+	f := tuiform.New("test", []field{
+		valued(tuiform.Decl{Label: "kind", Pos: 0, Kind: fieldChoice}, "annotated"),
+		valued(tuiform.Decl{Label: "thing", Flag: "thing", Kind: fieldChoice,
+			SourceBy: map[string]string{"annotated": src}}, "real-name  (annotated)"),
+	})
+	resolveSources(&f)
+	if got := strings.Join(f.Args(), " "); got != "annotated --thing real-name" {
+		t.Fatalf("args = %q, want the annotation stripped by the source's own mapping", got)
+	}
+}
+
+// The k8s case is the one that needed a function rather than a variable name:
+// the chosen cluster only means anything once a kubeconfig has been written
+// whose current-context is that cluster. It must keep working exactly as it
+// did when it was an `if connector == "k8s"` in launchArgs.
+func TestKubeContextStillTravelsAsAKubeconfig(t *testing.T) {
+	specs := envSpecsFor("k8s")
+	if len(specs) != 1 {
+		t.Fatalf("k8s declares %d environment contributors, want 1", len(specs))
+	}
+	if specs[0].Field != "context" {
+		t.Errorf("the k8s contributor reads %q, want the --context field", specs[0].Field)
+	}
+
+	env, cleanup, err := specs[0].Apply("")
+	if cleanup != nil {
+		cleanup()
+	}
+	if err != nil || len(env) != 0 {
+		t.Errorf("no chosen cluster gave env=%v err=%v, want nothing", env, err)
+	}
+
+	// And no other connector picks up the k8s treatment.
+	if len(envSpecsFor("docker")) != 0 {
+		t.Error("docker inherited an environment contributor it did not declare")
+	}
+}
+
+// The same case, all the way through launchArgs: a chosen cluster still leaves
+// as KUBECONFIG pointing at a copy whose current-context is that cluster.
+//
+// This is the assertion that says the generalisation did not change what k8s
+// does. It was not covered before -- kubeconfig_test.go tests the copy, not the
+// launch -- so the one connector the contract was extracted from had nothing
+// checking it arrived.
+func TestKubeTargetingSurvivesTheLaunch(t *testing.T) {
+	t.Setenv("KUBECONFIG", "testdata/kubeconfig")
+
+	c := Connector{
+		Provider: "k8s", Name: "k8s", Use: "k8s", Category: catContainer, Installed: true,
+		MaxArgs: 1,
+		Flags: []plugin.Flag{
+			{Long: "context", Type: plugin.FlagType_String},
+			{Long: "namespaces", Type: plugin.FlagType_String},
+		},
+	}
+	f := newForm(c)
+	for i := range f.Fields() {
+		if f.Fields()[i].Flag == "context" {
+			f.Fields()[i].SetValue("aks-trial")
+		}
+	}
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var kubeconfig string
+	for _, e := range plan.env {
+		if path, ok := strings.CutPrefix(e, "KUBECONFIG="); ok {
+			kubeconfig = path
+		}
+	}
+	if kubeconfig == "" {
+		t.Fatalf("the chosen cluster did not reach the child: env = %v", plan.env)
+	}
+	data, err := os.ReadFile(kubeconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "current-context: aks-trial") {
+		t.Errorf("the kubeconfig handed to the child does not select the chosen cluster:\n%s", data)
+	}
+	if plan.cleanup == nil {
+		t.Error("nothing removes the kubeconfig copy after the run")
+	}
+}
+
+// The three seams that used to sit here are gone with the registries they
+// declared into, and what they were guarding is worth recording once.
+//
+// registerSecretEnv named the variable a provider reads for itself, and it won
+// over the one mql derives from the flag name. registerInventoryVerified said
+// that somebody had checked a connector's inventory shape against the provider
+// that consumes it. And a reserved-name check refused any flag whose derived
+// variable was one cnspec reads for its own service account -- MONDOO_TOKEN and
+// MONDOO_PRIVATE_KEY above all, the second confirmed end to end by exporting it
+// and watching `cnspec status` fail with "invalid credentials: cannot load
+// retrieved key".
+//
+// All three existed because the launcher had to decide, for each connector,
+// where a credential could be put so that the provider would find it. It does
+// not decide any more: it hands the flags to that provider's own ParseCLI and
+// writes back the asset that comes out. There is no derived variable to collide
+// with a reserved name, no registry to keep in step with the providers, and no
+// shape to have checked by hand.
+//
+// What replaced them is one test that cannot be satisfied by anyone's
+// diligence: TestEveryCredentialFieldRoundTrips looks for the value it sent in
+// the asset that came back, over whatever providers are installed.
+
+// The launcher-owned field kinds are stubs, but a stub still has to be inert
+// rather than broken: nothing may open a picker over one, and nothing may put
+// a credential readout's contents on the command line.
+func TestLauncherOwnedKindsAreInert(t *testing.T) {
+	m := Model{detail: detailState{form: tuiform.New("test", []field{
+		valued(tuiform.Decl{Label: "token found", Kind: fieldCredentialState,
+			Special: "credential-state"}, "GITHUB_TOKEN"),
+		valued(tuiform.Decl{Label: "paste a token", Kind: fieldPaste,
+			Special: "paste", Secret: true}, "<PLACEHOLDER-not-a-real-secret>"),
+	})}}
+
+	for i, fd := range m.detail.form.Fields() {
+		m.detail.form.SetCursor(i)
+		if _, _ = m.openModal(); m.picker.modal.open {
+			t.Errorf("%s opened a picker with nothing to pick", fd.Label)
+			m.picker.modal = modalState{}
+		}
+		if !fd.IsSet() {
+			t.Errorf("%s holds a value but reports itself unset", fd.Label)
+		}
+	}
+
+	if got := m.detail.form.Fields()[0].Display(); got != "GITHUB_TOKEN" {
+		t.Errorf("the credential readout displayed %q, want where it came from", got)
+	}
+	if got := m.detail.form.Fields()[1].Display(); strings.Contains(got, "<PLACEHOLDER-not-a-real-secret>") {
+		t.Errorf("the paste field displayed its value: %q", got)
+	}
+	if args := m.detail.form.Args(); len(args) != 0 {
+		t.Errorf("launcher-owned fields reached the command line: %v", args)
+	}
+}

--- a/apps/cnspec/cmd/interactive/secrets_test.go
+++ b/apps/cnspec/cmd/interactive/secrets_test.go
@@ -1,0 +1,492 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+const sentinel = "S3CR3T-<PLACEHOLDER-not-a-real-secret>"
+
+// This is the test that matters most in the package.
+//
+// The launcher runs commands by re-executing cnspec. Every argument of that
+// re-execution is world-readable through `ps auxww`, so a credential that
+// reaches argv is disclosed to every user on the machine. Nothing in the form
+// engine may put one there, for any connector, ever.
+func TestNoSecretEverReachesArgv(t *testing.T) {
+	catalog := BuildCatalog()
+	if len(catalog) == 0 {
+		t.Skip("no catalog available")
+	}
+
+	checked := 0
+	for _, c := range catalog {
+		if !c.HasFormData() {
+			continue
+		}
+		f := newForm(c)
+
+		// Fill every field: secrets with the sentinel, everything else with
+		// something plausible, so nothing is skipped for being empty.
+		secretFields := 0
+		for i := range f.Fields() {
+			fd := &f.Fields()[i]
+			switch {
+			case fd.Secret:
+				fd.SetValue(sentinel)
+				secretFields++
+			case fd.Kind == fieldBool:
+				fd.SetOn(true)
+			case fd.Kind == fieldMultiChoice:
+				if len(fd.Options) > 0 {
+					fd.SetPicks(map[string]bool{fd.Options[0]: true})
+				}
+			default:
+				fd.SetValue("placeholder")
+			}
+		}
+		if secretFields == 0 {
+			continue
+		}
+		checked++
+
+		// The package-wide stand-in provider answers here; see TestMain. What
+		// is being checked is the launcher's own assembly over every connector
+		// in the catalog, not any one provider's mapping -- that is
+		// TestEveryCredentialFieldRoundTrips, which spends a subprocess per
+		// connector to do it properly.
+		r := launchRequest{form: f}
+		plan, err := r.plan(c, scanAction())
+		args, env, cleanup := plan.args, plan.env, plan.cleanup
+		if cleanup != nil {
+			defer cleanup()
+		}
+		if err != nil {
+			// A provider that keeps the credential nowhere refuses, which is
+			// the point: better a clear refusal than a scan that runs without
+			// the credential the user supplied.
+			t.Errorf("%s: %v", c.Name, err)
+			continue
+		}
+
+		for _, a := range args {
+			if strings.Contains(a, sentinel) {
+				t.Errorf("%s: secret reached the command line: %q", c.Name, strings.Join(args, " "))
+			}
+		}
+		for _, e := range env {
+			if strings.Contains(e, sentinel) {
+				t.Errorf("%s: secret reached the child's environment: %q", c.Name, e)
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Skip("no installed connector declares a secret-carrying flag")
+	}
+	t.Logf("checked %d connectors carrying secrets", checked)
+}
+
+// A password typed into a form is the password that gets used.
+//
+// This was the opposite assertion for a release. ssh declares --ask-pass, so a
+// typed password took the prompt route: the launcher dropped the value, put
+// --ask-pass on the command line in its place, and the child asked the user for
+// the password they had just typed. The whole command was
+// `cnspec scan ssh chris@10.0.0.4 --ask-pass`.
+//
+// Prompting is genuinely the strongest route -- the value never exists outside
+// the process that uses it -- and it is still available as a toggle on the
+// form. What is not available is substituting it for what somebody typed.
+func TestATypedPasswordIsTheOneThatTravels(t *testing.T) {
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+
+	p := withParser(t, &fakeParser{secretFlag: "password"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := p.sentValue("password"); got != sentinel {
+		t.Fatalf("the typed password reached the provider as %q", got)
+	}
+	if containsString(plan.args, "--ask-pass") {
+		t.Fatalf("the typed password was replaced by a prompt: %v", plan.args)
+	}
+	if strings.Contains(strings.Join(plan.args, " ")+strings.Join(plan.env, " "), sentinel) {
+		t.Fatal("the secret reached the command line or the environment")
+	}
+}
+
+// A credential reaches the provider, and nothing else.
+func TestTheCredentialReachesTheProviderAndNotArgv(t *testing.T) {
+	c := githubConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "kind").SetValue("org")
+	fieldByLabel(t, f, "name").SetValue("mondoohq")
+	fieldByLabel(t, f, "personal access token").SetValue(sentinel)
+
+	p := withParser(t, &fakeParser{secretFlag: "token"})
+	plan, err := (launchRequest{form: f}).plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+		t.Fatalf("secret on the command line: %v", plan.args)
+	}
+	if len(plan.env) != 0 {
+		t.Fatalf("the inventory route hands the child no environment, got %v", plan.env)
+	}
+	// The target used to travel on argv beside the credential's variable. It
+	// travels in the inventory now, which means this is a question about what
+	// the provider was told rather than about the words the child was given.
+	if got := p.args; len(got) != 2 || got[0] != "org" || got[1] != "mondoohq" {
+		t.Fatalf("the target was dropped along with the secret: %v", got)
+	}
+}
+
+// A bool flag named like a prompt is not a prompt, and the form must not offer
+// it as one.
+//
+// mql acts on exactly two kinds. --ask-pass it reads by name and turns into
+// --password; anything carrying FlagOption_AskInput it collects into an
+// "ask-flags" annotation and prompts for. A third kind exists in the wild --
+// clickhousecloud's --ask-secret and weaviate's --ask-api-key are declared as
+// plain bools -- and it does nothing at all.
+//
+// Verified against the shipped binary rather than read off the enum:
+//
+//	cnspec shell ssh chris@127.0.0.1 --ask-pass </dev/null
+//	→ FTL failed to get password error="asking input is only supported
+//	  when used with an interactive terminal (TTY)"
+//
+//	cnspec shell weaviate --host 127.0.0.1 --ask-api-key </dev/null
+//	→ status code: 404, error: 404 page not found
+//
+// The first is a prompt refusing a pipe. The second never asked for anything. A
+// toggle labelled "prompt for API key" that leads to an unauthenticated scan is
+// worse than an absent row, so the row is absent.
+//
+// This used to matter twice over: the inert flag also made the launcher take
+// the prompt route, leave the credential off argv, and connect with nothing.
+// The route is gone; the row is still a lie and is still not drawn.
+func TestAPromptFlagNothingActsOnIsNotOffered(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		option  plugin.FlagOption
+		offered bool
+	}{
+		{name: "inert bool", option: 0, offered: false},
+		{name: "declared AskInput", option: plugin.FlagOption_AskInput, offered: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Connector{
+				Provider: "test", Name: "test-ask", Use: "test", Installed: true,
+				Flags: []plugin.Flag{
+					{Long: "api-key", Type: plugin.FlagType_String, ConfigEntry: "-"},
+					{Long: "ask-api-key", Type: plugin.FlagType_Bool, Option: tc.option},
+				},
+			}
+			f := newForm(c)
+			if got := f.IndexOfFlag("ask-api-key") >= 0; got != tc.offered {
+				t.Errorf("--ask-api-key offered = %v, want %v", got, tc.offered)
+			}
+			// The credential itself is still on the form either way, and still
+			// classified as a secret: what an inert toggle costs it is a
+			// partner that was never going to arrive.
+			i := f.IndexOfFlag("api-key")
+			if i < 0 {
+				t.Fatal("the api-key field was not built")
+			}
+			f.Fields()[i].Secret = true
+			f.Fields()[i].SetValue(sentinel)
+			if got := deliveryFor(f); got != deliverInventory {
+				t.Errorf("delivery = %v, want the inventory", got)
+			}
+		})
+	}
+
+	// --ask-pass is the exception and stays one: mql reads it by name, so the
+	// providers that declare it as a plain bool -- which is all of them -- keep
+	// working.
+	c := Connector{
+		Provider: "test", Name: "test-ask-pass", Use: "test", Installed: true,
+		Flags: []plugin.Flag{
+			{Long: "password", Type: plugin.FlagType_String, ConfigEntry: "-"},
+			{Long: "ask-pass", Type: plugin.FlagType_Bool},
+		},
+	}
+	if newForm(c).IndexOfFlag("ask-pass") < 0 {
+		t.Error("--ask-pass is not offered, so nothing can ask the child to prompt")
+	}
+}
+
+// Without a secret the launcher must stay on the plain command line: routing
+// everything through a file would be a pointless regression.
+func TestNoSecretMeansNoInventoryFile(t *testing.T) {
+	c := awsConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "profile").SetValue("prod")
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	args, cleanup := plan.args, plan.cleanup
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsString(args, "--inventory-file") {
+		t.Fatalf("expected a plain command line, got %v", args)
+	}
+	if strings.Join(args, " ") != "scan aws --profile prod" {
+		t.Fatalf("args = %v", args)
+	}
+}
+
+// The command bar has to show what will really run, so a user can confirm for
+// themselves that no secret is on it.
+func TestCommandPreviewHidesSecrets(t *testing.T) {
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@host")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+
+	preview := (launchRequest{form: f}).preview(c, scanAction())
+	if strings.Contains(preview, sentinel) {
+		t.Fatalf("command preview leaked the secret: %q", preview)
+	}
+	// The bar names the file the launch will write, not a path that does not
+	// exist yet.
+	if !strings.Contains(preview, "--inventory-file") {
+		t.Fatalf("preview should show the inventory route, got %q", preview)
+	}
+}
+
+// A secret field must render masked, never in the clear.
+func TestSecretFieldsRenderMasked(t *testing.T) {
+	fd := valued(tuiform.Decl{Kind: fieldText, Secret: true}, sentinel)
+	if strings.Contains(fd.Display(), sentinel) {
+		t.Fatalf("secret field displayed in the clear: %q", fd.Display())
+	}
+}
+
+// FlagOption_Password is set by only a handful of providers, so the classifier
+// carries the weight. These are real flags from the installed set that leave
+// Option unset.
+func TestClassifierCatchesUnmarkedSecrets(t *testing.T) {
+	unmarked := []struct{ connector, flag string }{
+		{"azure", "client-secret"},
+		{"azure", "certificate-secret"},
+		{"github", "token"},
+		{"github", "app-private-key-content"},
+		{"neon", "token"},
+		{"okta", "token"},
+		{"alicloud", "access-key-secret"},
+		{"cloudflare", "token"},
+		{"openstack", "application-credential-secret"},
+	}
+	for _, u := range unmarked {
+		fl := plugin.Flag{Long: u.flag, Type: plugin.FlagType_String}
+		if !tuiform.IsSecretFlag(fl) {
+			t.Errorf("%s --%s not classified as a secret", u.connector, u.flag)
+		}
+	}
+
+	// Flags that name where a credential lives, or that toggle a prompt, must
+	// stay on the command line -- that is how the provider expects them.
+	//
+	// Descriptions are carried verbatim here because for one of these the name
+	// alone is genuinely ambiguous: github's --app-private-key holds a path,
+	// and only its description says so. A provider that ships that flag with no
+	// description gets it classified as a secret instead, which fails safe
+	// (the value moves into the inventory) but would not connect.
+	safe := []struct {
+		flag, desc string
+		typ        plugin.FlagType
+	}{
+		{"identity-file", "Select a file from which to read the identity", plugin.FlagType_String},
+		{"app-private-key", "GitHub App private key file path", plugin.FlagType_String},
+		{"certificate-path", "Path (in PKCS #12/PFX or PEM format) to the certificate", plugin.FlagType_String},
+		{"credentials-path", "The path to the service account credentials", plugin.FlagType_String},
+		{"federated-token-file", "Path to a file containing an OIDC token", plugin.FlagType_String},
+		{"auth-method", "Sign-in methods to use", plugin.FlagType_String},
+		{"application-credential-name", "Application credential name", plugin.FlagType_String},
+		{"tls-ca", "Path to the trusted CA certificate", plugin.FlagType_String},
+		{"sslrootcert", "Path to the trusted CA certificate for TLS", plugin.FlagType_String},
+		{"ask-pass", "Prompt for connection password", plugin.FlagType_Bool},
+		{"ask-api-key", "Prompt for the API key", plugin.FlagType_Bool},
+		{"ask-secret", "Prompt for the secret", plugin.FlagType_Bool},
+	}
+	for _, s := range safe {
+		if tuiform.IsSecretFlag(plugin.Flag{Long: s.flag, Desc: s.desc, Type: s.typ}) {
+			t.Errorf("--%s should not be classified as a secret value", s.flag)
+		}
+	}
+}
+
+// A sweep over everything installed, so a provider added later that names a
+// flag in the usual way is covered without anyone editing a list.
+func TestEverySecretShapedFlagIsClassified(t *testing.T) {
+	if _, err := providers.ListActive(); err != nil {
+		t.Skip("cannot read the installed provider set")
+	}
+	misses := 0
+	for _, c := range BuildCatalog() {
+		for _, fl := range c.Flags {
+			if fl.Option&plugin.FlagOption_Hidden != 0 || fl.Type != plugin.FlagType_String {
+				continue
+			}
+			name := strings.ToLower(fl.Long)
+			looksSecret := strings.HasSuffix(name, "password") ||
+				strings.HasSuffix(name, "token") ||
+				strings.HasSuffix(name, "secret") ||
+				strings.HasSuffix(name, "api-key")
+			if looksSecret && !tuiform.IsSecretFlag(fl) {
+				t.Errorf("%s --%s looks like a secret but is not classified", c.Name, fl.Long)
+				misses++
+			}
+		}
+	}
+	if misses == 0 {
+		t.Log("every secret-shaped flag in the installed set is classified")
+	}
+}
+
+// launcherOwnedFields are the `special` markers a form is allowed to carry.
+//
+// `special` means "a field the launcher owns rather than one the provider
+// declared", and there are legitimate ones -- the ambient-credential readout
+// and its paste box are exactly that. What must never come back is the keychain
+// toggle: it asked the user to choose between the operating system's protection
+// and a temporary file, and it appeared even for connectors whose credential
+// the launcher cannot carry at all, which made it doubly misleading.
+//
+// So this is an allowlist rather than a ban. A new launcher-owned field is
+// added here deliberately, by someone who has read the paragraph above.
+var launcherOwnedFields = map[string]bool{
+	// The ambient-credential readout, and digitalocean's second one for its
+	// env-only Spaces keys. Both hold the *name* of the variable a credential
+	// came from and never the credential; see source_ambient.go.
+	"credential-state":        true,
+	"credential-state.spaces": true,
+
+	// The two targets that have no flag to travel in, so they reach the child
+	// through its environment instead. Neither holds a credential: a profile
+	// name and a docker context name are both public, and what they select is
+	// which credentials the child finds for itself. See PositionalSpec.Special.
+	specialAlicloudProfile: true,
+	specialDockerContext:   true,
+}
+
+func TestNoKeychainToggleIsOffered(t *testing.T) {
+	for _, c := range BuildCatalog() {
+		if !c.HasFormData() {
+			continue
+		}
+		for _, fd := range newForm(c).Fields() {
+			if strings.Contains(strings.ToLower(fd.Label), "keychain") {
+				t.Fatalf("%s still asks about the keychain: %q", c.Name, fd.Label)
+			}
+			if fd.Special != "" && !launcherOwnedFields[fd.Special] {
+				t.Errorf("%s has an undeclared launcher-owned field %q; "+
+					"add it to launcherOwnedFields if it is meant to be there", c.Name, fd.Special)
+			}
+		}
+	}
+}
+
+// The keychain being unavailable must not lose the credential or put it on the
+// command line; it falls back to the inventory, which is still off argv.
+func TestKeychainFailureFallsBackToTheInventory(t *testing.T) {
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	args, env, cleanup := plan.args, plan.env, plan.cleanup
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Whichever route was taken, the secret is not on the command line.
+	if strings.Contains(strings.Join(args, " "), sentinel) {
+		t.Fatalf("secret reached argv: %v", args)
+	}
+	_ = env
+}
+
+// When the keychain cannot be used the scan still runs, the secret still stays
+// off the command line, and the user is told the guarantee is weaker.
+func TestKeychainFailureWarnsAndContinues(t *testing.T) {
+	orig := storeCredentialFn
+	storeCredentialFn = func(id string, cred *vault.Credential) error {
+		return errors.New("keyring unavailable")
+	}
+	defer func() { storeCredentialFn = orig }()
+
+	c := sshConnector()
+	f := newForm(c)
+	fieldByLabel(t, f, "user@host").SetValue("chris@10.0.0.4")
+	fieldByLabel(t, f, "password").SetValue(sentinel)
+	withParser(t, &fakeParser{secretFlag: "password"})
+
+	r := launchRequest{form: f}
+	plan, err := r.plan(c, scanAction())
+	if plan.cleanup != nil {
+		defer plan.cleanup()
+	}
+	if err != nil {
+		t.Fatalf("a keychain failure must not stop the scan: %v", err)
+	}
+	if plan.warn == "" {
+		t.Fatal("falling back to a file must warn")
+	}
+	for _, want := range []string{"keychain", "0600", "removed after"} {
+		if !strings.Contains(plan.warn, want) {
+			t.Errorf("the warning should mention %q: %q", want, plan.warn)
+		}
+	}
+	// The point of the fallback: still not on the command line.
+	if strings.Contains(strings.Join(plan.args, " "), sentinel) {
+		t.Fatalf("secret reached argv: %v", plan.args)
+	}
+	if !containsString(plan.args, "--inventory-file") {
+		t.Fatalf("expected the inventory route, got %v", plan.args)
+	}
+}
+
+// The warning reaches the screen, not just the struct.
+func TestKeychainWarningIsShown(t *testing.T) {
+	m := sized(newTestModel(), 140, 30)
+	m.lastWarn = "could not use the OS keychain (test) — written to a 0600 file"
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "could not use the OS keychain") {
+		t.Errorf("the warning should be on screen:\n%s", out)
+	}
+}

--- a/apps/cnspec/cmd/interactive/snapshot_test.go
+++ b/apps/cnspec/cmd/interactive/snapshot_test.go
@@ -1,0 +1,382 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/internal/connectors"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The recorded connector metadata, and why the specs are checked against it
+// rather than against the machine.
+//
+// Connector.Flags only exists for providers installed locally: the static
+// DefaultProviders list compiled into the binary strips it. CI creates an empty
+// .providers directory and points PROVIDERS_PATH at it, so ListActive() returns
+// nothing, BuildCatalog() degenerates to that flagless list, and every check
+// that needs a flag skips itself. Verified by running the suite that way: the
+// existing metadata tests log "not installed locally; skipped" and pass green.
+//
+// That matters because applySpec drops a flag the connector does not declare,
+// on purpose -- it is what makes a stale overlay degrade to the generic screen
+// instead of emitting a flag that no longer exists. The same mechanism makes a
+// typo invisible: the field simply never appears, and nothing says why. The one
+// gate that would catch it therefore has to run somewhere other than the
+// author's laptop, which is what the connector artifact is for.
+//
+// The file is generated from mql provider source by internal/connectorgen:
+//
+//	make connectors/generate MQL=../mql
+//
+// It is no longer written from the installed provider set. The generator reads
+// two things the installed metadata does not carry -- which environment
+// variable backs which flag, and the sub-command words a connector accepts --
+// and rewriting the file from a machine would drop both without saying so.
+// TestConnectorSnapshotMatchesLive still reports when the recorded flags have
+// drifted from what is installed here.
+//
+// It used to live in this package's testdata/. It now lives in
+// internal/connectors, embedded, because production reads it too: testdata is a
+// test-only location by convention and providerFormSpec is not a test. These
+// checks read the embedded bytes rather than a path, so a test and the launcher
+// can no longer be looking at two different files.
+
+const connectorSnapshotPath = "internal/connectors/connectors.json"
+
+// connectorSnapshot is the subset of a connector's declaration the spec checks
+// need. It carries no values, only what the connector says about itself: names,
+// argument counts, flags and discovery targets.
+type connectorSnapshot struct {
+	Name      string        `json:"name"`
+	Provider  string        `json:"provider"`
+	MinArgs   uint          `json:"min_args,omitempty"`
+	MaxArgs   uint          `json:"max_args,omitempty"`
+	Flags     []flagSnippet `json:"flags,omitempty"`
+	Discovery []string      `json:"discovery,omitempty"`
+
+	// Env is what the provider's own source does with a flag: the environment
+	// variables it reads that flag's value from, in the order it consults them.
+	// It is the fact the interim registry in delivery.go holds by hand.
+	Env []flagEnvSnippet `json:"env,omitempty"`
+	// Positional is the sub-command vocabulary -- github's org, user and repo --
+	// which exists nowhere else in machine-readable form.
+	Positional []positionalSnippet `json:"positional,omitempty"`
+
+	// Category is not recorded. categorize() owns it, and a second copy in a
+	// generated file would be a second thing to keep in step.
+}
+
+// connectorArtifact is the generated file: the connectors, plus what the
+// generator could not determine about them.
+type connectorArtifact struct {
+	Connectors []connectorSnapshot `json:"connectors"`
+	Gaps       []connectorGap      `json:"gaps"`
+}
+
+// connectorGap is one thing internal/connectorgen could not read out of the
+// provider source. It is recorded beside the metadata rather than in a separate
+// report so that a test can ask why a connector is missing something.
+type connectorGap struct {
+	Provider  string `json:"provider,omitempty"`
+	Connector string `json:"connector,omitempty"`
+	Kind      string `json:"kind"`
+	Detail    string `json:"detail"`
+}
+
+type flagEnvSnippet struct {
+	Flag string   `json:"flag"`
+	Vars []string `json:"vars"`
+	// Via is "parse-cli" when the variable is consulted while parsing the
+	// command line, and "connection" when the connection package reads it at
+	// connect time. The second sometimes takes precedence over the flag rather
+	// than yielding to it, which is a difference a launcher has to respect.
+	Via string `json:"via,omitempty"`
+	// Composed marks variables that are joined rather than chosen between, so
+	// setting only the first of them does not work.
+	Composed bool `json:"composed,omitempty"`
+}
+
+type positionalSnippet struct {
+	Index  int      `json:"index"`
+	Values []string `json:"values"`
+}
+
+type flagSnippet struct {
+	Long   string `json:"long"`
+	Type   int32  `json:"type,omitempty"`
+	Option int32  `json:"option,omitempty"`
+	Desc   string `json:"desc,omitempty"`
+	// Config is the flag's ConfigEntry: "-" means the flag is read from cobra
+	// alone and no configuration key or environment variable is consulted for
+	// it, and a non-empty entry sends it through viper on a key of the
+	// provider's choosing.
+	//
+	// It used to decide whether a credential could be delivered at all, because
+	// mql reads MONDOO_<FLAG> only for a flag that declares no config mapping
+	// and the launcher relied on that. It no longer decides anything the
+	// launcher does -- a credential goes into a ParseCLI request, which cobra's
+	// resolution never enters -- and it is still worth recording, because it is
+	// what a *user* running the same command by hand would be subject to.
+	Config string `json:"config,omitempty"`
+}
+
+// connector rebuilds a Connector from the snapshot, so a test can build the
+// real form for it.
+func (s connectorSnapshot) connector() Connector {
+	c := Connector{
+		Provider: s.Provider,
+		Name:     s.Name,
+		Use:      s.Name,
+		Category: categorize(s.Provider, s.Name),
+		MinArgs:  s.MinArgs,
+		MaxArgs:  s.MaxArgs,
+		// A snapshot only exists for a connector that was installed when it was
+		// taken, so it is one whose metadata is real.
+		Installed: true,
+		Discovery: s.Discovery,
+	}
+	for _, fl := range s.Flags {
+		c.Flags = append(c.Flags, plugin.Flag{
+			Long:        fl.Long,
+			Desc:        fl.Desc,
+			Type:        plugin.FlagType(fl.Type),
+			Option:      plugin.FlagOption(fl.Option),
+			ConfigEntry: fl.Config,
+		})
+	}
+	return c
+}
+
+// loadConnectorSnapshot reads the recorded connector metadata. It is a hard
+// failure rather than a skip: the whole point is that these checks run where no
+// provider is installed.
+//
+// It returns the connectors the launcher could offer, which is fewer than the
+// file holds. The file is a record of what the provider source declares, so it
+// includes the replay providers and the connectors that declare nothing at all;
+// the two filters below are the ones BuildCatalog already applies, and they
+// used to be applied when the file was written. Applying them here instead is
+// what keeps this file a faithful record of the source while every caller sees
+// the same set it always did.
+func loadConnectorSnapshot(t *testing.T) []connectorSnapshot {
+	t.Helper()
+	var art connectorArtifact
+	if err := json.Unmarshal(connectors.Raw(), &art); err != nil {
+		t.Fatalf("cannot parse %s: %v", connectorSnapshotPath, err)
+	}
+	if len(art.Connectors) == 0 {
+		t.Fatalf("%s is empty", connectorSnapshotPath)
+	}
+	out := make([]connectorSnapshot, 0, len(art.Connectors))
+	for _, s := range art.Connectors {
+		// mock and recording replay a connection rather than making one, and
+		// the launcher does not offer them.
+		if excludedProviders[s.Provider] {
+			continue
+		}
+		// A connector with no flag, no argument and no discovery target says
+		// nothing a form could be built from, and there is nothing here to
+		// check a spec against.
+		if !s.connector().DeclaresMetadata() {
+			continue
+		}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s holds no connector the launcher could offer", connectorSnapshotPath)
+	}
+	return out
+}
+
+// snapshotByName indexes the snapshot for lookups by connector name.
+func snapshotByName(t *testing.T) map[string]connectorSnapshot {
+	t.Helper()
+	out := map[string]connectorSnapshot{}
+	for _, s := range loadConnectorSnapshot(t) {
+		out[s.Name] = s
+	}
+	return out
+}
+
+// snapshotFromCatalog builds the snapshot from what is installed right now.
+func snapshotFromCatalog() []connectorSnapshot {
+	var out []connectorSnapshot
+	for _, c := range BuildCatalog() {
+		// DeclaresMetadata, not HasFormData: the snapshot records what a
+		// connector says about itself, including the connectors whose every
+		// flag is hidden. Filtering on renderability would drop `device` from
+		// the snapshot, and the reason device gets no spec is precisely a claim
+		// about its flags that a test has to be able to read.
+		if !c.Installed || !c.DeclaresMetadata() {
+			continue
+		}
+		s := connectorSnapshot{
+			Name:      c.Name,
+			Provider:  c.Provider,
+			MinArgs:   c.MinArgs,
+			MaxArgs:   c.MaxArgs,
+			Discovery: c.Discovery,
+		}
+		for _, fl := range c.Flags {
+			s.Flags = append(s.Flags, flagSnippet{
+				Long:   fl.Long,
+				Type:   int32(fl.Type),
+				Option: int32(fl.Option),
+				Desc:   fl.Desc,
+				Config: fl.ConfigEntry,
+			})
+		}
+		sort.Slice(s.Flags, func(i, j int) bool { return s.Flags[i].Long < s.Flags[j].Long })
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// TestConnectorSnapshot checks the recorded metadata parses and describes
+// something.
+//
+// -update used to rewrite the file from the installed provider set, and it
+// refuses now instead of doing it. The file gained two facts an installed
+// provider does not carry -- the environment variable behind each flag, and the
+// sub-command words -- so writing it from a machine would silently delete both,
+// leaving a file that still parses and still passes every test here while the
+// delivery routes it describes have vanished. Refusing points at the generator
+// that can produce all of it.
+func TestConnectorSnapshot(t *testing.T) {
+	if *updateSnapshot {
+		t.Fatalf("%s is generated from mql provider source and cannot be written from the installed providers: "+
+			"the installed metadata carries no environment variables and no sub-command words, so this would drop them. "+
+			"Run `make connectors/generate MQL=<path to an mql checkout>` instead.", connectorSnapshotPath)
+	}
+
+	snap := loadConnectorSnapshot(t)
+	for _, s := range snap {
+		if s.Name == "" || s.Provider == "" {
+			t.Errorf("snapshot entry with no name or provider: %+v", s)
+		}
+		if !s.connector().DeclaresMetadata() {
+			t.Errorf("%s: snapshotted but carries no declared metadata", s.Name)
+		}
+	}
+}
+
+// The snapshot is a copy, so it goes stale. This says so where it can be seen,
+// and skips where it cannot -- on CI, where no provider is installed, there is
+// nothing to compare against and the snapshot is all there is.
+func TestConnectorSnapshotMatchesLive(t *testing.T) {
+	// The condition is what the catalog actually yielded, not what ListActive
+	// returned: with PROVIDERS_PATH pointed at an empty directory it still
+	// returns entries, they just carry no Provider, so BuildCatalog degenerates
+	// to the flagless static list. Skipping on the empty result is what keeps
+	// this from passing vacuously and reading as "no drift".
+	live := snapshotFromCatalog()
+	if len(live) == 0 {
+		t.Skip("no connector metadata available here; the snapshot cannot be checked for drift")
+	}
+	recorded := snapshotByName(t)
+
+	checked, drifted := 0, 0
+	for _, l := range live {
+		r, ok := recorded[l.Name]
+		if !ok {
+			drifted++
+			t.Logf("drift: %s is installed but not recorded; re-run make connectors/generate", l.Name)
+			continue
+		}
+		checked++
+		have := map[string]bool{}
+		for _, fl := range r.Flags {
+			have[fl.Long] = true
+		}
+		for _, fl := range l.Flags {
+			if !have[fl.Long] {
+				drifted++
+				t.Logf("drift: %s --%s is declared locally but not recorded; re-run make connectors/generate",
+					l.Name, fl.Long)
+			}
+		}
+	}
+	// Counted, because a drift report that says nothing is indistinguishable
+	// from one that had nothing to compare against.
+	t.Logf("%d installed connectors compared against the recorded metadata, %d drifts", checked, drifted)
+}
+
+// The recorded environment routes used to be cross-checked against a registry
+// in delivery.go: the extractor read them out of provider source, the registry
+// was established by running the provider binaries, and where both spoke about
+// one flag they had to agree.
+//
+// The registry is gone -- the launcher asks the provider rather than listing
+// what it reads -- so there is nothing left to disagree with. The extracted
+// routes stay: they are what the ambient credential readouts describe, and
+// "which variable would this provider have used if you had supplied nothing" is
+// still a useful thing for a form to say. What they no longer decide is where a
+// credential the user typed goes.
+
+// A route the extraction found for a flag no connector declares would be a
+// field the launcher could never offer, so the artifact must not carry one.
+func TestRecordedEnvOnlyNamesDeclaredFlags(t *testing.T) {
+	for _, s := range loadConnectorSnapshot(t) {
+		declared := map[string]bool{}
+		for _, fl := range s.Flags {
+			declared[fl.Long] = true
+		}
+		for _, route := range s.Env {
+			if !declared[route.Flag] {
+				t.Errorf("%s records a route for --%s, which it does not declare", s.Name, route.Flag)
+			}
+			if len(route.Vars) == 0 {
+				t.Errorf("%s --%s records a route with no variable in it", s.Name, route.Flag)
+			}
+		}
+	}
+}
+
+// The sub-command words only mean something for a connector that takes an
+// argument to put them in.
+func TestRecordedPositionalFitsTheArgumentCount(t *testing.T) {
+	vocabularies := 0
+	for _, s := range loadConnectorSnapshot(t) {
+		for _, p := range s.Positional {
+			vocabularies++
+			if s.MaxArgs == 0 {
+				t.Errorf("%s records a vocabulary for argument %d but declares it takes no arguments",
+					s.Name, p.Index)
+			}
+			if p.Index >= int(s.MaxArgs) {
+				t.Errorf("%s records a vocabulary for argument %d but takes at most %d",
+					s.Name, p.Index, s.MaxArgs)
+			}
+			if len(p.Values) == 0 {
+				t.Errorf("%s records an empty vocabulary for argument %d", s.Name, p.Index)
+			}
+		}
+	}
+	if vocabularies == 0 {
+		t.Error("no connector records a sub-command vocabulary, so this checked nothing")
+	}
+}
+
+// github is the connector the whole extraction was justified by: its org, user
+// and repo live only in its help prose and in its own ParseCLI, and getting
+// them wrong is the trap delivery.go already names.
+func TestGithubVocabularyIsRecorded(t *testing.T) {
+	snap, ok := snapshotByName(t)["github"]
+	if !ok {
+		t.Fatal("github is not in the recorded metadata")
+	}
+	if len(snap.Positional) != 1 {
+		t.Fatalf("github records %d vocabularies, want 1: %+v", len(snap.Positional), snap.Positional)
+	}
+	got := strings.Join(snap.Positional[0].Values, "|")
+	if got != "org|user|repo" {
+		t.Errorf("github's sub-command words are %q, want %q", got, "org|user|repo")
+	}
+}

--- a/apps/cnspec/cmd/interactive/source.go
+++ b/apps/cnspec/cmd/interactive/source.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go.mondoo.com/cnspec/cli/launcher/source"
+)
+
+// The launcher's names for the value pickers.
+//
+// The pickers themselves are cli/launcher/source: what a Source declares about
+// itself, the readers behind each one, and the registry they live in. None of
+// that knows what a connector is or what a screen looks like, which is the
+// point of the move -- a picker that reads ~/.aws is not a fact about a
+// terminal UI.
+//
+// These are aliases rather than a rewrite at every use, for the same reason
+// the form engine's aliases exist in form.go: the rename would then have been
+// the change, across 423 uses of 77 names in this package, and a diff that size
+// hides whatever else is in it. Nothing here adds behaviour. Everything that
+// does is on the other side of the import.
+
+// The contract a picker declares about itself.
+type (
+	Source      = source.Source
+	Class       = source.Class
+	Cost        = source.Cost
+	EmitFunc    = source.EmitFunc
+	ExplainFunc = source.ExplainFunc
+)
+
+const (
+	ClassEnumerated     = source.ClassEnumerated
+	ClassAmbient        = source.ClassAmbient
+	ClassPostConnection = source.ClassPostConnection
+	ClassRequired       = source.ClassRequired
+
+	CostInstant = source.CostInstant
+	CostLocal   = source.CostLocal
+	CostRemote  = source.CostRemote
+)
+
+// The source-id namespace. A curated form names its pickers by id, so every
+// one of these is reached for by a curated form or by a test of one.
+const (
+	srcAWSProfile          = source.AWSProfile
+	srcKubeContext         = source.KubeContext
+	srcSSHHost             = source.SSHHost
+	srcDockerContainer     = source.DockerContainer
+	srcDockerImage         = source.DockerImage
+	srcGCPProject          = source.GCPProject
+	srcGCPProjectAll       = source.GCPProjectAll
+	srcGCPZone             = source.GCPZone
+	srcAzureSubscription   = source.AzureSubscription
+	srcOCIProfile          = source.OCIProfile
+	srcAlicloudProfile     = source.AlicloudProfile
+	srcSnowflakeConnection = source.SnowflakeConnection
+	srcDockerContext       = source.DockerContext
+	srcK8sNamespace        = source.K8sNamespace
+
+	srcGitHubToken       = source.GitHubToken
+	srcGitLabToken       = source.GitLabToken
+	srcSlackToken        = source.SlackToken
+	srcCloudflareToken   = source.CloudflareToken
+	srcDigitalOceanToken = source.DigitalOceanToken
+	srcHetznerToken      = source.HetznerToken
+	srcOktaToken         = source.OktaToken
+
+	srcDiscoverK8sNamespaces      = source.DiscoverK8sNamespaces
+	srcDiscoverGitHubRepos        = source.DiscoverGitHubRepos
+	srcDiscoverGitLabProjects     = source.DiscoverGitLabProjects
+	srcDiscoverGitLabGroups       = source.DiscoverGitLabGroups
+	srcDiscoverAzureSubscriptions = source.DiscoverAzureSubscriptions
+	srcDiscoverGCPProjects        = source.DiscoverGCPProjects
+	srcDiscoverAWSAccounts        = source.DiscoverAWSAccounts
+	srcDiscoverOCITenancy         = source.DiscoverOCITenancy
+	srcDiscoverAlicloudAccounts   = source.DiscoverAlicloudAccounts
+	srcDiscoverDigitalOceanDBs    = source.DiscoverDigitalOceanDBs
+	srcDiscoverNeonProjects       = source.DiscoverNeonProjects
+	srcDiscoverNetlifySites       = source.DiscoverNetlifySites
+	srcDiscoverVercelProjects     = source.DiscoverVercelProjects
+	srcDiscoverAtlasProjects      = source.DiscoverAtlasProjects
+	srcDiscoverHCPProjects        = source.DiscoverHCPProjects
+	srcDiscoverClaudeWorkspaces   = source.DiscoverClaudeWorkspaces
+	srcDiscoverMSSQLDatabases     = source.DiscoverMSSQLDatabases
+	srcDiscoverMySQLDatabases     = source.DiscoverMySQLDatabases
+	srcDiscoverPostgresDatabases  = source.DiscoverPostgresDatabases
+	srcDiscoverSnowflakeDatabases = source.DiscoverSnowflakeDatabases
+)
+
+// Names a curated form or a launch reaches for.
+const (
+	specialCredentialState = source.SpecialCredentialState
+	ambientWhyEnv          = source.AmbientWhyEnv
+	alicloudProfileEnv     = source.AlicloudProfileEnv
+	dockerContextEnv       = source.DockerContextEnv
+	dockerHostEnv          = source.DockerHostEnv
+	dockerDefaultContext   = source.DockerDefaultContext
+)
+
+// registry is the live source registry. The tests that install a source and
+// take it away again reach for it by this name; see source.Registry.
+var registry = source.Registry()
+
+var (
+	register             = source.Register
+	sourceByID           = source.ByID
+	activityFor          = source.ActivityFor
+	deferredSource       = source.Deferred
+	preferredValue       = source.PreferredValue
+	sourceEmit           = source.Emit
+	sourceKey            = source.Key
+	discoverSourceID     = source.DiscoverSourceID
+	refreshAmbient       = source.RefreshAmbient
+	sortedUnique         = source.SortedUnique
+	gcpActiveProject     = source.GCPActiveProject
+	neutralisedBy        = source.NeutralisedBy
+	dockerContextEnvFrom = source.DockerContextEnvFrom
+)
+
+// applyAmbient gives a connector's ambient credentials their widgets. The
+// pickers need the connector's name and nothing else about it, so this is
+// where the catalog stops.
+func applyAmbient(f *form, c Connector) { source.ApplyAmbient(f, c.Name) }
+
+// sourceValuesMsg carries a picker's values back into the model.
+//
+// The message stays on this side of the boundary because it is model plumbing:
+// bubbletea delivers it, Update reads it, and the fetch it reports on has no
+// opinion about either. What it reports is source.Result, field for field.
+type sourceValuesMsg struct {
+	source string
+	key    string
+	values []string
+	// err explains an empty list. A picker that cannot reach its cluster has
+	// to say so rather than look like a cluster with nothing in it.
+	err error
+	// cancelled marks the answer to a question nobody is waiting for any more.
+	// A killed child reports "signal: killed", which is true and useless: the
+	// user closed the picker, and reporting that their gcloud died is blaming
+	// them for their own esc key.
+	cancelled bool
+}
+
+// loadSourceCmd fetches a picker's values off the UI goroutine. Docker shells
+// out to a daemon that can be slow or wedged, so no source is ever resolved
+// inline in Update.
+//
+// The key is computed once, before the command runs, and carried into every
+// message it can produce. The model registers a loading key at that same point
+// and deletes it when the message lands, so a key that changed in between --
+// registered scoped and deleted unscoped -- would leave a spinner that can
+// never stop.
+func loadSourceCmd(ctx context.Context, id string, params []string) tea.Cmd {
+	key := sourceKey(id, params)
+	return func() tea.Msg {
+		r := source.Load(ctx, id, params)
+		return sourceValuesMsg{
+			source:    id,
+			key:       key,
+			values:    r.Values,
+			err:       r.Err,
+			cancelled: r.Cancelled,
+		}
+	}
+}
+
+func init() {
+	// The one thing cli/launcher/source needs from this package and cannot
+	// import, because this package imports it: pointing a namespace list at the
+	// cluster the user picked needs a kubeconfig copy written first, which is
+	// kubeconfig.go's job.
+	//
+	// There used to be a second, a loop registering the environment variable
+	// each ambient credential declared for its own paste box. Nothing needs it
+	// now: a pasted value travels the same way a typed one does, by inventory,
+	// and the variables the ambient rows name are only what the *provider*
+	// reads when the launcher supplies nothing.
+	source.KubeEnvApply = kubeEnvForContext
+}

--- a/apps/cnspec/cmd/interactive/source_ambient_test.go
+++ b/apps/cnspec/cmd/interactive/source_ambient_test.go
@@ -1,0 +1,408 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+
+	"go.mondoo.com/cnspec/cli/launcher/source"
+)
+
+// Every test in this file injects the environment.
+//
+// The variables the ambient class reads are exactly the ones a developer
+// running these tests is most likely to have exported, so a test that consulted
+// the real environment would pass or fail depending on whose machine it ran on
+// -- and would be reading that developer's actual tokens to do it. The
+// injected lookup answers from a map and nothing else.
+func withAmbientEnv(t *testing.T, vars map[string]string) {
+	t.Helper()
+	prev := source.SetAmbientEnv(func(name string) (string, bool) {
+		v, ok := vars[name]
+		return v, ok
+	})
+	t.Cleanup(func() { source.SetAmbientEnv(prev) })
+}
+
+// ambientConnector is a stand-in for an installed provider, so these tests say
+// the same thing on a machine with no providers installed at all.
+func ambientConnector(name string, flags ...plugin.Flag) Connector {
+	return Connector{
+		Provider: name, Name: name, Use: name, Category: catSaaS,
+		Installed: true,
+		Flags:     append([]plugin.Flag{{Long: "token", Type: plugin.FlagType_String}}, flags...),
+	}
+}
+
+const ambientToken = "tok-<PLACEHOLDER-not-a-real-secret>"
+
+// The one thing a credential readout exists to say is where the token came
+// from. The one thing it must never say is what the token is.
+func TestAmbientReadoutNamesTheVariableNeverTheToken(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"GITLAB_TOKEN": ambientToken})
+
+	f := newForm(ambientConnector("gitlab"))
+	fd := fieldByLabel(t, f, "credential")
+
+	if fd.Kind != tuiform.KindCredentialState {
+		t.Fatalf("the readout is a %v, want a credential-state field", fd.Kind)
+	}
+	if fd.Value() != "GITLAB_TOKEN" {
+		t.Errorf("readout = %q, want the variable that supplied the token", fd.Value())
+	}
+	if !fd.IsSet() {
+		t.Error("a token was found but the readout reports itself unset")
+	}
+	if strings.Contains(fd.Display(), ambientToken) {
+		t.Fatalf("the readout displayed the token: %q", fd.Display())
+	}
+	// Nothing else on the form may be holding it either: the launcher reads
+	// whether the variable is set, never what it holds.
+	for _, g := range f.Fields() {
+		if strings.Contains(g.Value(), ambientToken) {
+			t.Fatalf("%q holds the token itself: %q", g.Label, g.Value())
+		}
+	}
+}
+
+// An empty row and a row with nothing to fill in look identical, which is the
+// failure this widget exists to end.
+func TestAmbientReadoutSaysWhatToExportWhenNothingIsSet(t *testing.T) {
+	withAmbientEnv(t, nil)
+
+	f := newForm(ambientConnector("cloudflare"))
+	fd := fieldByLabel(t, f, "credential")
+	if fd.IsSet() {
+		t.Fatalf("nothing is exported but the readout says %q", fd.Value())
+	}
+
+	hint := credentialHint(*fd)
+	if !strings.Contains(hint, "CLOUDFLARE_TOKEN") {
+		t.Errorf("the hint should name the variable to export, got %q", hint)
+	}
+	if !strings.Contains(hint, "paste") {
+		t.Errorf("the hint should offer the other way in, got %q", hint)
+	}
+}
+
+// okta reads three levels in order -- --token, OKTA_API_TOKEN, then OKTA_TOKEN
+// -- so the readout has to name the one the provider will actually reach for.
+func TestOktaReadoutFollowsTheProvidersPrecedence(t *testing.T) {
+	both := map[string]string{
+		"OKTA_API_TOKEN": ambientToken,
+		"OKTA_TOKEN":     ambientToken,
+	}
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"both set", both, "OKTA_API_TOKEN"},
+		{"only the fallback", map[string]string{"OKTA_TOKEN": ambientToken}, "OKTA_TOKEN"},
+		{"only the first", map[string]string{"OKTA_API_TOKEN": ambientToken}, "OKTA_API_TOKEN"},
+		{"neither", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withAmbientEnv(t, tc.env)
+			f := newForm(oktaTestConnector())
+			if got := fieldByLabel(t, f, "credential").Value(); got != tc.want {
+				t.Errorf("readout = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func oktaTestConnector() Connector {
+	return ambientConnector("okta",
+		plugin.Flag{Long: "organization", Type: plugin.FlagType_String,
+			Desc: "The domain of the Okta organization to scan"},
+	)
+}
+
+// The launcher must not prefill an organization it composed out of nothing.
+// oktaOrganization itself is checked in cli/launcher/source; this is the form
+// honouring it.
+func TestOktaOrganizationIsNotPrefilledFromNothing(t *testing.T) {
+	withAmbientEnv(t, nil)
+	fd := fieldByLabel(t, newForm(oktaTestConnector()), "organization")
+	if fd.Value() != "" {
+		t.Fatalf("the organization field was prefilled with %q", fd.Value())
+	}
+	if fd.Prefilled() != "" {
+		t.Errorf("nothing was filled in, but it claims %q", fd.Prefilled())
+	}
+}
+
+// What the provider really will use is worth showing, and an editable field is
+// where a user gets to notice it.
+func TestOktaOrganizationReachesTheForm(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"OKTA_ORG_NAME": "dev-123", "OKTA_BASE_URL": "okta.com"})
+	f := newForm(oktaTestConnector())
+	fd := fieldByLabel(t, f, "organization")
+	if fd.Value() != "dev-123.okta.com" {
+		t.Fatalf("organization = %q, want the composed domain", fd.Value())
+	}
+	if fd.Prefilled() == "" {
+		t.Error("a value the user did not type must say where it came from")
+	}
+	// It is an ordinary flag, so it still travels on the command line.
+	if !slices.Contains(f.Args(), "--organization") {
+		t.Errorf("the composed organization did not reach the command: %v", f.Args())
+	}
+}
+
+// A typed value is never overwritten by the environment.
+func TestOktaOrganizationDoesNotOverwriteTheUser(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"OKTA_ORG_NAME": "dev-123", "OKTA_BASE_URL": "okta.com"})
+	f := newForm(oktaTestConnector())
+	fieldByLabel(t, f, "organization").SetValue("chosen.okta.com")
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "organization").Value(); got != "chosen.okta.com" {
+		t.Fatalf("organization = %q, want what the user typed", got)
+	}
+}
+
+// The flag beats the environment in every one of these providers, so a readout
+// that named a variable while a pasted token was about to be used would be
+// confidently wrong about the one fact it states.
+func TestPastedTokenBeatsTheEnvironment(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"SLACK_TOKEN": ambientToken})
+
+	f := newForm(ambientConnector("slack"))
+	if got := fieldByLabel(t, f, "credential").Value(); got != "SLACK_TOKEN" {
+		t.Fatalf("readout = %q, want the variable", got)
+	}
+
+	paste := fieldByLabel(t, f, "token")
+	if paste.Kind != fieldPaste {
+		t.Fatalf("the token flag is a %v, want a paste box", paste.Kind)
+	}
+	if !paste.Secret {
+		t.Fatal("the paste box is not marked secret, so its value could reach argv")
+	}
+	paste.SetValue("pasted-" + ambientToken)
+
+	// resolveSources is what the model runs after every keystroke.
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "credential").Value(); got != "pasted" {
+		t.Errorf("readout = %q, want it to follow the pasted token", got)
+	}
+	if strings.Contains(fieldByLabel(t, f, "credential").Display(), ambientToken) {
+		t.Fatal("the readout displayed the pasted token")
+	}
+
+	// Clearing it hands the row back to the environment.
+	fieldByLabel(t, f, "token").SetValue("")
+	resolveSources(&f)
+	if got := fieldByLabel(t, f, "credential").Value(); got != "SLACK_TOKEN" {
+		t.Errorf("readout = %q after clearing the paste box, want the variable back", got)
+	}
+}
+
+// A form can be rebuilt underneath the user when a provider install lands, and
+// the readout on the new form was derived before the old form's pasted token
+// was carried onto it.
+func TestReadoutFollowsATokenCarriedOntoARebuiltForm(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"GITLAB_TOKEN": ambientToken})
+
+	old := newForm(ambientConnector("gitlab"))
+	fieldByLabel(t, old, "token").SetValue("pasted-" + ambientToken)
+
+	rebuilt := newForm(ambientConnector("gitlab"))
+	carryOver(&rebuilt, old)
+
+	if got := fieldByLabel(t, rebuilt, "credential").Value(); got != "pasted" {
+		t.Errorf("readout = %q after a rebuild carried the token over, want it to follow", got)
+	}
+}
+
+// The readout is a launcher-owned field with no flag, which is precisely the
+// shape that used to be emitted as a positional argument.
+func TestAmbientReadoutNeverReachesTheCommandLine(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"HCLOUD_TOKEN": ambientToken})
+
+	c := ambientConnector("hetzner")
+	f := newForm(c)
+	fieldByLabel(t, f, "token").SetValue(ambientToken)
+
+	for _, a := range f.Args() {
+		if strings.Contains(a, "HCLOUD_TOKEN") || strings.Contains(a, ambientToken) {
+			t.Fatalf("the credential reached the command line: %v", f.Args())
+		}
+	}
+
+	assertCredentialReachesTheProvider(t, c, f, "token", ambientToken)
+}
+
+// A pasted token reaches the provider, for every ambient credential that
+// offers a box to paste into.
+//
+// This used to check that the variable the launcher would export was one the
+// provider reads, which was the right check while the launcher had to name one.
+// A paste box is now indistinguishable from typing into the field it sits over,
+// which is the point of the box.
+func TestEveryPasteBoxReachesTheProvider(t *testing.T) {
+	withAmbientEnv(t, nil)
+	checked := 0
+	for _, a := range source.AmbientCredentials() {
+		if a.Flag == "" {
+			continue
+		}
+		c := ambientConnector(a.Connector)
+		f := newForm(c)
+		i := f.IndexOfFlag(a.Flag)
+		if i < 0 {
+			t.Errorf("%s: no --%s field to paste into", a.Connector, a.Flag)
+			continue
+		}
+		f.Fields()[i].SetValue(ambientToken)
+		checked++
+
+		t.Run(a.Connector+"/"+a.Flag, func(t *testing.T) {
+			assertCredentialReachesTheProvider(t, c, f, a.Flag, ambientToken)
+		})
+	}
+	if checked == 0 {
+		t.Fatal("no paste box was checked, so this proved nothing")
+	}
+}
+
+// digitalocean's Spaces credentials are env-only: no flag carries any of them,
+// so they are reported and never collected. Every credential now reaches the
+// provider as a flag value, over its own ParseCLI, so a box over a value with
+// no flag would collect something with nowhere to hand it to.
+func TestDigitalOceanSpacesIsReportOnly(t *testing.T) {
+	withAmbientEnv(t, map[string]string{
+		"DIGITALOCEAN_TOKEN":         ambientToken,
+		"DIGITALOCEAN_SPACES_KEY":    "key",
+		"DIGITALOCEAN_SPACES_SECRET": "secret",
+	})
+
+	c := ambientConnector("digitalocean")
+	f := newForm(c)
+
+	spaces := fieldByLabel(t, f, "spaces keys")
+	if spaces.Flag != "" || spaces.Special == "" {
+		t.Fatalf("the spaces readout carries a flag (%q), so it is not report-only", spaces.Flag)
+	}
+	if !spaces.IsSet() {
+		t.Fatal("both spaces variables are set but the readout says nothing was found")
+	}
+	if !strings.Contains(spaces.Value(), "DIGITALOCEAN_SPACES_KEY") {
+		t.Errorf("spaces readout = %q, want the variables it found", spaces.Value())
+	}
+
+	// Nothing typed, so nothing to carry.
+	if got := deliveryFor(f); got != deliverPlain {
+		t.Errorf("delivery = %v with nothing typed, want the plain command line", got)
+	}
+	_ = c
+	if got := len(f.Secrets()); got != 0 {
+		t.Errorf("%d secret fields hold a value, want none: the readouts are not secrets", got)
+	}
+}
+
+// A partial set is not a credential: the provider needs both, and reporting
+// "found" off the first one would be confidently wrong.
+func TestDigitalOceanSpacesNeedsBothVariables(t *testing.T) {
+	withAmbientEnv(t, map[string]string{"DIGITALOCEAN_SPACES_KEY": "key"})
+
+	f := newForm(ambientConnector("digitalocean"))
+	fd := fieldByLabel(t, f, "spaces keys")
+	if fd.IsSet() {
+		t.Fatalf("half the credential reads as present: %q", fd.Value())
+	}
+	if !strings.Contains(credentialHint(*fd), "DIGITALOCEAN_SPACES_SECRET") {
+		t.Errorf("the hint should name what is missing, got %q", credentialHint(*fd))
+	}
+}
+
+// Inserting the readout ahead of a field must not re-point the selectors that
+// make a form guided: they hold plain indices into the field list.
+func TestInsertingAReadoutKeepsSelectorsPointing(t *testing.T) {
+	withAmbientEnv(t, nil)
+
+	// github's curated form leads with a kind/name pair, and the credential
+	// section comes after it.
+	f := newForm(githubConnector())
+	name := fieldByLabel(t, f, "name")
+	kindAt := -1
+	for i := range f.Fields() {
+		if f.Fields()[i].Label == "kind" {
+			kindAt = i
+		}
+	}
+	if kindAt < 0 {
+		t.Fatal("github lost its kind selector")
+	}
+	if name.DependsOn != kindAt {
+		t.Fatalf("name depends on field %d, want the kind selector at %d", name.DependsOn, kindAt)
+	}
+
+	// And a synthetic case where the readout really does land ahead of a
+	// dependent field.
+	g := tuiform.New("", []field{
+		tuiform.NewField(tuiform.Decl{Label: "a"}),
+		tuiform.NewField(tuiform.Decl{Label: "b", ShowIf: []string{"x"}, DependsOn: 0}),
+	})
+	g.InsertField(0, tuiform.NewField(tuiform.Decl{Label: "readout", Kind: tuiform.KindCredentialState}))
+	if got := g.Fields()[2].DependsOn; got != 1 {
+		t.Errorf("dependsOn = %d after an insert ahead of it, want 1", got)
+	}
+	if g.Fields()[0].DependsOn != 0 {
+		t.Errorf("the inserted field picked up a dependency: %d", g.Fields()[0].DependsOn)
+	}
+}
+
+// The declarations are the whole of this class, so what they must satisfy is
+// checked once over all of them rather than remembered per provider.
+func TestAmbientDeclarationsAreConsistent(t *testing.T) {
+	withAmbientEnv(t, nil)
+	seen := map[string]bool{}
+
+	for _, a := range source.AmbientCredentials() {
+		if a.Connector == "" || len(a.Env) == 0 {
+			t.Errorf("%+v: an ambient credential needs a connector and a variable", a)
+			continue
+		}
+		key := a.Connector + "/" + a.Name
+		if seen[key] {
+			t.Errorf("%s: declared twice, so one readout would overwrite the other", key)
+		}
+		seen[key] = true
+
+		if a.Source != "" {
+			s, ok := sourceByID(a.Source)
+			if !ok {
+				t.Errorf("%s: source %q is not registered", key, a.Source)
+			} else if s.Class != ClassAmbient {
+				t.Errorf("%s: source %q is class %v, want ClassAmbient", key, a.Source, s.Class)
+			}
+		}
+
+		// The readout is launcher-owned, and the allowlist in secrets_test.go
+		// is where that is granted deliberately.
+		if !launcherOwnedFields[a.Special()] {
+			t.Errorf("%s: %q is not in launcherOwnedFields", key, a.Special())
+		}
+
+		// args() tracks field visibility by label, so two fields sharing one
+		// would make a hidden field visible.
+		f := newForm(ambientConnector(a.Connector))
+		labels := map[string]int{}
+		for _, fd := range f.Fields() {
+			labels[fd.Label]++
+		}
+		for label, n := range labels {
+			if n > 1 {
+				t.Errorf("%s: %d fields labelled %q", key, n, label)
+			}
+		}
+	}
+}

--- a/apps/cnspec/cmd/interactive/source_picker_test.go
+++ b/apps/cnspec/cmd/interactive/source_picker_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// What a picker's failure looks like on the screen.
+//
+// The pickers themselves are cli/launcher/source and these tests are not: what
+// they assert is that a reason a source produced reaches a hint, a footer and a
+// modal, which is the model's half of the bargain rather than the source's.
+
+// Only the profile name is a command-line argument; the label the picker adds
+// is for reading. The mapping is the source's, and this is the launcher
+// honouring it.
+func TestAWSProfileLabelNeverReachesArgv(t *testing.T) {
+	f := newForm(awsConnector())
+	fd := fieldByLabel(t, f, "profile")
+	fd.SetValue("sso-prod  (123456789012)")
+	if got := strings.Join(f.Args(), " "); got != "--profile sso-prod" {
+		t.Fatalf("args = %q, want the bare profile name", got)
+	}
+}
+
+// A failed lookup must say why on the screen, not just that it failed.
+func TestPickerShowsTheReasonItIsEmpty(t *testing.T) {
+	m := selectEntry(t, sized(newTestModel(), 140, 30), "ssh")
+	fd := m.detail.form.Fields()[0]
+	setSourceErr(&m, fd.Source(), errors.New("gcloud needs signing in again — run: gcloud auth login"))
+
+	if got := m.picker.choiceHint(m.detail.form, fd); !strings.Contains(got, "gcloud auth login") {
+		t.Fatalf("hint = %q, want the actual reason", got)
+	}
+}
+
+// A live refresh that failed must say so even when the cheap read succeeded.
+// The list is showing, it is just incomplete, and without this the failure is
+// invisible: the field looks like a complete answer.
+func TestLiveFailureIsVisibleBesideLocalValues(t *testing.T) {
+	c := Connector{
+		Provider: "gcp", Name: "gcp", Use: "gcp", Category: catCloud,
+		Installed: true, MaxArgs: 2,
+	}
+	m := sized(NewModel([]Connector{c}), 140, 30)
+	fieldByLabel(t, m.detail.form, "what to scan").SetValue("project")
+	resolveSources(&m.detail.form)
+
+	// The cheap read succeeded and prefilled.
+	setSource(&m, srcGCPProject, []string{"attack-surface-scanner"})
+	m.detail.applyPrefill(srcGCPProject, []string{"attack-surface-scanner"}, m.focus == focusForm)
+
+	// The live one did not.
+	liveErr := errors.New("gcloud needs signing in again — run: gcloud auth login")
+	setSourceErr(&m, srcGCPProjectAll, liveErr)
+
+	id := fieldByLabel(t, m.detail.form, "id")
+	if got := m.picker.liveError(m.detail.form, *id); !strings.Contains(got, "gcloud auth login") {
+		t.Fatalf("liveSourceError = %q", got)
+	}
+
+	// In the footer, which is the only place with room for a sentence.
+	m.focus = focusForm
+	m.lastWarn = liveErr.Error()
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "gcloud auth login") {
+		t.Errorf("the footer should carry the reason:\n%s", out)
+	}
+
+	// And inside the picker, where the incomplete list is.
+	for i, fd := range m.detail.form.Fields() {
+		if fd.Label == "id" {
+			m.detail.form.SetCursor(i)
+		}
+	}
+	m.picker.modal = modalState{open: true, field: m.detail.form.Cursor()}
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "gcloud auth login") {
+		t.Errorf("the picker should carry the reason:\n%s", out)
+	}
+}

--- a/apps/cnspec/cmd/interactive/source_snapshot_test.go
+++ b/apps/cnspec/cmd/interactive/source_snapshot_test.go
@@ -1,0 +1,201 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/cli/launcher/source"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// What the value pickers claim about connectors, confronted with the recorded
+// connector metadata.
+//
+// The pickers are cli/launcher/source and these tests are not, because the
+// snapshot is: it is built from BuildCatalog, it is 190KB of recorded provider
+// declarations, and it belongs to the package that owns the catalog. What each
+// test asserts is still a property of a source -- that the flag a picker fills
+// exists, that the flag it deliberately does not fill really is absent -- so
+// each one names the source-side test it is the other half of.
+
+// declaredSourceIDs is the whole id namespace as the launcher names it, listed
+// once so the check below is about the set rather than about any one id.
+//
+// It is written out rather than derived for the same reason the list in
+// cli/launcher/source is: deriving it from the registry would make the test
+// agree with whatever happened to be registered.
+var declaredSourceIDs = []string{
+	srcAWSProfile, srcKubeContext, srcSSHHost, srcDockerContainer, srcDockerImage,
+	srcGCPProject, srcGCPProjectAll, srcGCPZone, srcAzureSubscription, srcOCIProfile,
+	srcAlicloudProfile, srcSnowflakeConnection, srcDockerContext, srcK8sNamespace,
+	srcGitHubToken, srcGitLabToken, srcSlackToken, srcCloudflareToken,
+	srcDigitalOceanToken, srcHetznerToken, srcOktaToken,
+	srcDiscoverK8sNamespaces, srcDiscoverGitHubRepos, srcDiscoverGitLabProjects,
+	srcDiscoverGitLabGroups, srcDiscoverAzureSubscriptions, srcDiscoverGCPProjects,
+	srcDiscoverAWSAccounts, srcDiscoverOCITenancy, srcDiscoverAlicloudAccounts,
+	srcDiscoverDigitalOceanDBs, srcDiscoverNeonProjects, srcDiscoverNetlifySites,
+	srcDiscoverVercelProjects, srcDiscoverAtlasProjects, srcDiscoverHCPProjects,
+	srcDiscoverClaudeWorkspaces, srcDiscoverMSSQLDatabases, srcDiscoverMySQLDatabases,
+	srcDiscoverPostgresDatabases, srcDiscoverSnowflakeDatabases,
+}
+
+// Every discovery constant names a target the connector actually declares.
+//
+// A discovery source asks `cnspec discover <connector> --discover <target>`, so
+// a target the connector does not offer produces an empty picker with a
+// plausible name -- which is the mistake the whole Source contract was written
+// to stop being made one provider at a time.
+func TestDiscoveryIDsNameDeclaredTargets(t *testing.T) {
+	byName := snapshotByName(t)
+	checked := 0
+	for _, id := range declaredSourceIDs {
+		rest, ok := strings.CutPrefix(id, "discover.")
+		if !ok {
+			continue
+		}
+		connector, target, ok := strings.Cut(rest, ".")
+		if !ok {
+			t.Errorf("%q does not name a connector and a target", id)
+			continue
+		}
+		snap, ok := byName[connector]
+		if !ok {
+			t.Logf("%s: %q is not in the connector snapshot", id, connector)
+			continue
+		}
+		checked++
+		if !slices.Contains(snap.Discovery, target) {
+			t.Errorf("%s: %q does not declare the discovery target %q; it declares %v",
+				id, connector, target, snap.Discovery)
+		}
+	}
+	t.Logf("checked %d discovery ids against %d snapshotted connectors", checked, len(byName))
+}
+
+// Both halves of a discovery row, checked against the recorded connector
+// metadata rather than against what the flag name suggests.
+//
+// The first half stops a picker asking for a target the connector cannot
+// enumerate. The second stops the mistake this whole class of source exists to
+// avoid: a plausible-looking flag that does not take what was discovered.
+// aws --filters looks like the place a discovered account goes and is not --
+// see TestExcludedPairsStayExcluded in cli/launcher/source.
+func TestEveryTargetIsDeclaredAndHasSomewhereToPutIt(t *testing.T) {
+	byName := snapshotByName(t)
+	checked := 0
+	for _, d := range source.DiscoverPairs() {
+		snap, ok := byName[d.Connector]
+		if !ok {
+			t.Logf("%s: %q is not in the connector snapshot; skipped", d.ID, d.Connector)
+			continue
+		}
+		checked++
+		if !slices.Contains(snap.Discovery, d.Target) {
+			t.Errorf("%s: %q does not declare the discovery target %q; it declares %v",
+				d.ID, d.Connector, d.Target, snap.Discovery)
+		}
+		dest := flagNamed(snap, d.Flag)
+		if dest == nil {
+			t.Errorf("%s: %q declares no --%s for the answer to land in", d.ID, d.Connector, d.Flag)
+			continue
+		}
+		// The flag types are not uniform: --filters is KeyValue and takes
+		// key=value pairs, so a bare discovered value put there is dropped by
+		// the provider's own prefix check. Only a String flag takes what these
+		// sources emit.
+		if plugin.FlagType(dest.Type) != plugin.FlagType_String {
+			t.Errorf("%s: --%s is %v, and these sources emit a bare value",
+				d.ID, d.Flag, plugin.FlagType(dest.Type))
+		}
+		// Every scope flag has to exist too.
+		for _, flag := range d.ScopeFlags {
+			if flagNamed(snap, flag) == nil {
+				t.Errorf("%s: scoped by --%s, which %q does not declare", d.ID, flag, d.Connector)
+			}
+		}
+	}
+	t.Logf("checked %d of %d discovery pairs; the rest are not in the snapshot",
+		checked, len(source.DiscoverPairs()))
+}
+
+// The flags the file-backed pickers fill in have to exist, or the picker is
+// decoration. The other half of TestTheFiveLocalPickersAreInstantAndEnumerated.
+func TestTheFlagBackedPickersNameRealFlags(t *testing.T) {
+	byName := snapshotByName(t)
+	checked, skipped := 0, 0
+	for connector, flag := range map[string]string{
+		"oci":       "profile",
+		"azure":     "subscription",
+		"snowflake": "account",
+	} {
+		snap, ok := byName[connector]
+		if !ok {
+			skipped++
+			t.Logf("%s is not in the connector snapshot; skipped", connector)
+			continue
+		}
+		checked++
+		if flagNamed(snap, flag) == nil {
+			t.Errorf("%s declares no --%s, so its picker has nowhere to put a value", connector, flag)
+		}
+	}
+	// snowflake's picker offers accounts rather than connection names, and the
+	// absence of --connection is why. See snowflakeAccountsFrom.
+	if snap, ok := byName["snowflake"]; ok && flagNamed(snap, "connection") != nil {
+		t.Error("snowflake declares --connection after all; that source should offer connection names")
+	}
+	t.Logf("checked %d connectors, skipped %d", checked, skipped)
+}
+
+// The pickers whose value travels in the environment do so because the
+// connector declares no flag for it. That absence is the whole justification,
+// so it is checked rather than asserted: a flag that appeared later would mean
+// the value should be travelling in it.
+func TestTheEnvBackedPickersFillNoFlag(t *testing.T) {
+	byName := snapshotByName(t)
+	checked, skipped := 0, 0
+	for _, tc := range []struct {
+		connectors []string
+		flag       string
+		id         string
+	}{
+		{[]string{"alicloud"}, "profile", srcAlicloudProfile},
+		{[]string{"docker", "container", "local"}, "context", srcDockerContext},
+	} {
+		s, ok := sourceByID(tc.id)
+		if !ok {
+			t.Errorf("%s is not registered", tc.id)
+			continue
+		}
+		if s.Env == "" {
+			t.Errorf("%s: no Env, but its value has no flag to travel in", tc.id)
+		}
+		for _, name := range tc.connectors {
+			snap, ok := byName[name]
+			if !ok {
+				skipped++
+				t.Logf("%s is not in the connector snapshot; skipped", name)
+				continue
+			}
+			checked++
+			if flagNamed(snap, tc.flag) != nil {
+				t.Errorf("%s declares --%s after all; the value should travel in it, not in %s",
+					name, tc.flag, s.Env)
+			}
+		}
+	}
+	t.Logf("checked %d connectors, skipped %d", checked, skipped)
+}
+
+func flagNamed(snap connectorSnapshot, long string) *flagSnippet {
+	for i := range snap.Flags {
+		if snap.Flags[i].Long == long {
+			return &snap.Flags[i]
+		}
+	}
+	return nil
+}

--- a/apps/cnspec/cmd/interactive/source_spec_test.go
+++ b/apps/cnspec/cmd/interactive/source_spec_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import "testing"
+
+// The ids used by the curated specs must exist, or a field silently gets no
+// values and the user sees an empty box with no explanation.
+func TestEverySourceNamedByASpecExists(t *testing.T) {
+	for name, spec := range formSpecs {
+		for flag, id := range spec.Sources {
+			if _, ok := sourceByID(id); !ok {
+				t.Errorf("%s --%s names unknown source %q", name, flag, id)
+			}
+		}
+		for flag, id := range spec.LiveSources {
+			if _, ok := sourceByID(id); !ok {
+				t.Errorf("%s --%s names unknown live source %q", name, flag, id)
+			}
+		}
+		for _, pos := range spec.Positional {
+			for _, id := range pos.SourceBy {
+				if _, ok := sourceByID(id); id != "" && !ok {
+					t.Errorf("%s %q names unknown source %q", name, pos.Label, id)
+				}
+			}
+			for _, id := range pos.LiveSourceBy {
+				if _, ok := sourceByID(id); id != "" && !ok {
+					t.Errorf("%s %q names unknown live source %q", name, pos.Label, id)
+				}
+			}
+		}
+	}
+}

--- a/apps/cnspec/cmd/interactive/source_test.go
+++ b/apps/cnspec/cmd/interactive/source_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/cli/launcher/source"
+)
+
+// The seams between the launcher and its value pickers.
+//
+// cli/launcher/source cannot import this package -- this package imports it --
+// so two things it needs are installed from here at init. Both are the kind of
+// wiring that fails silently if it is forgotten: a picker that answers for the
+// wrong cluster, and a paste box with nowhere to send what was pasted. The
+// tests below are what makes forgetting loud.
+
+// The namespace picker points its child at one cluster by writing a kubeconfig
+// copy first, and that writer is kubeconfig.go's. Without it installed, a
+// namespace list would come back for whichever cluster the ambient kubeconfig
+// happened to name -- with no error, which is the failure the whole contract
+// exists to prevent.
+func TestTheKubeconfigWriterIsInstalled(t *testing.T) {
+	env, cleanup, err := source.KubeEnvApply("does-not-exist")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	// It either produced a KUBECONFIG or refused; what it must not do is
+	// quietly return nothing, which is what the uninstalled default does for a
+	// context that was actually chosen.
+	if err == nil && len(env) == 0 {
+		t.Fatal("a chosen context produced no environment and no error, so the picker would answer for the ambient cluster")
+	}
+	if err != nil && strings.Contains(err.Error(), "did not install a kubeconfig writer") {
+		t.Fatalf("the launcher never installed its kubeconfig writer: %v", err)
+	}
+
+	// An empty context is nothing to do, and stays nothing to do.
+	env, cleanup, err = source.KubeEnvApply("")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil || len(env) != 0 {
+		t.Errorf("no context gave %v/%v, want nothing to do", env, err)
+	}
+}
+
+// The paste routes cli/launcher/source used to declare into the delivery
+// registry, and the test that checked they had arrived, are both gone. A pasted
+// value travels the same way a typed one does now -- into the connector's own
+// ParseCLI -- so there is nothing for a source to declare and nothing for a
+// registry to receive. What each ambient credential still declares is which
+// variables the *provider* reads when the launcher supplies nothing, which is
+// what its readout row says.
+
+// The docker sources name this field in their Needs and the form spec names it
+// when it creates the field. They are two constants in two packages, and a
+// mismatch is silent: the identity simply never matches, the enumeration runs
+// against the default daemon, and the list looks right.
+func TestTheDockerContextMarkerAgrees(t *testing.T) {
+	if specialDockerContext != source.SpecialDockerContext {
+		t.Fatalf("the form calls it %q, the picker %q",
+			specialDockerContext, source.SpecialDockerContext)
+	}
+	s, ok := sourceByID(srcDockerContainer)
+	if !ok {
+		t.Fatal("the container source is not registered")
+	}
+	want := "s:" + specialDockerContext
+	found := false
+	for _, need := range s.Needs {
+		found = found || need == want
+	}
+	if !found {
+		t.Errorf("the container picker depends on %v, want %q", s.Needs, want)
+	}
+}

--- a/apps/cnspec/cmd/interactive/testdata/aws_config
+++ b/apps/cnspec/cmd/interactive/testdata/aws_config
@@ -1,0 +1,11 @@
+[default]
+region = us-east-1
+
+# a comment
+[profile prod]
+region = eu-west-1
+role_arn = arn:aws:iam::123456789012:role/Admin
+
+[profile sso-prod]
+sso_account_id = 123456789012
+sso_role_name = AdministratorAccess

--- a/apps/cnspec/cmd/interactive/testdata/kubeconfig
+++ b/apps/cnspec/cmd/interactive/testdata/kubeconfig
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Config
+current-context: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+contexts:
+  - name: aks-trial
+    context: {cluster: aks, user: aks}
+  - name: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+    context: {cluster: eks, user: eks}
+  - name: chris-dev
+    context: {cluster: dev, user: dev}

--- a/apps/cnspec/cmd/interactive/testdata/scan_progress.ndjson
+++ b/apps/cnspec/cmd/interactive/testdata/scan_progress.ndjson
@@ -1,0 +1,12 @@
+{"seq":1,"time":"2026-08-20T19:18:44.398157Z","event":"scan_start","version":1}
+{"seq":2,"time":"2026-08-20T19:18:44.398378Z","event":"asset_added","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","name":"launcher-test-host","platform":"macos","num":1}
+{"seq":3,"time":"2026-08-20T19:18:44.398477Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1}
+{"seq":4,"time":"2026-08-20T19:18:44.404701Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":0.1111}
+{"seq":5,"time":"2026-08-20T19:18:44.410188Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":0.3333}
+{"seq":6,"time":"2026-08-20T19:18:44.411212Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":0.5556}
+{"seq":7,"time":"2026-08-20T19:18:44.411453Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":0.7778}
+{"seq":8,"time":"2026-08-20T19:18:44.411535Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":0.8889}
+{"seq":9,"time":"2026-08-20T19:18:44.646168Z","event":"asset_progress","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"percent":1}
+{"seq":10,"time":"2026-08-20T19:18:44.646317Z","event":"asset_score","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"score":"HIGH"}
+{"seq":11,"time":"2026-08-20T19:18:44.64633Z","event":"asset_done","index":"//platformid.api.mondoo.app/hostname/launcher-test-host.local","num":1,"state":"completed","total":1,"done":1,"duration_ms":247}
+{"seq":12,"time":"2026-08-20T19:18:44.654146Z","event":"scan_done","total":1,"done":1,"completed":1,"duration_ms":255}

--- a/apps/cnspec/cmd/interactive/testdata/scan_report.json
+++ b/apps/cnspec/cmd/interactive/testdata/scan_report.json
@@ -1,0 +1,1433 @@
+{
+  "assets": {
+    "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs": {
+      "mrn": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs",
+      "name": "launcher-test-host",
+      "platform_ids": [
+        "//platformid.api.mondoo.app/hostname/launcher-test-host.local",
+        "//platformid.api.mondoo.app/serialnumber/0000000000"
+      ],
+      "platform": {
+        "name": "macos",
+        "arch": "arm64",
+        "title": "macOS",
+        "family": [
+          "darwin",
+          "bsd",
+          "unix",
+          "os"
+        ],
+        "build": "25F71",
+        "version": "26.5",
+        "kind": "baremetal",
+        "technology_url_segments": [
+          "os",
+          "darwin",
+          "macos",
+          "26.5"
+        ],
+        "metadata": {
+          "mondoo.com/device-type": "workstation"
+        }
+      },
+      "connections": [
+        {
+          "id": 1,
+          "type": "local",
+          "options": {
+            "device-names": "",
+            "staged-discovery": ""
+          },
+          "discover": {
+            "targets": [
+              "auto"
+            ]
+          },
+          "capabilities": [
+            "run-command",
+            "file"
+          ]
+        }
+      ],
+      "labels": {
+        "mondoo.com/scan-source": "interactive"
+      },
+      "id_detector": [
+        "cloud-detect",
+        "hostname",
+        "serialnumber"
+      ],
+      "kind_string": "baremetal"
+    }
+  },
+  "bundle": {
+    "policies": [
+      {
+        "mrn": "//local.cnspec.io/run/local-execution/policies/example1",
+        "name": "Example policy 1",
+        "version": "1.0.0",
+        "groups": [
+          {
+            "checks": [
+              {
+                "mql": "sshd.config.params.Port == 22",
+                "code_id": "3/6XnKp0RJM=",
+                "checksum": "GbK64Zv5Lmg=",
+                "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-01",
+                "type": "\u0004",
+                "title": "Ensure the port is set to 22",
+                "impact": {
+                  "value": 30
+                }
+              },
+              {
+                "mql": "sshd.config.ciphers.none( /cbc/ )",
+                "code_id": "gkgeOLLSlw4=",
+                "checksum": "J5EBthnxk3w=",
+                "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-02",
+                "type": "\u0004",
+                "title": "Prevent weaker CBC ciphers from being used",
+                "impact": {
+                  "value": 60
+                }
+              },
+              {
+                "code_id": "tLW4zUJij+I=",
+                "checksum": "eY5xd1tW6d4=",
+                "mrn": "//local.cnspec.io/run/local-execution/queries/shared-query",
+                "type": "\u0004"
+              }
+            ],
+            "queries": [
+              {
+                "mql": "sshd.config.params",
+                "code_id": "eteO7RzprLM=",
+                "checksum": "7AoHokdoA/I=",
+                "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-d-1",
+                "type": "\u001a\u0007\u0007",
+                "title": "Gather SSH config params"
+              },
+              {
+                "mql": "file(props.home) { path basename user group }",
+                "code_id": "RlB1lGsIzrA=",
+                "checksum": "lzETJksJgjg=",
+                "mrn": "//local.cnspec.io/run/local-execution/queries/home-info",
+                "type": "\f",
+                "title": "Gather info about the user's home",
+                "props": [
+                  {
+                    "mql": "\"/home\"\n",
+                    "code_id": "WzbDNH/IgGY=",
+                    "checksum": "P/CbwPTzAkw=",
+                    "mrn": "//local.cnspec.io/run/local-execution/queries/home-info/properties/home",
+                    "type": "\u0007"
+                  }
+                ]
+              }
+            ],
+            "filters": {
+              "items": {
+                "u6qtHYJqMdA=": {
+                  "mql": "asset.family.contains('unix')",
+                  "code_id": "u6qtHYJqMdA=",
+                  "checksum": "WbYhRCWMivU=",
+                  "mrn": "//local.cnspec.io/run/local-execution/policies/example1/filter/u6qtHYJqMdA=",
+                  "type": "\u0004"
+                }
+              }
+            }
+          }
+        ],
+        "scoring_system": "highest impact",
+        "authors": [
+          {
+            "name": "Mondoo",
+            "email": "hello@mondoo.com"
+          }
+        ],
+        "tags": {
+          "mondoo.com/category": "test",
+          "mondoo.com/platform": "test"
+        },
+        "props": [
+          {
+            "mrn": "//local.cnspec.io/run/local-execution/policies/example1/properties/home",
+            "for": [
+              {
+                "mrn": "//local.cnspec.io/run/local-execution/queries/home-info/properties/home"
+              }
+            ]
+          }
+        ],
+        "require": [
+          {
+            "provider": "os"
+          }
+        ],
+        "computed_filters": {
+          "items": {
+            "u6qtHYJqMdA=": {
+              "mql": "asset.family.contains('unix')",
+              "code_id": "u6qtHYJqMdA=",
+              "checksum": "WbYhRCWMivU=",
+              "mrn": "//local.cnspec.io/run/local-execution/policies/example1/filter/u6qtHYJqMdA=",
+              "type": "\u0004"
+            }
+          }
+        }
+      }
+    ],
+    "queries": [
+      {
+        "mql": "sshd.config.params.StrictModes == \"yes\"",
+        "code_id": "tLW4zUJij+I=",
+        "checksum": "eY5xd1tW6d4=",
+        "mrn": "//local.cnspec.io/run/local-execution/queries/shared-query",
+        "type": "\u0004",
+        "title": "Enable strict mode",
+        "impact": {
+          "value": 70
+        }
+      },
+      {
+        "mql": "sshd.config.params",
+        "code_id": "eteO7RzprLM=",
+        "checksum": "7AoHokdoA/I=",
+        "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-d-1",
+        "type": "\u001a\u0007\u0007",
+        "title": "Gather SSH config params"
+      },
+      {
+        "mql": "file(props.home) { path basename user group }",
+        "code_id": "RlB1lGsIzrA=",
+        "checksum": "lzETJksJgjg=",
+        "mrn": "//local.cnspec.io/run/local-execution/queries/home-info",
+        "type": "\f",
+        "title": "Gather info about the user's home",
+        "props": [
+          {
+            "mql": "\"/home\"\n",
+            "code_id": "WzbDNH/IgGY=",
+            "checksum": "P/CbwPTzAkw=",
+            "mrn": "//local.cnspec.io/run/local-execution/queries/home-info/properties/home",
+            "type": "\u0007"
+          }
+        ]
+      },
+      {
+        "mql": "sshd.config.params.Port == 22",
+        "code_id": "3/6XnKp0RJM=",
+        "checksum": "GbK64Zv5Lmg=",
+        "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-01",
+        "type": "\u0004",
+        "title": "Ensure the port is set to 22",
+        "impact": {
+          "value": 30
+        }
+      },
+      {
+        "mql": "sshd.config.ciphers.none( /cbc/ )",
+        "code_id": "gkgeOLLSlw4=",
+        "checksum": "J5EBthnxk3w=",
+        "mrn": "//local.cnspec.io/run/local-execution/queries/sshd-02",
+        "type": "\u0004",
+        "title": "Prevent weaker CBC ciphers from being used",
+        "impact": {
+          "value": 60
+        }
+      }
+    ]
+  },
+  "reports": {
+    "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs": {
+      "scoring_mrn": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs",
+      "entity_mrn": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs",
+      "score": {
+        "risk_score": 30,
+        "qr_id": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs",
+        "type": 2,
+        "value": 30,
+        "weight": 3,
+        "score_completion": 100,
+        "data_total": 6,
+        "data_completion": 100,
+        "value_modified_time": 1787253524,
+        "failure_time": 1787253524
+      },
+      "scores": {
+        "//local.cnspec.io/run/local-execution/policies/example1": {
+          "risk_score": 30,
+          "qr_id": "//local.cnspec.io/run/local-execution/policies/example1",
+          "type": 2,
+          "value": 30,
+          "weight": 3,
+          "score_completion": 100,
+          "data_total": 6,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        },
+        "//local.cnspec.io/run/local-execution/queries/home-info": {
+          "qr_id": "//local.cnspec.io/run/local-execution/queries/home-info",
+          "type": 8,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 1,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "//local.cnspec.io/run/local-execution/queries/shared-query": {
+          "risk_score": 30,
+          "qr_id": "//local.cnspec.io/run/local-execution/queries/shared-query",
+          "type": 2,
+          "value": 30,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        },
+        "//local.cnspec.io/run/local-execution/queries/sshd-01": {
+          "risk_score": 70,
+          "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-01",
+          "type": 2,
+          "value": 70,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        },
+        "//local.cnspec.io/run/local-execution/queries/sshd-02": {
+          "risk_score": 100,
+          "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-02",
+          "type": 2,
+          "value": 100,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "//local.cnspec.io/run/local-execution/queries/sshd-d-1": {
+          "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-d-1",
+          "type": 8,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 1,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs": {
+          "risk_score": 30,
+          "qr_id": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs",
+          "type": 2,
+          "value": 30,
+          "weight": 3,
+          "score_completion": 100,
+          "data_total": 6,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        },
+        "3/6XnKp0RJM=": {
+          "qr_id": "3/6XnKp0RJM=",
+          "type": 2,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        },
+        "RlB1lGsIzrA=": {
+          "qr_id": "RlB1lGsIzrA=",
+          "type": 8,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 1,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "eteO7RzprLM=": {
+          "qr_id": "eteO7RzprLM=",
+          "type": 8,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 1,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "gkgeOLLSlw4=": {
+          "risk_score": 100,
+          "qr_id": "gkgeOLLSlw4=",
+          "type": 2,
+          "value": 100,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524
+        },
+        "tLW4zUJij+I=": {
+          "qr_id": "tLW4zUJij+I=",
+          "type": 2,
+          "weight": 1,
+          "score_completion": 100,
+          "data_total": 2,
+          "data_completion": 100,
+          "value_modified_time": 1787253524,
+          "failure_time": 1787253524
+        }
+      },
+      "data": {
+        "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==": {
+          "data": {
+            "type": "\u0019\u0007"
+          },
+          "code_id": "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ=="
+        },
+        "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==": {
+          "data": {
+            "type": "\u0002"
+          },
+          "code_id": "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA=="
+        },
+        "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ==": {
+          "data": {
+            "type": "\u0002"
+          },
+          "code_id": "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ=="
+        },
+        "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA==": {
+          "data": {
+            "type": "\u0004",
+            "value": "AA=="
+          },
+          "code_id": "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA=="
+        },
+        "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA==": {
+          "data": {
+            "type": "\f",
+            "map": {
+              "/bJ7DRO0he3qBfEr2h/yQs+YQbnkwnTP4T/dpyM0Em4dKk2Y+ioFzME+SAM3q4QScJCz6J+cuzz7/JKAdCJl3A==": {
+                "type": "\f",
+                "map": {
+                  "4c+nzG9nlz2YvjuU35w85A7ZNZK9fUt2fI7tvano/h6UXsNIhC/YeupKPqj4s3O1qvet2GL6oLpl8gnL33Vbsg==": {
+                    "type": "\u0005",
+                    "value": "AA=="
+                  },
+                  "_": {
+                    "type": "\u001bgroup",
+                    "value": "Z3JvdXAvMC93aGVlbA=="
+                  },
+                  "__s": {
+                    "type": "\u0002"
+                  },
+                  "__t": {
+                    "type": "\u0004",
+                    "value": "AA=="
+                  },
+                  "gC+SwfQGcWjbQ91+P2yYh4NQRydfh1LEhpRbpMAUmXc0FK/RHVVUmeJMD19JZsEwjYB/V5u5+uaIC2VTogIEIQ==": {
+                    "type": "\u0007",
+                    "value": "d2hlZWw="
+                  }
+                }
+              },
+              "EzE9aCjo1BpCEddspWaZ4S6bKRau+xj48BLp7+6pCs8YDaCMA9J83DG1dMgE1e5tze+Mv/rO73gaOdLEI6+Psg==": {
+                "type": "\f",
+                "map": {
+                  "6IPW+ftYDFGp/2bUXZp0vLW6wyhxeleGshWM/SByGuCRbUCwyGUGXhWmdMe3EtNcrvsDK4cMmzPrToFa7LWGaw==": {
+                    "type": "\u0005",
+                    "value": "AA=="
+                  },
+                  "D2IzJhSGvPYB1BdSjVV6ef1ZokZW7MP3AM2y2AiXk1/UxrZyqJ6aZOFBCmWoiKJc1vb/298lxLjN9sxJxx+NMg==": {
+                    "type": "\u0007",
+                    "value": "cm9vdA=="
+                  },
+                  "_": {
+                    "type": "\u001buser",
+                    "value": "dXNlci8wL3Jvb3Q="
+                  },
+                  "__s": {
+                    "type": "\u0002"
+                  },
+                  "__t": {
+                    "type": "\u0004",
+                    "value": "AA=="
+                  },
+                  "gLAjI2QQWmEWUKtwAWBBdNzR8OoAwskR2gflDhhxTwoSsxGEGKo/d8OVAbsqMa3ONEd7Uq0V6Yxr9EgZ2Cupzw==": {
+                    "type": "\u0005",
+                    "value": "AA=="
+                  }
+                }
+              },
+              "OJVDDHB0vJmITQUpjD71KKj7DSVqbfvfCQLXFI1C9pb0ubpl97NiemUggxLNUBJinEnZS5WLSXGCzsUleiK6SQ==": {
+                "type": "\u0007",
+                "value": "aG9tZQ=="
+              },
+              "_": {
+                "type": "\u001bfile",
+                "value": "L2hvbWU="
+              },
+              "__s": {
+                "type": "\u0002"
+              },
+              "__t": {
+                "type": "\u0004",
+                "value": "AA=="
+              },
+              "n+W9NReQ0tui4SQGrjCp3nOVirV2zbYgaTlePuaZYhDMMffEUVS7SZAUQOJZuUyPbhImW3m5mrLmj9oAiqlN9w==": {
+                "type": "\u0007",
+                "value": "L2hvbWU="
+              }
+            }
+          },
+          "code_id": "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA=="
+        },
+        "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA==": {
+          "data": {
+            "type": "\u0004",
+            "value": "AA=="
+          },
+          "code_id": "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA=="
+        },
+        "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==": {
+          "data": {
+            "type": "\u001a\u0007\u0007",
+            "map": {
+              "AcceptEnv": {
+                "type": "\u0007",
+                "value": "TEFORyBMQ18q"
+              },
+              "AuthorizedKeysFile": {
+                "type": "\u0007",
+                "value": "LnNzaC9hdXRob3JpemVkX2tleXM="
+              },
+              "Match": {
+                "type": "\u0007",
+                "value": "VXNlciBhbnNpYmxlLFVzZXIgZ3JhbmRjcnU="
+              },
+              "PasswordAuthentication": {
+                "type": "\u0007",
+                "value": "eWVz"
+              },
+              "PubkeyAuthentication": {
+                "type": "\u0007",
+                "value": "eWVz"
+              },
+              "Subsystem": {
+                "type": "\u0007",
+                "value": "c2Z0cCAvdXNyL2xpYmV4ZWMvc2Z0cC1zZXJ2ZXI="
+              },
+              "UsePAM": {
+                "type": "\u0007",
+                "value": "eWVz"
+              }
+            }
+          },
+          "code_id": "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw=="
+        },
+        "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==": {
+          "data": {
+            "type": "\u0002"
+          },
+          "code_id": "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ=="
+        },
+        "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA==": {
+          "data": {
+            "type": "\u0004",
+            "value": "AQ=="
+          },
+          "code_id": "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA=="
+        }
+      },
+      "risks": {},
+      "resolved_policy_version": "v2"
+    }
+  },
+  "resolved_policies": {
+    "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs": {
+      "execution_job": {
+        "checksum": "SZrVmZuAwf0=",
+        "queries": {
+          "3/6XnKp0RJM=": {
+            "query": "sshd.config.params.Port == 22",
+            "checksum": "GbK64Zv5Lmg=",
+            "datapoints": [
+              "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==",
+              "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "3/6XnKp0RJM=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "call": 1,
+                        "id": "sshd.config"
+                      },
+                      {
+                        "call": 1,
+                        "id": "params",
+                        "function": {
+                          "type": "\u001a\u0007\u0007",
+                          "binding": 4294967297
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "[]",
+                        "function": {
+                          "type": "\u0007",
+                          "args": [
+                            {
+                              "type": "\u0007",
+                              "value": "UG9ydA=="
+                            }
+                          ],
+                          "binding": 4294967298
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "==\u0005",
+                        "function": {
+                          "type": "\u0004",
+                          "args": [
+                            {
+                              "type": "\u0005",
+                              "value": "LA=="
+                            }
+                          ],
+                          "binding": 4294967299
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967300
+                    ],
+                    "datapoints": [
+                      4294967299
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "4294967297": "h1EPuzo5A02wYUOeDzbzv9YfwPO5Km0r1tmJ0UOceHGyO+M2vrEpnF3/XVJu0hOtyAITe0M4O6XOjLOTc8i8lA==",
+                  "4294967298": "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==",
+                  "4294967299": "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==",
+                  "4294967300": "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA=="
+                }
+              },
+              "source": "sshd.config.params.Port == 22",
+              "labels": {
+                "labels": {
+                  "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA==": "sshd.config.params[Port] == 22",
+                  "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==": "sshd.config.params[Port]"
+                }
+              },
+              "version": "unstable"
+            }
+          },
+          "RlB1lGsIzrA=": {
+            "query": "file(props.home) { path basename user group }",
+            "checksum": "lzETJksJgjg=",
+            "properties": {
+              "home": "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ=="
+            },
+            "datapoints": [
+              "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "RlB1lGsIzrA=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "call": 2,
+                        "id": "home",
+                        "primitive": {
+                          "type": "\u0007"
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "file",
+                        "function": {
+                          "type": "\u001bfile",
+                          "args": [
+                            {
+                              "type": "\u0007",
+                              "value": "cGF0aA=="
+                            },
+                            {
+                              "type": "\u0003",
+                              "value": "goCAgCA="
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "{}",
+                        "function": {
+                          "type": "\f",
+                          "args": [
+                            {
+                              "type": "\u001c\u0000",
+                              "value": "gICAgEA="
+                            }
+                          ],
+                          "binding": 4294967298
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967299
+                    ]
+                  },
+                  {
+                    "chunks": [
+                      {
+                        "primitive": {
+                          "type": "\u001bfile"
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "path",
+                        "function": {
+                          "type": "\u0007",
+                          "binding": 8589934593
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "basename",
+                        "function": {
+                          "type": "\u0007",
+                          "binding": 8589934593
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "user",
+                        "function": {
+                          "type": "\u001buser",
+                          "binding": 8589934593
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "group",
+                        "function": {
+                          "type": "\u001bgroup",
+                          "binding": 8589934593
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "{}",
+                        "function": {
+                          "type": "\f",
+                          "args": [
+                            {
+                              "type": "\u001c\u0000",
+                              "value": "gICAgGA="
+                            }
+                          ],
+                          "binding": 8589934596
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "{}",
+                        "function": {
+                          "type": "\f",
+                          "args": [
+                            {
+                              "type": "\u001c\u0000",
+                              "value": "gICAgIAB"
+                            }
+                          ],
+                          "binding": 8589934597
+                        }
+                      }
+                    ],
+                    "parameters": 1,
+                    "entrypoints": [
+                      8589934594,
+                      8589934595,
+                      8589934598,
+                      8589934599
+                    ]
+                  },
+                  {
+                    "chunks": [
+                      {
+                        "primitive": {
+                          "type": "\u001buser"
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "name",
+                        "function": {
+                          "type": "\u0007",
+                          "binding": 12884901889
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "uid",
+                        "function": {
+                          "type": "\u0005",
+                          "binding": 12884901889
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "gid",
+                        "function": {
+                          "type": "\u0005",
+                          "binding": 12884901889
+                        }
+                      }
+                    ],
+                    "parameters": 1,
+                    "entrypoints": [
+                      12884901890,
+                      12884901891,
+                      12884901892
+                    ]
+                  },
+                  {
+                    "chunks": [
+                      {
+                        "primitive": {
+                          "type": "\u001bgroup"
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "name",
+                        "function": {
+                          "type": "\u0007",
+                          "binding": 17179869185
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "gid",
+                        "function": {
+                          "type": "\u0005",
+                          "binding": 17179869185
+                        }
+                      }
+                    ],
+                    "parameters": 1,
+                    "entrypoints": [
+                      17179869186,
+                      17179869187
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "12884901889": "bQEq5+aEtpLSDRe+22AqoA0fCIPyNfG4mYiHjZdGW194hprMZuVyyuR2aQ2JKHvGXAxubvgW/NM4WJn6C7davA==",
+                  "12884901890": "D2IzJhSGvPYB1BdSjVV6ef1ZokZW7MP3AM2y2AiXk1/UxrZyqJ6aZOFBCmWoiKJc1vb/298lxLjN9sxJxx+NMg==",
+                  "12884901891": "gLAjI2QQWmEWUKtwAWBBdNzR8OoAwskR2gflDhhxTwoSsxGEGKo/d8OVAbsqMa3ONEd7Uq0V6Yxr9EgZ2Cupzw==",
+                  "12884901892": "6IPW+ftYDFGp/2bUXZp0vLW6wyhxeleGshWM/SByGuCRbUCwyGUGXhWmdMe3EtNcrvsDK4cMmzPrToFa7LWGaw==",
+                  "17179869185": "WU+PvFVy5JcBYMuAlmCty4ncz7AOSNaa61Ya87wnT+dLAF4hW675Ogl38qGECc00WXiRO5e5sd1SeBzmrRJZWw==",
+                  "17179869186": "gC+SwfQGcWjbQ91+P2yYh4NQRydfh1LEhpRbpMAUmXc0FK/RHVVUmeJMD19JZsEwjYB/V5u5+uaIC2VTogIEIQ==",
+                  "17179869187": "4c+nzG9nlz2YvjuU35w85A7ZNZK9fUt2fI7tvano/h6UXsNIhC/YeupKPqj4s3O1qvet2GL6oLpl8gnL33Vbsg==",
+                  "4294967297": "ya5qHIZ2Ultc7H3L7ojAabSZaLBRZmZ6GGQpLDZlzLIHJjX9k2yE3HsTpkz9Mh0ubMJalsYSRNmrQM8rbaHtiA==",
+                  "4294967298": "pmtxl4lUjEyAned7fTCO0C2dR22ru8IJsNd6fuyBjZCrl1k2slRHY7tVoxqX+B7wwk+HA3e+tCBAp/UkvWjj4g==",
+                  "4294967299": "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA==",
+                  "8589934593": "pmtxl4lUjEyAned7fTCO0C2dR22ru8IJsNd6fuyBjZCrl1k2slRHY7tVoxqX+B7wwk+HA3e+tCBAp/UkvWjj4g==",
+                  "8589934594": "n+W9NReQ0tui4SQGrjCp3nOVirV2zbYgaTlePuaZYhDMMffEUVS7SZAUQOJZuUyPbhImW3m5mrLmj9oAiqlN9w==",
+                  "8589934595": "OJVDDHB0vJmITQUpjD71KKj7DSVqbfvfCQLXFI1C9pb0ubpl97NiemUggxLNUBJinEnZS5WLSXGCzsUleiK6SQ==",
+                  "8589934596": "bQEq5+aEtpLSDRe+22AqoA0fCIPyNfG4mYiHjZdGW194hprMZuVyyuR2aQ2JKHvGXAxubvgW/NM4WJn6C7davA==",
+                  "8589934597": "WU+PvFVy5JcBYMuAlmCty4ncz7AOSNaa61Ya87wnT+dLAF4hW675Ogl38qGECc00WXiRO5e5sd1SeBzmrRJZWw==",
+                  "8589934598": "EzE9aCjo1BpCEddspWaZ4S6bKRau+xj48BLp7+6pCs8YDaCMA9J83DG1dMgE1e5tze+Mv/rO73gaOdLEI6+Psg==",
+                  "8589934599": "/bJ7DRO0he3qBfEr2h/yQs+YQbnkwnTP4T/dpyM0Em4dKk2Y+ioFzME+SAM3q4QScJCz6J+cuzz7/JKAdCJl3A=="
+                }
+              },
+              "source": "file(props.home) { path basename user group }",
+              "labels": {
+                "labels": {
+                  "/bJ7DRO0he3qBfEr2h/yQs+YQbnkwnTP4T/dpyM0Em4dKk2Y+ioFzME+SAM3q4QScJCz6J+cuzz7/JKAdCJl3A==": "group",
+                  "4c+nzG9nlz2YvjuU35w85A7ZNZK9fUt2fI7tvano/h6UXsNIhC/YeupKPqj4s3O1qvet2GL6oLpl8gnL33Vbsg==": "gid",
+                  "6IPW+ftYDFGp/2bUXZp0vLW6wyhxeleGshWM/SByGuCRbUCwyGUGXhWmdMe3EtNcrvsDK4cMmzPrToFa7LWGaw==": "gid",
+                  "D2IzJhSGvPYB1BdSjVV6ef1ZokZW7MP3AM2y2AiXk1/UxrZyqJ6aZOFBCmWoiKJc1vb/298lxLjN9sxJxx+NMg==": "name",
+                  "EzE9aCjo1BpCEddspWaZ4S6bKRau+xj48BLp7+6pCs8YDaCMA9J83DG1dMgE1e5tze+Mv/rO73gaOdLEI6+Psg==": "user",
+                  "OJVDDHB0vJmITQUpjD71KKj7DSVqbfvfCQLXFI1C9pb0ubpl97NiemUggxLNUBJinEnZS5WLSXGCzsUleiK6SQ==": "basename",
+                  "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA==": "file",
+                  "gC+SwfQGcWjbQ91+P2yYh4NQRydfh1LEhpRbpMAUmXc0FK/RHVVUmeJMD19JZsEwjYB/V5u5+uaIC2VTogIEIQ==": "name",
+                  "gLAjI2QQWmEWUKtwAWBBdNzR8OoAwskR2gflDhhxTwoSsxGEGKo/d8OVAbsqMa3ONEd7Uq0V6Yxr9EgZ2Cupzw==": "uid",
+                  "n+W9NReQ0tui4SQGrjCp3nOVirV2zbYgaTlePuaZYhDMMffEUVS7SZAUQOJZuUyPbhImW3m5mrLmj9oAiqlN9w==": "path"
+                }
+              },
+              "props": {
+                "home": "\u0007"
+              },
+              "version": "unstable",
+              "auto_expand": {
+                "/bJ7DRO0he3qBfEr2h/yQs+YQbnkwnTP4T/dpyM0Em4dKk2Y+ioFzME+SAM3q4QScJCz6J+cuzz7/JKAdCJl3A==": 17179869184,
+                "EzE9aCjo1BpCEddspWaZ4S6bKRau+xj48BLp7+6pCs8YDaCMA9J83DG1dMgE1e5tze+Mv/rO73gaOdLEI6+Psg==": 12884901888
+              }
+            }
+          },
+          "WzbDNH/IgGY=": {
+            "query": "\"/home\"\n",
+            "datapoints": [
+              "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "WzbDNH/IgGY=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "primitive": {
+                          "type": "\u0007",
+                          "value": "L2hvbWU="
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967297
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "4294967297": "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ=="
+                }
+              },
+              "source": "\"/home\"\n",
+              "labels": {
+                "labels": {
+                  "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ==": ""
+                }
+              },
+              "version": "unstable"
+            }
+          },
+          "eteO7RzprLM=": {
+            "query": "sshd.config.params",
+            "checksum": "7AoHokdoA/I=",
+            "datapoints": [
+              "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "eteO7RzprLM=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "call": 1,
+                        "id": "sshd.config"
+                      },
+                      {
+                        "call": 1,
+                        "id": "params",
+                        "function": {
+                          "type": "\u001a\u0007\u0007",
+                          "binding": 4294967297
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967298
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "4294967297": "h1EPuzo5A02wYUOeDzbzv9YfwPO5Km0r1tmJ0UOceHGyO+M2vrEpnF3/XVJu0hOtyAITe0M4O6XOjLOTc8i8lA==",
+                  "4294967298": "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw=="
+                }
+              },
+              "source": "sshd.config.params",
+              "labels": {
+                "labels": {
+                  "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==": "sshd.config.params"
+                }
+              },
+              "version": "unstable"
+            }
+          },
+          "gkgeOLLSlw4=": {
+            "query": "sshd.config.ciphers.none( /cbc/ )",
+            "checksum": "J5EBthnxk3w=",
+            "datapoints": [
+              "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==",
+              "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "gkgeOLLSlw4=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "call": 1,
+                        "id": "sshd.config"
+                      },
+                      {
+                        "call": 1,
+                        "id": "ciphers",
+                        "function": {
+                          "type": "\u0019\u0007",
+                          "binding": 4294967297
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "where",
+                        "function": {
+                          "type": "\u0019\u0007",
+                          "args": [
+                            {
+                              "type": "\u0003",
+                              "value": "hICAgCA="
+                            },
+                            {
+                              "type": "\u001c\u0000",
+                              "value": "gICAgEA="
+                            }
+                          ],
+                          "binding": 4294967298
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "$none",
+                        "function": {
+                          "type": "\u0004",
+                          "binding": 4294967299
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967300
+                    ],
+                    "datapoints": [
+                      4294967299
+                    ]
+                  },
+                  {
+                    "chunks": [
+                      {
+                        "primitive": {
+                          "type": "\u0007"
+                        }
+                      },
+                      {
+                        "primitive": {
+                          "type": "\b",
+                          "value": "Y2Jj"
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "==\b",
+                        "function": {
+                          "type": "\u0004",
+                          "args": [
+                            {
+                              "type": "\u0003",
+                              "value": "hICAgEA="
+                            }
+                          ],
+                          "binding": 8589934593
+                        }
+                      }
+                    ],
+                    "parameters": 1,
+                    "entrypoints": [
+                      8589934595
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "4294967297": "h1EPuzo5A02wYUOeDzbzv9YfwPO5Km0r1tmJ0UOceHGyO+M2vrEpnF3/XVJu0hOtyAITe0M4O6XOjLOTc8i8lA==",
+                  "4294967298": "L1uVAC1Xk4VwI/Qi2VdbZmacln2sPsRupgEa+wu3tZMkFHQl/raDrrtmmhXpPial8vIcCqRvPSX0oh2iZDuASA==",
+                  "4294967299": "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==",
+                  "4294967300": "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA==",
+                  "8589934593": "L1uVAC1Xk4VwI/Qi2VdbZmacln2sPsRupgEa+wu3tZMkFHQl/raDrrtmmhXpPial8vIcCqRvPSX0oh2iZDuASA==",
+                  "8589934594": "WiKmhI3cWzkB9LsUMUpskrTV5yk3MTYDT2sz8jldyon4WTSM13kmphBCO4nZ3ZSXtxp5O21lR/5z6jl08Hm3rQ==",
+                  "8589934595": "bBouPbwzXAf5r0Cye4ukH0oq3bgLXZ1lujJ9c/Wyu3QkJ5czfE/pKbX8xnRTr5HbKFYow2rflRUBDhSjlmeK9g=="
+                }
+              },
+              "source": "sshd.config.ciphers.none( /cbc/ )",
+              "labels": {
+                "labels": {
+                  "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==": "sshd.config.ciphers.where",
+                  "bBouPbwzXAf5r0Cye4ukH0oq3bgLXZ1lujJ9c/Wyu3QkJ5czfE/pKbX8xnRTr5HbKFYow2rflRUBDhSjlmeK9g==": " == <ref>",
+                  "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA==": "[].none()"
+                }
+              },
+              "version": "unstable"
+            }
+          },
+          "tLW4zUJij+I=": {
+            "query": "sshd.config.params.StrictModes == \"yes\"",
+            "checksum": "eY5xd1tW6d4=",
+            "datapoints": [
+              "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==",
+              "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA=="
+            ],
+            "code": {
+              "code_v2": {
+                "id": "tLW4zUJij+I=",
+                "blocks": [
+                  {
+                    "chunks": [
+                      {
+                        "call": 1,
+                        "id": "sshd.config"
+                      },
+                      {
+                        "call": 1,
+                        "id": "params",
+                        "function": {
+                          "type": "\u001a\u0007\u0007",
+                          "binding": 4294967297
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "[]",
+                        "function": {
+                          "type": "\u0007",
+                          "args": [
+                            {
+                              "type": "\u0007",
+                              "value": "U3RyaWN0TW9kZXM="
+                            }
+                          ],
+                          "binding": 4294967298
+                        }
+                      },
+                      {
+                        "call": 1,
+                        "id": "==\u0007",
+                        "function": {
+                          "type": "\u0004",
+                          "args": [
+                            {
+                              "type": "\u0007",
+                              "value": "eWVz"
+                            }
+                          ],
+                          "binding": 4294967299
+                        }
+                      }
+                    ],
+                    "entrypoints": [
+                      4294967300
+                    ],
+                    "datapoints": [
+                      4294967299
+                    ]
+                  }
+                ],
+                "checksums": {
+                  "4294967297": "h1EPuzo5A02wYUOeDzbzv9YfwPO5Km0r1tmJ0UOceHGyO+M2vrEpnF3/XVJu0hOtyAITe0M4O6XOjLOTc8i8lA==",
+                  "4294967298": "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==",
+                  "4294967299": "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==",
+                  "4294967300": "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA=="
+                }
+              },
+              "source": "sshd.config.params.StrictModes == \"yes\"",
+              "labels": {
+                "labels": {
+                  "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==": "sshd.config.params[StrictModes]",
+                  "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA==": "sshd.config.params[StrictModes] == \"yes\""
+                }
+              },
+              "version": "unstable"
+            }
+          }
+        }
+      },
+      "collector_job": {
+        "checksum": "ohaW8k1NNh4=",
+        "reporting_jobs": {
+          "0c1AMXCaexw=": {
+            "checksum": "5eB4cY0cpAk=",
+            "qr_id": "eteO7RzprLM=",
+            "uuid": "0c1AMXCaexw=",
+            "notify": [
+              "tH9w+uXYZHk="
+            ],
+            "datapoints": {
+              "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==": true
+            },
+            "type": 8
+          },
+          "1eyYrALMhIQ=": {
+            "checksum": "gsqQPIWN30M=",
+            "qr_id": "//local.cnspec.io/run/local-execution/queries/shared-query",
+            "uuid": "1eyYrALMhIQ=",
+            "notify": [
+              "xvHU4rHkKfo="
+            ],
+            "child_jobs": {
+              "bT1wzHq39mE=": {
+                "value": 70
+              }
+            },
+            "type": 1,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/queries/shared-query"
+            ]
+          },
+          "Fk9nXgaTw0g=": {
+            "checksum": "MiSwy7LJ+Bc=",
+            "qr_id": "3/6XnKp0RJM=",
+            "uuid": "Fk9nXgaTw0g=",
+            "notify": [
+              "pV7CkNUyzpc="
+            ],
+            "datapoints": {
+              "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA==": true,
+              "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==": true
+            },
+            "type": 8
+          },
+          "HxFRVnCuNUI=": {
+            "checksum": "V2eqkpoUyh4=",
+            "qr_id": "RlB1lGsIzrA=",
+            "uuid": "HxFRVnCuNUI=",
+            "notify": [
+              "lff8ogJUFi4="
+            ],
+            "datapoints": {
+              "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA==": true
+            },
+            "type": 8
+          },
+          "O9u8nLZf9U8=": {
+            "checksum": "nLda0L7d3JE=",
+            "qr_id": "root",
+            "uuid": "O9u8nLZf9U8=",
+            "child_jobs": {
+              "xvHU4rHkKfo=": null
+            },
+            "type": 4
+          },
+          "bT1wzHq39mE=": {
+            "checksum": "aDP3CmfJB4I=",
+            "qr_id": "tLW4zUJij+I=",
+            "uuid": "bT1wzHq39mE=",
+            "notify": [
+              "1eyYrALMhIQ="
+            ],
+            "datapoints": {
+              "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==": true,
+              "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA==": true
+            },
+            "type": 8
+          },
+          "jFnCkNUvzpc=": {
+            "checksum": "MsWHEpWi580=",
+            "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-02",
+            "uuid": "jFnCkNUvzpc=",
+            "notify": [
+              "xvHU4rHkKfo="
+            ],
+            "child_jobs": {
+              "oax7/2uxddg=": {
+                "value": 60
+              }
+            },
+            "type": 1,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/queries/sshd-02"
+            ]
+          },
+          "lff8ogJUFi4=": {
+            "checksum": "sGqDggg8Qpk=",
+            "qr_id": "//local.cnspec.io/run/local-execution/queries/home-info",
+            "uuid": "lff8ogJUFi4=",
+            "notify": [
+              "xvHU4rHkKfo="
+            ],
+            "child_jobs": {
+              "HxFRVnCuNUI=": null
+            },
+            "type": 2,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/queries/home-info"
+            ]
+          },
+          "oax7/2uxddg=": {
+            "checksum": "/ZtGAnQKUCQ=",
+            "qr_id": "gkgeOLLSlw4=",
+            "uuid": "oax7/2uxddg=",
+            "notify": [
+              "jFnCkNUvzpc="
+            ],
+            "datapoints": {
+              "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==": true,
+              "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA==": true
+            },
+            "type": 8
+          },
+          "pV7CkNUyzpc=": {
+            "checksum": "mb8IipkswWo=",
+            "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-01",
+            "uuid": "pV7CkNUyzpc=",
+            "notify": [
+              "xvHU4rHkKfo="
+            ],
+            "child_jobs": {
+              "Fk9nXgaTw0g=": {
+                "value": 30
+              }
+            },
+            "type": 1,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/queries/sshd-01"
+            ]
+          },
+          "tH9w+uXYZHk=": {
+            "checksum": "E79CKo9JvRI=",
+            "qr_id": "//local.cnspec.io/run/local-execution/queries/sshd-d-1",
+            "uuid": "tH9w+uXYZHk=",
+            "notify": [
+              "xvHU4rHkKfo="
+            ],
+            "child_jobs": {
+              "0c1AMXCaexw=": null
+            },
+            "type": 2,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/queries/sshd-d-1"
+            ]
+          },
+          "xvHU4rHkKfo=": {
+            "checksum": "6YXHmR/wn9M=",
+            "qr_id": "//local.cnspec.io/run/local-execution/policies/example1",
+            "uuid": "xvHU4rHkKfo=",
+            "notify": [
+              "O9u8nLZf9U8="
+            ],
+            "scoring_system": "highest impact",
+            "child_jobs": {
+              "1eyYrALMhIQ=": {
+                "value": 70
+              },
+              "jFnCkNUvzpc=": {
+                "value": 60
+              },
+              "lff8ogJUFi4=": {
+                "scoring": "ignore score",
+                "action": 4
+              },
+              "pV7CkNUyzpc=": {
+                "value": 30
+              },
+              "tH9w+uXYZHk=": {
+                "scoring": "ignore score",
+                "action": 4
+              }
+            },
+            "type": 4,
+            "mrns": [
+              "//local.cnspec.io/run/local-execution/policies/example1"
+            ]
+          }
+        },
+        "reporting_queries": {
+          "3/6XnKp0RJM=": {
+            "items": [
+              "Fk9nXgaTw0g="
+            ]
+          },
+          "gkgeOLLSlw4=": {
+            "items": [
+              "oax7/2uxddg="
+            ]
+          },
+          "tLW4zUJij+I=": {
+            "items": [
+              "bT1wzHq39mE="
+            ]
+          }
+        },
+        "datapoints": {
+          "+dRc/GLkG3Q1govuXwZ7+qAvW3vpYN8hDhpJ1YK/UPqIC067x2c/uh0Y2TX4XFeywGEQIuFDzrCtyZ2/ucH/GQ==": {
+            "type": "\u0019\u0007",
+            "notify": [
+              "oax7/2uxddg="
+            ]
+          },
+          "+kCnzP6P15iffB7fsSLxopgvKnvzgc/3r+tVJKi0/jXOuzSiB+kuL07/4iiiJJcQuwSzmD8ERaS7ivitzXV7FA==": {
+            "type": "\u0007",
+            "notify": [
+              "bT1wzHq39mE="
+            ]
+          },
+          "MF4JziqiEgju0vCtEhRXd8IKJjvhj7esTCbIoo9uKB3eh4QxbSf0cvyLDAZsAYCaJyVOtII+mZEzgQyc8SDlkQ==": {
+            "type": "\u0007"
+          },
+          "OSG/mAQsQ08cruLamBggOYG8t2LKZwGF9iVNcSn1u8IAlfikLhKrZSYpDYAzm/4mfiIwbjrI1Q+Cw/8fzfcLPA==": {
+            "type": "\u0004",
+            "notify": [
+              "bT1wzHq39mE="
+            ]
+          },
+          "V9IfWUGq0+pvk4r9lIjwRoj+e9idwsjNoP1ywL/UKozIYdUIaaVVaHwgnnpW4rURlAC6jN+lVdJlGM/pEMC+PA==": {
+            "type": "\f",
+            "notify": [
+              "HxFRVnCuNUI="
+            ]
+          },
+          "XTYgIWSTRTxQRAJEqKLCeHUeuTRLgVTPNG5mG21Ma5nj2HbCyC/HGelkOUBaakbRsYyKopLSow8A2xmRz0jpGA==": {
+            "type": "\u0004",
+            "notify": [
+              "Fk9nXgaTw0g="
+            ]
+          },
+          "mhgTAYWyl4RGL8my4EskNtiC8WdZdCnvto9+Vp+vdGvTXrsmNCZF2I1dGbbT/2LS8npk1ULPyVFyX4MEE7zwkw==": {
+            "type": "\u001a\u0007\u0007",
+            "notify": [
+              "0c1AMXCaexw="
+            ]
+          },
+          "t5XFdpQHRCGELcCtnRUjV6RqTpctewjWT5fmt7B/G+hFfI9ow/bh6Wy/rvuxakj3ehFXKAK8MSnDp7tw5kQ4iQ==": {
+            "type": "\u0007",
+            "notify": [
+              "Fk9nXgaTw0g="
+            ]
+          },
+          "x4t3XXS2DSILuOe+n5us1sgE6kB1lxh4p2b17HzWEha5FcEee2oXoas47eyhWPKT6X6o6Z21DkjIboxky/S+GA==": {
+            "type": "\u0004",
+            "notify": [
+              "oax7/2uxddg="
+            ]
+          }
+        }
+      },
+      "filters": [
+        {
+          "mql": "asset.family.contains('unix')",
+          "code_id": "u6qtHYJqMdA=",
+          "checksum": "bJUt9l0gqb0=",
+          "mrn": "//policy.api.mondoo.com/assets/3IC11wzbuXSoZNGvavIsNPvjjvs/assetfilter/u6qtHYJqMdA=",
+          "type": "\u0004"
+        }
+      ],
+      "graph_execution_checksum": "0LqJb4JeQRQ=",
+      "filters_checksum": "Mrq8J4F62Ww=",
+      "reporting_job_uuid": "O9u8nLZf9U8="
+    }
+  }
+}

--- a/apps/cnspec/cmd/interactive/upstream.go
+++ b/apps/cnspec/cmd/interactive/upstream.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/mql/cli/config"
+)
+
+// Where a scan's results go is not a detail. A scan that reports to Mondoo
+// Platform sends what it found off this machine; an incognito one keeps it
+// here. `cnspec scan` decides that silently -- it warns into the log when there
+// are no credentials and switches to incognito -- and a launcher that hides the
+// log has to say it on screen instead.
+
+// upstreamState is what the launcher knows about reporting, and it is
+// deliberately only what can be known cheaply.
+type upstreamState struct {
+	// configured is true when this machine has credentials to report with.
+	configured bool
+	// scope names the space those credentials belong to, when the config says.
+	scope string
+	// incognito is the user's choice, and is forced when configured is false.
+	incognito bool
+
+	// modal is the chooser that makes the choice, because the choice and the
+	// only thing that can change it are the same subject. See upstreammodal.go.
+	modal upstreamModalState
+}
+
+// reporting reports whether a scan launched now would send its results
+// upstream.
+func (u upstreamState) reporting() bool { return u.configured && !u.incognito }
+
+// canToggle reports whether the choice is the user's to make. Without
+// credentials there is nothing to toggle to.
+func (u upstreamState) canToggle() bool { return u.configured }
+
+// readUpstreamFn is the config read, replaceable in tests: the interesting
+// states are "no credentials" and "credentials for a named space", and a test
+// must not depend on which of those the developer happens to have.
+var readUpstreamFn = readUpstream
+
+// readUpstream asks the same question `cnspec scan` asks, in the one way that
+// does not touch the network.
+//
+// scan.go calls opts.GetServiceCredential(), which for the ssh and wif
+// authentication methods performs a *token exchange* -- ExchangeSSHKey and
+// ExchangeExternalToken both dial the API. Calling that to draw a badge would
+// put a network round trip on the render path and freeze the UI on a bad link,
+// which is the same defect the keychain write had. So this reads the config and
+// asks whether credentials are declared, which is a file read and nothing more.
+//
+// The consequence is worth stating: a declared credential can still turn out to
+// be invalid. This says "configured to report", not "proven to report", and the
+// scan itself remains the thing that finds out.
+func readUpstream() upstreamState {
+	opts, err := config.Read()
+	if err != nil || opts == nil {
+		return upstreamState{incognito: true}
+	}
+	configured := opts.ServiceAccountMrn != "" ||
+		opts.PrivateKey != "" ||
+		opts.Certificate != "" ||
+		opts.Authentication != nil
+
+	return upstreamState{
+		configured: configured,
+		scope:      spaceName(opts.GetScopeMrn()),
+		incognito:  !configured,
+	}
+}
+
+// badge says where a scan's results would go. It leads the header's right side
+// because it is the one thing on screen that decides whether what the scan finds
+// leaves this machine.
+//
+// Reporting is green and filled; incognito is hollow and dim. When there are no
+// credentials the badge is dimmer still and carries no key hint, because there
+// is nothing to toggle to -- pressing it explains rather than doing nothing.
+func (u upstreamState) badge() string {
+	if u.reporting() {
+		label := "connected"
+		if u.scope != "" {
+			label += " " + u.scope
+		}
+		return tui.StyleGood.Render("● " + label)
+	}
+	if u.canToggle() {
+		return tui.StyleWarn.Render("◌ incognito")
+	}
+	return tui.StyleFaint.Render("◌ incognito")
+}
+
+// badgeWidth is what the header reserves for the badge, so the clickable zone
+// and the drawn glyphs agree.
+func (u upstreamState) badgeWidth() int { return tui.Width(u.badge()) }
+
+// spaceName is the last segment of a space MRN, which is the part a person
+// recognises. An MRN is long and mostly boilerplate:
+// //captain.api.mondoo.app/spaces/keen-tesla-123456 -> keen-tesla-123456
+func spaceName(mrn string) string {
+	if mrn == "" {
+		return ""
+	}
+	for i := len(mrn) - 1; i >= 0; i-- {
+		if mrn[i] == '/' {
+			return mrn[i+1:]
+		}
+	}
+	return mrn
+}

--- a/apps/cnspec/cmd/interactive/upstream_test.go
+++ b/apps/cnspec/cmd/interactive/upstream_test.go
@@ -1,0 +1,228 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestMain pins the two things a launch would otherwise read off the machine it
+// is running on.
+//
+// Where a scan would report: without this the suite reads the developer's own
+// Mondoo configuration, and every assertion about an assembled command line
+// changes depending on whether whoever ran it happens to be logged in -- the
+// same form yields "scan aws" on a connected machine and "scan aws --incognito"
+// on a fresh one. Tests that care about the other states set m.upstream
+// themselves.
+//
+// And what a provider says a form means: plan() asks the connector's own
+// ParseCLI, which starts a plugin subprocess. A suite that did that per case
+// would spend a subprocess on every credential assertion in the package, and
+// would answer differently on CI, where PROVIDERS_PATH points at an empty
+// directory and nothing is installed. So the default is a stand-in, and the
+// tests that genuinely want a real provider -- TestEveryCredentialFieldRoundTrips
+// and the ssh join in inventory_test.go -- ask deliverypkg.Parser directly
+// rather than going through this.
+func TestMain(m *testing.M) {
+	readUpstreamFn = func() upstreamState {
+		return upstreamState{configured: true, scope: "test-space"}
+	}
+	defaultTestParser()
+	os.Exit(m.Run())
+}
+
+func TestReportingIsOnlyWithCredentialsAndConsent(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		state     upstreamState
+		reporting bool
+		canToggle bool
+	}{
+		{"connected", upstreamState{configured: true}, true, true},
+		{"chose local", upstreamState{configured: true, incognito: true}, false, true},
+		{"no credentials", upstreamState{incognito: true}, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.state.reporting(); got != tc.reporting {
+				t.Errorf("reporting() = %v, want %v", got, tc.reporting)
+			}
+			if got := tc.state.canToggle(); got != tc.canToggle {
+				t.Errorf("canToggle() = %v, want %v", got, tc.canToggle)
+			}
+		})
+	}
+}
+
+// The badge is the only thing on screen saying whether findings leave this
+// machine, so each state has to be distinguishable at a glance.
+func TestTheBadgeNamesEachState(t *testing.T) {
+	m := newTestModel()
+
+	m.upstream = upstreamState{configured: true, scope: "keen-tesla-123456"}
+	if got := m.upstream.badge(); !strings.Contains(got, "connected") || !strings.Contains(got, "keen-tesla-123456") {
+		t.Errorf("connected badge = %q, want the state and the space", got)
+	}
+
+	m.upstream = upstreamState{configured: true, incognito: true}
+	if got := m.upstream.badge(); !strings.Contains(got, "incognito") {
+		t.Errorf("incognito badge = %q", got)
+	}
+
+	m.upstream = upstreamState{incognito: true}
+	if got := m.upstream.badge(); !strings.Contains(got, "incognito") {
+		t.Errorf("no-credentials badge = %q", got)
+	}
+}
+
+// Toggling has to change the command, not just the label -- otherwise the badge
+// is decoration and the user cannot tell what will actually run.
+func TestTogglingReportingChangesTheCommand(t *testing.T) {
+	m := selectEntry(t, newTestModel(), "local")
+	m.upstream = upstreamState{configured: true}
+
+	plan, err := m.launchArgs(m.list.entries[m.list.cursor], scanAction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(plan.args, "--incognito") {
+		t.Errorf("connected, yet the command says --incognito: %v", plan.args)
+	}
+
+	m.upstream.openModal()
+	m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyDown})
+	m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.upstream.reporting() {
+		t.Fatal("choosing local did not take")
+	}
+	if m.upstream.modal.open {
+		t.Error("the chooser stayed open after a choice")
+	}
+	plan, err = m.launchArgs(m.list.entries[m.list.cursor], scanAction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(plan.args, "--incognito") {
+		t.Errorf("incognito, yet the command does not say so: %v", plan.args)
+	}
+}
+
+// A user who presses the key and sees nothing happen would be right to think it
+// broken, so the refusal has to say why.
+func TestTogglingWithoutCredentialsExplainsItself(t *testing.T) {
+	m := newTestModel()
+	m.upstream = upstreamState{incognito: true}
+
+	m.upstream.openModal()
+	m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyUp})
+	warn := m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.upstream.reporting() {
+		t.Fatal("reporting without credentials")
+	}
+	if !m.upstream.modal.open {
+		t.Error("the chooser closed on a choice that could not be honoured")
+	}
+	if warn == "" {
+		t.Fatal("refused silently")
+	}
+	if !strings.Contains(warn, "cnspec login") {
+		t.Errorf("warning does not say how to fix it: %q", warn)
+	}
+}
+
+func TestSpaceNameIsTheReadablePart(t *testing.T) {
+	for in, want := range map[string]string{
+		"//captain.api.mondoo.app/spaces/keen-tesla-123456": "keen-tesla-123456",
+		"keen-tesla-123456": "keen-tesla-123456",
+		"":                  "",
+	} {
+		if got := spaceName(in); got != want {
+			t.Errorf("spaceName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// The badge opens a chooser rather than flipping silently, because the two
+// answers differ in whether findings leave the machine and a one-word badge
+// cannot carry that.
+func TestTheChooserExplainsBothOptions(t *testing.T) {
+	m := sized(newTestModel(), 100, 22)
+	m.upstream = upstreamState{configured: true, scope: "keen-tesla-123456"}
+	m.upstream.openModal()
+	view := ansiStrip(m.View())
+
+	for _, want := range []string{
+		"Where do scan results go?",
+		"Report to Mondoo Platform",
+		"keen-tesla-123456",
+		"Keep results on this machine",
+		"--incognito",
+	} {
+		if !strings.Contains(view, want) {
+			t.Errorf("the chooser never says %q", want)
+		}
+	}
+}
+
+// Without credentials the option is not merely absent -- it is shown, disabled,
+// with the reason and the fix. A missing option teaches nothing.
+func TestTheChooserSaysWhyReportingIsUnavailable(t *testing.T) {
+	m := sized(newTestModel(), 100, 22)
+	m.upstream = upstreamState{incognito: true}
+	m.upstream.openModal()
+	view := ansiStrip(m.View())
+
+	if !strings.Contains(view, "Report to Mondoo Platform") {
+		t.Error("the unavailable option is hidden rather than explained")
+	}
+	if !strings.Contains(view, "cnspec login") {
+		t.Error("the chooser does not say how to get credentials")
+	}
+}
+
+// Esc leaves the decision as it was.
+func TestCancellingTheChooserChangesNothing(t *testing.T) {
+	m := sized(newTestModel(), 100, 22)
+	m.upstream = upstreamState{configured: true}
+	m.upstream.openModal()
+	m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyDown})
+	m.upstream.keyModal(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !m.upstream.reporting() {
+		t.Error("esc applied the choice it was cancelling")
+	}
+	if m.upstream.modal.open {
+		t.Error("esc left the chooser open")
+	}
+}
+
+// The chooser is a body overlay like a picker: the view stays exactly the
+// terminal height so the footer does not move under it.
+func TestTheChooserKeepsTheViewHeight(t *testing.T) {
+	for _, size := range [][2]int{{80, 24}, {100, 30}, {120, 40}, {60, 15}} {
+		m := sized(newTestModel(), size[0], size[1])
+		m.upstream = upstreamState{configured: true, scope: "s"}
+		m.upstream.openModal()
+		if got := len(strings.Split(m.View(), "\n")); got != size[1] {
+			t.Errorf("%dx%d: view is %d lines, want %d", size[0], size[1], got, size[1])
+		}
+	}
+}
+
+func ansiStrip(s string) string { return ansi.Strip(s) }

--- a/apps/cnspec/cmd/interactive/upstream_zone_test.go
+++ b/apps/cnspec/cmd/interactive/upstream_zone_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The badge is clickable, and a click that lands anywhere else is worse than no
+// click at all -- it would toggle where results go without the user meaning to.
+// Geometry and rendering are computed from one function so they cannot drift;
+// this proves it across widths, including one too narrow to draw the badge.
+func TestBadgeZoneLandsOnTheBadge(t *testing.T) {
+	for _, w := range []int{80, 100, 120, 200} {
+		m := sized(newTestModel(), w, 30)
+		l := computeLayout(m)
+		header := ansi.Strip(strings.Split(m.View(), "\n")[0])
+		var found bool
+		for _, z := range l.Zones {
+			if z.Kind != tui.ZoneUpstream {
+				continue
+			}
+			found = true
+			// Zones are display columns; a Go string index is bytes, and the
+			// header's ✦ is 3 bytes wide but 1 column.
+			seg := colSlice(header, z.Rect.X, z.Rect.W)
+			t.Logf("w=%3d zone x=%d w=%d -> %q", w, z.Rect.X, z.Rect.W, seg)
+			if !strings.Contains(seg, "connected") && !strings.Contains(seg, "incognito") {
+				t.Errorf("w=%d: zone does not cover the badge, covers %q", w, seg)
+			}
+		}
+		// A width too narrow to draw the badge must register no zone: a click
+		// on a badge that was never rendered would change where results go
+		// without the user having seen the control.
+		drawn := strings.Contains(header, "connected") || strings.Contains(header, "incognito")
+		if found != drawn {
+			t.Errorf("w=%d: zone present = %v but badge drawn = %v", w, found, drawn)
+		}
+	}
+}
+
+// colSlice takes w display columns starting at column x.
+func colSlice(s string, x, w int) string {
+	var out []rune
+	col := 0
+	for _, r := range s {
+		rw := tui.Width(string(r))
+		if col >= x && col < x+w {
+			out = append(out, r)
+		}
+		col += rw
+	}
+	return string(out)
+}

--- a/apps/cnspec/cmd/interactive/upstreammodal.go
+++ b/apps/cnspec/cmd/interactive/upstreammodal.go
@@ -1,0 +1,147 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Choosing where results go is not a toggle, it is a decision, and the two
+// answers differ in a way a one-word badge cannot carry: one sends what the
+// scan found off this machine, the other keeps it here. A blind flip would
+// leave a user guessing which state they are now in and what it costs them, so
+// the badge opens this instead and says what each option means.
+
+// upstreamModalState is the reporting chooser, if it is open.
+type upstreamModalState struct {
+	open   bool
+	cursor int // 0 = report to Mondoo Platform, 1 = stay local
+}
+
+// upstreamChoices are the two options in the order they are drawn. Reporting
+// leads because it is the one with consequences outside this machine.
+const (
+	upstreamChoiceReport = 0
+	upstreamChoiceLocal  = 1
+)
+
+// openModal opens the chooser with the current state under the cursor, so
+// pressing enter immediately is a no-op rather than a surprise.
+func (u *upstreamState) openModal() {
+	u.modal.open = true
+	u.modal.cursor = upstreamChoiceLocal
+	if u.reporting() {
+		u.modal.cursor = upstreamChoiceReport
+	}
+}
+
+// keyModal handles the chooser's keys and returns what the user has to be told,
+// which is empty for every key that simply did what it says.
+//
+// The warning is returned rather than written to the footer from here: the
+// footer is the launcher's chrome, and a chooser that reached into it would be
+// a second thing in the package deciding what the last line says.
+//
+// It is consulted before the rest of the launcher's keys, so while the chooser
+// is open the keys mean what it says they do.
+func (u *upstreamState) keyModal(msg tea.KeyMsg) string {
+	switch msg.String() {
+	case "esc", "q", "ctrl+r":
+		u.modal = upstreamModalState{}
+
+	case "up", "k", "shift+tab":
+		u.modal.cursor = upstreamChoiceReport
+
+	case "down", "j", "tab":
+		u.modal.cursor = upstreamChoiceLocal
+
+	case "enter", " ":
+		// Reporting needs credentials. Choosing it without them cannot be
+		// honoured, so the modal stays open and says why rather than closing on
+		// a choice that did not take.
+		if u.modal.cursor == upstreamChoiceReport && !u.canToggle() {
+			return noCredentialsWarning
+		}
+		u.incognito = u.modal.cursor == upstreamChoiceLocal
+		u.modal = upstreamModalState{}
+	}
+	return ""
+}
+
+// noCredentialsWarning is shared with the footer so the modal and the launcher
+// say the same thing about the same situation.
+const noCredentialsWarning = "no Mondoo Platform credentials on this machine, so scans stay local — run `cnspec login` to connect"
+
+// viewModal draws the chooser, occupying exactly bodyH lines so the footer does
+// not move.
+func (u upstreamState) viewModal(l layout) string {
+	boxW, contentW := modalGeom(l.Width)
+
+	var b strings.Builder
+	b.WriteString(tui.StyleAccent.Render(tui.Truncate("Where do scan results go?", contentW)))
+	b.WriteString("\n\n")
+
+	for _, opt := range []struct {
+		idx         int
+		label, desc string
+		available   bool
+	}{
+		{
+			idx:   upstreamChoiceReport,
+			label: u.reportChoiceLabel(),
+			desc: "Findings are uploaded, so they appear in the console, feed " +
+				"compliance reports, and are visible to your team.",
+			available: u.canToggle(),
+		},
+		{
+			idx:       upstreamChoiceLocal,
+			label:     "Keep results on this machine",
+			desc:      "Nothing leaves this computer. The scan runs with --incognito and the report is yours alone.",
+			available: true,
+		},
+	} {
+		mark := "  "
+		if (opt.idx == upstreamChoiceReport) == u.reporting() {
+			mark = "● " // the state you are in now
+		}
+		line := mark + opt.label
+		if opt.idx == u.modal.cursor {
+			b.WriteString(tui.Bar(tui.Truncate(line, contentW), contentW, tui.BandSelected))
+		} else if !opt.available {
+			b.WriteString(tui.StyleFaint.Render(tui.Truncate(line, contentW)))
+		} else {
+			b.WriteString(tui.Truncate(line, contentW))
+		}
+		b.WriteString("\n")
+
+		for _, wrapped := range tui.WrapWords(opt.desc, contentW-4) {
+			b.WriteString(tui.StyleDim.Render("    " + wrapped))
+			b.WriteString("\n")
+		}
+		if !opt.available {
+			b.WriteString(tui.StyleWarn.Render(tui.Truncate("    needs credentials — run `cnspec login`", contentW)))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(tui.StyleFaint.Render(tui.Truncate("↑/↓ choose · enter confirm · esc cancel", contentW)))
+
+	box := modalBox.Width(boxW).Render(b.String())
+	return lipgloss.Place(l.Width, l.BodyH, lipgloss.Center, lipgloss.Center, box)
+}
+
+// reportChoiceLabel names the space when the config declares one, because
+// "report to Mondoo Platform" is a different decision depending on which space
+// is on the other end.
+func (u upstreamState) reportChoiceLabel() string {
+	if u.scope != "" {
+		return "Report to Mondoo Platform · " + u.scope
+	}
+	return "Report to Mondoo Platform"
+}

--- a/apps/cnspec/cmd/interactive/view.go
+++ b/apps/cnspec/cmd/interactive/view.go
@@ -1,0 +1,620 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// What is left of the launcher's palette once cli/tui took the rest.
+//
+// The seven chrome colors, the six text styles and the two selection bands were
+// declared here and, identically, in the report viewer; they come from tui now,
+// so the two programs cannot drift apart by one of them being edited. Install
+// state -- green, amber, red -- was picked by hand here and missed the rating
+// palette on two of its three colors; it resolves through tui.Ratings now, like
+// every other colored fact in cnspec.
+//
+// These two are what remains, and they are the launcher's own: nothing else in
+// the repo draws them. Neither carries a margin, because a margin adds a line
+// that layout.go cannot account for and the panels are sized in exact lines.
+var (
+	// styleSpark is the ✦ in front of the wordmark, which is the one place the
+	// header spends the command colour on something that is not a command.
+	styleSpark = lipgloss.NewStyle().Foreground(tui.ColCyan).Bold(true)
+
+	// bandCommand is the command line at the foot of the detail panel, drawn as
+	// a full-width bar so the thing the whole screen is building toward reads as
+	// a command rather than as one more row.
+	bandCommand = lipgloss.NewStyle().Foreground(tui.ColCyan).Background(lipgloss.Color("236"))
+)
+
+// categoryIcon gives each category a glyph.
+var categoryIcon = map[string]string{
+	catCloud:     "☁",
+	catIdentity:  "◈",
+	catSaaS:      "⬡",
+	catAI:        "✦",
+	catContainer: "◈",
+	catHosts:     "▚",
+	catDatabase:  "⛁",
+	catNetwork:   "⟟",
+	catIaC:       "❏",
+	catDev:       "⚙",
+	catOther:     "•",
+}
+
+// cursorMark prefixes the row under the cursor. It is a dot rather than an
+// arrow because an arrow promises the row will open into something, and none of
+// these rows do -- the "enter ▸ scan" hints keep their arrow, where the glyph
+// means "leads to" rather than "is selected".
+const cursorMark = "● "
+
+// The launch affordance says what enter will do, because enter does two things:
+// it runs when the command is complete and opens the fields when it is not.
+// Both labels are the same width so the layout's clickable zone is fixed.
+const (
+	runButtonScan    = " enter ▸ scan    "
+	runButtonOptions = " enter ▸ options "
+)
+
+func (m Model) runButton() string {
+	if m.readyToRun() {
+		return runButtonScan
+	}
+	return runButtonOptions
+}
+
+func (m Model) View() string {
+	// The report viewer is a whole tea.Model, so it draws its own screen --
+	// header, panes and footer -- rather than being framed by this one. See
+	// viewer.go for how the user gets back.
+	if m.phase == phaseViewing {
+		return m.viewer.view()
+	}
+
+	l := computeLayout(m)
+
+	// A scan in the background is invisible without a screen of its own: the
+	// child has no terminal, so nothing it would normally print arrives here.
+	if m.phase == phaseScanning {
+		return m.viewHeader(l) + "\n" +
+			clipLines(m.scan.view(l, m.spinner.View()), l.BodyH) + "\n" + m.scan.viewFooter(l)
+	}
+
+	// An open picker takes over the body: nothing moves behind it, and the
+	// arrow keys mean one thing while it is up.
+	// The reporting chooser takes the body the way a picker does: while it is
+	// up, nothing behind it moves and its keys mean what it says they do.
+	if m.upstream.modal.open {
+		return m.viewHeader(l) + "\n" + clipLines(m.upstream.viewModal(l), l.BodyH) + "\n" + m.viewFooter(l)
+	}
+	// The export box takes the body the same way, and is checked before the
+	// pickers because a picker cannot be opened from behind it.
+	if m.export.open {
+		return m.viewHeader(l) + "\n" + clipLines(m.viewExport(l), l.BodyH) + "\n" + m.viewFooter(l)
+	}
+	if m.picker.modal.open && m.picker.modal.valid(m.detail.form.Fields()) {
+		return m.viewHeader(l) + "\n" + clipLines(m.viewModal(l), l.BodyH) + "\n" + m.viewFooter(l)
+	}
+
+	var body string
+	switch {
+	case l.TwoPane:
+		body = lipgloss.JoinHorizontal(lipgloss.Top,
+			m.list.panel(l, m.focus == focusList), " ", m.detailPanel(l))
+	case m.focus == focusList:
+		body = m.list.panel(l, m.focus == focusList)
+	default:
+		body = m.detailPanel(l)
+	}
+
+	// Defensive clip: the panels are already sized in exact lines, but the
+	// footer must stay on the last row even if one of them miscounts.
+	body = clipLines(body, l.BodyH)
+	return m.viewHeader(l) + "\n" + body + "\n" + m.viewFooter(l)
+}
+
+func clipLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// headerRight is the right-hand side of the header, built once so the renderer
+// and the hit-tester cannot disagree about where the badge is. The badge leads
+// it, so the badge starts exactly where this string starts.
+func (m Model) headerRight() string {
+	return m.upstream.badge() + tui.StyleFaint.Render(tui.HintSep) +
+		tui.StyleDim.Render(fmt.Sprintf("%d connectors", m.list.count())) + " "
+}
+
+func (m Model) headerLeft() string {
+	return " " + styleSpark.Render("✦") + " " + tui.StyleAccent.Render("cnspec") + "  " +
+		tui.StyleFaint.Render("AI-native security for your entire stack")
+}
+
+// headerRightX is the column headerRight starts at, or -1 when the header is
+// too narrow to draw it at all. computeLayout registers the badge's click zone
+// from this, so a click cannot land on a badge that was never drawn.
+//
+// It and viewHeader ask tui the same question about the same two strings, which
+// is the only reason the answer can be trusted: the renderer and the hit-tester
+// each had their own copy of this arithmetic, in a package that also carried two
+// more copies of it.
+func (m Model) headerRightX(width int) int {
+	return tui.BandRightX(m.headerLeft(), m.headerRight(), width)
+}
+
+func (m Model) viewHeader(l layout) string {
+	return tui.Band(m.headerLeft(), m.headerRight(), l.Width)
+}
+
+// --- left panel -------------------------------------------------------------
+
+// panel draws the connector list. It is a method on the list rather than on the
+// Model because focus is the only thing outside the list it needs, and that is
+// one bool rather than a whole launcher.
+func (s listState) panel(l layout, focused bool) string {
+	iw := tui.InnerWidth(l.LeftW)
+
+	var content []string
+
+	s.search.Width = iw - 3
+	content = append(content, ansi.Truncate(s.search.View(), iw, ""))
+	content = append(content, "")
+
+	if len(s.selectable) == 0 {
+		content = append(content, tui.StyleFaint.Render("no match — try a different term"))
+	} else {
+		off := l.offsetRow(s)
+		end := off + l.ListH
+		if end > len(s.rows) {
+			end = len(s.rows)
+		}
+		for i := off; i < end; i++ {
+			content = append(content, s.viewRow(s.rows[i], iw, focused))
+		}
+	}
+
+	title := tui.StyleAccent.Render("Connectors")
+	if !focused {
+		title = tui.StyleDim.Render("Connectors")
+	}
+	status := tui.StyleFaint.Render(s.scrollStatus(l.ListH))
+	return tui.Panel(title, status, content, l.LeftW, l.BodyH, tui.BorderColor(focused))
+}
+
+// scrollStatus reports the cursor's position in the list, so a long list says
+// where you are rather than just running off the edge.
+func (s listState) scrollStatus(height int) string {
+	if len(s.selectable) == 0 {
+		return "0"
+	}
+	if len(s.rows) <= height {
+		return fmt.Sprintf("%d", len(s.selectable))
+	}
+	return fmt.Sprintf("%d/%d", s.cursor+1, len(s.selectable))
+}
+
+func (s listState) viewRow(r row, w int, focused bool) string {
+	switch r.kind {
+	case rowBlank:
+		return ""
+	case rowHeader:
+		icon := categoryIcon[r.text]
+		label := strings.ToUpper(r.text)
+		head := tui.StyleFaint.Render(icon + "  " + label + " ")
+		rule := w - tui.Width(head)
+		if rule > 0 {
+			head += tui.StyleFaint.Render(strings.Repeat("─", rule))
+		}
+		return head
+	}
+
+	e := s.filtered[r.idx]
+	selected := r.sel == s.cursor
+
+	// The install marker gets a reserved column whether or not it is drawn, so
+	// it lines up down the panel instead of trailing each description.
+	mark := " "
+	if e.Installed {
+		mark = "●"
+	}
+
+	const cursorW, markW = 2, 2
+	avail := w - cursorW - markW
+	nameW := 14
+	if nameW > avail-6 {
+		nameW = avail - 6
+	}
+	if nameW < 4 {
+		nameW = 4
+	}
+	descW := max(avail-nameW-1, 0)
+
+	name := tui.PadRight(tui.Truncate(e.Name, nameW), nameW)
+	desc := tui.PadRight(tui.Truncate(e.Summary(), descW), descW)
+
+	// A selected row is one band, so it is built unstyled and colored whole:
+	// per-part colors would punch holes in the background.
+	if selected {
+		style := tui.BandSelected
+		if !focused {
+			style = tui.BandInactive
+		}
+		return tui.Bar(cursorMark+name+" "+desc+" "+mark, w, style)
+	}
+
+	return "  " + tui.StyleText.Render(name) + " " + tui.StyleFaint.Render(desc) + " " + tui.StyleGood.Render(mark)
+}
+
+// --- right panel ------------------------------------------------------------
+
+func (m Model) detailPanel(l layout) string {
+	c, ok := m.list.current()
+	if !ok {
+		return tui.Panel(tui.StyleDim.Render("Details"), "", []string{tui.StyleFaint.Render("Nothing selected.")},
+			l.RightW, l.BodyH, tui.BorderColor(false))
+	}
+	return m.connectorPanel(c, l)
+}
+
+func (m Model) connectorPanel(c Connector, l layout) string {
+	focused := m.focus != focusList
+	iw := tui.InnerWidth(l.RightW)
+
+	status := tui.Pill("installed", tui.ColInk, tui.ColGood)
+	switch {
+	case m.list.downloading(c):
+		status = tui.Pill("installing…", tui.ColInk, tui.ColCyan)
+	case !c.Installed:
+		status = tui.Pill("not installed", tui.ColInk, tui.ColWarn)
+	}
+
+	plan, command := splitPlan(m.detailPlan())
+	off := l.detailOffsetOf(m, len(plan))
+	visible := tui.InnerHeight(l.BodyH) - 1 // the pinned command bar
+
+	content := make([]string, 0, visible+1)
+	for i := off; i < len(plan) && len(content) < visible; i++ {
+		content = append(content, m.renderDetailItem(plan[i], c, iw))
+	}
+	// Pad so the command bar lands on the pane's last line every time.
+	for len(content) < visible {
+		content = append(content, "")
+	}
+	content = append(content, m.renderDetailItem(command, c, iw))
+
+	title := tui.StyleAccent.Render(c.Name)
+	if !focused {
+		title = tui.StyleDim.Render(c.Name)
+	}
+	if off > 0 || off+visible < len(plan) {
+		title += tui.StyleFaint.Render(scrollHint(off, visible, len(plan)))
+	}
+	return tui.Panel(title, status, content, l.RightW, l.BodyH, tui.BorderColor(focused))
+}
+
+func scrollHint(off, visible, total int) string {
+	if total <= visible {
+		return ""
+	}
+	pct := 100 * off / (total - visible)
+	return fmt.Sprintf("  ↕%d%%", pct)
+}
+
+func (m Model) renderDetailItem(item detailItem, c Connector, w int) string {
+	switch item.kind {
+	case diBlank:
+		return ""
+	case diLabel:
+		return tui.StyleLabel.Render(item.text)
+	case diText:
+		return tui.StyleDim.Render(tui.Truncate(item.text, w))
+
+	case diField:
+		return m.renderField(item.idx, w)
+
+	case diMore:
+		label := fmt.Sprintf("⋯ %d more options", item.idx)
+		if m.detail.onMore() && m.focus == focusForm {
+			return tui.Bar(cursorMark+label, w, tui.BandSelected)
+		}
+		return "  " + tui.StyleFaint.Render(label)
+
+	case diButton:
+		// Scanning is an explicit act, so it has a button of its own rather
+		// than being what enter happens to do at the end of a form.
+		label := "Scan"
+		switch {
+		case m.launching.preparing:
+			// The credential now reaches the keychain from a command rather
+			// than from Update, which is what stops a locked keychain freezing
+			// the screen -- but it also means enter no longer does anything
+			// visible on its own. Without this the button reads as a swallowed
+			// keypress for as long as the OS dialog is up.
+			label = "Preparing…"
+		case !m.readyToRun():
+			label = "Scan (fill in what is marked *)"
+		}
+		return "  " + xbutton(label, m.detail.onButton() && m.focus == focusForm)
+
+	case diCommand:
+		return tui.Bar(tui.Truncate("$ "+m.commandPreview(c), w), w, bandCommand)
+	}
+	return ""
+}
+
+// renderField draws one input row: label, current value, and -- when the field
+// has focus -- whatever help it can offer about what may go in it.
+func (m Model) renderField(idx, w int) string {
+	fd := m.detail.form.Fields()[idx]
+	focused := m.focus == focusForm && m.detail.form.Cursor() == idx
+
+	label := fd.Label
+	if fd.Required {
+		label += "*"
+	}
+	labelW := 18
+	if labelW > w/2 {
+		labelW = w / 2
+	}
+
+	var value string
+	switch fd.Kind {
+	case fieldBool:
+		value = "[ ] no"
+		if fd.On() {
+			value = "[x] yes"
+		}
+	case fieldMultiChoice:
+		if picked := fd.Selected(); len(picked) > 0 {
+			value = strings.Join(picked, ", ")
+		} else {
+			value = tui.StyleFaint.Render(fmt.Sprintf("%d to choose from", len(fd.Options)))
+		}
+		value += tui.StyleFaint.Render("  ▾")
+
+	case fieldCredentialState:
+		// A readout, not an input. It says whether a credential is present and
+		// which variable supplied it, and what it holds is that variable's
+		// name -- never the credential, which the launcher never reads.
+		//
+		// The mark is the same one the connector list uses for an installed
+		// provider, because it answers the same question: this is here.
+		if fd.IsSet() {
+			value = tui.StyleGood.Render("●") + " " + fd.Display()
+		} else {
+			// Empty and "nothing to fill in here" look identical otherwise,
+			// which is the failure this widget exists to end. The hint names
+			// the variable to export.
+			value = tui.StyleFaint.Render(credentialHint(fd))
+		}
+
+	case fieldPaste:
+		// A paste box is the secret text field it behaves as: the live input
+		// while focused -- already in password echo, see loadCursorField -- and
+		// bullets otherwise. Its value is never rendered in the clear, and the
+		// row says so while it is empty.
+		switch {
+		case focused:
+			value = m.detail.input.View()
+		case fd.IsSet():
+			value = fd.Display()
+		default:
+			value = tui.StyleFaint.Render(fd.Placeholder())
+		}
+
+	case fieldChoice:
+		// A picker has to show what it found. Rendering only the text input
+		// left the values invisible and the field looking empty.
+		//
+		// A strict choice -- a fixed set the provider understands, like the
+		// container kind -- is nothing but its options, so drawing a text box
+		// beside them just repeats the selected value. A suggestion picker
+		// (hosts, profiles, images) shows both, because a value it has not
+		// heard of still has to be typeable.
+		switch {
+		case focused && fd.Strict:
+			value = m.renderChoices(fd, w-labelW-6) + tui.StyleFaint.Render("  ▾")
+		case focused:
+			// The typed value and the offered values share the row, so the
+			// input only reserves what it is using -- an empty one would
+			// otherwise squeeze the list down to a single entry.
+			inputW := tui.Width(fd.Value()) + 2
+			if inputW < 6 {
+				inputW = 6
+			}
+			if maxInput := (w - labelW) / 2; inputW > maxInput {
+				inputW = maxInput
+			}
+			value = tui.PadRight(ansi.Truncate(m.detail.input.View(), inputW, ""), inputW) +
+				" " + m.renderChoices(fd, w-labelW-inputW-8) + tui.StyleFaint.Render("  ▾")
+		case fd.IsSet():
+			// No room for the reason a live refresh failed here -- the row has
+			// about forty columns and the message is longer. It goes in the
+			// footer, which has the whole width, and in the picker itself.
+			value = fd.Display() + prefillNote(fd) + tui.StyleFaint.Render("  ▾")
+		default:
+			value = tui.StyleFaint.Render(m.picker.choiceHint(m.detail.form, fd) + "  ▾")
+		}
+
+	default:
+		if focused {
+			// The live input carries the cursor, so it is what gets drawn.
+			value = m.detail.input.View()
+		} else if fd.IsSet() {
+			value = fd.Display()
+		} else {
+			value = tui.StyleFaint.Render(fd.Placeholder())
+		}
+	}
+
+	row := "  " + tui.PadRight(label, labelW) + " " + value
+	if focused {
+		style := tui.BandSelected
+		plain := cursorMark + tui.PadRight(label, labelW) + " "
+		// A focused text field keeps its own styling so the cursor stays
+		// visible; only the label gets the band. A credential-state field has
+		// no cursor either -- there is nothing to type into it -- so it takes
+		// the band, while a paste field is a text field and does not.
+		if fd.Kind == fieldBool || fd.Kind == fieldMultiChoice || fd.Kind == fieldChoice ||
+			fd.Kind == fieldCredentialState {
+			return tui.Bar(cursorMark+tui.PadRight(label, labelW)+" "+ansi.Strip(value), w, style)
+		}
+		return style.Render(plain) + " " + value
+	}
+	return tui.Truncate(row, w)
+}
+
+// renderChoices draws the values a picker offers, windowed around the one under
+// the cursor.
+func (m Model) renderChoices(fd field, w int) string {
+	if len(fd.Options) == 0 {
+		return tui.StyleFaint.Render(m.picker.choiceHint(m.detail.form, fd))
+	}
+	parts := make([]string, len(fd.Options))
+	for i, opt := range fd.Options {
+		if i == fd.OptCursor() {
+			parts[i] = "[" + opt + "]"
+			continue
+		}
+		parts[i] = opt
+	}
+
+	// Long values -- container names, EKS context ARNs -- mean the row often
+	// holds only one. Say how many are out of view, or the list reads as
+	// though it were the whole set. Only what is actually hidden is counted.
+	shown, hidden := windowAround(parts, fd.OptCursor(), max(w, 8))
+	if hidden == 0 {
+		return tui.Truncate(shown, max(w, 8))
+	}
+	count := fmt.Sprintf("  +%d", hidden)
+	avail := max(w-tui.Width(count), 8)
+	shown, hidden = windowAround(parts, fd.OptCursor(), avail)
+	if hidden == 0 {
+		return tui.Truncate(shown, avail)
+	}
+	return tui.Truncate(shown, avail) + tui.StyleFaint.Render(fmt.Sprintf("  +%d", hidden))
+}
+
+// credentialHint says what to do about a credential that is not there. It is
+// the field's own description, because only the declaration knows which
+// variable this connector reads; the fallback exists so a readout built without
+// one still says something rather than rendering as an empty row.
+func credentialHint(fd field) string {
+	if fd.Desc != "" {
+		return fd.Desc
+	}
+	return "none found"
+}
+
+// prefillNote explains a value the user did not type.
+//
+// It reads the field and nothing else, so it takes one rather than a launcher.
+func prefillNote(fd field) string {
+	if fd.Prefilled() == "" {
+		return ""
+	}
+	return tui.StyleFaint.Render("  (" + fd.Prefilled() + ")")
+}
+
+// windowAround renders as many entries as fit, keeping index i visible, and
+// reports how many were left out.
+func windowAround(parts []string, i, w int) (string, int) {
+	if len(parts) == 0 {
+		return "", 0
+	}
+	if i < 0 || i >= len(parts) {
+		i = 0
+	}
+	start, end := i, i+1
+	width := tui.Width(parts[i])
+	for {
+		grew := false
+		if start > 0 && width+tui.Width(parts[start-1])+2 <= w {
+			width += tui.Width(parts[start-1]) + 2
+			start--
+			grew = true
+		}
+		if end < len(parts) && width+tui.Width(parts[end])+2 <= w {
+			width += tui.Width(parts[end]) + 2
+			end++
+			grew = true
+		}
+		if !grew {
+			break
+		}
+	}
+	return strings.Join(parts[start:end], "  "), len(parts) - (end - start)
+}
+
+// viewFooter is the last row of the screen, and it is exactly one row.
+//
+// The notice is flattened rather than merely truncated. A provider error is a
+// string from somewhere else -- an exec failure, a Go client's wrapped chain --
+// and several of them contain newlines; truncation cuts a line to width and
+// leaves every newline in it, so a three-line error rendered a 24-row terminal
+// as 26 rows and pushed this row off the bottom of the screen. tui.OneLine is
+// what the report viewer already did to the same class of string.
+func (m Model) viewFooter(l layout) string {
+	if m.lastErr != "" {
+		return tui.StyleBad.Render(tui.Truncate(" ✗ "+tui.OneLine(m.lastErr), l.Width))
+	}
+	if m.lastWarn != "" {
+		return tui.StyleWarn.Render(tui.Truncate(" ! "+tui.OneLine(m.lastWarn), l.Width))
+	}
+	// Below the two that report trouble, and in the good color: this is a file
+	// that was written and the command that reads it, which is neither an error
+	// nor a weakened guarantee.
+	if m.lastNote != "" {
+		return tui.StyleGood.Render(tui.Truncate(" ✓ "+tui.OneLine(m.lastNote), l.Width))
+	}
+
+	var hints string
+	switch m.focus {
+	case focusForm:
+		hints = tui.Kbd("↑/↓", "field") + tui.HintSep + tui.Kbd("enter", "choose / scan") + tui.HintSep +
+			tui.Kbd("esc", "back")
+	default:
+		hints = tui.Kbd("↑/↓", "move") + tui.HintSep + tui.Kbd("type", "filter") + tui.HintSep +
+			tui.Kbd("enter", "configure") + tui.HintSep + tui.Kbd("esc", "quit")
+	}
+	// Shown even without credentials: the chooser is where a user finds out
+	// why their scans stay local and what to do about it.
+	hints += tui.HintSep + tui.Kbd("^r", "reporting")
+	hints += m.exportHint()
+	if m.viewer.loaded {
+		// Only offered once there is one. A key hint for a report that does not
+		// exist is a promise the launcher cannot keep.
+		hints += tui.HintSep + tui.Kbd("^o", "report")
+	}
+	hints = " " + hints
+
+	right := ""
+	if m.lastRun != "" {
+		right = tui.StyleFaint.Render("ran: "+m.lastRun) + " "
+	}
+	gap := l.Width - tui.Width(hints) - tui.Width(right)
+	if right == "" || gap < 2 {
+		return tui.Truncate(hints, l.Width)
+	}
+	return hints + strings.Repeat(" ", gap) + right
+}
+
+// xbutton renders a bracketed button, accented when focused.
+func xbutton(label string, focused bool) string {
+	if focused {
+		return tui.StyleAccent.Render(cursorMark + "[ " + label + " ]")
+	}
+	return tui.StyleFaint.Render("  [ " + label + " ]")
+}

--- a/apps/cnspec/cmd/interactive/viewer.go
+++ b/apps/cnspec/cmd/interactive/viewer.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/reportview"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The report viewer is a whole tea.Model of its own -- its own Init/Update/View,
+// its own panes, its own key map -- so the launcher does not reimplement any of
+// it. While a report is open the launcher delegates every message to it and
+// draws whatever it returns.
+//
+// That leaves exactly one thing to decide: how the user gets back.
+//
+// `cnspec report view <file>` runs the same model standalone, where esc and q
+// end the program, and the frame has no idea it is embedded. Rather than teach
+// it (that package is finished and shared), the launcher intercepts the quit it
+// asks for: a tea.Quit arriving out of the viewer means "done reading", and the
+// launcher turns it into a return to the connector list. Nothing about the
+// viewer changes, and a user who presses q lands back where they can scan the
+// next thing -- which is the entire point of the background scan.
+//
+// ctrl+c is the exception and is handled before delegation: it quits the whole
+// program from anywhere, which is what it does in every other pane too.
+
+// viewerClosedMsg is a quit the viewer asked for, converted into a return.
+type viewerClosedMsg struct{}
+
+// viewerState is the report of the most recent scan and the embedded viewer
+// drawing it.
+//
+// The two are one fact, not two: a viewer with no report draws nothing, and a
+// report with no viewer cannot be shown. They were separate fields on Model and
+// nothing but convention kept them in step -- the footer offers ^o on the
+// strength of the flag and reopenViewer draws on the strength of the model.
+type viewerState struct {
+	model reportview.Model
+	// loaded is whether there is a report to show. It stays true after the user
+	// leaves the report, so that pressing esc is not the same as losing it.
+	loaded bool
+}
+
+// open builds the viewer for a loaded report and hands it the terminal size,
+// which it needs before it can lay anything out.
+func (v *viewerState) open(collection *policy.ReportCollection, width, height int) tea.Cmd {
+	// Embedded, because q hands control back to the launcher here rather than
+	// ending the process, and a footer saying "quit" would promise otherwise.
+	v.model = reportview.NewModel(reportmodel.New(collection)).Embedded()
+	v.loaded = true
+	// A model that has never seen a WindowSizeMsg has zero width and draws
+	// nothing. The launcher already knows the size, so the viewer is told it at
+	// construction rather than on the next resize the user happens to cause.
+	// What that sizing returns is dropped: Init below is what the launcher runs.
+	v.deliver(tea.WindowSizeMsg{Width: width, Height: height})
+	return v.model.Init()
+}
+
+// deliver hands one message to the viewer and keeps what it returns.
+//
+// The type assertion is the whole reason this exists: reportview.Update returns
+// a tea.Model, and three call sites each had their own copy of unwrapping it
+// back into the concrete type. One that forgot would silently stop updating.
+func (v *viewerState) deliver(msg tea.Msg) tea.Cmd {
+	next, cmd := v.model.Update(msg)
+	if vm, ok := next.(reportview.Model); ok {
+		v.model = vm
+	}
+	return cmd
+}
+
+// update delegates a message to the viewer, translating a quit it asked for
+// into a return to the launcher. See interceptQuit.
+func (v *viewerState) update(msg tea.Msg) tea.Cmd { return interceptQuit(v.deliver(msg)) }
+
+// resize tells the viewer the terminal size again, which is what reopening a
+// report needs: the terminal may have changed shape while the report was away.
+func (v *viewerState) resize(width, height int) tea.Cmd {
+	return v.update(tea.WindowSizeMsg{Width: width, Height: height})
+}
+
+// view is the whole screen while a report is open: the viewer draws its own
+// header, panes and footer rather than being framed by the launcher's.
+func (v viewerState) view() string { return v.model.View() }
+
+// interceptQuit rewrites a quit the viewer requested into viewerClosedMsg.
+//
+// A tea.Cmd is a function returning a message, so this wraps rather than
+// inspects: the command still runs, and only its answer is translated. Batches
+// are unwrapped because tea.Batch returns its children as a BatchMsg for the
+// runtime to run, and the viewer's frame batches whatever its panes return.
+func interceptQuit(cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		return translateQuit(cmd())
+	}
+}
+
+func translateQuit(msg tea.Msg) tea.Msg {
+	switch msg := msg.(type) {
+	case tea.QuitMsg:
+		return viewerClosedMsg{}
+	case tea.BatchMsg:
+		out := make(tea.BatchMsg, 0, len(msg))
+		for _, c := range msg {
+			out = append(out, interceptQuit(c))
+		}
+		return out
+	}
+	return msg
+}

--- a/apps/cnspec/cmd/interactive/viewer_test.go
+++ b/apps/cnspec/cmd/interactive/viewer_test.go
@@ -1,0 +1,264 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/cli/reportview"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/reporter"
+)
+
+// recordedReport is the artifact a real scan wrote, read back the way the
+// launcher reads it.
+func recordedReport(t *testing.T) Model {
+	t.Helper()
+
+	collection, err := reporter.LoadCollectionFile(filepath.Join("testdata", "scan_report.json"))
+	if err != nil {
+		t.Fatalf("the recorded report no longer loads: %v", err)
+	}
+
+	m := newTestModel()
+	m.width, m.height = 120, 40
+	m.viewer.open(collection, m.width, m.height)
+	m.phase = phaseViewing
+	return m
+}
+
+// press delivers one key and runs whatever the model asked for, which is where
+// a quit the viewer requested gets translated.
+func press(t *testing.T, m Model, key string) Model {
+	t.Helper()
+
+	stroke := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+	if key == "esc" {
+		stroke = tea.KeyMsg{Type: tea.KeyEsc}
+	}
+
+	model, cmd := m.Update(stroke)
+	m = model.(Model)
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	if msg == nil {
+		return m
+	}
+	model, _ = m.Update(msg)
+	return model.(Model)
+}
+
+// The whole point of not handing the terminal over is scanning the next thing
+// without leaving, so q and esc return to the launcher rather than ending the
+// program -- even though the same viewer, run standalone by `cnspec report
+// view`, quits on both.
+func TestLeavingTheViewerReturnsToTheLauncher(t *testing.T) {
+	for _, key := range []string{"q", "esc"} {
+		t.Run(key, func(t *testing.T) {
+			m := press(t, recordedReport(t), key)
+			if m.phase != phaseForm {
+				t.Fatalf("%q did not return to the launcher (phase %d)", key, m.phase)
+			}
+			if !m.viewer.loaded {
+				t.Error("leaving the report is not the same as losing it")
+			}
+			if !strings.Contains(m.View(), "Connectors") {
+				t.Error("the connector list is not back on screen")
+			}
+		})
+	}
+}
+
+// ctrl+c is the exception, and it is handled before the viewer sees it: it ends
+// the program from anywhere, which is what it does in every other pane.
+func TestCtrlCQuitsFromTheViewer(t *testing.T) {
+	m := recordedReport(t)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c did nothing")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c did not quit, it produced %T", cmd())
+	}
+}
+
+// The report of the last scan stays in memory, so a stray esc does not throw
+// away what the user just waited for.
+func TestTheLastReportCanBeReopened(t *testing.T) {
+	m := press(t, recordedReport(t), "q")
+
+	if !strings.Contains(m.View(), "^o") {
+		t.Error("the launcher does not offer the report it is holding")
+	}
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = model.(Model)
+	if m.phase != phaseViewing {
+		t.Fatal("the report did not reopen")
+	}
+	if !strings.Contains(m.View(), "launcher-test-host") {
+		t.Error("the reopened report is not the one that was scanned")
+	}
+}
+
+// Offering a key for a report that does not exist is a promise the launcher
+// cannot keep.
+func TestReopeningWithoutAReportSaysSo(t *testing.T) {
+	m := newTestModel()
+	m.width, m.height = 120, 40
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = model.(Model)
+	if m.phase != phaseForm {
+		t.Fatal("there is nothing to open")
+	}
+	if m.lastWarn == "" {
+		t.Error("the key did nothing and said nothing, which reads as swallowed")
+	}
+	if strings.Contains(m.View(), "^o") {
+		t.Error("a hint is offered for a report that does not exist")
+	}
+}
+
+// The launcher's testing style: assert the geometry, not a screenshot. Every
+// screen it draws is exactly the terminal's height, because the footer has to
+// land on the last row.
+func TestEveryPhaseFillsTheTerminalExactly(t *testing.T) {
+	m := recordedReport(t)
+	for name, model := range map[string]Model{
+		"viewing":  m,
+		"scanning": scanningModel(t),
+		"form":     press(t, m, "q"),
+	} {
+		lines := strings.Split(model.View(), "\n")
+		if len(lines) != model.height {
+			t.Errorf("the %s screen drew %d lines into a %d-line terminal",
+				name, len(lines), model.height)
+		}
+	}
+}
+
+// scanningModel is a launcher watching a scan, with the recorded progress
+// stream already folded in.
+func scanningModel(t *testing.T) Model {
+	t.Helper()
+
+	m := newTestModel()
+	m.width, m.height = 120, 40
+	m.phase = phaseScanning
+	m.scan.session = newScanSession(launchPlan{args: []string{"scan", "local"}}, "local")
+	t.Cleanup(m.scan.session.cancel)
+
+	raw, err := os.Open(filepath.Join("testdata", "scan_progress.ndjson"))
+	if err != nil {
+		t.Fatalf("the recorded progress stream is missing: %v", err)
+	}
+	defer func() { _ = raw.Close() }()
+
+	// The same reader the child's pipe feeds, over the recording instead.
+	m.scan.session.readProgress(raw)
+	return m
+}
+
+// The scanning screen exists because a background child is invisible: its
+// stdout is not a terminal, so nothing it would normally print arrives. What it
+// shows has to come from the progress stream, and this is that stream.
+func TestTheRecordedProgressStreamReachesTheScreen(t *testing.T) {
+	m := scanningModel(t)
+
+	snap := m.scan.session.prog.snapshot()
+	if snap.Total != 1 || snap.Done != 1 {
+		t.Fatalf("the recording describes one finished asset, got %+v", snap)
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "launcher-test-host") {
+		t.Errorf("the asset being scanned is not named:\n%s", view)
+	}
+	if !strings.Contains(view, "1 of 1 assets") {
+		t.Errorf("the screen does not say how far along it is:\n%s", view)
+	}
+	if !strings.Contains(view, "cancel") {
+		t.Errorf("a scan with no way out is worse than no scan:\n%s", view)
+	}
+}
+
+// Esc while scanning cancels rather than backing out of a form.
+func TestEscCancelsARunningScan(t *testing.T) {
+	m := scanningModel(t)
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = model.(Model)
+
+	if m.phase != phaseForm {
+		t.Fatal("cancelling did not return to the launcher")
+	}
+	if m.scan.active() {
+		t.Error("the cancelled session is still attached to the model")
+	}
+	if m.lastWarn == "" {
+		t.Error("a cancelled scan disappears without a word")
+	}
+}
+
+// An event from a scan the user has already cancelled must not reanimate the
+// screen they left.
+func TestAStaleSessionIsIgnored(t *testing.T) {
+	m := scanningModel(t)
+	stale := m.scan.session
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = model.(Model)
+
+	for _, msg := range []tea.Msg{
+		scanRunningMsg{session: stale},
+		scanProgressMsg{session: stale},
+		scanExitedMsg{session: stale},
+		scanReportMsg{session: stale},
+	} {
+		model, _ := m.Update(msg)
+		m = model.(Model)
+		if m.phase != phaseForm {
+			t.Fatalf("%T from a cancelled scan moved the launcher to phase %d", msg, m.phase)
+		}
+	}
+	if m.viewer.loaded {
+		t.Error("a cancelled scan produced a report")
+	}
+}
+
+// A write can outlive the view that started it: close the report while a large
+// export is still running and the result arrives with the viewer gone. It must
+// land in the footer, not be dropped -- the user is waiting to hear that their
+// file was written.
+func TestALateExportNoticeReachesTheFooter(t *testing.T) {
+	m := sized(newTestModel(), 100, 24)
+	m.phase = phaseForm
+
+	nm, _ := m.Update(reportview.ExportDoneMsg{
+		Format: "json-full",
+		Path:   "/tmp/report.full.json",
+		Size:   1024,
+	})
+	got := nm.(Model)
+	if got.lastNote == "" && got.lastWarn == "" && got.lastErr == "" {
+		t.Fatal("the export result was dropped")
+	}
+	if !strings.Contains(got.lastNote+got.lastWarn+got.lastErr, "report.full.json") {
+		t.Errorf("the notice does not name the file: %q%q%q", got.lastNote, got.lastWarn, got.lastErr)
+	}
+	// A file that was written is not a warning. This used to go out through
+	// lastWarn, so the launcher announced a successful export in the warning
+	// color behind a "!"; lastNote is the third channel that fixed it.
+	if got.lastWarn != "" || got.lastErr != "" {
+		t.Errorf("a successful export was reported as trouble: warn=%q err=%q", got.lastWarn, got.lastErr)
+	}
+}

--- a/apps/cnspec/cmd/interactive/viewscan.go
+++ b/apps/cnspec/cmd/interactive/viewscan.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/progress"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The scanning screen is what replaced the handover.
+//
+// It exists because a background child is invisible: the scan bar `cnspec scan`
+// draws is gated on stdout being a terminal, and a backgrounded child's is not,
+// so without this the launcher would sit on a still screen for however long a
+// cloud scan takes. What it draws comes from the NDJSON progress stream (see
+// cli/progress/stream.go), folded into scanProgress.
+//
+// It obeys the same invariant as the rest of the launcher: one rendered element
+// is exactly one terminal line, and no style carries a margin. See layout.go.
+
+// scanBarWidth is how wide an asset's progress bar is drawn. Fixed rather than
+// proportional so the columns to its right line up down the pane.
+const scanBarWidth = 20
+
+// view draws the scanning screen.
+//
+// spin is the spinner's current frame rather than the spinner itself: the
+// spinner belongs to the launcher and the value pickers animate with the same
+// one, so this screen borrows a frame instead of owning something that would
+// then have to be ticked separately.
+func (s scanState) view(l layout, spin string) string {
+	sess := s.session
+	if sess == nil {
+		return tui.Panel(tui.StyleDim.Render("Scanning"), "", nil, l.Width, l.BodyH, tui.BorderColor(true))
+	}
+
+	snap := sess.prog.snapshot()
+	iw := tui.InnerWidth(l.Width)
+	avail := tui.InnerHeight(l.BodyH)
+
+	content := make([]string, 0, avail)
+	content = append(content, tui.Bar(tui.Truncate("$ cnspec "+shellJoin(sess.args), iw), iw, bandCommand))
+	content = append(content, "")
+	content = append(content, "  "+s.headline(snap, sess.elapsed(), spin))
+
+	if sess.warn != "" {
+		content = append(content, "", "  "+tui.StyleWarn.Render(tui.Truncate("! "+sess.warn, iw-2)))
+	}
+
+	if len(snap.Assets) > 0 {
+		content = append(content, "", "  "+tui.StyleLabel.Render("ASSETS"))
+		for _, a := range snap.Assets {
+			if len(content) >= avail {
+				break
+			}
+			content = append(content, scanAssetRow(a, iw))
+		}
+	}
+
+	title := tui.StyleAccent.Render(sess.label)
+	return tui.Panel(title, s.statusPill(snap), content, l.Width, l.BodyH, tui.BorderColor(true))
+}
+
+// statusPill says which of the three states the screen is in: running, reading
+// the report the child just wrote, or -- briefly -- finished.
+func (s scanState) statusPill(snap scanSnapshot) string {
+	switch {
+	case s.loading:
+		return tui.Pill("reading report…", tui.ColInk, tui.ColCyan)
+	case snap.ScanDone:
+		return tui.Pill("finishing…", tui.ColInk, tui.ColGood)
+	default:
+		return tui.Pill("scanning", tui.ColInk, tui.ColAccent)
+	}
+}
+
+// headline is the one line that says how far along the scan is.
+//
+// Assets are discovered while a scan runs, so the total moves; saying "3 of 7"
+// when the seven is still growing is honest as long as the discovered count is
+// there next to it, which is why both are shown rather than a percentage of a
+// number that is not final.
+func (s scanState) headline(snap scanSnapshot, elapsed time.Duration, spin string) string {
+	var parts []string
+
+	switch {
+	case s.loading:
+		parts = append(parts, tui.StyleText.Render("reading the report"))
+	case snap.Total == 0:
+		parts = append(parts, tui.StyleText.Render("connecting"))
+	default:
+		parts = append(parts, tui.StyleText.Render(fmt.Sprintf("%d of %d assets", snap.Done, snap.Total)))
+	}
+	if snap.Errored > 0 {
+		parts = append(parts, tui.StyleBad.Render(fmt.Sprintf("%d errored", snap.Errored)))
+	}
+	if snap.NotApplicable > 0 {
+		parts = append(parts, tui.StyleFaint.Render(fmt.Sprintf("%d not applicable", snap.NotApplicable)))
+	}
+	parts = append(parts, tui.StyleFaint.Render(formatElapsed(elapsed)))
+
+	return spin + strings.Join(parts, tui.StyleFaint.Render(tui.HintSep))
+}
+
+// scanAssetRow is one asset: its state, its name, its platform, and how far
+// through it is. It reads nothing but the asset, so it is a function.
+func scanAssetRow(a scanAsset, w int) string {
+	mark := tui.StyleFaint.Render("◌")
+	switch {
+	case a.State == progress.StateErrored:
+		mark = tui.StyleBad.Render("✗")
+	case a.State == progress.StateNotApplicable:
+		mark = tui.StyleFaint.Render("–")
+	case a.Done:
+		mark = tui.StyleGood.Render("●")
+	}
+
+	name := a.Label()
+	nameW := 24
+	if nameW > w/3 {
+		nameW = w / 3
+	}
+	if nameW < 8 {
+		nameW = 8
+	}
+
+	right := scanBar(a.Percent)
+	if a.Done && a.Score != "" {
+		right = tui.PadRight(a.Score, scanBarWidth)
+	}
+
+	line := "  " + mark + " " + tui.PadRight(tui.Truncate(name, nameW), nameW) + " "
+	if a.Platform != "" {
+		line += tui.StyleFaint.Render(tui.PadRight(tui.Truncate(a.Platform, 12), 12)) + " "
+	}
+	line += tui.StyleDim.Render(right)
+	return ansi.Truncate(line, w, "")
+}
+
+// scanBar draws a fixed-width progress bar. A bar rather than a number because
+// several assets scan at once and a column of percentages is harder to read at
+// a glance than a column of bars.
+func scanBar(percent float64) string {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 1 {
+		percent = 1
+	}
+	filled := int(percent * scanBarWidth)
+	return strings.Repeat("█", filled) + strings.Repeat("░", scanBarWidth-filled)
+}
+
+// formatElapsed renders a duration the way a person reads a stopwatch.
+func formatElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	secs := int(d.Seconds())
+	if secs < 60 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	return fmt.Sprintf("%dm%02ds", secs/60, secs%60)
+}
+
+// viewFooter is the scanning screen's key line. It offers exactly one thing,
+// because there is exactly one thing to do while waiting.
+func (s scanState) viewFooter(l layout) string {
+	hints := " " + tui.Kbd("esc", "cancel scan")
+	return tui.Truncate(hints, l.Width)
+}

--- a/apps/cnspec/cmd/launcher.go
+++ b/apps/cnspec/cmd/launcher.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/apps/cnspec/cmd/interactive"
+)
+
+func init() {
+	rootCmd.AddCommand(uiCmd)
+}
+
+// uiCmd is the interactive launcher: a searchable, categorized list of every
+// provider/connector cnspec supports next to a detail pane that shows what can
+// be done with the selected one. Commands run from inside the launcher, so a
+// session can run several.
+//
+// It is intentionally Hidden for now so we can ship and dogfood it as an
+// explicit `cnspec ui` without changing what a bare `cnspec` does. Once it is
+// stable, the plan is to make a bare `cnspec` in a terminal open this launcher.
+var uiCmd = &cobra.Command{
+	Use:     "ui",
+	Aliases: []string{"menu", "interactive", "launch"},
+	Short:   "Interactive launcher to discover providers and actions (experimental)",
+	Hidden:  true,
+	Args:    cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		runInteractiveLauncher()
+	},
+}
+
+// isInteractiveTerminal reports whether both stdin and stdout are real
+// terminals, so the TUI can draw and read keys.
+func isInteractiveTerminal() bool {
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	stdoutTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	stdinTTY := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+	return stdoutTTY && stdinTTY
+}
+
+func runInteractiveLauncher() {
+	if !isInteractiveTerminal() {
+		log.Error().Msg("the interactive launcher needs a terminal; try `cnspec scan local` or `cnspec --help`")
+		os.Exit(1)
+	}
+
+	// The launcher owns the screen and surfaces its own errors in the footer;
+	// keep the logger from scribbling over it. Commands launched from the
+	// launcher run in a child process with its own logger, so this does not
+	// quiet them.
+	prev := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	err := interactive.Run()
+	zerolog.SetGlobalLevel(prev)
+
+	if err != nil {
+		log.Error().Err(err).Msg("interactive launcher failed")
+		os.Exit(1)
+	}
+}

--- a/apps/cnspec/cmd/report.go
+++ b/apps/cnspec/cmd/report.go
@@ -6,13 +6,18 @@ package cmd
 import (
 	"os"
 
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"go.mondoo.com/cnspec/cli/reporter"
+	"go.mondoo.com/cnspec/cli/reportview"
+	"go.mondoo.com/cnspec/policy"
 )
 
 func init() {
 	reportCmd.AddCommand(cmpReportCmd)
+	reportCmd.AddCommand(viewReportCmd)
 	rootCmd.AddCommand(reportCmd)
 }
 
@@ -45,4 +50,68 @@ var cmpReportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+// viewReportCmd browses a scan report in the terminal.
+//
+// The artifact it reads is `--output json-full`, which is the only output format
+// that carries the bundle, the resolved policies and the raw results, and
+// therefore the only one a viewer can show anything but scores from. Handing it
+// a reduced json-v1/json-v2 report is a mistake worth naming: those decode
+// "successfully" into a collection with no reports, which looks exactly like a
+// scan where every asset failed. reporter.LoadCollectionFile refuses them and
+// says which format was given and which is needed.
+var viewReportCmd = &cobra.Command{
+	Use:   "view <file>",
+	Short: "Browse a scan report (--output json-full) in the terminal",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		collection, err := loadReportForView(args[0])
+		if err != nil {
+			// The message is the whole point here: a stack trace tells the user
+			// nothing they can act on, while "this is a reduced report, re-run
+			// with --output json-full" tells them exactly what to do next.
+			log.Error().Msg(err.Error())
+			os.Exit(1)
+		}
+
+		if !isInteractiveTerminal() {
+			log.Error().Msg("the report viewer needs a terminal; try `cnspec report cmp` or read the file directly")
+			os.Exit(1)
+		}
+
+		// The viewer owns the screen and surfaces its own errors in the footer;
+		// keep the logger from scribbling over it.
+		prev := zerolog.GlobalLevel()
+		zerolog.SetGlobalLevel(zerolog.Disabled)
+		err = reportview.RunCollection(collection)
+		zerolog.SetGlobalLevel(prev)
+
+		if err != nil {
+			log.Error().Err(err).Msg("report viewer failed")
+			os.Exit(1)
+		}
+	},
+}
+
+// loadReportForView reads the artifact the viewer is pointed at, turning the
+// three ways this goes wrong -- no such file, a directory, and a report in a
+// format that does not carry enough to show -- into messages a user can act on.
+func loadReportForView(path string) (*policy.ReportCollection, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Newf("no such report: %s", path)
+		}
+		return nil, errors.Wrapf(err, "cannot read %s", path)
+	}
+	if info.IsDir() {
+		return nil, errors.Newf("%s is a directory; pass the report file itself", path)
+	}
+
+	collection, err := reporter.LoadCollectionFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return collection, nil
 }

--- a/apps/cnspec/cmd/report_test.go
+++ b/apps/cnspec/cmd/report_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/internal/reportfixture"
+)
+
+// `report view` has to be wired onto the hidden report command next to `cmp`,
+// and it takes exactly one file.
+func TestViewSubcommandIsRegistered(t *testing.T) {
+	var found bool
+	for _, c := range reportCmd.Commands() {
+		if c.Name() == "view" {
+			found = true
+			require.Error(t, c.Args(c, []string{}), "view needs a file")
+			require.Error(t, c.Args(c, []string{"a", "b"}), "view takes one file")
+			require.NoError(t, c.Args(c, []string{"a"}))
+		}
+	}
+	require.True(t, found, "`cnspec report view` is not registered")
+}
+
+// The three ways this goes wrong all have to produce something a user can act
+// on, rather than a stack trace or -- worse -- a viewer that opens on an empty
+// screen because a reduced report decoded into a collection with no reports.
+func TestLoadReportForViewErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := loadReportForView(filepath.Join(dir, "nope.json"))
+	require.ErrorContains(t, err, "no such report")
+
+	_, err = loadReportForView(dir)
+	require.ErrorContains(t, err, "is a directory")
+
+	garbage := filepath.Join(dir, "garbage.json")
+	require.NoError(t, os.WriteFile(garbage, []byte("not json at all"), 0o600))
+	_, err = loadReportForView(garbage)
+	require.ErrorContains(t, err, "failed to parse report collection")
+
+	// A json-v1/json-v2 report decodes "successfully" into a collection with no
+	// reports, which is indistinguishable from a scan where every asset failed.
+	// The loader has to name both formats: the one given and the one needed.
+	reduced := filepath.Join(dir, "reduced.json")
+	require.NoError(t, os.WriteFile(reduced,
+		[]byte(`{"assets":{},"data":{},"scores":{},"errors":{}}`), 0o600))
+	_, err = loadReportForView(reduced)
+	require.ErrorContains(t, err, "reduced report")
+	require.ErrorContains(t, err, "json-full")
+}
+
+// The happy path: a collection on disk loads and builds a model with its assets
+// intact. loadReportForView takes a path, so the shared recorded scan -- which
+// is embedded, not a file -- is written out first.
+func TestLoadReportForView(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report-ubuntu.json")
+	require.NoError(t, os.WriteFile(path, reportfixture.UbuntuScanJSON(), 0o600))
+
+	collection, err := loadReportForView(path)
+	require.NoError(t, err)
+
+	report := reportmodel.New(collection)
+	require.Len(t, report.Assets, 1)
+	require.Equal(t, "ubuntu:24.04", report.Assets[0].Name)
+	require.True(t, report.Assets[0].Scanned())
+}
+
+// A multi-asset scan where every asset failed still loads, and every one of them
+// shows up as an errored asset rather than as nothing at all.
+func TestLoadReportForViewAllErrored(t *testing.T) {
+	collection, err := loadReportForView("../../../cli/reporter/testdata/report-k8s.json")
+	require.NoError(t, err)
+
+	report := reportmodel.New(collection)
+	require.Len(t, report.Assets, 15)
+	require.Equal(t, 15, report.AssetCounts.Errored)
+	for _, a := range report.Assets {
+		require.False(t, a.Scanned())
+		require.NotEmpty(t, a.ScanError)
+	}
+}

--- a/cli/launcher/catalog/catalog.go
+++ b/cli/launcher/catalog/catalog.go
@@ -1,0 +1,390 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package catalog answers "what can cnspec scan on this machine", and nothing
+// else. It merges the compiled-in provider list with the installed one and
+// flattens the result into connectors the launcher can put in a list.
+//
+// It depends on no other part of the launcher on purpose: the form engine, the
+// delivery layer and the scan runner all read connector metadata, and a
+// catalog that reached back into any of them would make that circular.
+package catalog
+
+import (
+	"sort"
+	"strings"
+
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Connector is one selectable target in the interactive launcher. It is a
+// flattened (provider, connector) pair, e.g. the "os" provider contributes
+// "local", "ssh", "docker", ... as separate connectors, because to a user
+// those are distinct things to scan.
+type Connector struct {
+	// Provider is the provider name that ships this connector (e.g. "os").
+	Provider string
+	// Name is the connector command word (e.g. "ssh", "aws", "docker"). This
+	// is what gets placed on the command line: `cnspec scan <Name>`.
+	Name string
+	// Use is the usage hint including expected args (e.g. "ssh user@host").
+	Use string
+	// Short is the human description (e.g. "a remote system via SSH").
+	Short string
+	// Aliases are alternate command words for the same connector.
+	Aliases []string
+	// Category groups connectors in the list (e.g. "Cloud").
+	Category string
+	// Installed is true when the provider binary is already present locally.
+	// When false, selecting it still works: the provider is downloaded on
+	// first use (auto-update), we just surface the difference to the user.
+	Installed bool
+
+	// The fields below come from the connector's own declaration and drive the
+	// input form. They are only populated for installed providers:
+	// providers.DefaultProviders strips them, so an uninstalled connector has
+	// no form to build and falls back to a free-text argument box.
+
+	// Long is the connector's full help text. It is the only place several
+	// providers document their sub-command shapes (`github org <ORG>`).
+	Long string
+	// MinArgs and MaxArgs bound the positional arguments the connector takes.
+	// This is authoritative, unlike reading the Use string.
+	MinArgs, MaxArgs uint
+	// Flags are the connector's declared CLI flags.
+	Flags []plugin.Flag
+	// Discovery lists the connector's valid --discover targets. "all" and
+	// "auto" are always additionally valid and are not repeated here.
+	Discovery []string
+}
+
+// HasFormData reports whether the connector declared enough for a real input
+// form. Only installed providers do.
+//
+// It counts only the flags a form could actually show. The launcher's
+// genericFields skips every Hidden or Deprecated flag, so counting len(c.Flags)
+// answers a question nobody asked: `device` declares nine flags and every one
+// of them is marked Hidden or Deprecated, so newForm(device) yields zero fields
+// while this said yes -- and the launcher drew an empty box instead of falling
+// back to the free-text argument entry that is the honest screen for it.
+func (c Connector) HasFormData() bool {
+	return len(formableFlags(c)) > 0 || c.MaxArgs > 0 || len(c.Discovery) > 0
+}
+
+// DeclaresMetadata reports whether the connector carries its own declaration at
+// all, as opposed to reaching the catalog from the static DefaultProviders list
+// that strips it.
+//
+// This is the question HasFormData used to be asked and is a different one:
+// "is MinArgs authoritative here" rather than "is there a form to draw". They
+// only diverge for a connector whose every flag is hidden, but that connector
+// exists, and conflating the two is what made the launcher confident about a
+// screen it had nothing to put on.
+func (c Connector) DeclaresMetadata() bool {
+	return len(c.Flags) > 0 || c.MaxArgs > 0 || len(c.Discovery) > 0
+}
+
+// formableFlags are the flags a form can render: everything the connector
+// declares except what it has marked Hidden or Deprecated, which is exactly
+// what the launcher's genericFields filters on. The two live in different
+// packages now, so they have to agree by hand: a flag this lets through but
+// that one drops puts HasFormData back to promising a form with nothing in it.
+func formableFlags(c Connector) []plugin.Flag {
+	out := make([]plugin.Flag, 0, len(c.Flags))
+	for _, fl := range c.Flags {
+		if fl.Option&plugin.FlagOption_Hidden != 0 || fl.Option&plugin.FlagOption_Deprecated != 0 {
+			continue
+		}
+		out = append(out, fl)
+	}
+	return out
+}
+
+// Summary is the connector's description with its leading article removed.
+//
+// Ninety-four of the hundred-odd descriptions begin "a " or "an ", which in a
+// list is two or three columns of nothing: every row says the same word, and
+// the part that distinguishes one connector from the next is what gets
+// truncated at the right edge. "a Proxmox VE hypervisor" and "an Ansible
+// playbook or role" carry exactly as much meaning without it.
+//
+// The provider's own text is left alone -- this is a presentation choice, and
+// the detail pane still shows the sentence as written.
+func (c Connector) Summary() string {
+	for _, article := range []string{"a ", "an ", "A ", "An "} {
+		if strings.HasPrefix(c.Short, article) {
+			return c.Short[len(article):]
+		}
+	}
+	return c.Short
+}
+
+// SearchText is the lowercased haystack used for fuzzy matching.
+func (c Connector) SearchText() string {
+	return strings.ToLower(c.Name + " " + c.Provider + " " + c.Short + " " + strings.Join(c.Aliases, " ") + " " + c.Category)
+}
+
+// ArgHint is the argument spec a connector declares in its usage string, e.g.
+// "user@host" for `ssh user@host`. Empty when the connector takes no argument.
+func (c Connector) ArgHint() string {
+	return strings.TrimSpace(strings.TrimPrefix(c.Use, c.Name))
+}
+
+// RequiresArg reports whether the connector needs a positional argument.
+//
+// MinArgs is authoritative and is used whenever it is available. It is not
+// available for a provider that is not installed locally, because the static
+// default list drops it -- there we fall back to reading the usage string,
+// where a bracketed spec ([host], [flags]) means optional by convention.
+func (c Connector) RequiresArg() bool {
+	// DeclaresMetadata rather than HasFormData: the question is whether MinArgs
+	// came from the connector or from the flagless static list, and a connector
+	// whose flags are all hidden still declared its argument count.
+	if c.DeclaresMetadata() {
+		return c.MinArgs > 0
+	}
+	h := c.ArgHint()
+	return h != "" && !strings.HasPrefix(h, "[")
+}
+
+// Category ordering and titles. Anything not mapped lands in "Other".
+const (
+	CatHosts     = "Hosts & Devices"
+	CatContainer = "Containers & Kubernetes"
+	CatCloud     = "Cloud & Virtualization"
+	CatIaC       = "Infrastructure as Code"
+	CatIdentity  = "Identity & Access"
+	CatSaaS      = "SaaS"
+	CatNetwork   = "Network & Security Devices"
+	CatDatabase  = "Databases"
+	CatAI        = "AI & LLM"
+	CatDev       = "Developer & Supply Chain"
+	CatOther     = "Other"
+)
+
+// CategoryOrder is the display order of categories in the launcher.
+var CategoryOrder = []string{
+	CatHosts,
+	CatContainer,
+	CatCloud,
+	CatIaC,
+	CatIdentity,
+	CatSaaS,
+	CatNetwork,
+	CatDatabase,
+	CatAI,
+	CatDev,
+	CatOther,
+}
+
+// providerCategory maps a provider name to a category. The "os" provider is
+// special-cased per-connector in Categorize().
+var providerCategory = map[string]string{
+	// Cloud & virtualization
+	"aws": CatCloud, "azure": CatCloud, "gcp": CatCloud, "oci": CatCloud,
+	"alicloud": CatCloud, "digitalocean": CatCloud, "hetzner": CatCloud,
+	"equinix": CatCloud, "stackit": CatCloud, "openstack": CatCloud,
+	"proxmox": CatCloud, "nutanix": CatCloud, "vcd": CatCloud, "vsphere": CatCloud,
+	"ibm": CatCloud, "hcp": CatCloud,
+
+	// Containers & Kubernetes
+	"k8s": CatContainer, "helm": CatContainer, "kustomize": CatContainer,
+	"portainer": CatContainer,
+
+	// Infrastructure as Code
+	"terraform": CatIaC, "cloudformation": CatIaC, "bicep": CatIaC,
+	"ansible": CatIaC,
+
+	// Identity & Access: the systems that decide who can sign in, and where
+	// credentials live. Separated from SaaS because "review our identity
+	// provider" and "review the tools we subscribe to" are different jobs, and
+	// twenty-six connectors in one list served neither.
+	//
+	// ms365 and google-workspace belong here rather than under SaaS despite
+	// being productivity suites: what a scan of either actually inspects is the
+	// tenant's directory, its sign-in policy and its admin roles.
+	"okta": CatIdentity, "auth0": CatIdentity, "keycloak": CatIdentity,
+	"jumpcloud": CatIdentity, "activedirectory": CatIdentity,
+	"bitwarden": CatIdentity,
+	"ms365":     CatIdentity, "google-workspace": CatIdentity,
+
+	// SaaS: the accounts an organisation holds with someone else.
+	"slack": CatSaaS, "github": CatSaaS, "gitlab": CatSaaS, "atlassian": CatSaaS,
+	"snowflake": CatSaaS, "databricks": CatSaaS,
+	"mondoo": CatSaaS, "datadog": CatSaaS, "grafana": CatSaaS, "vercel": CatSaaS,
+	"cloudflare": CatSaaS, "nextdns": CatSaaS, "tailscale": CatSaaS,
+	"mongodbatlas": CatSaaS, "netlify": CatSaaS,
+	"dropbox": CatSaaS, "zoom": CatSaaS,
+
+	// Apple device management. Iru is Kandji renamed, and sits with Jamf
+	// because they are the same job.
+	"jamf": CatSaaS, "iru": CatSaaS,
+
+	// Network & security devices
+	"network": CatNetwork, "networkdiscovery": CatNetwork,
+	"networkdevices": CatNetwork, "fortios": CatNetwork, "panos": CatNetwork,
+	"junos": CatNetwork, "arista": CatNetwork, "mikrotik": CatNetwork,
+	"bigip": CatNetwork, "checkpoint": CatNetwork, "opcua": CatNetwork,
+	"ipmi": CatNetwork, "redfish": CatNetwork, "nmap": CatNetwork,
+	"unifi": CatNetwork, "shodan": CatNetwork, "ipinfo": CatNetwork,
+
+	// Databases
+	"mongo": CatDatabase, "mssql": CatDatabase, "mysqldb": CatDatabase,
+	"postgresdb": CatDatabase, "redisdb": CatDatabase, "cassandra": CatDatabase,
+	"elasticsearch": CatDatabase, "opensearch": CatDatabase, "weaviate": CatDatabase,
+	"clickhouse": CatDatabase, "clickhousedb": CatDatabase,
+	"clickhousecloud": CatDatabase, "oracledb": CatDatabase, "neon": CatDatabase,
+	"db2": CatDatabase,
+
+	// AI & LLM
+	"ai": CatAI, "openai": CatAI, "claude": CatAI, "mistral": CatAI,
+	"ollama": CatAI, "huggingface": CatAI, "together": CatAI, "vllm": CatAI,
+	"anthropic": CatAI,
+
+	// Developer & supply chain
+	"depsdev": CatDev, "sbom": CatDev, "artifactory": CatDev,
+}
+
+// osConnectorCategory splits the multi-purpose "os" provider connectors into
+// the right buckets.
+var osConnectorCategory = map[string]string{
+	"local":      CatHosts,
+	"ssh":        CatHosts,
+	"winrm":      CatHosts,
+	"vagrant":    CatHosts,
+	"device":     CatHosts,
+	"filesystem": CatHosts,
+	"docker":     CatContainer,
+	"container":  CatContainer,
+}
+
+// ExcludedProviders ship user-visible connectors that are not scan targets:
+// they replay or fake a connection for debugging. Offering them in a launcher
+// whose whole premise is "pick something to secure" would be noise.
+var ExcludedProviders = map[string]bool{
+	"mock":      true,
+	"recording": true,
+}
+
+func Categorize(provider, connector string) string {
+	if provider == "os" {
+		if c, ok := osConnectorCategory[connector]; ok {
+			return c
+		}
+		return CatHosts
+	}
+	if c, ok := providerCategory[provider]; ok {
+		return c
+	}
+	return CatOther
+}
+
+// BuildCatalog returns every selectable connector, merging two sources:
+//
+//   - providers.DefaultProviders, the static list compiled into the binary. It
+//     is what cnspec can name in an air-gapped environment, so it is the floor.
+//   - providers.ListActive(), the providers actually installed on this machine.
+//     These win, because the static list lags behind what ships -- whole
+//     categories (every database provider, for one) exist only here.
+//
+// It never fails hard: if the installed set can't be read we still return the
+// static catalog.
+func BuildCatalog() []Connector {
+	type source struct {
+		provider  *plugin.Provider
+		installed bool
+	}
+	merged := make(map[string]source, len(providers.DefaultProviders))
+
+	for name, p := range providers.DefaultProviders {
+		if p.Provider == nil {
+			continue
+		}
+		merged[name] = source{provider: p.Provider}
+	}
+
+	// ListActive is keyed by provider ID (a full Go import path), so key the
+	// merge off the provider's Name instead -- that is what the catalog and the
+	// command line speak.
+	if active, err := providers.ListActive(); err == nil {
+		for _, p := range active {
+			if p.Provider == nil || p.Name == "" {
+				continue
+			}
+			merged[p.Name] = source{provider: p.Provider, installed: true}
+		}
+	}
+
+	var out []Connector
+	for name, src := range merged {
+		if ExcludedProviders[name] {
+			continue
+		}
+		out = append(out, ConnectorsOf(name, src.provider, src.installed)...)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		ci, cj := categoryIndex(out[i].Category), categoryIndex(out[j].Category)
+		if ci != cj {
+			return ci < cj
+		}
+		// Keep "local" first inside Hosts so the common case is at the top.
+		iLocal, jLocal := out[i].Name == "local", out[j].Name == "local"
+		if iLocal != jLocal {
+			return iLocal
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// ConnectorsOf flattens a provider's connectors into catalog entries. It is
+// shared by the initial catalog build and by the on-demand installer, so a
+// connector refreshed after an install is shaped exactly like one that was
+// there from the start.
+func ConnectorsOf(name string, p *plugin.Provider, installed bool) []Connector {
+	if p == nil {
+		return nil
+	}
+	// "core" and similar have no connectors; they contribute nothing.
+	out := make([]Connector, 0, len(p.Connectors))
+	for _, conn := range p.Connectors {
+		if conn.IsHidden || conn.Name == "" {
+			continue
+		}
+		out = append(out, Connector{
+			Provider:  name,
+			Name:      conn.Name,
+			Use:       firstNonEmpty(conn.Use, conn.Name),
+			Short:     conn.Short,
+			Aliases:   conn.Aliases,
+			Category:  Categorize(name, conn.Name),
+			Installed: installed,
+			Long:      conn.Long,
+			MinArgs:   conn.MinArgs,
+			MaxArgs:   conn.MaxArgs,
+			Flags:     conn.Flags,
+			Discovery: conn.Discovery,
+		})
+	}
+	return out
+}
+
+func categoryIndex(cat string) int {
+	for i, c := range CategoryOrder {
+		if c == cat {
+			return i
+		}
+	}
+	return len(CategoryOrder)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cli/launcher/catalog/catalog_test.go
+++ b/cli/launcher/catalog/catalog_test.go
@@ -1,0 +1,255 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package catalog
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/providers"
+)
+
+// The catalog is built from the machine's real provider set, so these tests
+// assert relationships rather than fixed contents.
+
+// providers.DefaultProviders is the static fallback compiled into the binary and
+// it lags behind what ships: whole categories exist only in the installed set.
+// Building the catalog from it alone silently drops them.
+func TestCatalogIncludesInstalledProviders(t *testing.T) {
+	active, err := providers.ListActive()
+	if err != nil || len(active) == 0 {
+		t.Skip("no providers installed locally")
+	}
+
+	inCatalog := map[string]bool{}
+	for _, c := range BuildCatalog() {
+		inCatalog[c.Provider] = true
+	}
+
+	for _, p := range active {
+		if p.Provider == nil || p.Name == "" || ExcludedProviders[p.Name] {
+			continue
+		}
+		hasVisibleConnector := false
+		for _, conn := range p.Connectors {
+			if !conn.IsHidden && conn.Name != "" {
+				hasVisibleConnector = true
+			}
+		}
+		if hasVisibleConnector && !inCatalog[p.Name] {
+			t.Errorf("provider %q is installed but missing from the catalog", p.Name)
+		}
+	}
+}
+
+// ListActive is keyed by provider ID, not name. Keying the install lookup off
+// the map key leaves every connector flagged as not installed.
+func TestInstalledFlagIsSet(t *testing.T) {
+	active, err := providers.ListActive()
+	if err != nil || len(active) == 0 {
+		t.Skip("no providers installed locally")
+	}
+
+	catalog := BuildCatalog()
+	installed := 0
+	for _, c := range catalog {
+		if c.Installed {
+			installed++
+		}
+	}
+	if installed == 0 {
+		t.Fatalf("no connector flagged installed, but %d providers are active", len(active))
+	}
+}
+
+// Every category the launcher offers must be reachable. A category that is
+// declared, ordered and given an icon but never populated is a dead end the UI
+// still advertises.
+func TestDeclaredCategoriesArePopulated(t *testing.T) {
+	if _, err := providers.ListActive(); err != nil {
+		t.Skip("cannot read the installed provider set")
+	}
+	counts := map[string]int{}
+	for _, c := range BuildCatalog() {
+		counts[c.Category]++
+	}
+	for _, cat := range CategoryOrder {
+		if cat == CatOther {
+			continue // a genuine catch-all; may legitimately be empty
+		}
+		if counts[cat] == 0 {
+			t.Errorf("category %q is declared and ordered but has no entries", cat)
+		}
+	}
+}
+
+// Replay/debug connectors are not scan targets and must stay out of a launcher
+// whose premise is "pick something to secure".
+func TestExcludedProvidersAreAbsent(t *testing.T) {
+	for _, c := range BuildCatalog() {
+		if ExcludedProviders[c.Provider] {
+			t.Errorf("connector %q from excluded provider %q is in the catalog", c.Name, c.Provider)
+		}
+	}
+}
+
+func TestCatalogSortsLocalFirst(t *testing.T) {
+	for _, c := range BuildCatalog() {
+		if c.Category != CatHosts {
+			continue
+		}
+		if c.Name != "local" {
+			t.Errorf("expected local first in %q, got %q", CatHosts, c.Name)
+		}
+		return
+	}
+}
+
+// The form is built from connector metadata that only installed providers
+// carry, so an installed connector must arrive with it attached.
+func TestInstalledConnectorsCarryFormMetadata(t *testing.T) {
+	if _, err := providers.ListActive(); err != nil {
+		t.Skip("cannot read the installed provider set")
+	}
+	want := map[string]bool{"aws": true, "ssh": true, "k8s": true, "docker": true, "github": true}
+	seen := map[string]bool{}
+	for _, c := range BuildCatalog() {
+		if !want[c.Name] || !c.Installed {
+			continue
+		}
+		seen[c.Name] = true
+		if !c.HasFormData() {
+			t.Errorf("%s: installed but carries no form metadata", c.Name)
+		}
+		if len(c.Flags) == 0 {
+			t.Errorf("%s: no flags carried through", c.Name)
+		}
+	}
+	for n := range want {
+		if !seen[n] {
+			t.Logf("connector %q not installed locally; skipped", n)
+		}
+	}
+}
+
+// MinArgs is authoritative where it exists. ssh declares exactly one required
+// positional argument; aws declares none.
+func TestRequiredArgUsesMinArgs(t *testing.T) {
+	if _, err := providers.ListActive(); err != nil {
+		t.Skip("cannot read the installed provider set")
+	}
+	for _, c := range BuildCatalog() {
+		if !c.Installed {
+			continue
+		}
+		switch c.Name {
+		case "ssh":
+			if !c.RequiresArg() || c.MinArgs != 1 {
+				t.Errorf("ssh: RequiresArg=%v MinArgs=%d, want true/1", c.RequiresArg(), c.MinArgs)
+			}
+		case "aws":
+			if c.RequiresArg() {
+				t.Errorf("aws: RequiresArg=true, but MinArgs=%d", c.MinArgs)
+			}
+		}
+	}
+}
+
+// Without metadata the usage-string heuristic still has to work, because that
+// is all an uninstalled connector has.
+func TestRequiresArgFallsBackToUsageString(t *testing.T) {
+	cases := []struct {
+		use, name string
+		want      bool
+	}{
+		{"ssh user@host", "ssh", true},
+		{"ansible PATH", "ansible", true},
+		{"mongo [host]", "mongo", false},
+		{"aws", "aws", false},
+	}
+	for _, c := range cases {
+		got := Connector{Name: c.name, Use: c.use}.RequiresArg()
+		if got != c.want {
+			t.Errorf("RequiresArg(%q) with no metadata = %v, want %v", c.use, got, c.want)
+		}
+	}
+}
+
+// Identity is its own shelf. "Review our identity provider" and "review the
+// tools we subscribe to" are different jobs, and twenty-six connectors in one
+// list served neither.
+func TestIdentityIsSeparateFromSaaS(t *testing.T) {
+	cat := map[string]string{}
+	for _, c := range BuildCatalog() {
+		cat[c.Name] = c.Category
+	}
+
+	for _, name := range []string{
+		"okta", "auth0", "keycloak", "jumpcloud", "activedirectory",
+		// Productivity suites, but a scan of either inspects the directory,
+		// the sign-in policy and the admin roles.
+		"ms365", "google-workspace",
+	} {
+		if got := cat[name]; got != CatIdentity {
+			t.Errorf("%s is in %q, want %q -- it decides who can sign in", name, got, CatIdentity)
+		}
+	}
+	for _, name := range []string{"slack", "github", "dropbox", "atlassian"} {
+		if got := cat[name]; got != CatSaaS {
+			t.Errorf("%s is in %q, want %q", name, got, CatSaaS)
+		}
+	}
+}
+
+// Iru is Kandji renamed: Apple device management, the same job as Jamf, so it
+// belongs wherever Jamf does rather than in the catch-all.
+func TestIruSitsWithJamf(t *testing.T) {
+	var iru, jamf string
+	for _, c := range BuildCatalog() {
+		switch c.Name {
+		case "iru":
+			iru = c.Category
+		case "jamf":
+			jamf = c.Category
+		}
+	}
+	if iru == "" || jamf == "" {
+		t.Skip("neither provider is installed here")
+	}
+	if iru != jamf {
+		t.Errorf("iru is in %q and jamf in %q; they do the same job", iru, jamf)
+	}
+	if iru == CatOther {
+		t.Error("iru fell back to the catch-all category")
+	}
+}
+
+// Ninety-four of the descriptions begin "a " or "an ", so in a list that word
+// is pure overhead -- every row says it, and what gets truncated at the right
+// edge is the part that tells connectors apart.
+func TestTheListDropsTheLeadingArticle(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"a Proxmox VE hypervisor", "Proxmox VE hypervisor"},
+		{"an Ansible playbook or role", "Ansible playbook or role"},
+		{"your local system", "your local system"},
+		{"Terraform HCL configuration", "Terraform HCL configuration"},
+		// Only the article, and only at the front: "an" inside the text stays,
+		// and a word merely starting with those letters is not an article.
+		{"a host running an agent", "host running an agent"},
+		{"another kind of target", "another kind of target"},
+		{"", ""},
+	} {
+		if got := (Connector{Short: tc.in}).Summary(); got != tc.want {
+			t.Errorf("Summary(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The provider's own sentence is left intact: this is a presentation choice for
+// a cramped list, not a rewrite of the catalog.
+func TestTheDetailPaneKeepsTheFullSentence(t *testing.T) {
+	c := Connector{Short: "a Proxmox VE hypervisor"}
+	if c.Short != "a Proxmox VE hypervisor" {
+		t.Errorf("the connector's own text was modified: %q", c.Short)
+	}
+}

--- a/cli/launcher/delivery/delivery.go
+++ b/cli/launcher/delivery/delivery.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// Package delivery is how a credential gets from the launcher's form to the
+// scan.
+//
+// The launcher runs commands by re-executing cnspec, so a secret on that
+// command line is world-readable through `ps auxww`. Everything here exists to
+// avoid that, and there is now exactly one way it does: the form is handed to
+// the connector's own ParseCLI, and the inventory.Asset that comes back is
+// written as an inventory file the child reads. The secret reaches the provider
+// in a protobuf field over the plugin's gRPC connection and reaches the child
+// through the OS keychain, referenced by id. See parsecli.go.
+//
+// # What this replaced, and why one route rather than four
+//
+// There used to be four: a prompt route that made the child ask, an environment
+// route over a registry of provider-native variable names, an inventory route
+// gated on a hand-written list of connectors somebody had checked, and a
+// refusal for everything else. Each of those was a claim about a provider that
+// only a person reading that provider's source could make, and the claims went
+// stale silently -- a variable a provider stops reading, or an option key
+// guessed rather than read, drops the credential and surfaces as a connection
+// error nowhere near its cause.
+//
+// Asking the provider makes all four unnecessary, because the mapping is no
+// longer ours to get right. What is left here is the part that is genuinely the
+// launcher's: whether a form has a credential at all, and the environment a
+// chosen *target* travels in when the connector declares no flag for it.
+
+// Kind is the route a form's answers travel.
+type Kind int
+
+const (
+	// Plain: no credential in the form, so the ordinary command line. This is
+	// what the user sees in the preview and can copy into a shell, and it is
+	// kept for exactly that reason: a command with nothing to protect reads
+	// better as a command than as a generated file.
+	Plain Kind = iota
+	// Inventory: the form holds a credential, so the provider's own reading of
+	// it is written as an inventory file and the child is pointed at that.
+	Inventory
+)
+
+// RouteFor decides how the form's answers travel.
+//
+// It takes only the form because that is now all it depends on, and the
+// shrunken signature is the point: a route that depended on the connector was a
+// route that could be wrong about the connector. Whether the child needs a file
+// is decided by whether the user typed a secret; what goes in the file is
+// decided by the provider.
+//
+// Note that a --ask-* toggle is an ordinary bool field on the form and stays on
+// the Plain route. That is a deliberate reversal. The prompt route used to fire
+// whenever a connector declared a working --ask-* flag and the user had typed
+// exactly one secret -- so a password typed into the ssh form was dropped, the
+// flag was added in its place, and the child asked for the password again.
+// Verified: `cnspec scan ssh chris@10.0.0.5 --ask-pass` was the whole command.
+// A user who wants to be prompted can still tick the box; what they can no
+// longer do is have their typed credential silently replaced by a prompt.
+func RouteFor(f tuiform.Form) Kind {
+	if len(f.Secrets()) == 0 {
+		return Plain
+	}
+	return Inventory
+}
+
+// EnvSpec declares that one field's value reaches the child process through its
+// environment rather than through the command line, in the case where naming a
+// variable is not enough because something has to be built first.
+//
+// FormSpec.Env covers the ordinary case -- ALIBABA_CLOUD_PROFILE=<the profile>
+// -- in one line of the spec, and needs nothing here. This exists for the case
+// k8s taught: the chosen cluster only means anything once a kubeconfig has been
+// written whose current-context is that cluster, so the contribution is a
+// function that returns both the variable and the cleanup for the file it made.
+//
+// This is about targets, not credentials, which is why it survived the
+// collapse above: a connector that declares no flag for the thing the user
+// picked has nothing for ParseCLI to be asked about.
+type EnvSpec struct {
+	// Connector is the connector this applies to.
+	Connector string
+	// Field is the field identity whose value travels -- "f:context", "p:1" --
+	// or a bare flag name as shorthand. See tuiform.MatchesIdentity.
+	Field string
+	// Apply turns the chosen value into environment entries, and returns the
+	// cleanup for anything it had to write. It is called only for a field that
+	// is actually set.
+	Apply func(value string) (env []string, cleanup func(), err error)
+}
+
+// EnvSpecs holds the declared environment contributors, keyed by connector.
+var EnvSpecs = map[string][]EnvSpec{}
+
+// RegisterEnv declares an environment contributor, and is called from the init
+// of whichever file owns the connector.
+func RegisterEnv(specs ...EnvSpec) {
+	for _, s := range specs {
+		EnvSpecs[s.Connector] = append(EnvSpecs[s.Connector], s)
+	}
+}
+
+// EnvSpecsFor returns the contributors declared for a connector.
+func EnvSpecsFor(connector string) []EnvSpec {
+	return EnvSpecs[connector]
+}

--- a/cli/launcher/delivery/inventory.go
+++ b/cli/launcher/delivery/inventory.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// When a form holds a credential, the launcher stops assembling a command line
+// and writes an inventory file instead.
+//
+// The reason is narrow and non-negotiable: the launcher runs the command by
+// re-executing cnspec, and anything on that command line is visible to every
+// user on the machine through `ps auxww`. A password typed into a form must not
+// end up there. An inventory file, written 0600 in a private directory and
+// deleted after the run, keeps it out of the process table.
+
+// Everything the launcher writes to disk is registered here, so that one call
+// removes all of it.
+//
+// The inventory carries a plaintext credential whenever the OS keychain was
+// unavailable, and it used to be removed on exactly one event: the command it
+// fed reporting that it had finished. That covers the happy path and nothing
+// else. Quitting the launcher before running the scan, or a signal, or a panic,
+// each left a file holding a password in the system temp directory, for as long
+// as the machine went without a reboot.
+//
+// Unlink-after-open, which is the usual answer, is not available here: the path
+// is handed to a child process, which opens it by name, so the file has to keep
+// one for as long as the child might start. What is available is to make every
+// exit this process can observe remove it -- the command finishing, quitting,
+// Run returning at all, a panic unwinding through it, and SIGHUP -- and that is
+// what this and CleanupTempFiles do. SIGKILL and losing power are observable by
+// nobody, and remain the residual risk; the file is 0600 inside a 0700
+// directory, which is what limits the damage there.
+var pendingTemp struct {
+	mu   sync.Mutex
+	next int
+	fns  map[int]func()
+}
+
+// TrackTemp registers a cleanup and returns it wrapped so that running it --
+// however it is reached -- also unregisters it. The wrapper is safe to call
+// more than once, which matters because both the launch path and the exit path
+// legitimately hold one.
+func TrackTemp(cleanup func()) func() {
+	if cleanup == nil {
+		return func() {}
+	}
+	pendingTemp.mu.Lock()
+	if pendingTemp.fns == nil {
+		pendingTemp.fns = map[int]func(){}
+	}
+	id := pendingTemp.next
+	pendingTemp.next++
+	pendingTemp.fns[id] = cleanup
+	pendingTemp.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			pendingTemp.mu.Lock()
+			delete(pendingTemp.fns, id)
+			pendingTemp.mu.Unlock()
+			cleanup()
+		})
+	}
+}
+
+// CleanupTempFiles removes everything the launcher has written and not yet
+// cleaned up. Calling it when there is nothing outstanding is free.
+func CleanupTempFiles() {
+	pendingTemp.mu.Lock()
+	fns := make([]func(), 0, len(pendingTemp.fns))
+	for id, fn := range pendingTemp.fns {
+		fns = append(fns, fn)
+		delete(pendingTemp.fns, id)
+	}
+	pendingTemp.mu.Unlock()
+
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+// RenderInventory marshals the inventory and checks that cnspec can read what
+// came out.
+//
+// Marshalling happens before PreProcess, which rewrites credentials into
+// spec.credentials under generated ids; validation runs on a copy so the bytes
+// stay in the readable shape while still being checked. Validating through the
+// same path `cnspec scan` uses is what makes a bad reference surface here
+// rather than as a connect-time failure later.
+func RenderInventory(inv *inventory.Inventory) ([]byte, error) {
+	data, err := inv.ToYAML()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot render the inventory")
+	}
+
+	check, err := inventory.InventoryFromYAML(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "generated an unreadable inventory")
+	}
+	if err := check.PreProcess(); err != nil {
+		return nil, errors.Wrap(err, "generated an invalid inventory")
+	}
+	if err := check.Validate(); err != nil {
+		return nil, errors.Wrap(err, "generated an invalid inventory")
+	}
+	return data, nil
+}
+
+// ExportInventory writes the inventory to a path the user chose.
+//
+// Three things separate this from WriteInventory, and all three follow from the
+// file being the user's rather than the launcher's:
+//
+//   - It is not registered with TrackTemp. Every other file this package writes
+//     is removed on the way out; this one is the artifact the user asked for,
+//     and an export that deleted itself when the launcher exited would be no
+//     export at all.
+//   - O_EXCL, so an export never replaces a file that is already there. The
+//     launcher cannot tell an accidental collision from a deliberate overwrite,
+//     and the destructive reading of that ambiguity is the one that cannot be
+//     undone.
+//   - It is still 0600. The permissions do not relax just because the path did:
+//     an exported inventory either references a keychain entry or, for the
+//     connectors whose provider keeps the secret in conn.Options, carries the
+//     secret itself, and neither is anybody else's business.
+func ExportInventory(inv *inventory.Inventory, path string) error {
+	data, err := RenderInventory(inv)
+	if err != nil {
+		return err
+	}
+
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return errors.Newf("%s already exists, remove it or choose another name", path)
+		}
+		return errors.Wrapf(err, "cannot create %s", path)
+	}
+	if _, err := fh.Write(data); err != nil {
+		_ = fh.Close()
+		// Removed rather than left behind: a half-written inventory under the
+		// name the user chose is a file a scheduled scan would later read as
+		// though it were complete.
+		_ = os.Remove(path)
+		return errors.Wrapf(err, "cannot write %s", path)
+	}
+	if err := fh.Close(); err != nil {
+		_ = os.Remove(path)
+		return errors.Wrapf(err, "cannot write %s", path)
+	}
+	return nil
+}
+
+// WriteInventory marshals the inventory to a private 0600 file and returns its
+// path along with a cleanup func.
+func WriteInventory(inv *inventory.Inventory) (path string, cleanup func(), err error) {
+	data, err := RenderInventory(inv)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// A private directory, not just a private file: on some systems the file
+	// name alone leaks, and 0700 on the directory keeps other users out.
+	dir, err := os.MkdirTemp("", "cnspec-ui-")
+	if err != nil {
+		return "", nil, errors.Wrap(err, "cannot create a directory for the inventory")
+	}
+	// Registered before the file is written, not after: from here on there is
+	// something on disk, and every way out of the process removes it.
+	cleanup = TrackTemp(func() { _ = os.RemoveAll(dir) })
+
+	path = filepath.Join(dir, "inventory.yml")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		cleanup()
+		return "", nil, errors.Wrap(err, "cannot write the inventory")
+	}
+	return path, cleanup, nil
+}

--- a/cli/launcher/delivery/inventory_test.go
+++ b/cli/launcher/delivery/inventory_test.go
@@ -1,0 +1,289 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// sshForm is a host-shaped form with a password in it, built here rather than
+// through the launcher's connector catalog: what this package promises is about
+// the file it writes, and it should be checkable without a screen. The
+// launcher's own tests cover the other half -- that its curated ssh form
+// produces exactly this shape.
+func sshForm() tuiform.Form {
+	target := tuiform.NewField(tuiform.Decl{
+		Label: "user@host", Pos: 1, Kind: tuiform.KindText,
+		Section: tuiform.SectionTarget,
+	})
+	target.SetValue("chris@10.0.0.4")
+
+	password := tuiform.NewField(tuiform.Decl{
+		Label: "password", Flag: "password", Kind: tuiform.KindText,
+		Secret: true, Section: tuiform.SectionCredential,
+	})
+	password.SetValue("<PLACEHOLDER-not-a-real-secret>")
+
+	return tuiform.New("ssh", []tuiform.Field{target, password})
+}
+
+// sshAsset is what the os provider's own ParseCLI answers for that form: a
+// connection with a host and a typed credential carrying the user.
+//
+// It is written out rather than fetched, because a unit test that started a
+// plugin subprocess would be testing the plugin. That the real providers
+// actually answer this way is asserted separately, over whatever is installed;
+// see TestEveryCredentialFieldRoundTrips in the launcher.
+func sshAsset() *inventory.Asset {
+	return &inventory.Asset{
+		Connections: []*inventory.Config{{
+			Type: "ssh",
+			Host: "10.0.0.4",
+			Credentials: []*vault.Credential{{
+				Type: vault.CredentialType_password, User: "chris", Password: "<PLACEHOLDER-not-a-real-secret>",
+			}},
+		}},
+	}
+}
+
+// The whole point of the vault route: the secret goes to the OS keychain and
+// the file carries an id, so the password is in neither the process table nor
+// anything the launcher wrote.
+func TestInventoryReferencesAVaultSecret(t *testing.T) {
+	f, asset := sshForm(), sshAsset()
+	saved := Keychainable(Locate(f, asset))
+	if saved == nil {
+		t.Fatal("the password did not land anywhere the keychain can hold")
+	}
+	inv := InventoryFor("ssh", asset, saved, "cnspec-ui-ssh-chris-20260818T120000")
+
+	creds := inv.Spec.Assets[0].Connections[0].Credentials
+	if len(creds) != 1 {
+		t.Fatalf("want exactly one credential reference, got %d", len(creds))
+	}
+	ref := creds[0]
+	if ref.SecretId != "cnspec-ui-ssh-chris-20260818T120000" {
+		t.Errorf("secret id = %q", ref.SecretId)
+	}
+	// The loader rejects a reference that also declares a type, and silently
+	// discards inline material when an id is present.
+	if ref.Type != vault.CredentialType_undefined {
+		t.Errorf("a reference must not declare a type, got %v", ref.Type)
+	}
+	if ref.Password != "" || len(ref.Secret) != 0 {
+		t.Error("a reference must carry no inline secret")
+	}
+	if inv.Spec.Vault == nil || inv.Spec.Vault.Type != vault.VaultType_KeyRing {
+		t.Fatalf("want the keyring vault named in the inventory, got %+v", inv.Spec.Vault)
+	}
+
+	data, err := inv.ToYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "<PLACEHOLDER-not-a-real-secret>") {
+		t.Fatalf("the secret was written into the inventory despite the vault:\n%s", data)
+	}
+}
+
+// What the keychain holds is the credential the *provider* built, type, user
+// and all -- not a password with no user assembled here.
+//
+// This is the difference the ParseCLI route makes and it is worth an assertion
+// of its own: artifactory needs a bearer credential and spends a password as
+// the legacy API key against the wrong header, azure and ms365 want pkcs12, and
+// okta wants private_key. Flattening every one of them into a password is what
+// the code this replaced did.
+func TestTheKeychainHoldsTheProvidersOwnCredential(t *testing.T) {
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Type: "artifactory",
+		Credentials: []*vault.Credential{{
+			Type: vault.CredentialType_bearer, User: "token", Password: "<PLACEHOLDER-not-a-real-secret>",
+		}},
+	}}}
+	saved := Keychainable(Locate(sshForm(), asset))
+	if saved == nil {
+		t.Fatal("the value did not land in a credential")
+	}
+	cred := saved.Credential()
+	if cred.Type != vault.CredentialType_bearer || cred.User != "token" {
+		t.Fatalf("the launcher would save %v/%q rather than what the provider built",
+			cred.Type, cred.User)
+	}
+}
+
+// The fallback route -- a keychain that was unavailable -- writes the
+// credential to disk, so the file it writes has to be one only this user can
+// read, and it has to be gone afterwards.
+func TestWriteInventoryIsPrivateAndCleansUp(t *testing.T) {
+	path, cleanup, err := WriteInventory(InventoryFor("ssh", sshAsset(), nil, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("inventory mode = %o, want 600", perm)
+	}
+	// The directory too: on some systems the file name alone leaks.
+	dir, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := dir.Mode().Perm(); perm != 0o700 {
+		t.Errorf("inventory directory mode = %o, want 700", perm)
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("inventory survived cleanup: %v", err)
+	}
+}
+
+func TestNewSecretIDIsStableAndScoped(t *testing.T) {
+	at := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	got := NewSecretID("ssh", "chris", at)
+	if got != "cnspec-ui-ssh-chris-20260818T120000" {
+		t.Fatalf("id = %q", got)
+	}
+	if NewSecretID("ssh", "", at) != "cnspec-ui-ssh-20260818T120000" {
+		t.Fatalf("id with no label = %q", NewSecretID("ssh", "", at))
+	}
+}
+
+// Everything the launcher writes is removed on every exit it can observe, not
+// only on the tidy one.
+//
+// The generated inventory holds a plaintext credential whenever the OS
+// keychain was unavailable, and cleanupLaunch used to run on exactly one
+// event: the command it fed reporting that it had finished. A quit before the
+// scan, a signal, or a panic each left that file in the system temp directory.
+func TestWhatTheLauncherWritesIsRemovedOnEveryExit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inventory.yml")
+	if err := os.WriteFile(path, []byte("password: <PLACEHOLDER-not-a-real-secret>\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := TrackTemp(func() { _ = os.RemoveAll(dir) })
+	CleanupTempFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("the file survived the exit hook: %v", err)
+	}
+
+	// Both the launch path and the exit path legitimately hold a cleanup, so
+	// running one after the other must be free rather than a double removal of
+	// whatever now sits at that path.
+	cleanup()
+	cleanup()
+	CleanupTempFiles()
+}
+
+// A cleanup that has already run is not run again by the exit hook, which is
+// what keeps a second launch's directory from being removed underneath it.
+func TestACompletedCleanupIsForgotten(t *testing.T) {
+	runs := 0
+	cleanup := TrackTemp(func() { runs++ })
+	cleanup()
+	CleanupTempFiles()
+	if runs != 1 {
+		t.Fatalf("the cleanup ran %d times, want once", runs)
+	}
+}
+
+// The generated inventory registers itself, so nothing has to remember to.
+func TestTheGeneratedInventoryIsTracked(t *testing.T) {
+	path, cleanup, err := WriteInventory(InventoryFor("ssh", sshAsset(), nil, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the inventory was not written: %v", err)
+	}
+	// Not through the returned cleanup: through the exit hook, which is the
+	// path a quit or a signal takes.
+	CleanupTempFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the generated inventory outlived the exit hook: %v", err)
+	}
+}
+
+// A provider can build two credentials at once -- a password and a private key
+// path -- and only one of them is the keychain's.
+//
+// The keychain holds a value. A key path is not a value to store, it is a
+// reference the provider resolves itself, so it has to stay in the file
+// whatever the keychain did. It did not: the reference used to replace the
+// credential list wholesale, so the key path survived when the keychain was
+// unavailable and disappeared when it worked -- the broken behaviour lived on
+// the path that succeeds. Both directions are checked here, because the bug was
+// that they disagreed.
+func TestAKeyPathSurvivesTheKeychain(t *testing.T) {
+	const key = "/home/chris/.ssh/id_ed25519"
+
+	build := func(secretID string) []*vault.Credential {
+		t.Helper()
+		asset := &inventory.Asset{Connections: []*inventory.Config{{
+			Type: "ssh", Host: "10.0.0.4",
+			Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_password, User: "chris", Password: "<PLACEHOLDER-not-a-real-secret>"},
+				{Type: vault.CredentialType_private_key, User: "chris", PrivateKeyPath: key},
+			},
+		}}}
+		saved := Keychainable(Locate(sshForm(), asset))
+		if saved == nil {
+			t.Fatal("the password did not land anywhere the keychain can hold")
+		}
+		inv := InventoryFor("ssh", asset, saved, secretID)
+		return inv.Spec.Assets[0].Connections[0].Credentials
+	}
+
+	for _, tc := range []struct {
+		name     string
+		secretID string
+	}{
+		{name: "keychain unavailable", secretID: ""},
+		{name: "keychain holds the password", secretID: "cnspec-ui-ssh-chris-20260818T120000"},
+	} {
+		creds := build(tc.secretID)
+
+		var sawKeyPath, sawPassword, sawReference bool
+		for _, cred := range creds {
+			switch {
+			case cred.SecretId != "":
+				sawReference = true
+			case cred.Type == vault.CredentialType_private_key:
+				sawKeyPath = cred.PrivateKeyPath == key
+			case cred.Type == vault.CredentialType_password:
+				sawPassword = true
+			}
+		}
+
+		if !sawKeyPath {
+			t.Errorf("%s: the private key path is not in the inventory: %+v", tc.name, creds)
+		}
+		if wantReference := tc.secretID != ""; sawReference != wantReference {
+			t.Errorf("%s: keychain reference present = %v, want %v", tc.name, sawReference, wantReference)
+		}
+		// The password travels one way or the other, never both: a reference
+		// beside the value it references would put the secret back in the file.
+		if sawPassword == (tc.secretID != "") {
+			t.Errorf("%s: the password is written into the file = %v, and referenced = %v",
+				tc.name, sawPassword, sawReference)
+		}
+	}
+}

--- a/cli/launcher/delivery/kubeconfig.go
+++ b/cli/launcher/delivery/kubeconfig.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// Targeting a specific Kubernetes cluster needs a workaround, and it is worth
+// writing down why.
+//
+// The k8s connector declares --context, described as "Target a specific
+// Kubernetes context from your kubeconfig". It does not do that. The connection
+// builds its client with the current-context override hardcoded to the empty
+// string (k8s/connection/api/connection.go, buildConfigFromFlags call), so the
+// kubeconfig's own current-context always wins. The flag's value is read in one
+// other place, to label the asset with a cluster name. Verified by querying two
+// different contexts and getting the same cluster's namespaces both times.
+//
+// The connection does read KUBECONFIG, but passes it whole as a single
+// ExplicitPath, so the colon-separated form kubectl supports does not work
+// either.
+//
+// What does work: point KUBECONFIG at one file whose current-context is the
+// wanted one. So the launcher copies the user's kubeconfig, rewrites that single
+// field, and hands the copy to the child. The rest of the document is passed
+// through untouched, which keeps exec-based auth plugins, certificate paths and
+// everything else working -- extracting a subset would risk dropping exactly
+// the fields that make a cluster reachable.
+
+// This is the case the environment contract in delivery.go was generalised
+// from: the value the user picked has no flag that carries it, and pointing the
+// child at it needs a file written first. Declaring it here rather than as an
+// `if connector == "k8s"` in launchArgs is what keeps the next four connectors
+// with the same problem from each adding their own branch to that function.
+//
+// It is also the one contributor an inventory cannot absorb, which was checked
+// rather than assumed. The obvious replacement -- a k8s asset naming the
+// kubeconfig and the context -- has nowhere to put either: NewConnection reads
+// os.Getenv("KUBECONFIG") and nothing else (k8s/connection/api/connection.go),
+// there is no option for a kubeconfig path, and Options["context"] is stored by
+// ParseCLI and then only used to label the asset -- buildConfigFromFlags is
+// called with an empty context, which is the bug this file already works
+// around. So KUBECONFIG stays, and it is worth being precise about what that
+// costs: nothing the user typed travels in it. The variable names a file, the
+// file is a copy of one the user already owns, and the child inherits the
+// ambient environment regardless. It is a target selector, not a credential
+// route.
+func init() {
+	RegisterEnv(EnvSpec{
+		Connector: "k8s",
+		Field:     "context",
+		Apply:     KubeEnvForContext,
+	})
+}
+
+// kubeconfigForContext writes a copy of the user's kubeconfig whose
+// current-context is ctx, and returns its path plus a cleanup func.
+func kubeconfigForContext(sourcePath, ctx string) (string, func(), error) {
+	if ctx == "" {
+		return "", nil, errors.New("no context given")
+	}
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "cannot read the kubeconfig")
+	}
+
+	// Decoded as a generic document so every field survives the round trip.
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", nil, errors.Wrap(err, "cannot parse the kubeconfig")
+	}
+	if doc == nil {
+		return "", nil, errors.New("the kubeconfig is empty")
+	}
+	doc["current-context"] = ctx
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "cannot render the kubeconfig")
+	}
+
+	dir, err := os.MkdirTemp("", "cnspec-ui-kube-")
+	if err != nil {
+		return "", nil, errors.Wrap(err, "cannot create a directory for the kubeconfig")
+	}
+	// A kubeconfig copy can hold client certificates and bearer tokens, so it
+	// is tracked for the same reason the generated inventory is: every exit the
+	// process can observe removes it, not only the tidy one. See TrackTemp.
+	cleanup := TrackTemp(func() { _ = os.RemoveAll(dir) })
+
+	// A kubeconfig can hold client certificates and tokens, so the copy is as
+	// private as the original should be.
+	path := filepath.Join(dir, "config")
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		cleanup()
+		return "", nil, errors.Wrap(err, "cannot write the kubeconfig")
+	}
+	return path, cleanup, nil
+}
+
+// defaultKubeconfigPath is the file the user's contexts were read from.
+func defaultKubeconfigPath() string {
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		// cnspec's k8s connection treats KUBECONFIG as one path, so only the
+		// first entry is meaningful to it.
+		if paths := filepath.SplitList(env); len(paths) > 0 {
+			return paths[0]
+		}
+	}
+	return home(".kube", "config")
+}
+
+// home is the launcher's own path-under-$HOME helper, kept here rather than
+// imported: this package is downstream of nothing in the launcher, and a
+// six-line join is a smaller thing to repeat than a dependency edge is to add.
+func home(rel ...string) string {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(append([]string{dir}, rel...)...)
+}
+
+// KubeEnvForContext returns the environment a child needs to target ctx, or
+// nothing when no context was chosen.
+func KubeEnvForContext(ctx string) ([]string, func(), error) {
+	if ctx == "" {
+		return nil, nil, nil
+	}
+	path, cleanup, err := kubeconfigForContext(defaultKubeconfigPath(), ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []string{"KUBECONFIG=" + path}, cleanup, nil
+}

--- a/cli/launcher/delivery/kubeconfig_test.go
+++ b/cli/launcher/delivery/kubeconfig_test.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The k8s connector's --context does not select a cluster: the connection
+// hardcodes the current-context override to "". Targeting therefore goes
+// through a kubeconfig copy whose current-context is the wanted one.
+func TestKubeconfigForContextRewritesCurrentContext(t *testing.T) {
+	path, cleanup, err := kubeconfigForContext("testdata/kubeconfig", "aks-trial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if got := doc["current-context"]; got != "aks-trial" {
+		t.Fatalf("current-context = %v, want aks-trial", got)
+	}
+
+	// Everything else must survive: dropping a field here means dropping the
+	// auth plugin or certificate that makes a cluster reachable.
+	src, _ := os.ReadFile("testdata/kubeconfig")
+	var orig map[string]any
+	_ = yaml.Unmarshal(src, &orig)
+	for _, key := range []string{"apiVersion", "kind", "contexts"} {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("the copy dropped %q", key)
+		}
+	}
+	if len(doc["contexts"].([]any)) != len(orig["contexts"].([]any)) {
+		t.Error("the copy lost contexts")
+	}
+}
+
+// A kubeconfig can hold client certificates and tokens.
+func TestKubeconfigCopyIsPrivate(t *testing.T) {
+	path, cleanup, err := kubeconfigForContext("testdata/kubeconfig", "aks-trial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("kubeconfig copy mode = %o, want 600", perm)
+	}
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("the copy survived cleanup")
+	}
+}
+
+func TestKubeconfigForContextRejectsBadInput(t *testing.T) {
+	if _, _, err := kubeconfigForContext("testdata/kubeconfig", ""); err == nil {
+		t.Error("expected an error with no context")
+	}
+	if _, _, err := kubeconfigForContext("testdata/does-not-exist", "x"); err == nil {
+		t.Error("expected an error for a missing kubeconfig")
+	}
+}
+
+// The copy is tracked for the same reason the generated inventory is: it can
+// hold client certificates and bearer tokens, so every exit the process can
+// observe removes it, not only the tidy one.
+func TestTheKubeconfigCopyIsTracked(t *testing.T) {
+	path, cleanup, err := kubeconfigForContext("testdata/kubeconfig", "aks-trial")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	CleanupTempFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the kubeconfig copy outlived the exit hook: %v", err)
+	}
+}

--- a/cli/launcher/delivery/parsecli.go
+++ b/cli/launcher/delivery/parsecli.go
@@ -1,0 +1,424 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/types"
+)
+
+// The launcher does not know what a connector's flags mean, and it never has
+// to: the provider that reads them will say, over the same call `cnspec scan`
+// itself makes.
+//
+// ParseCLI takes a connector name, the positional arguments and a map of flag
+// values, and answers with the inventory.Asset it would have connected to. That
+// asset *is* the mapping -- which option key each flag lands under, whether the
+// credential wants a password, a bearer token, a pkcs12 bundle or a private
+// key, which label cred.User has to carry for the provider's credential switch
+// to route it, and what the connection type is called.
+//
+// A hand-written table cannot produce that answer, and the previous one did not.
+// Of the connectors audited before this was written, thirteen needed a
+// credential shape the launcher's own BuildInventory did not produce and seven
+// needed a positional mapping no metadata carries -- github's two arguments
+// become organization, user or repository depending on the first one, shodan's
+// first becomes Options["search"] and its second becomes conn.Host. Every one
+// of those is a fact the provider already knows and nobody else does.
+//
+// The secret travels to the provider in a protobuf field over the plugin's
+// gRPC connection. That is the invariant this whole package exists for: it
+// never becomes a word in a child process's argv, where `ps auxww` publishes
+// it to every user on the machine.
+
+// CLIParser answers what a command line means, in the provider's own terms.
+//
+// It is an interface with one method so that the tests can answer for a
+// provider that is not installed -- and so that the launcher's own tests do not
+// each spawn a plugin subprocess. See ProviderParser for the real one.
+type CLIParser interface {
+	ParseCLI(provider, connector string, args []string, flags map[string]*llx.Primitive) (*inventory.Asset, error)
+}
+
+// Parser is what the launcher asks. It is a variable so a test can answer
+// without a provider on disk; nothing else replaces it.
+var Parser CLIParser = ProviderParser{}
+
+// ProviderParser starts the provider plugin and asks it.
+type ProviderParser struct{}
+
+// ParseCLI installs the provider if it is missing, starts it, and asks it what
+// this command line means.
+//
+// The install is EnsureProvider, the same call the launcher already makes when
+// a user opens a form, and the same one a scan would make on first use. By the
+// time a credential is being delivered the provider is therefore almost always
+// already on disk and already warm, because the form the credential was typed
+// into could not have been drawn without it.
+//
+// AutoUpdate is off for the runtime because EnsureProvider has just done it.
+// Leaving it on costs a second HTTPS round trip to releases.mondoo.com on every
+// launch -- measured at roughly 250ms of the 400ms a cold parse takes -- to
+// re-answer a question asked moments earlier.
+func (ProviderParser) ParseCLI(providerName, connector string, args []string, flags map[string]*llx.Primitive) (*inventory.Asset, error) {
+	p, err := providers.EnsureProvider(
+		providers.ProviderLookup{ProviderName: providerName}, true, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot load the "+providerName+" provider")
+	}
+
+	runtime := providers.Coordinator.NewRuntime()
+	runtime.AutoUpdate = providers.UpdateProvidersConfig{Enabled: false}
+	defer runtime.Close()
+
+	if err := runtime.UseProvider(p.ID); err != nil {
+		return nil, errors.Wrap(err, "cannot start the "+providerName+" provider")
+	}
+	res, err := runtime.Provider.Instance.Plugin.ParseCLI(&plugin.ParseCLIReq{
+		Connector: connector,
+		Args:      args,
+		Flags:     flags,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil || res.Asset == nil {
+		// The provider accepted the arguments and produced no target. mql's own
+		// caller only warns about this and carries on into a connection that
+		// cannot work; here it is the difference between an inventory and an
+		// empty file, so it is an error.
+		return nil, errors.New(connector + " did not produce a target from these settings")
+	}
+	return res.Asset, nil
+}
+
+// CLIRequest is one connector invocation in the shape ParseCLI takes.
+type CLIRequest struct {
+	Args  []string
+	Flags map[string]*llx.Primitive
+}
+
+// RequestFor renders a filled-in form as a ParseCLI request.
+//
+// It is the same reading of the form that Args() makes -- the same visibility
+// rule, the same argument order -- with one difference: secrets are included.
+// See tuiform.Form.FlagFields.
+//
+// Only answered flags are sent. mql's own caller sends a zero value for every
+// flag that declares ConfigEntry "-", and a provider that distinguishes "absent"
+// from "empty" would see a difference; sending less is the safe direction,
+// because an absent key is what a provider sees when a user omits the flag.
+func RequestFor(f tuiform.Form, flags []plugin.Flag) CLIRequest {
+	byName := make(map[string]plugin.Flag, len(flags))
+	for _, fl := range flags {
+		byName[fl.Long] = fl
+	}
+
+	out := CLIRequest{Args: f.Positional(), Flags: map[string]*llx.Primitive{}}
+	for _, fd := range f.FlagFields() {
+		out.Flags[fd.Flag] = primitiveFor(fd, byName[fd.Flag])
+	}
+	return out
+}
+
+// primitiveFor renders one answer as the flag's declared type.
+//
+// The connector's own declaration decides, not the widget, because the type is
+// what the provider unmarshals on the other side. Sending the wrong one is not
+// a type error anywhere: llx.Primitive carries opaque bytes, so a provider
+// reading string(prim.Value) on an int gets the varint's bytes as text. That is
+// not hypothetical -- `cnspec shell activedirectory --dc x --user u --password
+// p --port 389` fails today with `port flag must be a valid integer:
+// strconv.Atoi: parsing "\x8a\x06"`, which is 389 zigzagged, because that
+// provider declares --port as an int and reads it as a string. Nothing the
+// launcher does can fix that; sending what mql's own CLI sends at least means
+// the launcher is not a second cause of it.
+//
+// plugin.FlagType counts from 1, so a zero Type means no declaration reached
+// here at all, and the widget answers instead. --discover is the case that
+// matters: the CLI synthesizes it rather than the provider declaring it, so it
+// is absent from Connector.Flags, and it is a list.
+func primitiveFor(fd tuiform.Field, fl plugin.Flag) *llx.Primitive {
+	switch fl.Type {
+	case plugin.FlagType_Bool:
+		return llx.BoolPrimitive(fd.On())
+	case plugin.FlagType_Int:
+		return llx.IntPrimitive(parseInt(fd.Emitted()))
+	case plugin.FlagType_String:
+		return llx.StringPrimitive(stringValue(fd))
+	case plugin.FlagType_List:
+		return llx.ArrayPrimitiveT(listValue(fd), llx.StringPrimitive, types.String)
+	case plugin.FlagType_KeyValue:
+		return llx.MapPrimitiveT(keyValue(fd), llx.StringPrimitive, types.String)
+	}
+
+	switch fd.Kind {
+	case tuiform.KindBool:
+		return llx.BoolPrimitive(fd.On())
+	case tuiform.KindMultiChoice:
+		return llx.ArrayPrimitiveT(fd.Selected(), llx.StringPrimitive, types.String)
+	default:
+		return llx.StringPrimitive(fd.Emitted())
+	}
+}
+
+// stringValue is a string flag's answer. A multi-choice answering one spells
+// itself the way pflag's own StringSlice would be read back, which is how
+// `--values a.yaml,b.yaml` already reaches a provider from a shell.
+func stringValue(fd tuiform.Field) string {
+	if fd.Kind == tuiform.KindMultiChoice {
+		return strings.Join(fd.Selected(), ",")
+	}
+	return fd.Emitted()
+}
+
+// listValue is a list flag's answer, from whichever widget answered it.
+// TypeEmptyLists turns a list with nothing to pick from into a text box, so
+// both spellings reach here and pflag splits both on commas.
+func listValue(fd tuiform.Field) []string {
+	if fd.Kind == tuiform.KindMultiChoice {
+		return fd.Selected()
+	}
+	return splitList(fd.Emitted())
+}
+
+func keyValue(fd tuiform.Field) map[string]string {
+	out := map[string]string{}
+	for _, pair := range splitList(fd.Emitted()) {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = v
+	}
+	return out
+}
+
+func splitList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := strings.Split(s, ",")
+	for i := range out {
+		out[i] = strings.TrimSpace(out[i])
+	}
+	return out
+}
+
+func parseInt(s string) int64 {
+	var n int64
+	var neg bool
+	for i, r := range s {
+		if i == 0 && r == '-' {
+			neg = true
+			continue
+		}
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int64(r-'0')
+	}
+	if neg {
+		return -n
+	}
+	return n
+}
+
+// Placement is where a provider put a secret it was handed.
+//
+// It is detected rather than declared, which is the one thing a hand-written
+// table could never do: the launcher looks for the value it sent in the asset
+// that came back, and the answer decides whether the OS keychain can hold it.
+type Placement int
+
+const (
+	// PlacedNowhere: the value is not in the asset at all. The provider read
+	// the flag and dropped it, or never read it. Launching would scan
+	// unauthenticated -- or, for databricks, whatever DATABRICKS_TOKEN in the
+	// ambient environment names, because its credential switch has no default
+	// arm and the SDK resolves the variable itself. That is a refusal.
+	PlacedNowhere Placement = iota
+	// PlacedCredential: the value is in conf.Credentials, so it can be
+	// replaced by a reference to an OS keychain entry.
+	PlacedCredential
+	// PlacedOption: the value is in conf.Options, where the provider reads it
+	// as a plain connection setting. A vault reference is not read from there,
+	// so this credential can only travel as plaintext inside the generated
+	// file.
+	//
+	// This is commoner than the AI connectors it was first noticed on. Measured
+	// against the installed provider set, thirteen credential fields across
+	// eleven connectors land here: anthropic and claude (--token and
+	// --admin-token each), datadog (--app-key), elasticsearch (--api-key),
+	// huggingface, ollama, openai and proxmox (--token), nutanix (--api-key),
+	// openstack (--application-credential-secret) and tailscale
+	// (--client-secret). Four of those connectors put a *different* credential
+	// in conf.Credentials on the same form, so "reads conf.Credentials at all"
+	// is not the question -- the question is where this value went, which is
+	// why it is detected per value rather than declared per connector.
+	//
+	// The set is printed on every run by
+	// TestEveryConnectorExportsSomethingTheLoaderAccepts, so nobody has to
+	// trust this paragraph.
+	PlacedOption
+)
+
+// Located is one secret the launcher sent, and what the provider did with it.
+type Located struct {
+	// Flag is the form field the value came from.
+	Flag string
+	// Placement is where it landed.
+	Placement Placement
+	// conn and index name the exact credential to swap for a keychain
+	// reference, so that a form carrying two secrets replaces the one that was
+	// saved and leaves the other alone.
+	conn  *inventory.Config
+	index int
+}
+
+// Credential is the credential the provider built to hold this secret, or nil
+// when it did not build one.
+func (l Located) Credential() *vault.Credential {
+	if l.Placement != PlacedCredential || l.conn == nil || l.index >= len(l.conn.Credentials) {
+		return nil
+	}
+	return l.conn.Credentials[l.index]
+}
+
+// Keychainable picks the one credential the launcher saves to the OS keychain,
+// or nil when none of the form's secrets landed somewhere a vault reference is
+// read from.
+//
+// One rather than all, because a keychain entry is referenced by a single id
+// and the reference replaces exactly the credential it stands for. A form
+// holding two secrets -- ssh with a password and an identity file, unifi with
+// two alternative credentials -- gets the first protected and the rest left as
+// the provider built them. Replacing the whole list is what the code this
+// succeeded did, and it meant the second credential survived a keychain
+// *failure* and vanished when the keychain *worked*: the broken behaviour lived
+// on the path that succeeds.
+func Keychainable(placed []Located) *Located {
+	for i := range placed {
+		if placed[i].Placement == PlacedCredential {
+			return &placed[i]
+		}
+	}
+	return nil
+}
+
+// Locate reports, for each secret the form holds, where the provider put it.
+//
+// Matching is by value: the launcher knows what it sent and looks for it in
+// what came back. That is exact rather than heuristic, and it is why a provider
+// that renames the option, retypes the credential or tags cred.User with a
+// label needs nothing registered here.
+//
+// Reference secrets are skipped. A field marked Reference names a file holding
+// a credential rather than holding one, so the path is not a secret to protect
+// and the provider is free to read the file rather than carry the path.
+func Locate(f tuiform.Form, asset *inventory.Asset) []Located {
+	var out []Located
+	for _, fd := range f.Secrets() {
+		if fd.Reference {
+			continue
+		}
+		out = append(out, locateValue(fd.Flag, fd.Value(), asset))
+	}
+	return out
+}
+
+func locateValue(flag, value string, asset *inventory.Asset) Located {
+	found := Located{Flag: flag}
+	if value == "" || asset == nil {
+		return found
+	}
+	for _, conn := range asset.Connections {
+		for i, cred := range conn.Credentials {
+			if cred == nil {
+				continue
+			}
+			if credentialHolds(cred, value) {
+				return Located{Flag: flag, Placement: PlacedCredential, conn: conn, index: i}
+			}
+		}
+		for _, v := range conn.Options {
+			if v == value {
+				// Keep looking: a provider that writes the value into both an
+				// option and a credential can still be keychain-protected, and
+				// the credential is the better answer.
+				found = Located{Flag: flag, Placement: PlacedOption, conn: conn}
+			}
+		}
+	}
+	return found
+}
+
+// credentialHolds reports whether this credential carries the value, in
+// whichever of its fields the provider chose to put it.
+//
+// User is one of them, and it is not a mistake. A provider is free to decide
+// that the secret *is* the identity: clickhousecloud's --api-key becomes the
+// user of a password credential whose password is --api-secret, which is what
+// that service's key pair actually is. Reading the credential fields
+// selectively is what would be wrong -- the whole credential goes to the
+// keychain and comes back whole, so wherever the value sits inside it, it is
+// protected.
+//
+// Matching User cannot collide with the labels several providers put there --
+// hcp's "client-secret", stackit's option name, databricks' "token" -- because
+// the comparison is against the value the launcher sent, not against a name.
+func credentialHolds(cred *vault.Credential, value string) bool {
+	return cred.Password == value ||
+		cred.User == value ||
+		string(cred.Secret) == value ||
+		string(cred.PrivateKey) == value ||
+		cred.PrivateKeyPath == value
+}
+
+// InventoryFor wraps the provider's own asset as a scannable inventory, with
+// the saved credential swapped for a reference to it.
+//
+// The asset is used as it came back. Nothing is added to it and nothing is
+// re-keyed, because every one of those edits would be the launcher second-
+// guessing the provider that has to read the result -- which is the failure
+// this replaced.
+//
+// secretID, when set, is a keychain entry the OS is holding, and it stands in
+// for exactly one credential: the one Save picked. The rest are left as the
+// provider built them.
+func InventoryFor(connector string, asset *inventory.Asset, saved *Located, secretID string) *inventory.Inventory {
+	if asset.Id == "" {
+		asset.Id = "cnspec-ui-" + connector
+	}
+	if asset.Name == "" {
+		asset.Name = connector
+	}
+
+	if secretID != "" && saved != nil && saved.conn != nil &&
+		saved.index < len(saved.conn.Credentials) {
+		// A credential reference carries the id and nothing else: the loader
+		// rejects a reference that also declares a type, and silently discards
+		// inline material when an id is present.
+		saved.conn.Credentials[saved.index] = &vault.Credential{SecretId: secretID}
+	}
+
+	inv := inventory.New(inventory.WithAssets(asset))
+	if secretID != "" {
+		// There is no --vault flag; naming the vault in the inventory is the
+		// only way to point cnspec at the OS keychain.
+		inv.Spec.Vault = &vault.VaultConfiguration{
+			Name: vaultService,
+			Type: vault.VaultType_KeyRing,
+		}
+	}
+	return inv
+}

--- a/cli/launcher/delivery/parsecli_test.go
+++ b/cli/launcher/delivery/parsecli_test.go
@@ -1,0 +1,207 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"testing"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/types"
+)
+
+// A secret is sent to the provider and left off the command line, and those are
+// two different things about the same field.
+//
+// Args() and RequestFor() read the same form through the same visibility rule
+// and disagree about exactly one row, which is the whole reason FlagFields
+// exists. If they ever agree about a secret, one of two bugs has happened: the
+// credential is on a command line `ps auxww` publishes, or it never reached the
+// provider at all.
+func TestASecretIsSentToTheProviderAndNotToArgv(t *testing.T) {
+	f := sshForm()
+	req := RequestFor(f, []plugin.Flag{{Long: "password", Type: plugin.FlagType_String}})
+
+	if got := req.Flags["password"]; got == nil || string(got.Value) != "<PLACEHOLDER-not-a-real-secret>" {
+		t.Fatalf("the password did not reach the provider: %+v", req.Flags)
+	}
+	for _, arg := range f.Args() {
+		if arg == "<PLACEHOLDER-not-a-real-secret>" || arg == "--password" {
+			t.Fatalf("the password reached the command line: %v", f.Args())
+		}
+	}
+	if len(req.Args) != 1 || req.Args[0] != "chris@10.0.0.4" {
+		t.Fatalf("positional arguments = %v", req.Args)
+	}
+}
+
+// The connector's declaration decides a flag's type, not the widget drawn over
+// it, because that is what the provider unmarshals on the other side.
+//
+// --discover is the one flag with no declaration at all: the CLI synthesizes it
+// rather than the provider declaring it, so a zero plugin.Flag arrives and the
+// widget has the last word. Getting that backwards sends a list flag a string
+// and the provider reads raw protobuf bytes as text -- which is not
+// hypothetical, see the activedirectory --port note in parsecli.go.
+func TestFlagTypesFollowTheConnectorsDeclaration(t *testing.T) {
+	mk := func(d tuiform.Decl, set func(*tuiform.Field)) tuiform.Field {
+		fd := tuiform.NewField(d)
+		set(&fd)
+		return fd
+	}
+	f := tuiform.New("probe", []tuiform.Field{
+		mk(tuiform.Decl{Label: "port", Flag: "port", Kind: tuiform.KindText},
+			func(fd *tuiform.Field) { fd.SetValue("8443") }),
+		mk(tuiform.Decl{Label: "sudo", Flag: "sudo", Kind: tuiform.KindBool},
+			func(fd *tuiform.Field) { fd.SetOn(true) }),
+		mk(tuiform.Decl{Label: "discover", Flag: "discover", Kind: tuiform.KindMultiChoice,
+			Options: []string{"auto", "all"}},
+			func(fd *tuiform.Field) { fd.TogglePick("all") }),
+		mk(tuiform.Decl{Label: "repos", Flag: "repos", Kind: tuiform.KindText},
+			func(fd *tuiform.Field) { fd.SetValue("one, two") }),
+	})
+
+	req := RequestFor(f, []plugin.Flag{
+		{Long: "port", Type: plugin.FlagType_Int},
+		{Long: "sudo", Type: plugin.FlagType_Bool},
+		{Long: "repos", Type: plugin.FlagType_List},
+		// discover is deliberately absent: the CLI synthesizes it.
+	})
+
+	if got := req.Flags["port"]; got == nil || got.Type != string(types.Int) {
+		t.Errorf("port = %+v, want an int primitive", got)
+	}
+	if got := req.Flags["sudo"]; got == nil || got.Type != string(types.Bool) {
+		t.Errorf("sudo = %+v, want a bool primitive", got)
+	}
+	if got := req.Flags["repos"]; got == nil || got.Type != string(types.Array(types.String)) {
+		t.Errorf("repos = %+v, want a string array", got)
+	}
+	if got := req.Flags["discover"]; got == nil || got.Type != string(types.Array(types.String)) {
+		t.Errorf("discover = %+v, want a string array from the multi-choice", got)
+	}
+}
+
+// Where the provider put the secret is looked up rather than declared, and it
+// has to be found wherever the provider chose to put it.
+func TestLocateFindsTheValueWhereverItLanded(t *testing.T) {
+	cases := []struct {
+		name string
+		conn *inventory.Config
+		want Placement
+	}{
+		{
+			name: "a password credential, the common case",
+			conn: &inventory.Config{Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_password, Password: "<PLACEHOLDER-not-a-real-secret>"}}},
+			want: PlacedCredential,
+		},
+		{
+			// clickhousecloud: the api key is the user of the pair whose
+			// password is the api secret.
+			name: "the credential's user, because the key is the identity",
+			conn: &inventory.Config{Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_password, User: "<PLACEHOLDER-not-a-real-secret>"}}},
+			want: PlacedCredential,
+		},
+		{
+			name: "a bearer token in Secret",
+			conn: &inventory.Config{Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_bearer, Secret: []byte("<PLACEHOLDER-not-a-real-secret>")}}},
+			want: PlacedCredential,
+		},
+		{
+			// openai, ollama, huggingface and claude never read Credentials.
+			name: "a connection option, which no vault reference reaches",
+			conn: &inventory.Config{Options: map[string]string{"api-key": "<PLACEHOLDER-not-a-real-secret>"}},
+			want: PlacedOption,
+		},
+		{
+			// alicloud --sts-token, verified against the installed provider.
+			name: "nowhere, because the provider dropped it",
+			conn: &inventory.Config{Options: map[string]string{"region": "eu-central-1"}},
+			want: PlacedNowhere,
+		},
+		{
+			// A provider free to echo the value into an option as well is
+			// still keychain-protectable, and the credential is the better
+			// answer of the two.
+			name: "both, and the credential wins",
+			conn: &inventory.Config{
+				Options:     map[string]string{"password": "<PLACEHOLDER-not-a-real-secret>"},
+				Credentials: []*vault.Credential{{Password: "<PLACEHOLDER-not-a-real-secret>"}},
+			},
+			want: PlacedCredential,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			placed := Locate(sshForm(), &inventory.Asset{Connections: []*inventory.Config{tc.conn}})
+			if len(placed) != 1 {
+				t.Fatalf("want one located secret, got %d", len(placed))
+			}
+			if placed[0].Placement != tc.want {
+				t.Errorf("placement = %v, want %v", placed[0].Placement, tc.want)
+			}
+		})
+	}
+}
+
+// A field that names a file holding a credential is not a credential, so it is
+// not looked for and cannot make a launch refuse.
+//
+// The provider is free to open the file and never carry the path at all, which
+// is what okta does with --private-key. Treating the path as a lost secret
+// would refuse every one of those launches.
+func TestAReferenceFieldIsNotLookedFor(t *testing.T) {
+	key := tuiform.NewField(tuiform.Decl{
+		Label: "identity-file", Flag: "identity-file", Kind: tuiform.KindText,
+		Secret: true, Reference: true, Section: tuiform.SectionCredential,
+	})
+	key.SetValue("~/.ssh/id_ed25519")
+	f := sshForm()
+	f.SetFields(append(f.Fields(), key))
+
+	placed := Locate(f, sshAsset())
+	if len(placed) != 1 || placed[0].Flag != "password" {
+		t.Fatalf("want only the password located, got %+v", placed)
+	}
+}
+
+// A form with no credential does not need a file, and one with a credential
+// does. That is the whole of the route decision now.
+func TestRouteForDependsOnlyOnWhetherASecretWasTyped(t *testing.T) {
+	if got := RouteFor(tuiform.New("local", nil)); got != Plain {
+		t.Errorf("an empty form routes as %v, want Plain", got)
+	}
+	if got := RouteFor(sshForm()); got != Inventory {
+		t.Errorf("a form holding a password routes as %v, want Inventory", got)
+	}
+
+	// The reversal worth asserting: a typed password used to be discarded in
+	// favour of --ask-pass, so the child prompted for a credential the user had
+	// already given it. Ticking the toggle is still available and is still the
+	// Plain route; typing is no longer silently converted into it.
+	ask := tuiform.NewField(tuiform.Decl{
+		Label: "ask-pass", Flag: "ask-pass", Kind: tuiform.KindBool,
+		Section: tuiform.SectionCredential,
+	})
+	ask.SetOn(true)
+	withAsk := sshForm()
+	withAsk.SetFields(append(withAsk.Fields(), ask))
+	if got := RouteFor(withAsk); got != Inventory {
+		t.Errorf("a typed password beside --ask-pass routes as %v, want Inventory", got)
+	}
+
+	noPassword := tuiform.New("ssh", []tuiform.Field{ask})
+	if got := RouteFor(noPassword); got != Plain {
+		t.Errorf("--ask-pass on its own routes as %v, want Plain", got)
+	}
+	if args := noPassword.Args(); len(args) != 1 || args[0] != "--ask-pass" {
+		t.Errorf("--ask-pass did not reach the command line: %v", args)
+	}
+}

--- a/cli/launcher/delivery/testdata/kubeconfig
+++ b/cli/launcher/delivery/testdata/kubeconfig
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Config
+current-context: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+contexts:
+  - name: aks-trial
+    context: {cluster: aks, user: aks}
+  - name: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+    context: {cluster: eks, user: eks}
+  - name: chris-dev
+    context: {cluster: dev, user: dev}

--- a/cli/launcher/delivery/vault.go
+++ b/cli/launcher/delivery/vault.go
@@ -1,0 +1,195 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+	_ "go.mondoo.com/mql/vault/keyring"
+)
+
+// Saving a credential puts it in the operating system's own store -- Keychain
+// on macOS, Credential Manager on Windows, Secret Service, KWallet or pass on
+// Linux -- and leaves only an id behind in the inventory. The secret then never
+// touches a file the launcher writes.
+//
+// Two limits are worth knowing, both of them in the vault API rather than here:
+//
+//   - There is no way to list what a vault holds. vault.Vault is Get/Set/Delete
+//     and nothing else, so the launcher cannot show you your saved credentials.
+//     It keeps its own index of the ids it created, which is why savedIndex
+//     exists; anything saved by other means has to be referenced by typing its
+//     id.
+//   - Delete is not implemented for the keyring backend, so a credential saved
+//     here is removed with the OS's own tooling, not from cnspec.
+
+// vaultService is the keychain service name secrets are filed under. It matches
+// the name used throughout the cnspec vault documentation, so a credential
+// saved here is visible to a hand-written inventory too.
+const vaultService = "mondoo-client-vault"
+
+// keyringVault opens the OS keychain.
+func keyringVault() (vault.Vault, error) {
+	return vault.New(&vault.VaultConfiguration{
+		Name: vaultService,
+		Type: vault.VaultType_KeyRing,
+	})
+}
+
+// StoreFunc is the keychain write itself. StoreCredentialWithin takes one
+// rather than reaching for StoreCredential directly, because the failure path
+// matters more than the success one and cannot be provoked otherwise: the
+// launcher passes its own replaceable variable, and a test passes a write that
+// never answers.
+type StoreFunc = func(id string, cred *vault.Credential) error
+
+// KeychainTimeout is how long the launcher waits for the OS keychain.
+//
+// A locked keychain does not fail, it asks: macOS raises an authentication
+// dialog and Set does not return until it is answered. The launcher is drawing
+// a full-screen UI at that moment, so the dialog and the launcher are two
+// programs competing for one screen, and a user who does not notice the dialog
+// sees a frozen scan. Long enough to type a password, short enough that a
+// dialog nobody is looking at does not hold the scan for ever.
+const KeychainTimeout = 30 * time.Second
+
+// StoreCredentialWithin is the keychain write with a bound on how long it may
+// take, whatever the backend does with the context it is given.
+//
+// The context passed into vault.Set below is the polite half of this and is not
+// enough on its own: the keyring backends reach into the OS through cgo and
+// blocking system calls that no context can interrupt, so a timeout that only
+// lives in the context would be a timeout that never fires. Waiting on a
+// channel instead is a bound that holds regardless.
+//
+// The write is left running when the wait gives up. It has nowhere else to go,
+// and its two outcomes are both harmless: it either lands, leaving a keychain
+// entry the inventory did not reference, or it fails. The caller has already
+// fallen back to the 0600 inventory by then and has told the user so.
+func StoreCredentialWithin(limit time.Duration, write StoreFunc, id string, cred *vault.Credential) error {
+	// The write is passed in rather than read from a variable here, and the
+	// caller reads its own before calling: the write is left running when the
+	// wait gives up, so a goroutine that read a variable could still be reading
+	// it after a test had put the real one back.
+	done := make(chan error, 1)
+	go func() { done <- write(id, cred) }()
+
+	timer := time.NewTimer(limit)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return errors.New("the OS keychain did not answer within " + limit.String() +
+			" — it may be locked and waiting on a dialog behind this window")
+	}
+}
+
+// StoreCredential writes a credential to the OS keychain under id.
+//
+// The encoding is not a free choice: the keyring backend rejects anything but
+// JSON on write and reports JSON on read regardless of what went in, so a
+// secret stored any other way cannot be read back as a credential.
+func StoreCredential(id string, cred *vault.Credential) error {
+	v, err := keyringVault()
+	if err != nil {
+		return errors.Wrap(err, "cannot open the OS keychain")
+	}
+	secret, err := vault.NewSecret(cred, vault.SecretEncoding_encoding_json)
+	if err != nil {
+		return errors.Wrap(err, "cannot encode the credential")
+	}
+	secret.Key = id
+
+	// Bounded rather than context.Background(): a backend that does honour a
+	// context should give up here rather than hold the launcher open, and one
+	// that does not is caught by StoreCredentialWithin instead.
+	ctx, cancel := context.WithTimeout(context.Background(), KeychainTimeout)
+	defer cancel()
+	if _, err := v.Set(ctx, secret); err != nil {
+		return errors.Wrap(err, "cannot save the credential to the OS keychain")
+	}
+	return nil
+}
+
+// SavedEntry is one credential the launcher put in the keychain. It records
+// where the credential belongs, never what it is.
+type SavedEntry struct {
+	ID        string `json:"id"`
+	Connector string `json:"connector"`
+	Label     string `json:"label"`
+	SavedAt   string `json:"saved_at"`
+}
+
+// savedIndexPath is the launcher's own record of ids it created, which stands
+// in for the listing the vault API does not provide.
+func savedIndexPath() string {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, ".config", "mondoo", "cnspec-ui-credentials.json")
+}
+
+func loadSavedIndex() []SavedEntry {
+	path := savedIndexPath()
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []SavedEntry
+	if json.Unmarshal(data, &out) != nil {
+		return nil
+	}
+	return out
+}
+
+// RecordSaved adds an entry to the index, replacing any entry with the same id.
+func RecordSaved(e SavedEntry) error {
+	path := savedIndexPath()
+	if path == "" {
+		return errors.New("cannot locate the cnspec config directory")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return errors.Wrap(err, "cannot create the cnspec config directory")
+	}
+
+	entries := loadSavedIndex()
+	out := entries[:0]
+	for _, existing := range entries {
+		if existing.ID != e.ID {
+			out = append(out, existing)
+		}
+	}
+	out = append(out, e)
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "cannot encode the credential index")
+	}
+	// The index holds no secrets, but it does describe what exists and where,
+	// so it stays owner-only.
+	return os.WriteFile(path, data, 0o600)
+}
+
+// NewSecretID mints an id for a credential the launcher is about to save. The
+// timestamp is passed in rather than read here so the result is testable.
+func NewSecretID(connector, label string, now time.Time) string {
+	id := "cnspec-ui-" + connector
+	if label != "" {
+		id += "-" + label
+	}
+	return id + "-" + now.UTC().Format("20060102T150405")
+}

--- a/cli/launcher/delivery/vault_test.go
+++ b/cli/launcher/delivery/vault_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package delivery
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// The wait for the keychain is bounded, and the bound is not the context.
+//
+// A locked keychain raises an OS dialog and the write does not return until it
+// is answered; the keyring backends reach the OS through blocking calls no
+// context can interrupt, so a timeout that lived only in the context would be
+// a timeout that never fires. This one holds regardless of what the backend
+// does, which is what lets the launcher fall back to the 0600 inventory rather
+// than wait for a dialog nobody is looking at.
+func TestTheKeychainWaitIsBounded(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	// A write that never answers, which is what a locked keychain waiting on a
+	// dialog behind the launcher looks like from here.
+	never := func(string, *vault.Credential) error {
+		<-release
+		return nil
+	}
+
+	start := time.Now()
+	err := StoreCredentialWithin(20*time.Millisecond, never, "cnspec-ui-test",
+		&vault.Credential{Type: vault.CredentialType_password, Password: "<PLACEHOLDER-not-a-real-secret>"})
+	if err == nil {
+		t.Fatal("a keychain that never answered was reported as a success")
+	}
+	if waited := time.Since(start); waited > 5*time.Second {
+		t.Fatalf("the wait was not bounded: %s", waited)
+	}
+	// The message has to point at the dialog, because the dialog is behind the
+	// full-screen UI and is the thing the user has to go and find.
+	if !strings.Contains(err.Error(), "keychain") || !strings.Contains(err.Error(), "locked") {
+		t.Errorf("the timeout should say where to look, got %q", err)
+	}
+}
+
+// A keychain that answers is not slowed down by the bound, and its own error
+// is passed through rather than replaced by a timeout.
+func TestTheKeychainAnswerIsPassedThrough(t *testing.T) {
+	answers := func(string, *vault.Credential) error { return nil }
+	if err := StoreCredentialWithin(KeychainTimeout, answers, "id", nil); err != nil {
+		t.Fatalf("a successful write reported %v", err)
+	}
+
+	refuses := func(string, *vault.Credential) error {
+		return errors.New("keyring unavailable")
+	}
+	err := StoreCredentialWithin(KeychainTimeout, refuses, "id", nil)
+	if err == nil || !strings.Contains(err.Error(), "keyring unavailable") {
+		t.Fatalf("the backend's own reason was lost: %v", err)
+	}
+}

--- a/cli/launcher/forms/doc.go
+++ b/cli/launcher/forms/doc.go
@@ -1,0 +1,134 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package forms holds the curated connector overlays: what a connector's input
+// screen asks for, in what order, and where a field's suggested values come
+// from.
+//
+// Curated overlays. The generic layer in the launcher already produces a
+// working screen for every connector from its declared metadata; an overlay
+// improves the ones people reach for most, by naming the positional arguments
+// the usage string only hints at, promoting the two or three fields that
+// actually matter into TARGET, and attaching value pickers.
+//
+// An overlay never invents a flag. Every entry is matched against what the
+// installed provider declares, and anything unmatched is dropped, so an overlay
+// that goes stale degrades to the generic screen instead of emitting a flag
+// that no longer exists. That graceful degradation is also why a typo is
+// invisible at runtime, and why TestEverySpecNamesRealFlags exists.
+//
+// # One file per category, and a test that says so
+//
+// The specs are split across forms_<category>.go, one file per entry in
+// cli/launcher/catalog's own taxonomy -- the same taxonomy the launcher groups
+// the connector list by. A reader looking for the jamf form finds it where the
+// UI shows jamf.
+//
+// The files used to be named forms_saas_a.go, forms_saas_b.go, forms_cloud_a.go
+// and so on, where the letter was where one contributor's file ended and the
+// next began. That kept two people from editing the same file and produced no
+// structure at all: forms_cloud_a.go held alicloud through nutanix and
+// forms_cloud_b.go held oci through vsphere, with the four virtualization
+// connectors split across both for no reason a reader could recover.
+//
+// TestEverySpecIsFiledUnderItsCategory is what keeps the taxonomy a rule rather
+// than a convention. registerSpec records the file each spec was registered
+// from, and the test resolves each connector's category through
+// catalog.Categorize -- so a spec added to the wrong file fails with the name of
+// the file it belongs in.
+//
+// # Why this is its own package
+//
+// The specs need three things and none of them is a screen: the FormSpec shape,
+// the source ids a picker is named by, and the launcher-owned field markers.
+// The engine that turns a spec into fields (applySpec), the provider-derived
+// half (providerFormSpec) and the merge between them stay in the launcher,
+// because those read connector metadata and build widgets. What is here is the
+// data and the registry it lives in.
+//
+// The import direction is forms -> {source, tui/form} and nothing more. source
+// and tui/form know nothing about connectors or about this package, so a spec
+// cannot reach a screen and a screen cannot reach back for a spec.
+//
+// # The six connectors with no snapshot entry
+//
+// auth0, bitwarden, dropbox, jumpcloud, keycloak and zoom reach the catalog only
+// through the compiled-in static list.
+//
+// providers.DefaultProviders strips Flags, MinArgs, MaxArgs and Discovery, so
+// on a machine without these providers installed a Connector for one carries
+// nothing and HasFormData() is false: the pane says "open this connector to
+// install its provider" and the spec is a no-op, because applySpec drops every
+// flag the connector does not declare. The spec only starts mattering once the
+// provider is installed -- and at that point the connector declares the flags
+// named in it.
+//
+// They are absent from internal/connectors/connectors.json for the same reason,
+// so TestEverySpecNamesRealFlags logs "no snapshot entry, so its flags were not
+// checked" and moves on. That is a real gap and it is stated rather than papered
+// over: those specs are checked by hand and by the launcher's own tests, not by
+// the shared gate. The gap closes by itself the next time somebody refreshes the
+// snapshot on a machine with these six installed:
+//
+//	cnspec providers install auth0 bitwarden dropbox jumpcloud keycloak zoom
+//	go test ./apps/cnspec/cmd/interactive/ -run TestConnectorSnapshot -update
+//
+// What made curating them the better answer than leaving them generic is that
+// the generic screen is actively wrong for four of them. The secret classifier
+// puts --client-secret in CREDENTIAL and leaves --domain, --url, --account-id
+// and --client-id in OPTIONS, which is collapsed behind a single row: the
+// Auth0 tenant, the Keycloak server and the Zoom account -- the things being
+// scanned -- are hidden, and the client id is separated from the secret it
+// pairs with. And none of the six had a delivery route, so every one of them
+// drew a credential field and then refused to launch.
+//
+// The classifier needs no correcting for any of them, which is why no Secret or
+// NotSecret entry appears in those specs: --client-secret, --password, --token
+// and --api-key are read as secrets, while --client-id, --account-id, --org-id
+// and --username are read as the identifiers they are, and keycloak's --ca-cert
+// is correctly public.
+//
+// # Credential delivery declares nothing here any more
+//
+// Four of the files this package was assembled from ended with a block of
+// registered environment variables -- PORTAINER_ACCESS_TOKEN, IRU_TOKEN,
+// ARTIFACTORY_TOKEN and ARTIFACTORY_API_KEY; JAMF_CLIENT_SECRET, the two
+// MONGODB_ATLAS_*, NETLIFY_AUTH_TOKEN, NEXTDNS_API_KEY and
+// OKTA_API_PRIVATE_KEY; TAILSCALE_OAUTH_CLIENT_SECRET, VERCEL_TOKEN,
+// AUTH0_CLIENT_SECRET and seven more; ATLASSIAN_USER_TOKEN, DATABRICKS_TOKEN,
+// DD_API_KEY and six more. Each was read out of the receiving provider's own
+// ParseCLI and confirmed by running the provider with the credential missing,
+// so that the provider named the variable itself. Each was still a claim that a
+// particular provider reads a particular name, made by a person, checkable only
+// by another person.
+//
+// None of them is needed now that the launcher calls ParseCLI rather than
+// reading it, and the reasons those blocks gave are why the table could never
+// have been right:
+//
+//   - artifactory's --token needs a `bearer` credential; a password credential
+//     is spent as the legacy API key against the wrong header.
+//   - jamf routes its credential on cred.User carrying the client id,
+//     mongodbatlas on the labels "private-key" and "client-secret", and okta's
+//     key wants a private_key credential rather than a password. An untagged
+//     credential is dropped by all three without a word.
+//   - tailscale reads the same credential as the API token or as the OAuth
+//     client secret depending on whether --client-id is set, which is a decision
+//     only tailscale can make and which a variable name cannot express.
+//   - databricks resolves DATABRICKS_TOKEN itself, inside the SDK, when its own
+//     credential switch falls through -- and that switch has no default arm, so
+//     an untagged credential does not fail, it scans whatever account the
+//     ambient variable names. The launcher refuses instead: it looks for the
+//     value it sent in the asset that came back, and databricks either tagged it
+//     or it is gone.
+//   - helm's --password is the chart repository's, the provider reads no HELM_*
+//     variable, and there is no --ask-pass to hand the prompt to the child, so a
+//     typed credential with no registered route was refused outright.
+//   - activedirectory reads LOGONSERVER, USERDNSDOMAIN, USERDOMAIN and USERNAME
+//     to infer a controller and a principal, and reads nothing at all for the
+//     password. There was no honest variable to register, so a typed password
+//     was refused.
+//
+// All of them travel by inventory now, in whatever shape their own ParseCLI
+// builds. Nothing in this package decides where a credential lands.
+package forms

--- a/cli/launcher/forms/forms_ai.go
+++ b/cli/launcher/forms/forms_ai.go
@@ -1,0 +1,360 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+import "strings"
+
+// The AI & LLM family: nine connectors that mostly reduce to one API key from
+// one environment variable.
+//
+// That shape is the one the launcher got wrong first. A provider with a single
+// token has nothing to enumerate, so a value picker over it renders an empty
+// box with no explanation -- which is a category error, not a missing feature.
+// The credential-state readout in source_ambient.go is the widget for this
+// class: it names the *variable* that supplied the token, never the token, and
+// it is paired with a paste box for the shell the user has already left.
+//
+// But the family is not uniform, and applying one template to all nine would be
+// its own version of the same mistake:
+//
+//   - ambient API key: anthropic, claude, huggingface, mistral, openai,
+//     together. One token, one variable, a readout and a paste box.
+//   - URL-addressed, credential optional: ollama and vllm. Both are usually
+//     something you run yourself, addressed by host or endpoint, with no key at
+//     all. Each provider *does* declare a token for its hosted form, so the
+//     readout says so rather than implying the local case is missing something.
+//   - neither: mcp. Its target is a transport plus either a URL or a command to
+//     run, and its bearer token applies only to the HTTP(S) form. A readout that
+//     could not be hidden for the stdio form would be wrong half the time, so
+//     mcp gets an ordinary credential field with a verified route instead.
+//
+// Every environment variable named below was read out of the provider that
+// receives it, and each was then confirmed a second way -- the string is present
+// in the shipped binary, and for most of them the running provider was observed
+// using it. The flag *descriptions* were not treated as evidence: openai's
+// --token description does not mention OPENAI_API_KEY even though
+// connection.go reads it, and claude's --organization-id description names
+// ANTHROPIC_ORGANIZATION_ID which the connector never reads (only the SDK's
+// env-federation path does, which is why nothing below prefills from it).
+//
+//	anthropic   ANTHROPIC_API_KEY        --token
+//	            ANTHROPIC_ADMIN_API_KEY  --admin-token
+//	claude      ANTHROPIC_API_KEY        --token
+//	            ANTHROPIC_ADMIN_API_KEY  --admin-token
+//	huggingface HF_TOKEN                 --token
+//	mcp         MCP_TOKEN                --token
+//	mistral     MISTRAL_API_KEY          --token, then MISTRAL_KEY
+//	ollama      OLLAMA_API_TOKEN         --token
+//	            OLLAMA_HOST              --host
+//	openai      OPENAI_API_KEY           --token
+//	            OPENAI_ORG_ID            --organization
+//	            OPENAI_PROJECT_ID        --project
+//	            OPENAI_BASE_URL          --base-url
+//	together    TOGETHER_API_KEY         --token
+//	vllm        VLLM_API_KEY             --api-key
+//
+// None of these declare a ClassAmbient source id: the readout is filled
+// synchronously by refreshAmbient, and a source only adds an Activity for
+// something to wait on. `Source: ""` is the shape for a credential the launcher
+// reports on without one, and it keeps nine ids out of source_ids.go that
+// nothing would ever name.
+
+func init() {
+	registerAmbient(
+		// anthropic and claude are two connectors over the same platform and
+		// read the same two variables. Verified twice over: claude's
+		// connection.go reads ANTHROPIC_API_KEY and ANTHROPIC_ADMIN_API_KEY
+		// directly, and the shipped anthropic provider was observed doing the
+		// same -- with nothing set it refuses with "admin API key required: set
+		// --admin-token or ANTHROPIC_ADMIN_API_KEY", and with the variable set
+		// to a junk value it reaches the API and is turned away with a 401.
+		//
+		// Only the plain key gets a readout, though both connectors read a
+		// second variable for --admin-token. A second readout needs a `special`
+		// marker of its own and that marker has to be declared in
+		// launcherOwnedFields, which lives in a file this one does not own; the
+		// admin key therefore keeps its ordinary --admin-token field and the
+		// verified ANTHROPIC_ADMIN_API_KEY route registered below, and simply
+		// does not get a row saying whether the environment already holds one.
+		// Adding it later is one line there and a Name:"admin" credential here.
+		ambientCredential{
+			Connector: "anthropic", Flag: "token",
+			Env: []string{"ANTHROPIC_API_KEY"},
+		},
+		ambientCredential{
+			Connector: "claude", Flag: "token",
+			Env: []string{"ANTHROPIC_API_KEY"},
+		},
+
+		ambientCredential{
+			Connector: "huggingface", Flag: "token",
+			Env: []string{"HF_TOKEN"},
+		},
+
+		// mistral reads two, in this order, and Env order is what the readout
+		// reports, so it has to match: tokenFromConfig takes MISTRAL_API_KEY
+		// and falls back to MISTRAL_KEY. Both were observed on the shipped
+		// provider -- with neither set it refuses with "mistral: API key is
+		// required (use --token or set MISTRAL_API_KEY)", and MISTRAL_KEY alone
+		// gets past that check.
+		ambientCredential{
+			Connector: "mistral", Flag: "token",
+			Env: []string{"MISTRAL_API_KEY", "MISTRAL_KEY"},
+		},
+
+		// ollama is normally a server on this machine with no authentication at
+		// all, so the default hint -- "export OLLAMA_API_TOKEN, or paste one
+		// below" -- reads as an instruction and would send a local user looking
+		// for a credential that does not exist. This still names the variable,
+		// because that is what a hint is for, and adds the part the generic
+		// wording cannot know: that the token is for Ollama Cloud.
+		ambientCredential{
+			Connector: "ollama", Flag: "token",
+			Env: []string{"OLLAMA_API_TOKEN"},
+			Hint: "not set — for Ollama Cloud export OLLAMA_API_TOKEN or paste " +
+				"one below; a local server does not need one",
+			PasteHint: "paste an Ollama Cloud token — it never reaches the command line",
+			Compose:   composeOllamaHost,
+		},
+
+		ambientCredential{
+			Connector: "openai", Flag: "token",
+			Env:     []string{"OPENAI_API_KEY"},
+			Compose: composeOpenAIAccount,
+		},
+
+		ambientCredential{
+			Connector: "together", Flag: "token",
+			Env: []string{"TOGETHER_API_KEY"},
+		},
+
+		// vllm's credential flag is --api-key rather than --token, and an
+		// ambient credential can only redraw a flag it names into a paste box.
+		// The flag is already classified as a secret and already sits in
+		// CREDENTIAL with a verified route, so this is a readout on its own:
+		// it reports whether VLLM_API_KEY is set and says that an
+		// unauthenticated server -- the usual case -- needs neither.
+		//
+		// The hint points at the field by name rather than by direction. A
+		// readout with no flag to sit above is appended to the form, so it
+		// lands after the field it is talking about, and "below" would be
+		// pointing at the wrong half of the screen.
+		ambientCredential{
+			Connector: "vllm",
+			Env:       []string{"VLLM_API_KEY"},
+			Hint: "not set — export VLLM_API_KEY, or fill in the API key " +
+				"field; an unauthenticated server needs neither",
+		},
+	)
+
+	// There used to be a table of delivery routes here, one variable per flag,
+	// because a typed credential with no registered variable could not be
+	// carried at all. The connector's own ParseCLI answers that now, so the
+	// variables above are only what the *readouts* name -- what the provider
+	// reads when the launcher supplies nothing -- and no longer double as the
+	// launcher's only way to hand a value over.
+	//
+	// This family is where that distinction bites hardest. openai, ollama,
+	// huggingface and claude never read conn.Credentials at all, so a token
+	// typed into any of their forms lands in conn.Options and the OS keychain
+	// cannot hold it; the launch says so by name rather than pretending
+	// otherwise. See launchRequest.inventoryPlan.
+
+	// anthropic asks for nothing but a credential: no target, no options, and
+	// MinArgs of zero, so the empty Positional is what suppresses the derived
+	// argument slot the generic layer would otherwise offer.
+	registerSpec("anthropic", FormSpec{
+		Credential: []string{"token", "admin-token"},
+		Labels: map[string]string{
+			"token":       "API key",
+			"admin-token": "admin API key",
+		},
+	})
+
+	// claude is the same platform with a workload-identity path and discovery
+	// on top. The workspace picker is the one live source in this family:
+	// srcDiscoverClaudeWorkspaces asks cnspec's own discovery, which costs a
+	// round trip and a credential, so it is a LiveSource that runs when the
+	// field is opened rather than when the form is built.
+	//
+	// The WIF fields sit in CREDENTIAL because that is what they configure, not
+	// because they are secret -- an id and a path are neither, and they travel
+	// on the command line as the provider expects. Only the two keys are
+	// secrets, and both are classified as such by their names.
+	registerSpec("claude", FormSpec{
+		Target:      []string{"organization-id", "workspace-id"},
+		LiveSources: map[string]string{"workspace-id": srcDiscoverClaudeWorkspaces},
+		Credential: []string{
+			"token", "admin-token",
+			"identity-token-file", "federation-rule-id", "service-account-id",
+		},
+		Labels: map[string]string{
+			"organization-id":     "organization",
+			"workspace-id":        "workspace",
+			"token":               "API key",
+			"admin-token":         "admin API key",
+			"identity-token-file": "OIDC token file",
+			"federation-rule-id":  "federation rule",
+			"service-account-id":  "service account",
+		},
+	})
+
+	// huggingface scopes a scan to one user or organization. The two values
+	// --namespace-type accepts are the provider's own: it rejects anything
+	// other than "user" or "org" in ParseCLI, so offering them is offering the
+	// whole set.
+	registerSpec("huggingface", FormSpec{
+		Target:  []string{"namespace", "namespace-type"},
+		Choices: map[string][]string{"namespace-type": {"user", "org"}},
+		Labels: map[string]string{
+			"namespace":      "user or organization",
+			"namespace-type": "namespace kind",
+			"token":          "API token",
+		},
+	})
+
+	// mcp takes two arguments -- a transport and then either a URL or the
+	// command that starts a server -- and which of its flags mean anything
+	// depends on the first. A bearer token is for the HTTP(S) form; a working
+	// directory is for the stdio one.
+	//
+	// --env stays hidden, and now for one reason rather than two. It was both
+	// unfillable -- a list flag with no values to list, drawn as a multi-select
+	// with nothing in it -- and unsafe, and typeEmptyLists fixed the first: an
+	// optionless list is a typed, comma-separated field now, so a row here
+	// would work.
+	//
+	// The second reason is the one that decides it. What goes in --env for a
+	// stdio MCP server is that server's own credentials, `--env
+	// GITHUB_TOKEN=…` being the documented shape, and the flag is a list of
+	// KEY=VALUE pairs rather than a credential the classifier can recognise --
+	// so the launcher would put it on a command line `ps auxww` can read, with
+	// nothing to warn the person typing. It is not dropped from cnspec, only
+	// from this screen; `--env KEY=VALUE` still works on the command line,
+	// which is where the person typing it can see where it goes.
+	registerSpec("mcp", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "transport", Desc: "how to reach the server",
+				Required: true,
+				Options:  []string{"http", "https", "stdio"},
+			},
+			{
+				Label: "server", Desc: "the server URL, or the command that starts one",
+				Required: true,
+			},
+		},
+		Target:     []string{"cwd"},
+		Credential: []string{"token"},
+		Labels: map[string]string{
+			"cwd":   "working directory",
+			"token": "bearer token",
+		},
+		ShowFlagsIf: map[string][]string{
+			"token": {"http", "https"},
+			"cwd":   {"stdio"},
+		},
+		Hide: []string{"env"},
+	})
+
+	registerSpec("mistral", FormSpec{
+		Target: []string{"workspace", "base-url"},
+		Labels: map[string]string{
+			"workspace": "workspace",
+			"base-url":  "API base URL",
+			"token":     "API key",
+		},
+	})
+
+	// ollama is addressed by URL, and the default is the one every local
+	// install listens on. It is offered as a suggestion rather than a fixed
+	// value: the field stays free text, so a server on another host or port
+	// still works.
+	registerSpec("ollama", FormSpec{
+		Target:  []string{"host"},
+		Choices: map[string][]string{"host": {"http://localhost:11434"}},
+		Labels: map[string]string{
+			"host":  "server",
+			"token": "cloud API token",
+		},
+	})
+
+	registerSpec("openai", FormSpec{
+		Target: []string{"organization", "project", "base-url"},
+		Labels: map[string]string{
+			"organization": "organization",
+			"project":      "project",
+			"base-url":     "API base URL",
+			"token":        "API key",
+		},
+	})
+
+	registerSpec("together", FormSpec{
+		Target: []string{"project", "base-url"},
+		Labels: map[string]string{
+			"project":  "project",
+			"base-url": "API base URL",
+			"token":    "API key",
+		},
+	})
+
+	// vllm is the other locally-hosted one, and the only connector in the
+	// family that takes its target as an argument: `vllm <endpoint>`, declared
+	// MinArgs and MaxArgs of one.
+	registerSpec("vllm", FormSpec{
+		Positional: []PositionalSpec{{
+			Label:    "endpoint",
+			Desc:     "the vLLM server URL, e.g. http://localhost:8000",
+			Required: true,
+		}},
+		Credential: []string{"api-key"},
+		Labels: map[string]string{
+			"api-key":  "API key",
+			"insecure": "skip TLS verification",
+		},
+	})
+}
+
+// composeOllamaHost shows the server the scan will actually talk to.
+//
+// The provider takes --host, then OLLAMA_HOST, then localhost:11434. Mirroring
+// the middle step into an editable field is how a user gets to notice that a
+// variable in their shell is pointing the scan somewhere other than where they
+// assumed.
+func composeOllamaHost(f *form, env envLookup) {
+	prefillFromEnv(f, env, "host", "OLLAMA_HOST")
+}
+
+// composeOpenAIAccount fills in the three non-secret values openai reads from
+// the environment alongside its key.
+//
+// Only these three: OPENAI_ADMIN_KEY and the webhook and custom-header
+// variables also appear in the shipped binary, but they come from the vendored
+// SDK rather than from the connector, and the connector's own reads are the
+// only ones a launcher can honestly report.
+func composeOpenAIAccount(f *form, env envLookup) {
+	prefillFromEnv(f, env, "organization", "OPENAI_ORG_ID")
+	prefillFromEnv(f, env, "project", "OPENAI_PROJECT_ID")
+	prefillFromEnv(f, env, "base-url", "OPENAI_BASE_URL")
+}
+
+// prefillFromEnv fills one non-secret field from the variable the provider
+// reads for it, and says so.
+//
+// A value the user typed is never overwritten, and neither is one another
+// source already found: the environment is what the provider would have fallen
+// back to, not an override. Nothing here is ever called for a secret -- a
+// credential's value is exactly what the launcher does not hold.
+func prefillFromEnv(f *form, env envLookup, flag, name string) {
+	value := strings.TrimSpace(envValue(env, name))
+	if value == "" {
+		return
+	}
+	i := f.IndexOfFlag(flag)
+	if i < 0 || f.Fields()[i].Secret || f.Fields()[i].IsSet() {
+		return
+	}
+	f.Fields()[i].SetValue(value)
+	f.Fields()[i].SetPrefilled(ambientWhyEnv)
+}

--- a/cli/launcher/forms/forms_cloud.go
+++ b/cli/launcher/forms/forms_cloud.go
@@ -1,0 +1,538 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// The Cloud & Virtualization family: the three big clouds people reach for
+// first -- aws, azure and gcp -- the smaller ones addressed by a token or a
+// named local profile, and the four hypervisors.
+//
+// They divide into three shapes, and the specs below are built around the
+// division rather than around who wrote them:
+//
+//   - Account-wide clouds (aws, azure, gcp, alicloud, digitalocean, equinix,
+//     hcp, hetzner, oci, stackit). The target is an account, a project or a
+//     tenancy, and the useful screen leads with the thing that selects one --
+//     a profile, a subscription, a project id -- rather than with a host.
+//   - OpenStack, which is addressed by a project and authenticated with a
+//     token or a password, and is neither a public cloud nor a host.
+//   - The hypervisors (nutanix, proxmox, vcd, vsphere). Each is addressed by a
+//     host, and its credential is a password or an API token for that host.
+//     They were split across two files before this one and are together now,
+//     because "a box you log in to" is what they have in common and the letter
+//     in the old file name was not.
+//
+// Every flag named below was read out of internal/connectors/connectors.json,
+// which is the recorded copy of what the installed providers declare. Nothing
+// here is inferred from a usage string or from what a sibling cloud happens to
+// spell its flags -- applySpec drops a flag the connector does not declare, so
+// an invented name produces a field that silently never appears.
+//
+// The credential notes below were established by running the provider, not by
+// reading its prose, and several of them are kept even though the route they
+// describe no longer exists: they record what a provider does with a value it
+// is handed, which is still what decides whether a launch is safe. What has
+// changed is that the launcher asks the provider rather than consulting a table
+// written from those transcripts. Where no route exists, the flag is left out
+// of Credential and said so, rather than pointed at a plausible-looking
+// variable the provider never reads.
+
+// awsRegions is a display list, not a validation list: the region flag stays
+// free text so a region newer than this binary still works.
+var awsRegions = []string{
+	"us-east-1", "us-east-2", "us-west-1", "us-west-2",
+	"eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1",
+	"ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
+	"ap-northeast-2", "ca-central-1", "sa-east-1",
+}
+
+// alicloudRegions is a display list, not a validation list: the region flag
+// stays free text so a region newer than this binary still works. Every id here
+// was found in the installed alicloud provider's own string table.
+var alicloudRegions = []string{
+	"cn-hangzhou", "cn-shanghai", "cn-beijing", "cn-shenzhen", "cn-qingdao",
+	"cn-zhangjiakou", "cn-huhehaote", "cn-wulanchabu", "cn-chengdu",
+	"cn-heyuan", "cn-guangzhou", "cn-hongkong",
+	"ap-southeast-1", "ap-southeast-3", "ap-southeast-5", "ap-southeast-6",
+	"ap-southeast-7", "ap-northeast-1", "ap-northeast-2", "ap-south-1",
+	"us-east-1", "us-west-1", "eu-central-1", "eu-west-1",
+	"me-east-1", "me-central-1",
+}
+
+// ociRegions is a display list, not a validation list: the region flag stays
+// free text so a region newer than this binary still works. The entries are the
+// commercial-realm (oc1) identifiers from the OCI Go SDK's own regions.json,
+// trimmed to the ones people actually reach for -- the full realm has 46.
+var ociRegions = []string{
+	"us-ashburn-1", "us-phoenix-1", "us-chicago-1", "us-sanjose-1",
+	"ca-toronto-1", "ca-montreal-1",
+	"eu-frankfurt-1", "eu-amsterdam-1", "eu-zurich-1", "eu-madrid-1",
+	"eu-paris-1", "eu-milan-1", "eu-stockholm-1",
+	"uk-london-1", "uk-cardiff-1",
+	"ap-tokyo-1", "ap-osaka-1", "ap-seoul-1", "ap-singapore-1",
+	"ap-sydney-1", "ap-melbourne-1", "ap-mumbai-1",
+	"sa-saopaulo-1", "sa-vinhedo-1", "sa-santiago-1",
+	"me-dubai-1", "me-jeddah-1", "il-jerusalem-1", "af-johannesburg-1",
+}
+
+// ociAuthMethods mirrors connection.SupportedAuthMethods in the oci provider,
+// which ParseCLI validates --auth-method against and rejects anything outside
+// of. A value not on this list is a hard error before the scan starts, so this
+// is one of the few lists that really is the whole set.
+var ociAuthMethods = []string{
+	"api-key", "instance-principal", "resource-principal",
+	"workload-identity", "security-token",
+}
+
+func init() {
+	// alicloud authenticates with an AccessKey pair. --access-key-id is not a
+	// secret -- the classifier reads the "-id" suffix as a reference, and it is
+	// half of a pair whose other half is the credential -- so it travels on the
+	// command line while the secret travels in the environment. That split was
+	// checked end to end rather than assumed:
+	//
+	//	ALIBABA_CLOUD_ACCESS_KEY_SECRET=… cnspec shell alicloud \
+	//	    --region cn-hangzhou --access-key-id …
+	//	→ SDKError … Code: InvalidAccessKeyId.NotFound
+	//
+	// which is the STS round trip refusing a bogus key, i.e. the pair arrived.
+	// Dropping the flag from that same command instead gives
+	//
+	//	unable to get credentials … Access key ID must be specified via
+	//	environment variable (ALIBABA_CLOUD_ACCESS_KEY_ID)
+	//
+	// so the provider really is combining the flag with the variable.
+	//
+	// --sts-token is the one credential in this file the provider throws away,
+	// and the launcher now says so rather than guessing around it. alicloud's
+	// own ParseCLI keeps --access-key-id, --region, --regions, --role-arn and
+	// --role-session-name and drops --sts-token entirely -- confirmed by
+	// sending it and looking for it in the asset that came back, which is what
+	// TestEveryCredentialFieldRoundTrips does and records. A launch that fills
+	// only that box is refused with a message naming the flag.
+	//
+	// It was previously left unrouted on weaker evidence: ALIBABA_CLOUD_SECURITY_TOKEN
+	// is in the binary's string table, and probing it produced the same
+	// InvalidAccessKeyId.NotFound with and without the variable, which proved
+	// nothing either way.
+	//
+	// A hand-written inventory did not work either, and that was worth checking
+	// rather than assuming: a file carrying options.access-key-id and
+	// options.access-key-secret scans and then fails with the same "Access key
+	// ID must be specified via environment variable" -- the provider never
+	// reads those options back. Which option key it *does* read is alicloud's
+	// business, and asking its ParseCLI is how the launcher now finds out.
+	//
+	// The profile leads TARGET, and it is the one field here that is not a
+	// flag: alicloud declares no --profile, so the chosen profile travels to
+	// the child as ALIBABA_CLOUD_PROFILE. See the note at the bottom of this
+	// file for why that needed a seam rather than a spelling.
+	registerSpec("alicloud", FormSpec{
+		Positional: []PositionalSpec{{
+			Label:   "profile",
+			Desc:    "a profile from ~/.alibabacloud/credentials",
+			Special: SpecialAlicloudProfile,
+			Source:  srcAlicloudProfile,
+		}},
+		Target:     []string{"region", "regions", "role-arn"},
+		Credential: []string{"access-key-id", "access-key-secret"},
+		Choices:    map[string][]string{"region": alicloudRegions},
+		Labels: map[string]string{
+			"access-key-id":     "AccessKey ID",
+			"access-key-secret": "AccessKey secret",
+			"sts-token":         "STS security token",
+			"role-arn":          "assume RAM role",
+			"role-session-name": "RAM role session name",
+			"region":            "region",
+			"regions":           "regions to scan (optional)",
+		},
+	})
+
+	registerSpec("aws", FormSpec{
+		Target:  []string{"profile", "region", "role"},
+		Sources: map[string]string{"profile": srcAWSProfile},
+		Choices: map[string][]string{"region": awsRegions},
+		Labels: map[string]string{
+			"profile": "profile", "region": "region", "role": "assume role",
+		},
+	})
+
+	registerSpec("azure", FormSpec{
+		Target:     []string{"subscriptions"},
+		Credential: []string{"auth-method", "tenant-id", "client-id", "client-secret", "certificate-path", "certificate-secret", "federated-token-file"},
+		Choices: map[string][]string{
+			"auth-method": {"cli", "env", "workload-identity", "managed-identity"},
+		},
+		Labels: map[string]string{"subscriptions": "subscriptions"},
+	})
+
+	// digitalocean is a token and nothing else: the account is the target, and
+	// what varies is which of its resources to look at. So --discover is the
+	// TARGET here rather than an option behind the "more" fold, which is the
+	// rule this file follows for a connector that declares no scoping flag at
+	// all. Promoting it anywhere a real target flag exists would only push that
+	// flag down.
+	//
+	// The credential widgets -- the readout naming DIGITALOCEAN_TOKEN, the
+	// paste box over --token, and the second, report-only readout for the
+	// Spaces keys -- are declared in source_ambient.go and are not repeated
+	// here. DIGITALOCEAN_TOKEN is registered there too, so --token already has
+	// its route.
+	registerSpec("digitalocean", FormSpec{
+		Target:     []string{"discover"},
+		Credential: []string{"token"},
+		// --token is deliberately not relabelled. applyAmbient redraws it as
+		// the paste box and gives it the guarantee as its description, and the
+		// flag's own name is what the readout above it is about; a second name
+		// for the same thing only makes the pair harder to read.
+		Labels: map[string]string{"filters": "filter discovered assets"},
+	})
+
+	// equinix takes a sub-command pair -- `equinix org <id>` or `equinix
+	// project <id>` -- which MinArgs=2 records and the usage string only hints
+	// at. The two words come from the connector's own help and are emitted
+	// verbatim.
+	//
+	// PACKET_AUTH_TOKEN is already in the delivery registry, and the provider
+	// names it itself: without it the command refuses, and with it
+	//
+	//	PACKET_AUTH_TOKEN=… cnspec shell equinix project …
+	//	→ GET https://api.equinix.com/metal/v1/projects: 401 Invalid authentication token
+	//
+	// which is the API rejecting a bogus token, i.e. the token arrived.
+	registerSpec("equinix", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "kind", Desc: "an organization, or a single project",
+				Required: true,
+				Options:  []string{"org", "project"},
+			},
+			{
+				Label: "id", Desc: "the organization or project id",
+				Required: true,
+			},
+		},
+		Credential: []string{"token"},
+		Labels:     map[string]string{"token": "API token"},
+	})
+
+	// gcp follows the same shape as k8s: ask what is being scanned, then only
+	// what that answer needs. The sub-command words come from the connector's
+	// own help -- `gcp project <ID>`, `gcp org <ID>`, `gcp instance <NAME>
+	// --project-id <ID> --zone <ZONE>` -- and are emitted verbatim.
+	registerSpec("gcp", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "what to scan", Desc: "the kind of Google Cloud resource",
+				Required: true,
+				Options: []string{
+					"project", "organization", "folder",
+					"compute instance", "compute snapshot", "container registry",
+				},
+				Emit: map[string]string{
+					"project":            "project",
+					"organization":       "org",
+					"folder":             "folder",
+					"compute instance":   "instance",
+					"compute snapshot":   "snapshot",
+					"container registry": "gcr",
+				},
+			},
+			{
+				Label: "id", Desc: "project, organization, folder id or resource name",
+				Required: true,
+				SourceBy: map[string]string{
+					"project":            srcGCPProject,
+					"container registry": srcGCPProject,
+				},
+				// gcloud config names one project; the full list is a live
+				// call, fetched when the picker is opened. It belongs only to
+				// the kinds that take a project -- an organization id is not
+				// one of them.
+				LiveSourceBy: map[string]string{
+					"project":            srcGCPProjectAll,
+					"container registry": srcGCPProjectAll,
+				},
+			},
+		},
+		Target:      []string{"project-id", "zone", "repository"},
+		Sources:     map[string]string{"project-id": srcGCPProject, "zone": srcGCPZone},
+		LiveSources: map[string]string{"project-id": srcGCPProjectAll},
+		Labels: map[string]string{
+			"project-id":       "project",
+			"credentials-path": "service account key",
+		},
+		// A single instance or snapshot is addressed by project and zone; a
+		// registry by its repository. Nothing else needs either.
+		ShowFlagsIf: map[string][]string{
+			"project-id": {"compute instance", "compute snapshot"},
+			"zone":       {"compute instance", "compute snapshot"},
+			"repository": {"container registry"},
+		},
+		Credential: []string{"credentials-path"},
+	})
+
+	// hcp connects with a service principal. The client id is not a secret and
+	// travels as a flag; the client secret travels in HCP_CLIENT_SECRET, which
+	// was confirmed as the exact mixture the launcher produces:
+	//
+	//	cnspec shell hcp --client-id …
+	//	→ HCP credentials required: set --client-id and --client-secret
+	//	HCP_CLIENT_SECRET=… cnspec shell hcp --client-id …
+	//	→ failed to get new token: oauth2: "unauthorized" "Authentication failed."
+	//
+	// The second reached HashiCorp's token endpoint, so the flag and the
+	// variable were combined into one credential.
+	//
+	// --org-id and --project-id scope the connection and are optional: with
+	// neither, the connection is the service principal's whole organization.
+	// Neither gets a picker -- discover.hcp.projects is a declared id with no
+	// registered source, excluded in source_discover_test.go because a
+	// discovered project's id is composed at runtime and nothing shows where it
+	// lands. Naming it here would fail TestEverySourceNamedByASpecExists.
+	registerSpec("hcp", FormSpec{
+		Target:     []string{"org-id", "project-id"},
+		Credential: []string{"client-id", "client-secret"},
+		Labels: map[string]string{
+			"org-id":        "organization (optional)",
+			"project-id":    "project (optional)",
+			"client-id":     "service principal client id",
+			"client-secret": "service principal client secret",
+		},
+	})
+
+	// hetzner is the same shape as digitalocean: one token, and the only
+	// question left is what to enumerate, so --discover leads. --endpoint
+	// stays an option -- it points the client at a different Hetzner Cloud API,
+	// which almost nobody wants and which would otherwise sit above the thing
+	// the form is for.
+	//
+	// The readout and paste box come from source_ambient.go, and HCLOUD_TOKEN
+	// is registered there.
+	registerSpec("hetzner", FormSpec{
+		Target:     []string{"discover"},
+		Credential: []string{"token"},
+		// As digitalocean: the paste box names itself.
+		Labels: map[string]string{"endpoint": "API endpoint (optional)"},
+	})
+
+	// nutanix reaches a Prism Central instance, so the endpoint is the target
+	// and it is the connector's one required flag -- named in TARGET so it is
+	// reachable without opening the "more" fold, where focusFirstMissing would
+	// otherwise park a cursor that cannot be moved to it.
+	//
+	// It authenticates two ways -- basic auth, or an IAM API key -- and neither
+	// has an environment variable to travel in. NUTANIX_API_KEY,
+	// NUTANIX_PASSWORD and PRISM_CENTRAL_API_KEY were all tried against
+	// `cnspec shell nutanix --endpoint …` and all three left the provider
+	// saying "missing credentials: provide --user with --password/--ask-pass,
+	// or --api-key".
+	//
+	// Neither needs one. Both travel by inventory, in whatever shape the
+	// provider's own ParseCLI builds for them, and --ask-pass remains a toggle
+	// the user can tick to be prompted instead.
+	registerSpec("nutanix", FormSpec{
+		Target:     []string{"endpoint", "port", "user"},
+		Credential: []string{"ask-pass", "password", "api-key"},
+		Labels: map[string]string{
+			"endpoint": "Prism Central host",
+			"user":     "username",
+			"ask-pass": "prompt for password",
+			"api-key":  "IAM API key",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// oci has three ways in and the form has to show all of them without
+	// implying they combine: a named profile out of ~/.oci/config, an explicit
+	// API key (tenancy + user + region + fingerprint + key file), or one of the
+	// keyless principal flows selected with --auth-method.
+	//
+	// The scope is --tenancy. --filters narrows what is *inside* a tenancy --
+	// its keys are regions=, compartments=, tag:, and the exclude: forms of
+	// each, checked against filterKeyPrefixes in the provider -- so it is not a
+	// second way to name an account and gets no discovery picker.
+	//
+	// --key-secret is the passphrase for an encrypted API key, and it is named
+	// here now that it has somewhere to go. It was left out while three things
+	// were true and still are: oci declares no --ask-key-secret, reads no
+	// environment variable of its own anywhere in its provider or connection
+	// code, and its inventory shape cannot be produced from this form --
+	// NewOciConnection requires conf.Credentials[0] to be a private_key
+	// credential carrying both the key and the passphrase, while --key-path is
+	// classified as a plain reference and never becomes a credential at all.
+	//
+	// None of that is a problem the launcher has to solve any more. The
+	// connector's own ParseCLI builds whatever credential oci wants out of the
+	// flags it is handed, including the private_key shape this form could never
+	// have produced, and the launcher writes back what it gets.
+	registerSpec("oci", FormSpec{
+		Target:     []string{"profile", "region", "tenancy", "filters"},
+		Credential: []string{"auth-method", "config-file", "user", "fingerprint", "key-path", "key-secret"},
+		Sources:    map[string]string{"profile": srcOCIProfile},
+		Choices:    map[string][]string{"region": ociRegions, "auth-method": ociAuthMethods},
+		Labels: map[string]string{
+			"profile":     "config profile",
+			"config-file": "config file",
+			"tenancy":     "tenancy OCID",
+			"user":        "user OCID",
+			"fingerprint": "API key fingerprint",
+			"key-path":    "API key file",
+			"key-secret":  "API key passphrase",
+			"auth-method": "authentication method",
+			"filters":     "filters (regions, compartments, tags)",
+		},
+	})
+
+	// openstack is a Keystone endpoint plus a scope. Either half can come from
+	// a clouds.yaml entry named by --cloud, which is why --cloud leads TARGET:
+	// choosing one answers the auth URL, the project and the region at once.
+	//
+	// Both of its secrets travel in the environment. resolveAuth in the
+	// provider hands everything to gophercloud's clientconfig, whose v2auth and
+	// v3auth read OS_PASSWORD and OS_APPLICATION_CREDENTIAL_SECRET whenever the
+	// corresponding field is still empty -- which is exactly the state the
+	// launcher leaves them in when it strips the secret off the command line.
+	// The inventory route is *not* available here and must not be claimed: the
+	// provider comments say passwords are deliberately never read back out of
+	// conf.Options, and conn.Options is where a generated inventory would put
+	// one, since openstack spells its user flag --username and the launcher
+	// only recognises --user.
+	registerSpec("openstack", FormSpec{
+		Target: []string{
+			"cloud", "auth-url", "region",
+			"project-name", "project-id", "project-domain-name", "project-domain-id",
+		},
+		Credential: []string{
+			"username", "password", "user-domain-name", "user-domain-id",
+			"application-credential-id", "application-credential-name",
+			"application-credential-secret",
+		},
+		Labels: map[string]string{
+			"cloud":                         "clouds.yaml entry",
+			"auth-url":                      "Keystone auth URL",
+			"project-name":                  "project",
+			"project-id":                    "project ID",
+			"project-domain-name":           "project domain",
+			"project-domain-id":             "project domain ID",
+			"user-domain-name":              "user domain",
+			"user-domain-id":                "user domain ID",
+			"application-credential-id":     "application credential ID",
+			"application-credential-name":   "application credential",
+			"application-credential-secret": "application credential secret",
+			"insecure":                      "skip TLS verification",
+		},
+	})
+
+	// proxmox is a host URL and an API token. It declares no --ask-token and
+	// reads no environment variable of its own -- there is no os.Getenv
+	// anywhere in the provider, and no PROXMOX_* string in the shipped binary
+	// -- so an inventory file is the only way its token travels, which is what
+	// every credential now does.
+	registerSpec("proxmox", FormSpec{
+		Target:     []string{"host"},
+		Credential: []string{"token"},
+		Labels: map[string]string{
+			"host":     "host URL",
+			"token":    "API token",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// stackit is one project, named by --project-id. That is required *input*,
+	// not something to discover: NewStackitConnection refuses to build without
+	// it, and there is no API to list projects before you have authenticated to
+	// one. So no picker is attached to it.
+	//
+	// --service-account-key is a JSON key blob and the shared classifier does
+	// not see it: the name ends in "-key", which is neither a strong secret
+	// word nor a reference, so without the override below the whole key would
+	// go on the command line where `ps auxww` reads it. The two "-path"
+	// variants are genuinely paths and are correctly left unmarked.
+	registerSpec("stackit", FormSpec{
+		Target: []string{"project-id", "region", "endpoint"},
+		Credential: []string{
+			"token", "service-account-key", "service-account-key-path",
+			"private-key", "private-key-path",
+		},
+		Secret: []string{"service-account-key"},
+		Labels: map[string]string{
+			"project-id":               "project",
+			"token":                    "service account token",
+			"service-account-key":      "service account key (JSON)",
+			"service-account-key-path": "service account key file",
+			"private-key":              "service account private key",
+			"private-key-path":         "service account private key file",
+		},
+	})
+
+	// vcd names its host and user as flags rather than as a positional, and
+	// marks both FlagOption_Required -- so they have to be promoted into TARGET
+	// here or they sit in OPTIONS behind the fold, where a cursor parked on a
+	// missing required field cannot be reached.
+	//
+	// --ask-pass stays an ordinary toggle on the form. Ticking it makes the
+	// child prompt, which is the best route there is because the value never
+	// exists outside the process that uses it; typing the password instead
+	// carries it by keychain. What the launcher no longer does is substitute
+	// the first for the second.
+	registerSpec("vcd", FormSpec{
+		Target:     []string{"host", "user", "organization"},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"ask-pass":     "prompt for password",
+			"organization": "organization (optional)",
+		},
+	})
+
+	// vsphere is addressed by a single positional argument, and its shape is
+	// the reason this spec exists at all: ParseCLI prepends "scheme://" to the
+	// argument and hands it to url.Parse, so the user half is everything before
+	// the *last* @ and vCenter's realm form -- chris@vsphere.local@host --
+	// parses as user "chris@vsphere.local" on host "host". There is no flag for
+	// it and there is no separate realm flag, so a spec that mapped the value
+	// onto one would be inventing something the connector does not declare. It
+	// is a positional field, labelled to say what belongs in it, and an
+	// optional :port rides along the same way url.Parse takes one.
+	//
+	// Like vcd, the password rides --ask-pass and needs no registration.
+	registerSpec("vsphere", FormSpec{
+		Positional: []PositionalSpec{{
+			Label:    "user@realm@host",
+			Desc:     "vCenter or ESXi host, with the user and realm to log in as",
+			Required: true,
+		}},
+		Credential: []string{"ask-pass", "password"},
+		Labels:     map[string]string{"ask-pass": "prompt for password"},
+	})
+}
+
+// How srcAlicloudProfile is attached, and why it took a change to the contract.
+//
+// The source reads ~/.alibabacloud/credentials and declares
+// Env: ALIBABA_CLOUD_PROFILE, so a chosen profile can travel to a connector
+// that has no --profile flag. Attaching it needs a field, and until
+// PositionalSpec.Special existed the only field shape a spec could add for a
+// flagless value was a positional -- which was exactly the problem:
+//
+//   - args() emits every visible positional whose emitted() is non-empty, so
+//     the profile would also be appended to the command line. alicloud declares
+//     MinArgs=0 and MaxArgs=0, and `cnspec shell alicloud staging` answers
+//     `unknown command "staging" for "cnspec shell alicloud"`. The form would
+//     assemble a command that cannot run.
+//   - the obvious escape, an empty Emit map, suppressed the argument by making
+//     emitted() return "" for every value -- but formEnvironment builds the
+//     variable out of emitted() too, so the child would get
+//     ALIBABA_CLOUD_PROFILE= instead. An empty variable is not an absent one;
+//     the SDK reads it as an explicit empty profile.
+//
+// Both halves of the seam read the same accessor, so no spelling of a spec
+// carried the value without also emitting it. Special is the missing half: it
+// marks the field as the launcher's, which args() already skips for both
+// positionals and flags, while leaving emitted() -- and therefore
+// formEnvironment -- untouched. The same seam is what attaches DOCKER_CONTEXT
+// to docker and container in forms_container.go.
+//
+// Leaving the field empty is still the old behaviour and still correct: no
+// variable is set, and whatever the credentials file and ALIBABA_CLOUD_PROFILE
+// already say in the user's own shell is inherited by the child untouched.

--- a/cli/launcher/forms/forms_container.go
+++ b/cli/launcher/forms/forms_container.go
@@ -1,0 +1,215 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Containers & Kubernetes: container, docker, helm, k8s, kustomize and
+// portainer.
+//
+// Two of the six are live systems and four are files on disk, and the split is
+// what most of the curation here is about. docker, container and k8s can be
+// pointed at something running -- a daemon, a cluster -- or at something
+// written down, and the first question each of them asks is which. helm and
+// kustomize are renderers: they take a chart or an overlay and produce
+// manifests, so their form is a path plus the few values that change what gets
+// rendered. portainer is neither; it is an API service reached with an address
+// and a token.
+//
+// The path-shaped members of this family have the same problem the
+// infrastructure-as-code readers do: the derived slot spells the usage string
+// verbatim, so an uncurated helm asks for "PATH" where it means "a chart
+// directory, a packaged chart, or a release in a cluster". Naming the argument
+// in the connector's own vocabulary is most of what a spec buys here.
+
+// containerSpec splits what used to be one opaque reference into the four
+// things it can actually be. A registry image is deliberately not enumerated:
+// listing a registry needs credentials and a round trip, and cnspec already
+// does it properly through --discover container-images.
+//
+// The context comes before the reference because it decides what the reference
+// can be. docker and container declare no --context -- verified against the
+// installed os provider metadata, which lists only --sudo, --id-detector,
+// --disable-cache and --container-proxy -- so the chosen context travels as
+// DOCKER_CONTEXT, which is what the docker CLI reads and what mql's own
+// dockerclient honours. It is only shown for the two kinds it can affect: a
+// Dockerfile is read off this disk, and a registry reference is resolved by
+// cnspec rather than by a daemon.
+var containerSpec = FormSpec{
+	Positional: []PositionalSpec{
+		{
+			Label:    "kind",
+			Desc:     "what the reference points at",
+			Required: true,
+			Options:  []string{"running container", "local image", "registry image", "dockerfile"},
+			Emit: map[string]string{
+				"running container": "",
+				"local image":       "",
+				"registry image":    "",
+				"dockerfile":        "file",
+			},
+		},
+		{
+			Label:   "docker context",
+			Desc:    "which daemon to ask; leave empty for the current one",
+			Special: SpecialDockerContext,
+			Source:  srcDockerContext,
+			ShowIf:  []string{"running container", "local image"},
+		},
+		{
+			Label:    "reference",
+			Desc:     "container name, image tag, registry reference or path",
+			Required: true,
+			SourceBy: map[string]string{
+				"running container": srcDockerContainer,
+				"local image":       srcDockerImage,
+			},
+			// A registry holds more than one image, and cnspec enumerates it
+			// properly through discovery.
+			DiscoverBy: map[string][]string{
+				"registry image": {"container-images"},
+			},
+		},
+	},
+}
+
+func init() {
+	registerSpec("container", containerSpec)
+
+	// cnspec infers what a container reference points at from the reference
+	// itself: `scan docker <id>` and `scan docker ubuntu:latest` are the same
+	// syntax, and the only sub-command word the connector accepts is `file`.
+	// So the kind here steers which values are offered, and emits nothing --
+	// except for a Dockerfile, where `file` is real.
+	registerSpec("docker", containerSpec)
+
+	// A helm chart is two different things wearing one argument. `helm ./chart`
+	// reads a directory or a .tgz off disk; `helm ingress-nginx --repo <url>`
+	// fetches one by name, and only then do --repo, --version and the registry
+	// credentials mean anything. Both were run to confirm the second shape
+	// takes a bare chart name as its positional.
+	//
+	// --values is shown. It used to be hidden, along with the other five
+	// list-typed flags, because a FlagType_List field became a multi-choice
+	// with no options and no keystroke could fill one -- a true description of
+	// the field engine and a poor answer for this flag, since a chart rendered
+	// without its values file is not the chart anyone deploys. typeEmptyLists
+	// makes an optionless list a typed, comma-separated field, which is how
+	// `--values a.yaml,b.yaml` already reaches a provider from a shell.
+	//
+	// The four --set variants stay hidden on their own merits. They set
+	// individual template keys, with helm's own escaping rules for the dots and
+	// commas that appear inside a value, which a comma-separated box would
+	// mangle rather than express; --values takes the same content as a file and
+	// is the shape a launcher can offer honestly. --api-versions is render
+	// fidelity for one cluster rather than a description of the target.
+	registerSpec("helm", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "chart source", Desc: "a chart on disk, or one fetched from a repository",
+				Required: true,
+				Options:  []string{"local chart", "chart repository"},
+				// helm takes no sub-command word: the selector steers which
+				// questions are asked and contributes nothing to the command.
+				Emit: map[string]string{"local chart": "", "chart repository": ""},
+			},
+			{
+				Label: "chart", Desc: "a directory or .tgz on disk, or the chart name to fetch",
+				Required: true,
+			},
+		},
+		// release-name and namespace belong in TARGET because a chart rendered
+		// under a different release or namespace is a different set of
+		// manifests -- which is the thing being scanned. --kube-version shapes
+		// the render too but has a working default and is a knob rather than a
+		// target, so it keeps its label and stays in OPTIONS.
+		Target:     []string{"repo", "version", "release-name", "namespace", "values"},
+		Credential: []string{"username", "password"},
+		Labels: map[string]string{
+			"repo":         "repository URL",
+			"version":      "chart version",
+			"release-name": "release name",
+			"namespace":    "release namespace",
+			"kube-version": "target Kubernetes version",
+			"username":     "repository user",
+			"password":     "repository password",
+			"values":       "values files",
+		},
+		// Everything a remote fetch needs, and nothing a local chart has any
+		// use for.
+		ShowFlagsIf: map[string][]string{
+			"repo":     {"chart repository"},
+			"version":  {"chart repository"},
+			"username": {"chart repository"},
+			"password": {"chart repository"},
+		},
+		Hide: []string{
+			// Per-key overrides and render fidelity; see above.
+			"set", "set-string", "set-json", "set-file", "api-versions",
+			// Helm's own plumbing: where the repository index is cached and
+			// which repositories.yaml to read. Neither describes the target.
+			"repository-config", "repository-cache",
+			// Render fidelity for an upgrade rather than an install. A
+			// security scan of a chart does not turn on it.
+			"is-upgrade",
+		},
+	})
+
+	// k8s asks what shape of thing is being scanned first, then only what that
+	// shape needs: a live cluster asks for a cluster and, optionally, which
+	// namespaces; a manifest asks for a path. Neither screen shows the other's
+	// questions.
+	registerSpec("k8s", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "what to scan", Desc: "a running cluster, or Kubernetes YAML on disk",
+				Required: true,
+				Options:  []string{"live cluster", "manifest file"},
+				Emit:     map[string]string{"live cluster": "", "manifest file": ""},
+			},
+			{
+				Label: "manifest path", Desc: "the file or directory to read",
+				Required: true, ShowIf: []string{"manifest file"},
+			},
+		},
+		Target:  []string{"context", "namespaces"},
+		Sources: map[string]string{"context": srcKubeContext, "namespaces": srcK8sNamespace},
+		Labels:  map[string]string{"context": "cluster", "namespaces": "namespaces (optional)"},
+		// The cluster and its namespaces are meaningless for a manifest.
+		ShowFlagsIf: map[string][]string{
+			"context":    {"live cluster"},
+			"namespaces": {"live cluster"},
+		},
+		// --context is declared and parsed, and then never reaches the client
+		// config, so the chosen cluster travels as a kubeconfig copy instead.
+		// The value needs a file written for it, so it is an EnvSpec in
+		// kubeconfig.go rather than a plain variable here.
+	})
+
+	// kustomize declares no flags at all -- the overlay directory is the whole
+	// input -- so the only thing worth saying is what the argument is. The
+	// derived slot would say "PATH".
+	registerSpec("kustomize", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "overlay path", Desc: "the Kustomize overlay directory to render",
+			Required: true,
+		}},
+	})
+
+	// portainer's address is both a positional and --address, and the two are
+	// the same value; asking twice would be the form's own invention. The
+	// positional is the shape the connector documents, so --address is hidden
+	// rather than the other way round. Both routes were run against the
+	// installed provider to confirm they are interchangeable.
+	registerSpec("portainer", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "instance address", Desc: "host, host:port or URL; https is assumed",
+			Required: true,
+		}},
+		Credential: []string{"access-token"},
+		Labels: map[string]string{
+			"access-token": "access token",
+			"insecure":     "skip TLS verification",
+		},
+		Hide: []string{"address"},
+	})
+}

--- a/cli/launcher/forms/forms_database.go
+++ b/cli/launcher/forms/forms_database.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// The Databases family: fifteen connectors that share one spec.
+//
+// This is the only file here whose specs are not written one per connector, and
+// that is a fact about the providers rather than a shortcut. They declare one
+// flag vocabulary between them, so one spec is the honest description; see
+// databaseSpec for why the union of the vocabulary is deliberate and what
+// TestEverySpecNamesRealFlags does about it.
+
+// The database providers share one flag vocabulary -- host, port, user,
+// database, then a password and an --ask-pass -- so they share one spec rather
+// than a dozen near-identical copies. They are the best-behaved family in the
+// tree: every one of them marks its password flag FlagOption_Password, so the
+// secret classifier needs no help here, and the spec only fixes the ordering.
+//
+// Their usage strings read "postgresdb [host]" but they declare MinArgs=0 and
+// MaxArgs=0: the host is a flag, not a positional. The empty Positional here is
+// what suppresses the derived slot.
+var databaseSpec = FormSpec{
+	Target: []string{
+		"host", "port", "instance", "service", "sid", "database",
+		"auth-db", "scheme", "organization", "user",
+	},
+	// --ask-api-key is not named here, and neither is clickhousecloud's
+	// --ask-secret. weaviate declares one as a plain bool with no
+	// FlagOption_AskInput, which mql parses and nothing reads, so the toggle
+	// promised a prompt that never came and the scan ran unauthenticated.
+	// genericFields drops both; see isInertPromptFlag.
+	Credential: []string{
+		"ask-pass", "password", "api-key", "token", "auth",
+	},
+	Labels: map[string]string{
+		"ask-pass":     "prompt for password",
+		"tls-insecure": "skip TLS verification",
+	},
+}
+
+var databaseConnectors = []string{
+	"postgresdb", "mysqldb", "mssql", "mongo", "redisdb", "cassandra",
+	"elasticsearch", "opensearch", "weaviate", "clickhouse", "clickhousedb",
+	"clickhousecloud", "oracledb", "db2", "neon",
+}
+
+func init() {
+	for _, name := range databaseConnectors {
+		registerSpec(name, databaseSpec)
+	}
+}

--- a/cli/launcher/forms/forms_dev.go
+++ b/cli/launcher/forms/forms_dev.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Developer & Supply Chain: artifactory, depsdev and sbom.
+//
+// Two of the three are path-shaped -- sbom reads a bill of materials off disk,
+// depsdev takes a package coordinate -- so the useful form is the one that
+// names the argument in the connector's own vocabulary rather than repeating
+// the usage string. artifactory is the odd one out and is deliberately left
+// uncurated; the reason is in the init below, in code, because "nobody got to
+// it" and "there is nothing a spec can say" are indistinguishable from an empty
+// registry.
+
+func init() {
+	// artifactory reaches the catalog from providers.DefaultProviders, the
+	// static list compiled into the binary, which carries no Flags, no MinArgs
+	// and no MaxArgs. On a machine that has not installed the provider,
+	// HasFormData() is false and the launcher shows its free-text argument box
+	// -- a spec would never be applied at all. On a machine that has installed
+	// it the flags are real (--url, --token, --api-key, verified against
+	// 13.1.0), but internal/connectors/connectors.json has no artifactory entry, so
+	// TestEverySpecNamesRealFlags logs "no snapshot entry" and checks nothing.
+	// A spec would ship on one laptop's authority, which is exactly the
+	// condition the snapshot was introduced to end.
+	//
+	// Refreshing the snapshot does not fix it: the provider is not installed on
+	// the machine the snapshot was last taken on either, and `-update` records
+	// what BuildCatalog found rather than what it wished it had found. db2 is
+	// in the same position, and so are auth0, bitwarden, dropbox, jumpcloud,
+	// keycloak and zoom -- all of which TestEverySpecNamesRealFlags reports by
+	// name.
+	//
+	// Its credential is registered below regardless: that is a fact about the
+	// provider, not a claim about a form, and without it the generic form
+	// refuses to launch.
+	registerUncurated("artifactory",
+		"static-list only, so it carries no flags and has no snapshot entry to check a spec against")
+
+	// depsdev is the one connector here whose target is genuinely optional:
+	// with a go.mod it reports on that module's direct dependencies, without
+	// one it answers questions about individual packages by name. So the
+	// positional is not Required, and the description says what leaving it
+	// empty means rather than leaving the reader to find out by launching.
+	//
+	// --path and the positional were both run against the installed provider
+	// and parse the same file, so the flag is hidden rather than offered as a
+	// second way to say the same thing.
+	registerSpec("depsdev", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "go.mod path",
+			Desc:  "the go.mod whose dependencies to check; leave empty to query packages by name",
+		}},
+		Hide: []string{"path"},
+	})
+
+	// sbom reads a CycloneDX or SPDX document off disk. --format is left as
+	// free text with only its label improved: the provider is not installed on
+	// this machine and its source is not in the module graph, so the strings
+	// its --format accepts could only be guessed. mql's own sbom package
+	// decodes cyclonedx-json, cyclonedx-xml, spdx-json, spdx-tag-value and
+	// json, but whether the provider spells them that way is exactly the kind
+	// of plausible-looking assumption that has already cost this branch once.
+	// Auto-detect is the default and needs no answer.
+	registerSpec("sbom", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "SBOM file", Desc: "the CycloneDX or SPDX document to scan",
+			Required: true,
+		}},
+		Labels: map[string]string{"format": "format (default: auto-detect)"},
+	})
+}

--- a/cli/launcher/forms/forms_hosts.go
+++ b/cli/launcher/forms/forms_hosts.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Hosts & Devices: device, filesystem, local, ssh, vagrant and winrm.
+//
+// The two shapes here are "this machine" and "a machine reached over the
+// network", and both are curated the same way: name the target, put the
+// credential in CREDENTIAL with its --ask-* partner first, and leave the rest
+// as options. local is the degenerate case and declares an empty spec on
+// purpose -- it takes no target at all, so the only thing its spec does is
+// suppress the derived positional slot.
+//
+// ssh and winrm are the worked examples the network devices in
+// forms_network.go were written from, and filesystem is the worked example for
+// the path-shaped connectors elsewhere: "PATH" is the label a spec exists to
+// replace, because the derived slot spells the usage string verbatim.
+//
+// device is deliberately left uncurated. The reason is in the init below rather
+// than in this comment, because it is a claim about the connector that stops
+// being true if the connector changes.
+
+func init() {
+	// The one connector this file owns and deliberately did not register a
+	// spec for. It fails the same test artifactory does over in forms_dev.go: a
+	// FormSpec is a set of claims about flags, and neither has flags a spec can
+	// reach or that CI can check.
+	//
+	// device declares nine flags and every one of them is marked Hidden or
+	// Deprecated, so genericFields skips all nine and the form has no field a
+	// spec could name. applySpec's at() returns nil for a flag that was never
+	// built, so a spec naming --lun or --device-name would be dropped in
+	// silence -- while still passing TestEverySpecNamesRealFlags, which reads
+	// the snapshot's flag list including the hidden ones. That is the
+	// invisible-typo failure this phase exists to prevent, arrived at from the
+	// other direction, so the honest answer is not to write the spec.
+	// `cnspec scan device --help` shows the same emptiness: the CLI lists none
+	// of them either, while the connector's own examples still say
+	// `--lun <N>`.
+	//
+	// HasFormData() reports false for it now, which is the other half of the
+	// same finding: it used to count the hidden flags, so the launcher drew an
+	// empty form instead of the free-text argument box that is the honest
+	// screen for a connector with nothing to ask.
+	registerUncurated("device",
+		"every flag it declares is Hidden or Deprecated, so no field exists for a spec to name")
+
+	registerSpec("filesystem", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "path", Desc: "the mounted filesystem to scan",
+			Required: true}},
+	})
+
+	// local takes no target at all -- it is this machine -- so it declares an
+	// empty spec purely to suppress the derived positional slot. Promoting
+	// anything into TARGET here would be misleading now that TARGET is the
+	// first thing on the pane.
+	registerSpec("local", FormSpec{})
+
+	registerSpec("ssh", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the remote system to connect to",
+			Required: true, Source: srcSSHHost}},
+		Credential: []string{"ask-pass", "identity-file", "password"},
+		Labels:     map[string]string{"ask-pass": "prompt for password"},
+	})
+
+	// vagrant is host-shaped but not a host connector: the argument is a
+	// machine name out of the Vagrantfile, not user@host, and the connection
+	// is made through `vagrant ssh-config` rather than by the launcher. It
+	// declares no credential, so there is nothing for delivery.go to route.
+	//
+	// The machine names are enumerable -- `vagrant status --machine-readable`
+	// lists them -- but a value picker is a Source, which lives in a file this
+	// one does not own. Noted for whoever adds the enumerated sources.
+	registerSpec("vagrant", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "machine", Desc: "the Vagrant machine name, as `vagrant status` lists it",
+			Required: true,
+		}},
+		Labels: map[string]string{"sudo": "elevate privileges with sudo"},
+	})
+
+	registerSpec("winrm", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the remote Windows system to connect to",
+			Required: true}},
+		Credential: []string{"ask-pass", "password"},
+		Labels:     map[string]string{"ask-pass": "prompt for password"},
+	})
+}

--- a/cli/launcher/forms/forms_iac.go
+++ b/cli/launcher/forms/forms_iac.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Infrastructure as Code: ansible, bicep, cloudformation and terraform.
+//
+// All four are path-shaped -- each takes a file or a directory and no
+// credential at all -- so the useful form is the one that names the path in the
+// connector's own vocabulary. "PATH" is the label these specs exist to replace:
+// the derived slot spells the usage string verbatim, so an uncurated bicep asks
+// for "PATH" where it means "a .bicep file, a directory of them, or an ARM
+// template".
+//
+// terraform is the one that also has to say *what shape* of Terraform is being
+// read, because HCL source, a plan and a state file are three different things
+// behind one connector word.
+
+func init() {
+	// The three IaC readers below take one path and declare no flags. Each is
+	// its own registration rather than a shared spec because the only thing
+	// each one carries is the sentence describing its own argument, and a
+	// shared spec would have to drop exactly that.
+
+	registerSpec("ansible", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "playbook or project path",
+			// The connector reads both, and reads more from a project: a
+			// single playbook gives plays, tasks and handlers, a directory
+			// additionally gives roles, inventory and vault files.
+			Desc:     "a playbook file, or a project directory with roles and inventory",
+			Required: true,
+		}},
+	})
+
+	registerSpec("bicep", FormSpec{
+		Positional: []PositionalSpec{{
+			Label:    "path",
+			Desc:     "a .bicep file, a directory of them, or an ARM template JSON",
+			Required: true,
+		}},
+	})
+
+	registerSpec("cloudformation", FormSpec{
+		Positional: []PositionalSpec{{
+			Label:    "template path",
+			Desc:     "the CloudFormation or AWS SAM template to scan",
+			Required: true,
+		}},
+	})
+
+	registerSpec("terraform", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "kind", Desc: "leave empty for HCL source",
+				Options: []string{"plan", "state"},
+			},
+			{Label: "path", Desc: "directory or file to scan", Required: true},
+		},
+	})
+}

--- a/cli/launcher/forms/forms_identity.go
+++ b/cli/launcher/forms/forms_identity.go
@@ -1,0 +1,224 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Identity & Access: activedirectory, auth0, bitwarden, google-workspace,
+// jumpcloud, keycloak, ms365 and okta.
+//
+// These are the systems that decide who can sign in, and where credentials
+// live. The catalog separates them from SaaS because "review our identity
+// provider" and "review the tools we subscribe to" are different jobs, and
+// ms365 and google-workspace are here rather than under SaaS despite being
+// productivity suites: what a scan of either actually inspects is the tenant's
+// directory, its sign-in policy and its admin roles.
+//
+// None of the eight has a positional target, so the whole screen is flags, and
+// the generic layer renders that as one undifferentiated list in declaration
+// order. The work below is saying which two or three of those flags name the
+// thing being scanned, which ones are the credential, and -- for the several
+// that authenticate two different ways -- keeping the alternatives next to each
+// other so it is visible that they are alternatives.
+//
+// Every flag named below was read out of the provider's own declaration rather
+// than inferred from a flag description: applySpec drops a flag the connector
+// does not declare, so an invented name produces a field that silently never
+// appears. Four of the eight -- auth0, bitwarden, jumpcloud and keycloak --
+// reach the catalog only through the compiled-in static list and so have no
+// snapshot entry to check against; the package doc says what that costs and
+// how it closes.
+
+func init() {
+	// activedirectory is the one host-shaped connector on this shelf: the
+	// target is a domain controller and everything else describes how to bind
+	// to it. The order here is the order the provider needs them in -- the DC
+	// is the only flag ParseCLI refuses to proceed without.
+	//
+	// --backend is hidden. It declares two values and the connection rejects
+	// one of them outright ("backend 'rsat' is not yet implemented; use
+	// --backend=ldap (the default)"), so the flag can currently only do
+	// nothing or fail.
+	registerSpec("activedirectory", FormSpec{
+		Target:     []string{"dc", "domain", "base-dn", "port"},
+		Credential: []string{"user", "password", "kerberos", "keytab", "ccache", "krb5conf"},
+		Hide:       []string{"backend"},
+		Labels: map[string]string{
+			"dc":         "domain controller",
+			"base-dn":    "base DN",
+			"user":       "bind user",
+			"kerberos":   "use Kerberos (GSSAPI)",
+			"keytab":     "Kerberos keytab",
+			"ccache":     "Kerberos credential cache",
+			"krb5conf":   "krb5.conf",
+			"ldaps":      "LDAPS on port 636 (default)",
+			"starttls":   "StartTLS on port 389",
+			"plain-ldap": "plaintext LDAP on port 389",
+			"insecure":   "skip TLS verification",
+		},
+	})
+
+	// auth0 authenticates a machine-to-machine application against one tenant.
+	// The tenant domain is the target; the client id and secret are one
+	// credential in two fields and belong together.
+	registerSpec("auth0", FormSpec{
+		Target:     []string{"domain"},
+		Credential: []string{"client-id", "client-secret"},
+		Labels: map[string]string{
+			"domain":        "tenant domain",
+			"client-id":     "M2M client ID",
+			"client-secret": "M2M client secret",
+		},
+	})
+
+	// bitwarden reads organization governance through an organization API key.
+	// The two URLs are what point the scan at a self-hosted deployment instead
+	// of the hosted one, which makes them the target rather than options.
+	registerSpec("bitwarden", FormSpec{
+		Target:     []string{"api-url", "identity-url"},
+		Credential: []string{"client-id", "client-secret"},
+		Labels: map[string]string{
+			"api-url":       "API base URL (self-hosted only)",
+			"identity-url":  "identity URL (self-hosted only)",
+			"client-id":     "organization client ID",
+			"client-secret": "organization client secret",
+		},
+	})
+
+	// google-workspace carries no secret at all, which is worth stating
+	// because the screen looks like it should. --credentials-path names a
+	// service account JSON file rather than holding one, so the classifier
+	// reads it as a reference and it travels on the command line, which is
+	// exactly what the provider expects: getGoogleCreds opens the path.
+	//
+	// All three flags are mandatory -- ParseCLI logs and fails for each one
+	// missing -- so none of them is hidden and the two that identify the
+	// tenant lead.
+	registerSpec("google-workspace", FormSpec{
+		Target:     []string{"customer-id", "impersonated-user-email"},
+		Credential: []string{"credentials-path"},
+		Labels: map[string]string{
+			"customer-id":             "customer id",
+			"impersonated-user-email": "impersonate user",
+			"credentials-path":        "service account key",
+		},
+	})
+
+	// jumpcloud rejects a missing key in ParseCLI rather than on connect, so
+	// the environment route has to reach the child before it parses -- which it
+	// does, and which is what the positive control confirmed. --org-id only
+	// applies to multi-tenant keys, and the label says so rather than leaving
+	// an unexplained field in TARGET.
+	registerSpec("jumpcloud", FormSpec{
+		Target:     []string{"org-id"},
+		Credential: []string{"api-key"},
+		Labels: map[string]string{
+			"org-id":  "organization ID (multi-tenant keys only)",
+			"api-key": "API key",
+		},
+	})
+
+	// keycloak has two alternative authentication methods -- an admin user with
+	// a password, or a service account on a confidential client -- and the
+	// provider says so itself when neither is complete. Both secrets therefore
+	// sit in CREDENTIAL, because either one alone is a valid form. Only one is
+	// ever filled in practice, and keycloak is picky about which: it reads an
+	// untagged password as the *client* secret and needs cred.User to mean the
+	// admin one. Its own ParseCLI is what tags them.
+	//
+	// --url is the server and --realm narrows the scan, so those are TARGET.
+	// --auth-realm sits with the credential because it says where the token is
+	// requested from, not what gets scanned.
+	registerSpec("keycloak", FormSpec{
+		Target:     []string{"url", "realm"},
+		Credential: []string{"username", "password", "client-id", "client-secret", "auth-realm"},
+		Labels: map[string]string{
+			"url":           "server URL",
+			"realm":         "realm (leave empty for every realm)",
+			"username":      "admin user",
+			"client-id":     "service account client",
+			"client-secret": "service account secret",
+			"auth-realm":    "realm the token is requested from",
+			"ca-cert":       "CA certificate",
+		},
+	})
+
+	// ms365 identifies its target by tenant id -- the connection refuses
+	// without one and builds its platform id out of it -- so tenant id leads
+	// TARGET rather than sitting with the service principal it also belongs
+	// to. The organization and the SharePoint site narrow what is scanned
+	// inside that tenant.
+	//
+	// The three sign-in shapes are: a certificate, a client secret, or none of
+	// the above and let the Azure identity chain find one, which --auth-method
+	// names a single link of. The keyless shape is the one the connector's own
+	// help recommends, and it is also the only one the launcher can run end to
+	// end -- see the note below the spec.
+	//
+	// MaxArgs=5 is vestigial in the same way mondoo's is: ParseCLI reads
+	// req.GetFlags() and never touches the arguments. Declaring no Positional
+	// suppresses the box.
+	registerSpec("ms365", FormSpec{
+		Target: []string{"tenant-id", "organization", "sharepoint-url"},
+		// The two secrets are named beside the halves they pair with, now that
+		// they have somewhere to travel -- see the note below the spec.
+		Credential: []string{
+			"auth-method", "client-id", "client-secret",
+			"certificate-path", "certificate-secret",
+		},
+		Choices: map[string][]string{
+			"auth-method": {"cli", "env", "workload-identity", "managed-identity"},
+		},
+		Labels: map[string]string{
+			"tenant-id":          "tenant id",
+			"organization":       "organization (optional)",
+			"sharepoint-url":     "SharePoint site (optional)",
+			"auth-method":        "sign-in method",
+			"client-id":          "application (client) id",
+			"client-secret":      "application secret",
+			"certificate-path":   "certificate (PKCS #12 or PEM)",
+			"certificate-secret": "certificate passphrase",
+		},
+	})
+
+	// okta authenticates two ways: an API token, which carries the full
+	// privileges of the admin who minted it, or a service app with a private
+	// key JWT, which holds only the scopes it was granted. The token is
+	// ambient -- source_ambient.go owns its readout, its paste box and its
+	// OKTA_API_TOKEN route, and composes --organization out of OKTA_ORG_NAME
+	// and OKTA_BASE_URL around the provider's "." bug -- so all that is left
+	// here is the ordering and the service app beneath it.
+	//
+	// The four service-app flags stay together and in the order the
+	// connector's own example gives them, because three of them are useless
+	// without the fourth and a form that scatters them across two sections
+	// makes that a discovery rather than a layout.
+	registerSpec("okta", FormSpec{
+		Target: []string{"organization"},
+		Credential: []string{
+			"token",
+			"client-id", "private-key", "private-key-id", "scopes",
+		},
+		// --private-key holds either the PEM itself or a path to it, and the
+		// shared classifier reads it as a path: isSecretReference matches
+		// "path to" in its description and returns before the private-key word
+		// is ever consulted. That is right for github's --app-private-key,
+		// which really is only a path, and wrong here, where pasting a PEM
+		// would put a private key into `ps auxww`. Correcting it in the shared
+		// word lists would re-read every other connector's flags; saying it
+		// here corrects okta and nothing else.
+		Secret: []string{"private-key"},
+		// --organization keeps the flag's own name. It is the one field on this
+		// form that the launcher fills in for the user, and the tests that
+		// prove it does -- the ones guarding the "." bug in source_ambient.go
+		// -- find it by label. Its description already reads "The domain of
+		// the Okta organization to scan", so a nicer label would buy very
+		// little and take those tests down with it.
+		Labels: map[string]string{
+			"token":          "API token",
+			"client-id":      "service app client id",
+			"private-key":    "service app private key",
+			"private-key-id": "service app key id",
+			"scopes":         "service app scopes",
+		},
+	})
+}

--- a/cli/launcher/forms/forms_network.go
+++ b/cli/launcher/forms/forms_network.go
@@ -1,0 +1,449 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// Network & Security Devices: arista, bigip, checkpoint, ciscocatalyst,
+// fortios, host, ipinfo, ipmi, junos, mikrotik, nd-ssh, networkdiscovery, nmap,
+// opcua, panos, redfish, shodan and unifi.
+//
+// The category name is misleading -- these do not share a shape -- and the
+// three shapes it actually covers are all here.
+//
+// Twelve are appliances: a box on the network, a user, a password. Five take
+// the device as a positional (`arista user@host`, `ipmi USER@HOST`,
+// `mikrotik user@host`, `ciscocatalyst hostname`, `host HOST`); the rest
+// address it through a --hostname flag with --port and --username beside it
+// (bigip, checkpoint, fortios, junos), or through their own spelling of the
+// same thing (nd-ssh, panos, redfish, opcua, unifi). All of them are curated
+// the way ssh and winrm are in forms_hosts.go: name the target, put the
+// credential in CREDENTIAL with its --ask-* partner first, and leave the rest
+// as options.
+//
+// nmap and networkdiscovery take a network or a domain as the *input* to a scan
+// and have no credential at all. shodan and ipinfo are API services reached
+// with a token and no host.
+//
+// Every spec below was written from that connector's own declaration in
+// ~/.config/mondoo/providers/<name>/<name>.json and its provider source, not
+// from the category it is filed under, and cross-checked against
+// internal/connectors/connectors.json, which is what TestEverySpecNamesRealFlags
+// reads. Note that ciscocatalyst and nd-ssh are served by the `networkdevices`
+// provider and host by `network`, so the provider file is not always named
+// after the connector.
+//
+// Two things decided most of what is here.
+//
+// The first is that --networks is not a discovery picker. Both nmap and shodan
+// declare it, and it reads like somewhere a list of discovered ranges would
+// go. It is the opposite: it is what the scan is pointed *at*. Attaching a
+// picker to it would offer the answer as the question.
+//
+// The second is that a credential the receiving provider does not keep makes a
+// form that refuses at the moment the user presses enter. Every credential
+// named below was checked against the provider that receives it, which is now
+// something the launcher does for itself at launch rather than something
+// recorded here -- see TestEveryCredentialFieldRoundTrips.
+//
+// # Exactly one ssh-config picker in this file, and it is nd-ssh's
+//
+// srcSSHHost lists the Host aliases in ~/.ssh/config, and the temptation is to
+// hang it off every `user@host` field here. It is attached to nd-ssh and to
+// nothing else, because for the others it would be offering values that do not
+// work:
+//
+//   - arista connects with goeapi over HTTPS -- verified in the provider's own
+//     connection.go, which calls goeapi.Connect("https", host, user, secret,
+//     port). It is not an SSH client at all.
+//   - ipmi talks RMCP to a BMC on port 623 (verified likewise: the connection
+//     defaults conf.Port to 623). A BMC has its own address, separate from the
+//     SSH address of the OS running on the same chassis.
+//   - mikrotik uses the RouterOS API service on 8728/8729, and bigip,
+//     checkpoint and fortios are REST APIs. None of them is reached by ssh.
+//   - ciscocatalyst addresses a Catalyst Center appliance through its API. Its
+//     --password description mentions SSH, but that flag set is shared with the
+//     sibling nd-ssh connector in the same networkdevices provider, and nd-ssh
+//     is where the SSH client in that binary belongs -- which is why nd-ssh has
+//     the picker and ciscocatalyst does not.
+//   - host is not a login at all; see its spec below.
+//
+// junos is the one genuine remaining candidate -- NETCONF over SSH on port 830,
+// and --identity-file really is an SSH private key. It is still left off,
+// because sshHosts() returns the alias from the `Host` line rather than the
+// resolved HostName, and an alias only means something to a client that reads
+// ~/.ssh/config. cnspec's os provider does; there is no evidence the junos
+// provider does, and a picker whose values get dialled literally as DNS names
+// would fail more often than it helped. If someone confirms junos resolves
+// ssh_config aliases, attaching srcSSHHost to its --hostname is a one-line
+// change here.
+
+func init() {
+	// arista takes the device as its single argument and declares nothing else
+	// but the password pair, so there is no TARGET beyond the positional.
+	registerSpec("arista", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the Arista EOS device to connect to",
+			Required: true,
+		}},
+		Credential: []string{"ask-pass", "password"},
+		Labels:     map[string]string{"ask-pass": "prompt for password"},
+	})
+
+	// bigip is addressed by flag rather than by argument: `bigip` takes no
+	// positional at all, and the device is --hostname.
+	registerSpec("bigip", FormSpec{
+		Target:     []string{"hostname", "port", "username"},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"port":     "iControl REST port",
+			"username": "user",
+			"ask-pass": "prompt for password",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// checkpoint scans a management server, not a gateway -- the gateways are
+	// what --discover finds behind it, and the generic layer already builds
+	// that field from the connector's declared discovery targets.
+	//
+	// --api-key is deliberately absent from Credential. It is the documented
+	// alternative to username/password, but the connector declares no
+	// --ask-api-key to prompt for it and no environment variable that the
+	// provider is confirmed to read, so there is no verified route to deliver
+	// it and this file does not claim one. The classifier still marks it a
+	// secret and still puts it in CREDENTIAL; filling it produces the
+	// launcher's honest refusal rather than a credential sent somewhere that
+	// may ignore it.
+	registerSpec("checkpoint", FormSpec{
+		Target:     []string{"hostname", "port", "domain", "username"},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"hostname":    "management server",
+			"port":        "Management API port",
+			"domain":      "management domain",
+			"username":    "user",
+			"ask-pass":    "prompt for password",
+			"insecure":    "skip TLS verification",
+			"fingerprint": "pin TLS fingerprint (SHA-1)",
+		},
+	})
+
+	// ciscocatalyst is `ciscocatalyst hostname`: the Catalyst Center appliance
+	// is the argument, and --user is the account on it. --discover devices is
+	// how the switches it manages are reached.
+	registerSpec("ciscocatalyst", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "hostname", Desc: "the Cisco Catalyst Center to connect to",
+			Required: true,
+		}},
+		Target:     []string{"user"},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"user":     "user",
+			"ask-pass": "prompt for password",
+		},
+	})
+
+	// fortios has no Credential section, and that is the whole story of this
+	// entry. Its only credential is --token, which the classifier puts in
+	// CREDENTIAL by itself, so a Credential list would only be repeating what
+	// already happened.
+	//
+	// It used to be an unrouted credential, and the reasoning is worth keeping
+	// because it says something true about the provider: fortios declares no
+	// --ask-token, and while FORTIOS_ACCESS_TOKEN appears in the shipped binary
+	// it sits in a block with FORTIOS_ACCESS_USERNAME, FORTIOS_ACCESS_PASSWORD
+	// and FORTIOS_CA_* -- variables for flags this connector does not declare
+	// -- which places that block in the vendored FortiOS SDK rather than in the
+	// provider's own ParseCLI. None of that decides anything now: the token is
+	// handed to that ParseCLI as --token, and the round-trip test confirms
+	// fortios keeps it as a bearer credential.
+	//
+	// --enable-forti-sdk-logs is a debugging switch and is hidden.
+	registerSpec("fortios", FormSpec{
+		Target: []string{"hostname"},
+		Hide:   []string{"enable-forti-sdk-logs"},
+		Labels: map[string]string{
+			"token":    "REST API token",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// host is the odd one in this family: it is a scanning target, not a
+	// login. The network provider's ParseCLI splits the argument into scheme,
+	// host, port and path and connects to whatever is listening, so this asks
+	// for a URL or a host and nothing else. It declares no credential flag at
+	// all, which is why there is no CREDENTIAL section to give it.
+	registerSpec("host", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "host", Desc: "hostname, URL or host:port to inspect",
+			Required: true,
+		}},
+		Labels: map[string]string{
+			"insecure":         "skip TLS verification",
+			"follow-redirects": "follow HTTP redirects",
+		},
+	})
+
+	// unifi declares no --ask-api-key and reads no environment variable of its
+	// own, and its --api-key travels regardless.
+	//
+	// Two workarounds preceded that. The first was a registered variable, which
+	// unifi has none of. The second was MONDOO_API_KEY, the name mql derives
+	// from any flag with no config mapping -- verified against the shipped
+	// binary at the time: with nothing set, `cnspec scan unifi --hostname
+	// 127.0.0.99` failed in ParseCLI with "username is required (or use
+	// --api-key)", and with the variable set it got past ParseCLI and failed on
+	// the TLS connection instead. Both were routes into req.Flags. The launcher
+	// fills req.Flags directly now, so neither is needed and neither can be
+	// shadowed by a configuration key that happens to share a name.
+
+	// Not curated, and deliberately: ipinfo.
+	//
+	// The connector declares no flags, no positional arguments and no
+	// discovery targets -- `cnspec scan ipinfo` is the whole command line, and
+	// an IP address is passed to the resource in MQL rather than to the
+	// connector. HasFormData is therefore false for it, which is also why it
+	// is absent from internal/connectors/connectors.json. A FormSpec would have nothing
+	// to name: applySpec drops every flag the connector does not declare, so
+	// each entry would be silently ignored.
+	//
+	// Its one credential, IPINFO_TOKEN, has no flag either -- the connection
+	// reads the variable directly and nothing on the command line carries it --
+	// so there is nothing for a form to collect and nothing for ParseCLI to be
+	// handed. It is left on the generic form, where the launcher inherits the
+	// user's own environment and the variable works as documented.
+	registerUncurated("ipinfo",
+		"it declares no flags, no arguments and no discovery targets, so a spec would have nothing to name")
+
+	// ipmi addresses the BMC, which is a different machine from the OS on the
+	// same hardware and has its own address. `ipmi USER@HOST` carries the
+	// account in the argument, so --password is all that is left.
+	registerSpec("ipmi", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the BMC or service processor to connect to",
+			Required: true,
+		}},
+		Credential: []string{"ask-pass", "password"},
+		Labels:     map[string]string{"ask-pass": "prompt for password"},
+	})
+
+	// junos is ssh's closest relative here -- NETCONF over SSH on port 830 --
+	// so its CREDENTIAL is ordered the way ssh's is: the prompt first, then
+	// the key, then the password. --identity-file is a path rather than a
+	// secret, and the classifier already reads it that way, so naming it in
+	// Credential moves it into the section without making it a masked field.
+	registerSpec("junos", FormSpec{
+		Target:     []string{"hostname", "port", "username"},
+		Credential: []string{"ask-pass", "identity-file", "password"},
+		Labels: map[string]string{
+			"port":          "NETCONF port",
+			"username":      "user",
+			"ask-pass":      "prompt for password",
+			"identity-file": "SSH private key",
+		},
+	})
+
+	// mikrotik declares MinArgs=1 with the usage string
+	// `mikrotik user@host [flags]`, which the derived layer cannot line up: two
+	// tokens against one argument falls through to the single-argument case and
+	// labels the box "user@host [flags]". Naming the positional here is what
+	// fixes that.
+	//
+	// The two ports are the RouterOS API service and its TLS twin, and which
+	// one applies depends on --tls. They are offered as suggestions, not as a
+	// validation list -- Choices on a flag leaves the field free text, the same
+	// way the aws region list does.
+	registerSpec("mikrotik", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the MikroTik RouterOS device to connect to",
+			Required: true,
+		}},
+		Target:     []string{"port"},
+		Credential: []string{"ask-pass", "password"},
+		Choices:    map[string][]string{"port": {"8728", "8729"}},
+		Labels: map[string]string{
+			"port":     "RouterOS API port",
+			"ask-pass": "prompt for password",
+			"tls":      "use the API-SSL service",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// nd-ssh is `ssh` for network gear: the same transport, the same
+	// user@host, and the same ~/.ssh/config to suggest from. The picker is a
+	// suggestion rather than a list of valid values, so a device that is not
+	// in that file is still typed in as normal.
+	//
+	// Three of its flags carry a secret, and the two prompts are promoted over
+	// the two boxes that would collect the same values by hand.
+	//
+	// The route no longer forces that choice -- one ParseCLI call carries as
+	// many secrets as the form holds -- but the screen is still the better one.
+	// --ask-pass is built into the CLI and --ask-enable-password carries
+	// FlagOption_AskInput, so the child prompts for each and sets the flag
+	// itself; the value never exists outside the process that uses it, which is
+	// stronger than anything the keychain can offer. A Cisco login password and
+	// enable password are also two boxes nobody wants to fill twice.
+	registerSpec("nd-ssh", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the network device to connect to",
+			Required: true, Source: srcSSHHost,
+		}},
+		Credential: []string{"ask-pass", "password", "ask-enable-password", "private-key-path"},
+		Labels: map[string]string{
+			"ask-pass":              "prompt for password",
+			"ask-enable-password":   "prompt for enable password",
+			"private-key-path":      "private key",
+			"system-transport-args": "extra ssh transport options",
+		},
+		// --enable-password and --private-key-passphrase are covered by the
+		// prompts above; --store-commands writes every command run on the
+		// device to a file for debugging, which is not a launcher's business.
+		Hide: []string{"enable-password", "private-key-passphrase", "store-commands"},
+	})
+
+	// networkdiscovery declares no flags at all: one domain in, subdomains
+	// out. The only thing worth curating is that the enumeration is the point
+	// of the connector rather than an option, so --discover leads the form
+	// instead of sitting behind the fold.
+	registerSpec("networkdiscovery", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "domain", Desc: "the FQDN whose subdomains to enumerate",
+			Required: true,
+		}},
+		Target: []string{"discover"},
+		Labels: map[string]string{"discover": "what to enumerate"},
+	})
+
+	// nmap and shodan answer the same three questions -- one host, one domain,
+	// a range of addresses -- through the same `host <TARGET>` / `domain
+	// <TARGET>` sub-commands plus a --networks flag, and neither shape is
+	// visible in the generic form: MaxArgs=2 with no argument names in the
+	// usage string renders one box labelled "argument 1".
+	//
+	// The leading selector is what makes the three shapes separate screens.
+	// "network range" emits nothing, because a range is passed as --networks
+	// rather than as a sub-command word, and the flag is shown only for it:
+	// the provider ignores --networks once a sub-command names a single
+	// target.
+	registerSpec("nmap", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "what to scan", Desc: "one host, a domain, or a range of addresses",
+				Required: true,
+				Options:  []string{"host", "domain", "network range"},
+				Emit: map[string]string{
+					"host": "host", "domain": "domain", "network range": "",
+				},
+			},
+			{
+				Label: "target", Desc: "IP address or hostname",
+				Required: true, ShowIf: []string{"host", "domain"},
+			},
+		},
+		Target: []string{"networks", "ports"},
+		Labels: map[string]string{
+			"networks": "address ranges",
+			"ports":    "ports to scan",
+		},
+		// --networks is the input to the scan, not a place to put something
+		// discovery found, so it gets no picker.
+		ShowFlagsIf: map[string][]string{"networks": {"network range"}},
+	})
+
+	// opcua is a single field. It matters only that --endpoint carries
+	// FlagOption_Required: a required flag left where the classifier put it
+	// sits in OPTIONS, behind the "more" fold, where the form asks for
+	// something the user cannot see.
+	registerSpec("opcua", FormSpec{
+		Target: []string{"endpoint"},
+		Labels: map[string]string{"endpoint": "endpoint URL"},
+	})
+
+	// panos and redfish are the simple case: exactly one secret flag, and an
+	// --ask-pass partner for it, so the child prompts and nothing is carried.
+	// panos addresses the device by --hostname and redfish by a user@host
+	// argument, which is the only real difference between their forms.
+	registerSpec("panos", FormSpec{
+		Target:     []string{"hostname", "username"},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"hostname": "device",
+			"username": "user",
+			"ask-pass": "prompt for password",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	registerSpec("redfish", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "user@host", Desc: "the management controller to connect to",
+			Required: true,
+		}},
+		Credential: []string{"ask-pass", "password"},
+		Labels: map[string]string{
+			"ask-pass": "prompt for password",
+			"insecure": "skip TLS verification",
+		},
+	})
+
+	// shodan is the same sub-command shape with an account behind it: with no
+	// argument at all the target is the Shodan account itself, which is what
+	// the connector's own summary calls it, so that is a fourth option rather
+	// than an empty form.
+	//
+	// --token has no --ask-token partner, so it travels in SHODAN_TOKEN, which
+	// the provider reads in both its ParseCLI and its connection. That entry
+	// is already registered in delivery.go; nothing is added for it here.
+	registerSpec("shodan", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "what to query", Desc: "the account, one host, a domain, or a range of addresses",
+				Required: true,
+				Options:  []string{"account", "host", "domain", "network range"},
+				Emit: map[string]string{
+					"account": "", "host": "host", "domain": "domain", "network range": "",
+				},
+			},
+			{
+				Label: "target", Desc: "IP address or hostname",
+				Required: true, ShowIf: []string{"host", "domain"},
+			},
+		},
+		Target:      []string{"networks"},
+		Credential:  []string{"token"},
+		Labels:      map[string]string{"token": "API token", "networks": "address ranges"},
+		ShowFlagsIf: map[string][]string{"networks": {"network range"}},
+	})
+
+	// unifi is the one connector here with two ways in, and the connector's
+	// own help says they are alternatives: an API key, or a username and
+	// password. Showing both at once is not just noise -- deliveryFor carries
+	// one secret, so a form holding both has nowhere to send either. The
+	// selector keeps them on separate screens.
+	registerSpec("unifi", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "sign in with", Desc: "how to authenticate to the controller",
+			Required: true,
+			Options:  []string{"username and password", "API key"},
+			Emit:     map[string]string{"username and password": "", "API key": ""},
+		}},
+		Target:     []string{"hostname", "port", "site", "username"},
+		Credential: []string{"ask-pass", "password", "api-key"},
+		Labels: map[string]string{
+			"hostname": "controller",
+			"username": "user",
+			"site":     "site",
+			"ask-pass": "prompt for password",
+			"api-key":  "API key",
+			"insecure": "skip TLS verification",
+		},
+		ShowFlagsIf: map[string][]string{
+			"username": {"username and password"},
+			"password": {"username and password"},
+			"ask-pass": {"username and password"},
+			"api-key":  {"API key"},
+		},
+	})
+}

--- a/cli/launcher/forms/forms_saas.go
+++ b/cli/launcher/forms/forms_saas.go
@@ -1,0 +1,454 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+// SaaS: the accounts an organisation holds with someone else -- atlassian,
+// cloudflare, databricks, datadog, dropbox, github, gitlab, grafana, iru, jamf,
+// mondoo, mongodbatlas, netlify, nextdns, slack, snowflake, tailscale, vercel
+// and zoom.
+//
+// The systems that decide who can sign in are next door in forms_identity.go.
+// What is left here is a wide shelf with two recurring difficulties, and the
+// specs below divide along them rather than along who wrote them.
+//
+// For some the difficulty is the *target*: what is being scanned, and which
+// questions that answer makes relevant. atlassian is a sub-command shape the
+// usage string only hints at, github and gitlab are an org or a repo or a user,
+// databricks is an account plane or a workspace plane, and each of those
+// choices changes which credential flags are even applicable. Showing all of
+// them at once was the old screen's worst offence: most are always wrong.
+//
+// For the rest the difficulty is the *credential*. Most have no positional
+// target at all, so the whole screen is flags, and the generic layer renders
+// that as one undifferentiated list in declaration order. The work is saying
+// which two or three of those flags name the thing being scanned, which ones
+// are the credential, and -- for the ones that authenticate two different ways
+// -- keeping the alternatives next to each other so it is visible that they are
+// alternatives.
+//
+// Every flag named below was read out of the provider's own declaration --
+// internal/connectors/connectors.json, the recorded copy of what the installed
+// providers declare -- rather than inferred from a flag description: applySpec
+// drops a flag the connector does not declare, so an invented name produces a
+// field that silently never appears. dropbox and zoom reach the catalog only
+// through the compiled-in static list and so have no snapshot entry to check
+// against; the package doc says what that costs and how it closes.
+
+// datadogSites is a display list, not a validation list: the site flag stays
+// free text so a Datadog region newer than this binary still works.
+var datadogSites = []string{
+	"datadoghq.com",
+	"us3.datadoghq.com",
+	"us5.datadoghq.com",
+	"datadoghq.eu",
+	"ap1.datadoghq.com",
+	"ddog-gov.com",
+}
+
+func init() {
+	// atlassian is a sub-command shape the usage string only hints at. Its
+	// ParseCLI refuses outright without a first argument -- "use `atlassian
+	// jira`, `atlassian admin`, `atlassian confluence`, or `atlassian scim
+	// {directoryID}`" -- and refuses again if `scim` arrives without a
+	// directory id, while the metadata declares MinArgs=0 and MaxArgs=2 and
+	// says nothing about any of it. So the product is a required picker whose
+	// four options are the four words the connector accepts, emitted verbatim,
+	// and the directory id only appears for the one that takes it.
+	//
+	// The credential differs per product as well, and each is read by a
+	// different connection constructor: jira and confluence take a site, an
+	// account email and a user API token; admin takes an admin token and
+	// nothing else; scim takes a SCIM token and the directory id. Showing all
+	// five credential flags at once was the old screen's worst offence here --
+	// four of them are always wrong.
+	registerSpec("atlassian", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "product", Desc: "which Atlassian product to scan",
+				Required: true,
+				Options:  []string{"jira", "confluence", "admin", "scim"},
+			},
+			{
+				Label: "directory id", Desc: "the SCIM directory to scan",
+				Required: true, ShowIf: []string{"scim"},
+			},
+		},
+		Target:     []string{"host"},
+		Credential: []string{"user", "user-token", "admin-token", "scim-token"},
+		Labels: map[string]string{
+			"host":        "site URL",
+			"user":        "account email",
+			"user-token":  "API token",
+			"admin-token": "admin API token",
+			"scim-token":  "SCIM API token",
+		},
+		// Read off the four connection constructors, not guessed from the flag
+		// descriptions: jira/connection.go and confluence/connection.go read
+		// host, user and user-token; admin/connection.go reads admin-token
+		// alone; scim/connection.go reads scim-token and the directory id.
+		ShowFlagsIf: map[string][]string{
+			"host":        {"jira", "confluence"},
+			"user":        {"jira", "confluence"},
+			"user-token":  {"jira", "confluence"},
+			"admin-token": {"admin"},
+			"scim-token":  {"scim"},
+		},
+	})
+
+	// cloudflare's entire form is its credential: one --token flag and the
+	// discovery list. The ambient widgets and the CLOUDFLARE_TOKEN route are
+	// already declared in source_ambient.go, so all that is left is to say
+	// where the flag belongs and what to call it.
+	registerSpec("cloudflare", FormSpec{
+		Credential: []string{"token"},
+		Labels:     map[string]string{"token": "API token"},
+	})
+
+	// databricks has two connection planes and one flag vocabulary spanning
+	// both, which is why the flat screen was unreadable: --account-id is
+	// meaningless for a workspace and --token is meaningless for the account
+	// console, and nothing on the screen said so.
+	//
+	// The plane is a UI distinction rather than a sub-command -- the connector
+	// declares MaxArgs=0 and infers the plane from whether an account id
+	// arrived -- so the selector emits nothing at all, the way the container
+	// kind selector does. It only steers which questions are asked.
+	registerSpec("databricks", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "connect to", Desc: "the account console, or a single workspace",
+			Required: true,
+			Options:  []string{"account console", "workspace"},
+			// Neither word is one cnspec would understand: the connector takes
+			// no positional argument at all.
+			Emit: map[string]string{"account console": "", "workspace": ""},
+		}},
+		Target:     []string{"host", "account-id"},
+		Credential: []string{"token", "client-id", "client-secret"},
+		Labels: map[string]string{
+			"host":          "host",
+			"account-id":    "account id",
+			"token":         "personal access token",
+			"client-id":     "OAuth client id",
+			"client-secret": "OAuth client secret",
+		},
+		// An account id routes to the account console and a personal access
+		// token is workspace-only ("Personal access token for a direct
+		// workspace connect"); OAuth M2M works on both planes, so it is not
+		// gated. The host is asked for either way -- it is optional for the
+		// account console, which defaults to accounts.cloud.databricks.com,
+		// and required for a workspace.
+		ShowFlagsIf: map[string][]string{
+			"account-id": {"account console"},
+			"token":      {"workspace"},
+		},
+	})
+
+	// datadog needs two credentials at once, and the shared classifier only
+	// catches one of them: --api-key ends in a strong secret word and
+	// --app-key does not, so the application key would have gone on the
+	// command line where `ps auxww` reads it. Saying so here rather than
+	// widening the word list is the point of FormSpec.Secret -- "app-key"
+	// added to the shared list would re-classify every other connector's
+	// key-shaped flag.
+	//
+	// Filling both boxes used to be refused: the launcher could name one
+	// environment variable for one secret, and a form holding two fell through
+	// to an inventory shape datadog does not read. Both travel now, because
+	// datadog's own ParseCLI is what decides where they land -- and if it
+	// turns out to keep only one of them, the launch says which one it dropped
+	// rather than half-delivering.
+	registerSpec("datadog", FormSpec{
+		Target:     []string{"site"},
+		Credential: []string{"api-key", "app-key"},
+		Secret:     []string{"app-key"},
+		Choices:    map[string][]string{"site": datadogSites},
+		Labels: map[string]string{
+			"api-key": "API key",
+			"app-key": "application key",
+			"site":    "site",
+		},
+	})
+
+	// dropbox is a single team token and nothing else. The classifier already
+	// puts it in CREDENTIAL, so the spec only names it properly -- the flag is
+	// --token but the thing being asked for is a team-scoped token, and a
+	// per-user one fails in a way the label can prevent.
+	registerSpec("dropbox", FormSpec{
+		Credential: []string{"token"},
+		Labels:     map[string]string{"token": "team access token"},
+	})
+
+	registerSpec("github", FormSpec{
+		Positional: []PositionalSpec{
+			{
+				Label: "kind", Desc: "what to scan", Required: true,
+				Options: []string{"org", "repo", "user"},
+			},
+			{Label: "name", Desc: "ORG, OWNER/REPO, or USER", Required: true},
+		},
+		Target:     []string{"enterprise-url"},
+		Credential: []string{"token", "app-id", "app-installation-id", "app-private-key", "app-private-key-content"},
+		Labels:     map[string]string{"token": "personal access token"},
+	})
+
+	// gitlab's group and project are the whole target, and both can be
+	// enumerated -- but only through cnspec's own discovery, which needs the
+	// token first. So they are live pickers: nothing runs until the field is
+	// opened, and by then the credential above it is filled in.
+	//
+	// The token itself is left alone. gitlab is an ambient connector, so the
+	// readout and the paste box come from source_ambient.go and its
+	// GITLAB_TOKEN route is registered there; curating it again here would put
+	// two claims about one credential in two files.
+	registerSpec("gitlab", FormSpec{
+		Target: []string{"group", "project", "url"},
+		LiveSources: map[string]string{
+			"group":   srcDiscoverGitLabGroups,
+			"project": srcDiscoverGitLabProjects,
+		},
+		// Only --url is relabelled. The token row belongs to the ambient
+		// widgets: source_ambient_test.go reaches for gitlab's field by the
+		// label "token", so renaming it here would break a claim made about a
+		// credential this file does not own.
+		Labels: map[string]string{"url": "self-managed URL"},
+	})
+
+	// grafana needs exactly two things and refuses without either: an instance
+	// URL and a service account token.
+	registerSpec("grafana", FormSpec{
+		Target:     []string{"url"},
+		Credential: []string{"token"},
+		Labels: map[string]string{
+			"url":   "instance URL",
+			"token": "service account token",
+		},
+	})
+
+	// iru takes no argument at all: the tenant is --subdomain and the
+	// credential is --token, which the provider marks FlagOption_Password, so
+	// the classifier needs no correction here. The empty Positional is what
+	// suppresses the derived slot the way local's does.
+	registerSpec("iru", FormSpec{
+		Target:     []string{"subdomain"},
+		Credential: []string{"token"},
+		Labels: map[string]string{
+			"subdomain": "tenant subdomain",
+			"token":     "API token",
+		},
+	})
+
+	// jamf authenticates one way: a Jamf Pro API client id and secret against
+	// an instance domain. The domain is the target -- it names the tenant --
+	// and the pair below it is the credential.
+	//
+	// --client-secret is the one flag in this file that the provider itself
+	// marks FlagOption_Password, so the classifier needs no help with it.
+	registerSpec("jamf", FormSpec{
+		Target:     []string{"instance-domain"},
+		Credential: []string{"client-id", "client-secret"},
+		Labels: map[string]string{
+			"instance-domain": "Jamf Pro URL",
+			"client-id":       "API client id",
+			"client-secret":   "API client secret",
+		},
+	})
+
+	// mondoo takes nothing at all. Its ParseCLI builds an inventory config
+	// from req.Connector and returns; it reads no flag and no argument, and
+	// the credential comes from the workstation's Mondoo registration through
+	// req.Upstream rather than from anything a form could ask for.
+	//
+	// The connector nevertheless declares MaxArgs=4, which the generic layer
+	// faithfully renders as an "argument 1" box whose contents ParseCLI
+	// discards without a word. The empty spec is what suppresses it -- the
+	// same reason `local` has one.
+	registerSpec("mondoo", FormSpec{})
+
+	// mongodbatlas is the two-credentials connector. A programmatic API key is
+	// a public/private pair; a service account is a client id and secret. Both
+	// pairs are declared at once and only one is filled, so they are listed in
+	// pair order, public half before secret half, to make the pairing visible.
+	//
+	// --public-key and --client-id are not secrets and stay on the command
+	// line, which is where the provider expects them. They are in CREDENTIAL
+	// anyway because a public key sitting under OPTIONS, three fields away
+	// from the private half it is useless without, reads as an unrelated
+	// setting.
+	//
+	// The org id and the project id are the two targets: with a project id the
+	// connection scopes to that project, without one it connects to the
+	// organization and discovers its projects. The project picker is that same
+	// discovery, so it narrows to the organization already chosen.
+	registerSpec("mongodbatlas", FormSpec{
+		Target:  []string{"org-id", "project-id"},
+		Sources: map[string]string{"project-id": srcDiscoverAtlasProjects},
+		Credential: []string{
+			"public-key", "private-key",
+			"client-id", "client-secret",
+		},
+		Labels: map[string]string{
+			"org-id":        "organization id",
+			"project-id":    "project id (optional)",
+			"public-key":    "API key — public",
+			"private-key":   "API key — private",
+			"client-id":     "service account client id",
+			"client-secret": "service account client secret",
+		},
+	})
+
+	// ms365 reads no environment variable of its own: its ParseCLI takes its
+	// flags out of req.GetFlags() and calls os.Getenv for nothing whatsoever.
+	// That is now the whole story, because req.GetFlags() is exactly what the
+	// launcher fills -- over gRPC, straight into the provider, with no command
+	// line and no variable in between.
+	//
+	// It is also the connector that shows what a hand-written inventory could
+	// not do. ms365's connection reads conf.Credentials[0] and wants the
+	// certificate as a pkcs12 credential with the passphrase in Password; the
+	// launcher's own builder had no user here to attach a typed credential to
+	// and would have written conn.Options["client-secret"], which ms365 reads
+	// its options from a fixed list that has no such key. Its own ParseCLI
+	// builds the right thing, and that is now what gets written.
+	//
+	// `--auth-method env` remains a different thing from either flag: it makes
+	// the Azure identity chain read its own AZURE_* triple.
+
+	// netlify is one token and an optional account to narrow to. The account
+	// picker is cnspec's own discovery, which is why it costs a round trip and
+	// only runs when the picker is opened.
+	registerSpec("netlify", FormSpec{
+		Target:     []string{"account"},
+		Sources:    map[string]string{"account": discoverSourceID("netlify", "accounts")},
+		Credential: []string{"token"},
+		Labels: map[string]string{
+			"account": "account (optional)",
+			"token":   "personal access token",
+		},
+	})
+
+	// nextdns is one API key and nothing else: no target flag, no positional,
+	// and its two discovery targets (accounts, profiles) have no flag to
+	// consume them, so there is nothing to attach a picker to. The whole form
+	// is the credential, which is exactly what the screen should say.
+	registerSpec("nextdns", FormSpec{
+		Credential: []string{"api-key"},
+		Labels:     map[string]string{"api-key": "API key"},
+	})
+
+	// slack's credential is ambient and already has its readout, its paste box
+	// and its SLACK_TOKEN route; see source_ambient.go. All that is left is the
+	// rest of the screen: the team is what is being scanned, so --team-id leads
+	// TARGET.
+	//
+	// --token is deliberately left with its own name. Relabelling it costs
+	// nothing on screen -- applyAmbient replaces the description with "paste a
+	// token — it never reaches the command line" and the readout above it
+	// already says what the field is -- and slack is the connector
+	// TestPastedTokenBeatsTheEnvironment reaches for by label, precisely
+	// because it is the ambient one whose token flag is still called "token".
+	registerSpec("slack", FormSpec{
+		Target:     []string{"team-id"},
+		Credential: []string{"token"},
+		Labels:     map[string]string{"team-id": "team ID"},
+	})
+
+	// snowflake identifies the target with --account, and the account
+	// identifier is the one thing in ~/.snowflake/connections.toml the
+	// connector can actually use -- no flag takes a connection name, which is
+	// the finding srcSnowflakeConnection records. --user leads CREDENTIAL
+	// rather than TARGET because ParseCLI reads it only to name the password or
+	// private-key credential it builds; it is who you sign in as, not what is
+	// being scanned.
+	//
+	// --password has --ask-pass, so it delivers by prompt, which is the best
+	// route there is: the secret never exists outside the process that uses it.
+	//
+	// --token, the programmatic access token, was the launcher's last standing
+	// refusal and is not one any more. The provider reads no environment
+	// variable for it -- verified by running it: with SNOWFLAKE_TOKEN,
+	// SNOWFLAKE_PASSWORD and SNOWFLAKE_PAT all set, the connector still failed
+	// with "missing credentials for snowflake connection" -- and it declares
+	// both --token and --password with ConfigEntry "-", so mql derived no name
+	// for them either. Every one of those facts is about how a flag *value*
+	// gets into the process, and the value now goes straight into req.Flags,
+	// which is where cobra would have put it. See TestSnowflakeTokenTravels.
+	registerSpec("snowflake", FormSpec{
+		Target:     []string{"account", "region", "role"},
+		Credential: []string{"user", "ask-pass", "password", "identity-file", "token"},
+		Sources:    map[string]string{"account": srcSnowflakeConnection},
+		Labels: map[string]string{
+			"account":       "account identifier",
+			"user":          "user name",
+			"ask-pass":      "prompt for password",
+			"identity-file": "private key file",
+			"token":         "programmatic access token (PAT)",
+		},
+	})
+
+	// tailscale takes the tailnet as its single positional argument, and the
+	// usage string does not name it: Use is the bare word "tailscale", so
+	// positionalLabels falls through to "argument 1". Naming it is most of what
+	// this spec is for. It reaches Options["tailnet"] straight from req.Args --
+	// confirmed by running it, which logs "connecting to custom tailnet
+	// tailnet=example.com" -- so it needs no environment route of its own.
+	//
+	// CREDENTIAL follows the provider's own precedence: AuthenticationMethod
+	// checks for an OAuth client first and only then for a token, so the OAuth
+	// pair leads and the token is the alternative below it.
+	//
+	// --base-url is left in OPTIONS. It points at a different coordination
+	// server rather than selecting what to scan, and promoting an override into
+	// TARGET would suggest it is a question every user has to answer.
+	registerSpec("tailscale", FormSpec{
+		Positional: []PositionalSpec{{
+			Label: "tailnet",
+			Desc:  "the tailnet to scan, e.g. example.com — leave empty for the default one",
+		}},
+		Credential: []string{"client-id", "client-secret", "token"},
+		Labels: map[string]string{
+			"client-id":     "OAuth client ID",
+			"client-secret": "OAuth client secret",
+			"token":         "API access token",
+			"base-url":      "API base URL",
+		},
+	})
+
+	// vercel scopes a scan with --team, and cnspec's own discovery is the only
+	// thing that can enumerate them, so the picker is the registered
+	// discover.vercel.teams source. It is CostRemote, which means it is skipped
+	// when the form opens, shows "press enter to look it up" and runs only when
+	// the field is opened -- the designed path for a source that needs a
+	// credential and a round trip.
+	//
+	// It is attached through Sources rather than LiveSources on purpose:
+	// applySources only fills a field whose `source` is set, so a field with
+	// nothing but a live source would spin, answer, and never show what it
+	// found. LiveSources is the second half of a pair, not a source on its own.
+	//
+	// discoverSourceID is called rather than srcDiscoverVercelProjects because
+	// the latter is declared but not registered -- vercel's registered target
+	// is teams, which is also the one --team consumes.
+	registerSpec("vercel", FormSpec{
+		Target:     []string{"team"},
+		Credential: []string{"token"},
+		Sources:    map[string]string{"team": discoverSourceID("vercel", "teams")},
+		Labels: map[string]string{
+			"team":  "team (slug or ID)",
+			"token": "API token",
+		},
+	})
+
+	// zoom uses Server-to-Server OAuth: an account id plus a client id and
+	// secret. The account is what is being scanned; the other two are the
+	// credential.
+	registerSpec("zoom", FormSpec{
+		Target:     []string{"account-id"},
+		Credential: []string{"client-id", "client-secret"},
+		Labels: map[string]string{
+			"account-id":    "account ID",
+			"client-id":     "S2S OAuth client ID",
+			"client-secret": "S2S OAuth client secret",
+		},
+	})
+}

--- a/cli/launcher/forms/forms_test.go
+++ b/cli/launcher/forms/forms_test.go
@@ -1,0 +1,189 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/cli/launcher/catalog"
+	"go.mondoo.com/cnspec/internal/connectors"
+)
+
+// categoryFile is where a connector's spec belongs, by the category the
+// launcher files that connector under.
+//
+// This is the whole convention, written down once. Every entry in
+// catalog.CategoryOrder has a file and no file is shared, so "where is the jamf
+// form" has the same answer as "where does the launcher show jamf".
+var categoryFile = map[string]string{
+	catalog.CatHosts:     "forms_hosts.go",
+	catalog.CatContainer: "forms_container.go",
+	catalog.CatCloud:     "forms_cloud.go",
+	catalog.CatIaC:       "forms_iac.go",
+	catalog.CatIdentity:  "forms_identity.go",
+	catalog.CatSaaS:      "forms_saas.go",
+	catalog.CatNetwork:   "forms_network.go",
+	catalog.CatDatabase:  "forms_database.go",
+	catalog.CatAI:        "forms_ai.go",
+	catalog.CatDev:       "forms_dev.go",
+	catalog.CatOther:     "forms_other.go",
+}
+
+// A category the catalog groups connectors under, with nowhere here to put its
+// specs, is how the taxonomy drifts back apart: the first spec for it lands in
+// whichever file its author had open.
+func TestEveryCatalogCategoryHasAFile(t *testing.T) {
+	for _, cat := range catalog.CategoryOrder {
+		if categoryFile[cat] == "" {
+			t.Errorf("the catalog groups connectors under %q and no file is named for it; "+
+				"add one to categoryFile and create it", cat)
+		}
+	}
+	if len(categoryFile) != len(catalog.CategoryOrder) {
+		t.Errorf("categoryFile has %d entries, the catalog has %d categories",
+			len(categoryFile), len(catalog.CategoryOrder))
+	}
+
+	seen := map[string]string{}
+	for cat, file := range categoryFile {
+		if other, taken := seen[file]; taken {
+			t.Errorf("%s is named for both %q and %q; one file per category",
+				file, other, cat)
+		}
+		seen[file] = cat
+	}
+}
+
+// The rule that keeps the file names structural rather than historical.
+//
+// The files used to be forms_saas_a.go, forms_saas_b.go, forms_saas_c.go and so
+// on, where the letter recorded which contributor wrote which half. Nothing
+// objected, because nothing could: a spec is registered by its own init and the
+// registry never asked where the call came from. registerSpec records that now,
+// and this is what reads it back.
+//
+// A spec in the wrong file fails here with the name of the file it belongs in.
+// It does not fail at run time and it does not change a single screen, which is
+// exactly why it needs a test: the launcher works perfectly well with every
+// spec in one file, and so does a launcher with a hundred of them scattered at
+// random.
+func TestEverySpecIsFiledUnderItsCategory(t *testing.T) {
+	art, err := connectors.Load()
+	if err != nil {
+		t.Fatalf("the connector artifact does not parse: %v", err)
+	}
+	provider := make(map[string]string, len(art.Connectors))
+	for _, c := range art.Connectors {
+		provider[c.Name] = c.Provider
+	}
+
+	names := make([]string, 0, len(specFiles))
+	for name := range specFiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	checked := 0
+	for _, name := range names {
+		// The provider is what decides the category, and it is not always the
+		// connector's own name: ciscocatalyst and nd-ssh are served by
+		// networkdevices, host by network, mcp by ai.
+		prov, ok := provider[name]
+		if !ok {
+			t.Errorf("%s has a spec but is not in internal/connectors/connectors.json, "+
+				"so its category cannot be resolved and its file cannot be checked. "+
+				"Refresh the artifact with `make connectors/generate`, or say here why it "+
+				"is absent", name)
+			continue
+		}
+		want := categoryFile[catalog.Categorize(prov, name)]
+		if want == "" {
+			t.Errorf("%s is categorized as %q, which no file is named for",
+				name, catalog.Categorize(prov, name))
+			continue
+		}
+		checked++
+		if got := specFiles[name]; got != want {
+			t.Errorf("%s is registered in %s but the launcher files it under %q, "+
+				"so its spec belongs in %s", name, got, catalog.Categorize(prov, name), want)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no spec was checked against its category, so this test proves nothing")
+	}
+	t.Logf("checked %d of %d registrations", checked, len(specFiles))
+}
+
+// The other half of the rule: a file that is not named for a category is a
+// place a spec can hide from the test above.
+//
+// forms_saas_d.go is the failure this exists for. It would compile, its inits
+// would run, every screen would be identical -- and the split by category would
+// be back to a split by author with the first spec somebody appended to it.
+func TestNoSpecFileIsNamedForSomethingElse(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{}
+	for _, f := range categoryFile {
+		allowed[f] = true
+	}
+
+	found := 0
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasPrefix(n, "forms_") || !strings.HasSuffix(n, ".go") ||
+			strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		found++
+		if !allowed[n] {
+			t.Errorf("%s is not named for a catalog category. The specs are split by "+
+				"what the launcher shows, not by who wrote them; put its contents in the "+
+				"file for each connector's category", n)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no spec file was found, so this test proves nothing")
+	}
+	t.Logf("checked %d spec files", found)
+}
+
+// Registering a connector twice means two people each believed they owned it,
+// and init order decides which one the user gets. The launcher reports this
+// too; it is asserted here as well because this is the package where the second
+// registration would be written.
+func TestNoConnectorIsRegisteredTwice(t *testing.T) {
+	for _, name := range Duplicates() {
+		t.Errorf("%s has more than one registered spec", name)
+	}
+}
+
+// Specs() and Uncurated() hand out copies, so that the only way into the
+// registry is registerSpec's first-wins rule. A caller that could reach the
+// live map could add a connector's form from anywhere.
+func TestTheRegistryIsNotWritableThroughItsAccessors(t *testing.T) {
+	before := len(formSpecs)
+	Specs()["not-a-connector"] = FormSpec{}
+	Uncurated()["not-a-connector"] = "nor is this"
+	dup := Duplicates()
+	Duplicates()
+	_ = dup
+
+	if len(formSpecs) != before {
+		t.Errorf("the spec registry grew from %d to %d through a returned map",
+			before, len(formSpecs))
+	}
+	if _, ok := SpecFor("not-a-connector"); ok {
+		t.Error("a connector written into a returned map reached the registry")
+	}
+	if _, ok := UncuratedReason("not-a-connector"); ok {
+		t.Error("a reason written into a returned map reached the registry")
+	}
+}

--- a/cli/launcher/forms/sources.go
+++ b/cli/launcher/forms/sources.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+import (
+	"go.mondoo.com/cnspec/cli/launcher/source"
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// This package's names for the value pickers, and for the two things a spec
+// file does besides register a spec.
+//
+// The pickers themselves are cli/launcher/source: what a Source declares about
+// itself, the readers behind each one, and the registry they live in. None of
+// that knows what a connector is or what a screen looks like, and nothing here
+// adds behaviour -- these are the identifiers the spec files below spell, kept
+// as aliases so that moving the specs into this package was a move rather than
+// a rewrite of three thousand curated lines.
+//
+// Only the ids a spec file actually names are listed. The launcher aliases the
+// full namespace for its own tests; a picker nothing here attaches has no
+// business being spelled here.
+
+type (
+	// form is the engine's form, which an ambient credential's Compose func
+	// fills in. Nothing in this package builds one.
+	form = tuiform.Form
+	// envLookup is how the ambient credentials read the environment. Tests
+	// substitute it rather than exporting a developer's own tokens into an
+	// assertion.
+	envLookup = source.EnvLookup
+	// ambientCredential declares a connector whose whole credential is one
+	// token from one variable.
+	ambientCredential = source.AmbientCredential
+)
+
+// The source-id namespace, for the pickers a curated form attaches.
+const (
+	srcAWSProfile          = source.AWSProfile
+	srcKubeContext         = source.KubeContext
+	srcSSHHost             = source.SSHHost
+	srcDockerContainer     = source.DockerContainer
+	srcDockerImage         = source.DockerImage
+	srcGCPProject          = source.GCPProject
+	srcGCPProjectAll       = source.GCPProjectAll
+	srcGCPZone             = source.GCPZone
+	srcOCIProfile          = source.OCIProfile
+	srcAlicloudProfile     = source.AlicloudProfile
+	srcSnowflakeConnection = source.SnowflakeConnection
+	srcDockerContext       = source.DockerContext
+	srcK8sNamespace        = source.K8sNamespace
+
+	srcDiscoverGitLabProjects   = source.DiscoverGitLabProjects
+	srcDiscoverGitLabGroups     = source.DiscoverGitLabGroups
+	srcDiscoverVercelProjects   = source.DiscoverVercelProjects
+	srcDiscoverAtlasProjects    = source.DiscoverAtlasProjects
+	srcDiscoverClaudeWorkspaces = source.DiscoverClaudeWorkspaces
+)
+
+// ambientWhyEnv is the note put on a field prefilled from a variable, so the
+// screen says where a value it did not ask for came from.
+const ambientWhyEnv = source.AmbientWhyEnv
+
+var (
+	// registerAmbient declares a connector whose credential is ambient. It is
+	// the source registry's, not this package's: a spec file calls it beside
+	// the spec it belongs to, which is the only reason it is spelled here.
+	registerAmbient = source.RegisterAmbient
+	// envValue reads one variable through the lookup a caller supplied.
+	envValue = source.EnvValue
+)
+
+// discoverSourceID names a picker that runs cnspec's own discovery for a
+// connector and a target. A spec calls it rather than spelling a src id when
+// the target it wants has no registered id of its own.
+var discoverSourceID = source.DiscoverSourceID

--- a/cli/launcher/forms/spec.go
+++ b/cli/launcher/forms/spec.go
@@ -1,0 +1,246 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package forms
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// FormSpec describes a connector's input screen: which fields appear, in what
+// order, which are the target and which are the credential, and where a field's
+// suggested values come from.
+//
+// This is deliberately a data shape rather than Go logic, because it is the
+// shape proposed for the provider SDK. A provider that declares its own form
+// emits exactly this, and providerFormSpec, over in the launcher, is the single
+// place that reading it plugs in. The specs registered here today are the
+// interim source for the connectors people reach for most; each one deletes
+// itself the day its provider ships the same declaration.
+type FormSpec struct {
+	// Positional replaces the derived positional fields wholesale, because the
+	// usage string cannot describe a sub-command shape like `github org <ORG>`.
+	Positional []PositionalSpec `json:"positional,omitempty"`
+	// Target and Credential move flags into those sections, in this order.
+	Target     []string `json:"target,omitempty"`
+	Credential []string `json:"credential,omitempty"`
+	// Secret and NotSecret override the shared classifier for one flag of one
+	// connector.
+	//
+	// The classifier in secrets_classify.go reads flag names for every
+	// connector at once, so correcting one connector's odd flag by widening a
+	// word list re-classifies every other flag that happens to contain that
+	// word. Saying it here keeps the correction where the person who found it
+	// is already working, and keeps it from reaching anyone else's connector.
+	//
+	// Secret is the safe direction and NotSecret is not: marking a real
+	// credential NotSecret puts it on the command line, where `ps auxww` reads
+	// it. Use it only for a flag that names where a credential lives -- a path,
+	// an id -- and that the provider therefore has to receive as an argument.
+	Secret    []string `json:"secret,omitempty"`
+	NotSecret []string `json:"not_secret,omitempty"`
+	// Labels renames a flag for display; Sources attaches a value picker;
+	// Choices attaches a static option list.
+	Labels  map[string]string `json:"labels,omitempty"`
+	Sources map[string]string `json:"sources,omitempty"`
+	// LiveSources attach a picker that only runs when the field is opened,
+	// merged into whatever Sources already found.
+	LiveSources map[string]string   `json:"live_sources,omitempty"`
+	Choices     map[string][]string `json:"choices,omitempty"`
+	// Hide drops flags that are noise in a launcher.
+	Hide []string `json:"hide,omitempty"`
+	// ShowFlagsIf hides a flag unless the first positional field holds one of
+	// the listed values, so a form only asks what the chosen shape needs.
+	ShowFlagsIf map[string][]string `json:"show_flags_if,omitempty"`
+	// Env names the environment variable a field's value travels in, keyed by
+	// field identity -- "f:profile", "p:1", or a bare flag name as shorthand.
+	//
+	// Not every value the user picks has a flag to travel in. alicloud
+	// declares no --profile, snowflake takes no connection name, docker and
+	// container take no --context, and k8s --context is parsed and then never
+	// reaches the client config. For those the child process is reached
+	// through its environment instead, and this is where a spec says so. The
+	// general case -- a value that has to be written to a file before it means
+	// anything, which is what k8s needs -- is an EnvSpec instead.
+	Env map[string]string `json:"env,omitempty"`
+}
+
+// PositionalSpec describes one field in the TARGET section: a positional
+// argument, or -- with Special set -- a question the launcher owns that
+// contributes no argument at all.
+type PositionalSpec struct {
+	Label    string `json:"label"`
+	Desc     string `json:"desc,omitempty"`
+	Required bool   `json:"required,omitempty"`
+	// Special marks this field as the launcher's rather than the connector's,
+	// so it is drawn and answered like a target but never reaches the command
+	// line -- not as an argument, and not as a flag.
+	//
+	// This is what makes a value with no flag expressible. alicloud has a
+	// profile and no --profile; docker, container and local have a context and
+	// no --context. Both have to travel in the child's environment, and until
+	// this existed there was no way to say so: the only field a spec could add
+	// for a flagless value was a positional, args() emits every visible
+	// positional, and alicloud is MinArgs=0/MaxArgs=0 -- so `cnspec shell
+	// alicloud staging` answered `unknown command "staging"`. The obvious
+	// escape, an Emit map with no entries, suppressed the argument by making
+	// emitted() return "" for every value, but formEnvironment reads the same
+	// accessor, so the child got ALIBABA_CLOUD_PROFILE= instead. An empty
+	// variable is not an absent one.
+	//
+	// The name is the field's identity as "s:<Special>", which is how Env and
+	// a source's Needs refer to it, and it has to be declared in
+	// launcherOwnedFields -- see TestNoKeychainToggleIsOffered for why that
+	// allowlist exists.
+	Special string `json:"special,omitempty"`
+	// Options makes it a picker; Source names a live value picker instead.
+	Options []string `json:"options,omitempty"`
+	Source  string   `json:"source,omitempty"`
+	// Emit maps a chosen option to what it contributes to the command line. An
+	// option mapping to "" contributes nothing, which is how a selector steers
+	// the UI without adding a word cnspec would not understand.
+	Emit map[string]string `json:"emit,omitempty"`
+	// SourceBy picks this field's value source from the value of the preceding
+	// positional argument.
+	SourceBy map[string]string `json:"source_by,omitempty"`
+	// LiveSourceBy attaches a picker that only runs when the field is opened,
+	// chosen by the preceding positional the same way SourceBy is.
+	LiveSourceBy map[string]string `json:"live_source_by,omitempty"`
+	// DiscoverBy preselects --discover targets for a chosen value, for targets
+	// that are enumerated by cnspec's own discovery rather than locally.
+	DiscoverBy map[string][]string `json:"discover_by,omitempty"`
+	// ShowIf hides this field unless the preceding positional holds one of
+	// these values.
+	ShowIf []string `json:"show_if,omitempty"`
+}
+
+// The launcher-owned target fields, named here because two things refer to
+// each one: the spec that creates it, and whatever names its identity --
+// "s:alicloud-profile" -- in an Env map or a source's Needs. A literal in both
+// places is a typo waiting to be silent, since fieldMatchesIdentity simply
+// never matches and the value goes nowhere.
+//
+// Every one of these must also be listed in launcherOwnedFields; see
+// TestNoKeychainToggleIsOffered.
+const (
+	// SpecialAlicloudProfile is a profile from ~/.alibabacloud/credentials.
+	// alicloud declares no --profile, so it travels as ALIBABA_CLOUD_PROFILE.
+	SpecialAlicloudProfile = "alicloud-profile"
+	// SpecialDockerContext is a docker context. docker and container declare
+	// no --context, so it travels as DOCKER_CONTEXT.
+	SpecialDockerContext = "docker-context"
+)
+
+// formSpecs holds every registered overlay, keyed by connector name.
+//
+// It used to be one map literal, which meant every connector curated after the
+// first twelve was an edit to the same block of the same file. It is a registry
+// for the same reason the source registry is one: adding a connector should be
+// an append in a file its author owns.
+var formSpecs = map[string]FormSpec{}
+
+// uncurated records the connectors that deliberately have no FormSpec, and
+// why. It is the other half of formSpecs: without it, "nobody has curated this
+// yet" and "there is nothing a spec could say about this" are the same empty
+// entry, and the reach test cannot tell a gap from a decision.
+//
+// The reasons are load-bearing rather than decorative. Each one is a claim
+// about the connector that stops being true if the connector changes -- device
+// hiding every flag it declares, ipinfo declaring none at all -- so a reason
+// that has gone stale is a spec that should now be written.
+var uncurated = map[string]string{}
+
+// registerUncurated declares that a connector has no form on purpose, and is
+// called from the init of the file that owns it, beside the specs its
+// neighbours got.
+func registerUncurated(connector, reason string) {
+	uncurated[connector] = reason
+	specFiles[connector] = callerFile()
+}
+
+// uncuratedReason returns the recorded reason a connector has no spec.
+func uncuratedReason(connector string) (string, bool) {
+	reason, ok := uncurated[connector]
+	return reason, ok
+}
+
+// duplicateSpecs records connectors registered more than once, for
+// TestNoConnectorHasTwoSpecs to report. Two registrations mean two people each
+// believed they owned the connector, and whichever init ran second would
+// otherwise silently win -- a merge conflict that leaves no conflict marker.
+var duplicateSpecs []string
+
+// registerSpec declares a connector's form, and is called from each spec file's
+// init. The first registration wins; a later one is recorded and ignored rather
+// than allowed to overwrite, because init order across files is not something
+// either author controls.
+func registerSpec(connector string, spec FormSpec) {
+	if _, taken := formSpecs[connector]; taken {
+		duplicateSpecs = append(duplicateSpecs, connector)
+		return
+	}
+	formSpecs[connector] = spec
+	specFiles[connector] = callerFile()
+}
+
+// specFiles records which file each registration came from, so
+// TestEverySpecIsFiledUnderItsCategory can check that a spec is written where
+// the launcher shows its connector.
+//
+// It is taken from the call stack rather than declared, because a declared file
+// name is a second thing to keep in step and would be wrong in exactly the case
+// the test exists to catch: a spec pasted into the wrong file, along with the
+// name of the file it came from. The stack cannot be pasted.
+var specFiles = map[string]string{}
+
+// callerFile is the base name of the spec file that called register*. Two
+// frames up: this function, then the register* that called it.
+func callerFile() string {
+	if _, file, _, ok := runtime.Caller(2); ok {
+		return filepath.Base(file)
+	}
+	return ""
+}
+
+// Specs returns every registered overlay, keyed by connector name.
+//
+// The map is a copy: the registry is written once, by the inits in this
+// package, and a caller that could reach the live map could add a connector's
+// form from anywhere -- which is the arrangement registerSpec's first-wins rule
+// exists to prevent.
+func Specs() map[string]FormSpec {
+	out := make(map[string]FormSpec, len(formSpecs))
+	for k, v := range formSpecs {
+		out[k] = v
+	}
+	return out
+}
+
+// SpecFor returns the curated overlay for a connector, if one is registered.
+func SpecFor(connector string) (FormSpec, bool) {
+	spec, ok := formSpecs[connector]
+	return spec, ok
+}
+
+// Uncurated returns every connector deliberately left without a form, and the
+// reason recorded for it.
+func Uncurated() map[string]string {
+	out := make(map[string]string, len(uncurated))
+	for k, v := range uncurated {
+		out[k] = v
+	}
+	return out
+}
+
+// UncuratedReason returns the recorded reason a connector has no spec.
+func UncuratedReason(connector string) (string, bool) {
+	return uncuratedReason(connector)
+}
+
+// Duplicates returns the connectors registered more than once. Two
+// registrations mean two people each believed they owned the connector; see
+// registerSpec.
+func Duplicates() []string {
+	return append([]string(nil), duplicateSpecs...)
+}

--- a/cli/launcher/scan/progress.go
+++ b/cli/launcher/scan/progress.go
@@ -1,0 +1,204 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"sync"
+
+	"go.mondoo.com/cnspec/cli/progress"
+)
+
+// Progress is what the launcher knows about a scan in flight.
+//
+// It is an aggregate rather than a log. The child emits one NDJSON event per
+// whole percent per asset (cli/progress/stream.go), which on a large policy is
+// still thousands of lines, and nothing on screen can use more than the latest
+// state of each asset. Folding them here -- off the event loop, in the reader
+// goroutine -- is what lets the display coalesce: a UI that falls behind
+// redraws once with the current numbers instead of replaying a queue.
+//
+// It is written by exactly one goroutine and read by the renderer on the event
+// loop, so every access takes the lock and the renderer works from a snapshot
+// rather than from the live struct.
+type Progress struct {
+	mu sync.Mutex
+
+	order   []string
+	byIndex map[string]*Asset
+
+	discovered    int
+	filtered      int
+	completed     int
+	errored       int
+	notApplicable int
+
+	// scanDone records the summary event, which is the child's own statement
+	// that it is finished -- distinct from the process exiting, which is all
+	// the exit status can tell us.
+	scanDone bool
+}
+
+// Asset is one asset's state, in the order the scan announced it.
+type Asset struct {
+	Index    string
+	Name     string
+	Platform string
+	Num      int
+	Percent  float64
+	Score    string
+	State    string
+	Done     bool
+}
+
+// Label is what the asset is called on screen: its name, falling back to the
+// platform id the scanner keys it by.
+func (a Asset) Label() string {
+	if a.Name != "" {
+		return a.Name
+	}
+	return a.Index
+}
+
+// Snapshot is a consistent copy of the aggregate for one frame.
+type Snapshot struct {
+	Assets []Asset
+
+	Total         int
+	Done          int
+	Completed     int
+	Errored       int
+	NotApplicable int
+	Discovered    int
+	Filtered      int
+
+	ScanDone bool
+}
+
+func NewProgress() *Progress {
+	return &Progress{byIndex: map[string]*Asset{}}
+}
+
+// apply folds one event into the aggregate.
+//
+// Unknown event names are ignored rather than rejected: the stream's schema
+// says adding an event type is backwards compatible, so a launcher that
+// refused one would break on the first scanner that emits more than it did.
+func (p *Progress) apply(ev progress.StreamEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	switch ev.Event {
+	case progress.EventScanStart:
+		// Nothing to record: the session already knows when it started, and
+		// the child's own clock is not the one the elapsed time is measured on.
+
+	case progress.EventDiscovered:
+		p.discovered = ev.Discovered
+
+	case progress.EventFiltered:
+		p.filtered = ev.Filtered
+
+	case progress.EventAssetAdded:
+		a := p.assetLocked(ev.Index, ev.Num)
+		if ev.Name != "" {
+			a.Name = ev.Name
+		}
+		if ev.Platform != "" {
+			a.Platform = ev.Platform
+		}
+
+	case progress.EventAssetProgress:
+		a := p.assetLocked(ev.Index, ev.Num)
+		// Never backwards: events can only be reordered by a consumer, not by
+		// the writer, but a bar that jumps back reads as a bug either way.
+		if ev.Percent > a.Percent {
+			a.Percent = ev.Percent
+		}
+
+	case progress.EventAssetScore:
+		p.assetLocked(ev.Index, ev.Num).Score = ev.Score
+
+	case progress.EventAssetDone:
+		a := p.assetLocked(ev.Index, ev.Num)
+		a.Done = true
+		a.State = ev.State
+		a.Percent = 1
+		// The counters come from the event rather than being incremented here,
+		// so a duplicate asset_done cannot double-count.
+		p.completed, p.errored, p.notApplicable = p.tallyLocked()
+
+	case progress.EventScanDone:
+		p.scanDone = true
+		p.completed = ev.Completed
+		p.errored = ev.Errored
+		p.notApplicable = ev.NotApplicable
+		if ev.Discovered > 0 {
+			p.discovered = ev.Discovered
+		}
+		if ev.Filtered > 0 {
+			p.filtered = ev.Filtered
+		}
+	}
+}
+
+// assetLocked returns the tracked asset, announcing it first when the stream
+// reports on one it never added. Num comes from the event because it is the
+// writer's ordering, not ours.
+func (p *Progress) assetLocked(index string, num int) *Asset {
+	if a, ok := p.byIndex[index]; ok {
+		if a.Num == 0 {
+			a.Num = num
+		}
+		return a
+	}
+	a := &Asset{Index: index, Num: num}
+	if a.Num == 0 {
+		a.Num = len(p.order) + 1
+	}
+	p.byIndex[index] = a
+	p.order = append(p.order, index)
+	return a
+}
+
+// tallyLocked recounts the terminal states from the assets themselves.
+func (p *Progress) tallyLocked() (completed, errored, notApplicable int) {
+	for _, index := range p.order {
+		a := p.byIndex[index]
+		if !a.Done {
+			continue
+		}
+		switch a.State {
+		case progress.StateErrored:
+			errored++
+		case progress.StateNotApplicable:
+			notApplicable++
+		default:
+			completed++
+		}
+	}
+	return completed, errored, notApplicable
+}
+
+// Snapshot copies the aggregate for one frame. The renderer never touches the
+// live struct, so a repaint cannot tear across an event.
+func (p *Progress) Snapshot() Snapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	out := Snapshot{
+		Assets:        make([]Asset, 0, len(p.order)),
+		Total:         len(p.order),
+		Completed:     p.completed,
+		Errored:       p.errored,
+		NotApplicable: p.notApplicable,
+		Discovered:    p.discovered,
+		Filtered:      p.filtered,
+		ScanDone:      p.scanDone,
+	}
+	for _, index := range p.order {
+		out.Assets = append(out.Assets, *p.byIndex[index])
+	}
+	out.Done = out.Completed + out.Errored + out.NotApplicable
+	return out
+}

--- a/cli/launcher/scan/scan.go
+++ b/cli/launcher/scan/scan.go
@@ -1,0 +1,584 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package scan runs one `cnspec scan` as a background child and reports on it.
+//
+// It owns the process, the progress stream it emits, the report it writes and
+// the single cleanup that removes all of it. It owns none of the presentation:
+// there is no bubbletea message and no rendering in here, because what a scan
+// *is* does not change with the screen that happens to be watching it.
+package scan
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/cli/progress"
+	"go.mondoo.com/cnspec/cli/reporter"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// A scan started from the launcher is a background child, not a handover.
+//
+// The launcher used to release the terminal to `cnspec scan` (tea.Exec) and
+// take it back when the child was done, which made it a menu that got out of
+// the way. It is now a place you stay: the child runs detached from the
+// terminal, its progress arrives as NDJSON on a descriptor the launcher holds,
+// and the report it writes is read back and rendered in the TUI.
+//
+// Three properties are load-bearing, and each one is a bug that was possible
+// without it:
+//
+//   - The child writes a full-fidelity report. `-o json-full --output-target`
+//     writes the whole policy.ReportCollection, which is the only artifact the
+//     viewer can be built from; every other output format is a reduction that
+//     has already thrown away the titles, docs and remediation.
+//   - The child is pinned to this binary. Without MONDOO_AUTO_UPDATE=false it
+//     hands off to whatever release sits in the auto-update cache -- a binary
+//     that may never have heard of json-full, which would write nothing and
+//     leave the viewer opening on a file that is not there.
+//   - The child is killable. exec.CommandContext gets the context the UI
+//     cancels, so a scan the user walks away from dies rather than carrying on
+//     against a cloud account nobody is watching.
+
+// ReportFormat is the output format the child is asked for, and ReportFile is
+// what the artifact is called inside its private directory.
+const (
+	ReportFormat = "json-full"
+	ReportFile   = "report.json"
+)
+
+// KillDelay is how long a cancelled child gets to exit on its own before
+// os/exec kills it outright.
+const KillDelay = 5 * time.Second
+
+// OutputTail is how much of the child's output is kept for the error path.
+const OutputTail = 16 << 10
+
+// Binary names what a scan re-executes: this same binary, so the child goes
+// through the exact same startup path as if the user had typed the command.
+//
+// It is a variable for one reason, and the reason is that the alternative is
+// untestable. Everything that makes this phase worth having -- the inherited
+// descriptor the progress stream arrives on, a non-zero exit that still carries
+// a report, a cancel that actually kills something -- only exists once a real
+// process has been forked. Substituting the child is what lets a test prove
+// those against a real fork instead of asserting that the arguments look right.
+var Binary = func() string {
+	self, err := os.Executable()
+	if err != nil {
+		return os.Args[0]
+	}
+	return self
+}
+
+// Outcome is how the child ended: the error from Wait (nil for a clean exit)
+// and whatever it wrote to its output streams.
+//
+// A non-nil Err is emphatically not "the scan failed". `cnspec scan` exits 1
+// when any asset errored *or* when the worst score crosses the risk threshold
+// (apps/cnspec/cmd/scan.go), so a scan that worked perfectly and found two
+// failing checks lands here with an ExitError. Only the report file decides
+// which of the two happened -- see LoadReport, and the launcher's scanExited.
+type Outcome struct {
+	Err    error
+	Output string
+}
+
+// Request is what a scan has to be handed to run: an argv, the environment it
+// needs on top of this process's own, and the release for whatever the caller
+// wrote to disk to make the command possible.
+//
+// It is deliberately not the launcher's own assembly type. A launch plan also
+// carries the warning line the scanning screen shows, which is a fact about a
+// pane rather than about a process, and depending on it here would point the
+// scan engine back at the layer that decides what to run. Naming what a scan
+// needs is what leaves this package with no edge to the launcher at all.
+type Request struct {
+	// Args is the command line as the user sees it. The reporting flags the
+	// launcher adds for itself are not in here and are never shown: they are
+	// how the caller reads the result, not part of what was asked for.
+	Args []string
+	// Env is what the caller asked for, on top of this process's environment.
+	Env []string
+	// Cleanup releases whatever the caller wrote for this command -- a
+	// generated inventory holding a credential, a rewritten kubeconfig. It is
+	// released with the rest of the session, so there is one thing that ends a
+	// scan rather than two.
+	Cleanup func()
+	// TrackTemp registers a cleanup in the caller's process-wide registry and
+	// returns it wrapped, so that every exit the process can observe -- a
+	// signal, a panic unwinding, quitting -- removes what this session wrote.
+	//
+	// A nil TrackTemp is honoured rather than rejected, but it means the report
+	// directory is only removed on the paths this package reaches itself. The
+	// launcher always supplies one; see the shim in apps/cnspec/cmd/interactive.
+	TrackTemp func(func()) func()
+}
+
+// Session is one background scan: the child, the temp artifact it writes, the
+// progress stream it emits, and the single cleanup that removes all of it.
+//
+// It is created on the caller's event loop -- which is why the context and the
+// channels exist before the process does, so a user who presses esc while the
+// fork is still in flight has something to cancel -- and started from a command
+// that runs off it.
+type Session struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	args      []string
+	env       []string
+	trackTemp func(func()) func()
+
+	// reportPath is where the child writes the json-full artifact. It is set
+	// before the fork and read only after the child has exited.
+	reportPath string
+
+	// prog is the aggregate of the NDJSON progress stream, written by the
+	// reader goroutine and read by the renderer. It carries its own lock.
+	prog *Progress
+	// wake carries one token per progress event and is closed when the stream
+	// ends. It is a notification, not a queue: the state lives in prog, so a
+	// coalesced wake loses nothing and a UI that fell behind never becomes
+	// back-pressure on the child's writes.
+	wake chan struct{}
+
+	// exit carries the child's outcome exactly once.
+	exit chan Outcome
+	// done is closed once that outcome has been published, so an abort can wait
+	// for the child to be reaped before removing the files it was reading.
+	done chan struct{}
+
+	startedAt time.Time
+
+	cleanupMu sync.Mutex
+	cleanups  []func()
+	released  bool
+}
+
+// NewSession builds the session for a prepared request. Nothing is forked here:
+// this runs on the caller's event loop, and the whole point of it is that the
+// cancel function exists from the moment the launcher switches screens.
+func NewSession(req Request) *Session {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:       ctx,
+		cancel:    cancel,
+		args:      req.Args,
+		env:       req.Env,
+		trackTemp: req.TrackTemp,
+		prog:      NewProgress(),
+		wake:      make(chan struct{}, 1),
+		exit:      make(chan Outcome, 1),
+		done:      make(chan struct{}),
+		startedAt: time.Now(),
+	}
+	if s.trackTemp == nil {
+		s.trackTemp = func(fn func()) func() { return fn }
+	}
+	s.AddCleanup(req.Cleanup)
+	return s
+}
+
+// Progress is the live aggregate of the child's progress stream.
+func (s *Session) Progress() *Progress { return s.prog }
+
+// Wake yields one token per progress event and is closed when the stream ends.
+func (s *Session) Wake() <-chan struct{} { return s.wake }
+
+// Exit carries the child's outcome exactly once.
+func (s *Session) Exit() <-chan Outcome { return s.exit }
+
+// ReportPath is where the child was told to write its artifact. It is empty
+// until Start has run.
+func (s *Session) ReportPath() string { return s.reportPath }
+
+// Cancel asks the child to stop. It is safe to call more than once and before
+// the fork, which is the point of it existing from construction.
+func (s *Session) Cancel() { s.cancel() }
+
+// AddCleanup registers something to release when the scan is over.
+func (s *Session) AddCleanup(fn func()) {
+	if fn == nil {
+		return
+	}
+	s.cleanupMu.Lock()
+	if s.released {
+		// Registering after the session ended -- a fork that lost a race with
+		// a cancel -- must still release, or the file it names outlives the UI.
+		s.cleanupMu.Unlock()
+		fn()
+		return
+	}
+	s.cleanups = append(s.cleanups, fn)
+	s.cleanupMu.Unlock()
+}
+
+// Release runs every cleanup exactly once, whichever path reaches it first.
+func (s *Session) Release() {
+	s.cleanupMu.Lock()
+	if s.released {
+		s.cleanupMu.Unlock()
+		return
+	}
+	s.released = true
+	fns := s.cleanups
+	s.cleanups = nil
+	s.cleanupMu.Unlock()
+
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+// Abort kills the child and releases everything once it has been reaped.
+//
+// Waiting matters: the child may still be reading the generated inventory, and
+// removing that out from under a process that has not died yet turns a
+// cancelled scan into a confusing connection error instead of a cancelled scan.
+func (s *Session) Abort() {
+	s.cancel()
+	go func() {
+		<-s.done
+		s.Release()
+	}()
+}
+
+// finish publishes the outcome and marks the session reaped. It is called
+// exactly once, by whichever goroutine owns the child.
+func (s *Session) finish(out Outcome) {
+	s.exit <- out
+	close(s.done)
+}
+
+// Elapsed is how long the scan has been running.
+func (s *Session) Elapsed() time.Duration { return time.Since(s.startedAt) }
+
+// Start forks the child and wires up its progress stream and its exit.
+//
+// Everything after Start runs in goroutines: one folding the NDJSON stream into
+// the aggregate, one waiting for the process. The caller gets control back as
+// soon as the fork succeeds.
+//
+// A Start that fails ends the session on the way out -- the progress stream is
+// closed and the failure is published as the outcome -- because nothing was
+// forked and so no goroutine will ever do it. That is what makes a session end
+// exactly one way whatever happened, and it is why the caller has nothing to do
+// with the error beyond showing it.
+func (s *Session) Start() error {
+	if err := s.start(); err != nil {
+		close(s.wake)
+		s.finish(Outcome{Err: err})
+		return err
+	}
+	return nil
+}
+
+func (s *Session) start() error {
+	self := Binary()
+
+	// A private directory, not just a private file, the same way the generated
+	// inventory does it: the report is not a secret, but it names every asset
+	// and every failing check on them.
+	dir, err := os.MkdirTemp("", "cnspec-ui-report-")
+	if err != nil {
+		return errors.Wrap(err, "cannot create a directory for the report")
+	}
+	s.reportPath = filepath.Join(dir, ReportFile)
+	// Registered before the child can write a byte, in the caller's registry --
+	// the same one the generated inventory holding a credential goes in -- so
+	// every way out of this process -- quitting, SIGHUP, a panic unwinding --
+	// removes it. Cancelling goes in the same cleanup: an abnormal exit must
+	// kill the child rather than leave it writing into a directory that is
+	// already gone.
+	s.AddCleanup(s.trackTemp(func() {
+		s.cancel()
+		_ = os.RemoveAll(dir)
+	}))
+
+	sink, err := newProgressSink(dir)
+	if err != nil {
+		return err
+	}
+
+	// The reporting flags go on the end and are deliberately not stored back on
+	// the session: they are how the launcher reads the answer, not part of the
+	// command the user asked for, and the scanning screen shows the latter.
+	args := append(append([]string{}, s.args...),
+		"-o", ReportFormat, "--output-target", s.reportPath)
+
+	cmd := exec.CommandContext(s.ctx, self, args...)
+	cmd.Env = append(os.Environ(), s.env...)
+	// os/exec keeps the last entry for a repeated key, so both of these win
+	// over anything inherited.
+	cmd.Env = append(cmd.Env,
+		"MONDOO_AUTO_UPDATE=false",
+		progress.StreamEnvVar+"="+sink.target)
+	cmd.ExtraFiles = sink.extraFiles
+
+	// Cancel is a request first and a kill second: cnspec closes its provider
+	// connections on an interrupt. WaitDelay is what makes cancel mean cancel
+	// anyway when it does not.
+	cmd.Cancel = func() error {
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = KillDelay
+
+	// The child gets no terminal: stdin is /dev/null and both output streams
+	// are captured. os/exec promises at most one goroutine writes when Stdout
+	// and Stderr are the same comparable writer. The tail is bounded because a
+	// debug-level scan produces megabytes of log lines and only the last
+	// screenful of them has ever explained anything.
+	out := &tailWriter{limit: OutputTail}
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	if err := cmd.Start(); err != nil {
+		sink.closeAll()
+		return errors.Wrapf(err, "cannot start %s", filepath.Base(self))
+	}
+
+	// The parent's copy of the write end is closed here, once, on purpose:
+	// while it stays open the reader below never sees EOF. It is also why the
+	// pipe is held as an *os.File all the way through Start rather than reduced
+	// to a descriptor number. A file whose Fd was handed elsewhere and which
+	// then becomes collectable is closed a second time by the runtime's own
+	// cleanup, on a number the process has since reused -- and because os.File
+	// uses runtime.AddCleanup now, SetFinalizer(f, nil) does not prevent it.
+	sink.childStarted()
+
+	go func() {
+		defer sink.closeAll()
+		s.ReadProgress(sink.reader)
+	}()
+
+	go func() {
+		err := cmd.Wait()
+		s.finish(Outcome{Err: err, Output: out.String()})
+	}()
+
+	return nil
+}
+
+// ReadProgress folds the child's NDJSON stream into the aggregate, waking the
+// caller once per event. It returns when the stream ends, which on the pipe is
+// when the child has exited and the parent's write end is closed.
+func (s *Session) ReadProgress(r io.Reader) {
+	defer close(s.wake)
+	if r == nil {
+		return
+	}
+
+	sc := bufio.NewScanner(r)
+	// One event is one line and an asset name can be long. The ceiling stops a
+	// corrupt stream from growing the buffer without bound.
+	sc.Buffer(make([]byte, 0, 8<<10), 1<<20)
+
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev progress.StreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// A line the launcher cannot read is a display problem, never a
+			// reason to stop watching a scan that is running perfectly well.
+			continue
+		}
+		s.prog.apply(ev)
+		select {
+		case s.wake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// LoadReport reads the artifact the child wrote back into memory. On a real
+// scan it is a multi-megabyte JSON document, which is not something to parse
+// between two keystrokes -- callers run this off their event loop.
+func (s *Session) LoadReport() (*policy.ReportCollection, error) {
+	if s.reportPath == "" {
+		return nil, errors.New("the scan wrote no report")
+	}
+	return reporter.LoadCollectionFile(s.reportPath)
+}
+
+// --- the progress destination ------------------------------------------------
+
+// progressSink is the parent's end of the child's progress stream.
+//
+// There are two shapes because there have to be. A pipe is what a live consumer
+// wants -- the reader blocks and events arrive as they happen -- but it reaches
+// the child as an inherited descriptor, and exec.Cmd.ExtraFiles is not
+// supported on Windows. There the stream goes to a file in the same private
+// directory as the report, and is tailed.
+type progressSink struct {
+	// target is the MONDOO_PROGRESS_STREAM value handed to the child.
+	target string
+	// extraFiles are the descriptors the child inherits, if any.
+	extraFiles []*os.File
+	// reader yields the NDJSON stream to the parent.
+	reader io.Reader
+
+	// write is the parent's copy of the pipe's write end, closed as soon as the
+	// child owns its own.
+	write *os.File
+	// closers release what is left when the stream is done.
+	closers []io.Closer
+	once    sync.Once
+}
+
+// progressFD is the descriptor the first entry of ExtraFiles lands on in the
+// child; 0, 1 and 2 are the standard streams.
+const progressFD = 3
+
+func newProgressSink(dir string) (*progressSink, error) {
+	if runtime.GOOS == "windows" {
+		return newFileSink(dir)
+	}
+	return newPipeSink()
+}
+
+func newPipeSink() (*progressSink, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open the progress stream")
+	}
+	return &progressSink{
+		target:     "fd:" + strconv.Itoa(progressFD),
+		extraFiles: []*os.File{w},
+		reader:     r,
+		write:      w,
+		closers:    []io.Closer{r},
+	}, nil
+}
+
+func newFileSink(dir string) (*progressSink, error) {
+	path := filepath.Join(dir, "progress.ndjson")
+	// Created here rather than left to the child, because the tail opens it
+	// before the child has necessarily written anything.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open the progress stream")
+	}
+	t := &tailReader{f: f}
+	return &progressSink{
+		target:  path,
+		reader:  t,
+		closers: []io.Closer{t, f},
+	}, nil
+}
+
+// childStarted releases the parent's copy of anything the child now owns.
+func (s *progressSink) childStarted() {
+	if s.write != nil {
+		_ = s.write.Close()
+		s.write = nil
+	}
+}
+
+// closeAll releases everything the sink holds, including a write end the child
+// never got because the fork failed.
+func (s *progressSink) closeAll() {
+	s.once.Do(func() {
+		s.childStarted()
+		for _, c := range s.closers {
+			_ = c.Close()
+		}
+	})
+}
+
+// tailInterval is how often the Windows fallback looks for new events.
+const tailInterval = 100 * time.Millisecond
+
+// tailReader turns a file being appended to by another process into a stream
+// that ends when the reader is closed.
+//
+// It exists only for the platform that cannot inherit a pipe. Read polls rather
+// than returning (0, nil), which an io.Reader caller is entitled to treat as a
+// broken reader.
+type tailReader struct {
+	f      *os.File
+	closed atomic.Bool
+}
+
+func (t *tailReader) Read(p []byte) (int, error) {
+	for {
+		n, err := t.f.Read(p)
+		if n > 0 {
+			return n, nil
+		}
+		if err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+		if t.closed.Load() {
+			return 0, io.EOF
+		}
+		time.Sleep(tailInterval)
+	}
+}
+
+func (t *tailReader) Close() error {
+	t.closed.Store(true)
+	return nil
+}
+
+// --- the child's output ------------------------------------------------------
+
+// tailWriter keeps the last limit bytes written to it. It is what the error
+// path shows when a scan produced no readable report, because the reason it
+// did not is on the child's stderr and nowhere else.
+type tailWriter struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
+}
+
+func (w *tailWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	if w.limit > 0 && len(w.buf) > w.limit {
+		w.buf = w.buf[len(w.buf)-w.limit:]
+	}
+	return len(p), nil
+}
+
+func (w *tailWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return string(w.buf)
+}
+
+// LastLines returns the final n non-empty lines of the child's output, which is
+// what there is room for in a footer.
+func LastLines(s string, n int) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	if len(out) > n {
+		out = out[len(out)-n:]
+	}
+	return out
+}

--- a/cli/launcher/scan/scan_test.go
+++ b/cli/launcher/scan/scan_test.go
@@ -1,0 +1,423 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mondoo.com/cnspec/cli/progress"
+	"go.mondoo.com/cnspec/cli/reporter"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// These tests fork a real child, and that is the point of them.
+//
+// Everything this package is for only exists once a process has actually been
+// started: the descriptor the progress stream is inherited on, an exit status
+// that says failure while the report says otherwise, a cancel that has
+// something to kill. A test that asserted the assembled arguments look right
+// would prove none of it -- and the three bugs worth having a test for (a pipe
+// that never reaches EOF, a scan treated as broken because it found problems,
+// an abandoned child left running) are exactly the three it would miss.
+//
+// The child is this test binary, re-executed with -test.run pointed at
+// TestScanChild, which is the pattern os/exec's own tests use. Binary is the
+// seam. It writes what it emits rather than replaying a recording, because what
+// is under test here is the transport and the lifecycle, not the shape of a
+// real scan's output: the launcher's own tests, which drive a Model, are the
+// ones that run against recorded fixtures.
+
+const (
+	childEnv     = "CNSPEC_SCAN_TEST_CHILD"
+	childModeEnv = "CNSPEC_SCAN_TEST_CHILD_MODE"
+	childExitEnv = "CNSPEC_SCAN_TEST_CHILD_EXIT"
+
+	// childModeReport writes a report and a progress stream: what a scan that
+	// worked looks like.
+	childModeReport = "report"
+	// childModeSilent writes progress but no report: a scan that fell over
+	// before it had anything to say.
+	childModeSilent = "silent"
+	// childModeHang never exits on its own, so only a kill ends it.
+	childModeHang = "hang"
+)
+
+// childAsset is what the stand-in child claims to have scanned, on both the
+// progress stream and in the report, so a test can tell one end from the other.
+const (
+	childAssetIndex = "//platformid.api.mondoo.app/hostname/scan-test-host"
+	childAssetName  = "scan-test-host"
+	childAssetScore = "HIGH"
+)
+
+// TestScanChild is the stand-in scan. It is not a test: it returns immediately
+// unless it was started as a child, and when it was, it exits the process
+// itself rather than letting the testing framework decide the status.
+func TestScanChild(t *testing.T) {
+	if os.Getenv(childEnv) != "1" {
+		return
+	}
+
+	// Always the first thing on stderr, so a parent that captured the output
+	// can see for itself which value the child was pinned to.
+	childSay("MONDOO_AUTO_UPDATE=" + os.Getenv("MONDOO_AUTO_UPDATE"))
+
+	writeChildProgress(os.Getenv(progress.StreamEnvVar))
+
+	if os.Getenv(childModeEnv) == childModeReport {
+		if format := childFlag("-o"); format != ReportFormat {
+			childDie(96, "the child was asked for format "+strconv.Quote(format))
+		}
+		writeChildReport(childFlag("--output-target"))
+	}
+
+	if os.Getenv(childModeEnv) == childModeHang {
+		childSay("the child is waiting to be killed")
+		time.Sleep(2 * time.Minute)
+	}
+
+	code, _ := strconv.Atoi(os.Getenv(childExitEnv))
+	os.Exit(code)
+}
+
+func childSay(line string) { _, _ = fmt.Fprintln(os.Stderr, line) }
+
+func childDie(code int, line string) {
+	childSay(line)
+	os.Exit(code)
+}
+
+// writeChildReport writes a json-full artifact through the same writer the real
+// scan uses, so what comes back is a collection the loader accepts rather than
+// a shape this test invented.
+func writeChildReport(path string) {
+	if path == "" {
+		childDie(94, "no output target")
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		childDie(94, err.Error())
+	}
+	defer func() { _ = f.Close() }()
+
+	collection := &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			childAssetIndex: {
+				Mrn:  childAssetIndex,
+				Name: childAssetName,
+			},
+		},
+	}
+	if err := reporter.WriteCollection(collection, f); err != nil {
+		childDie(93, err.Error())
+	}
+}
+
+// writeChildProgress emits an NDJSON stream to wherever the parent asked for
+// it, through both destination forms the real writer honors.
+func writeChildProgress(target string) {
+	if target == "" {
+		return
+	}
+
+	var out *os.File
+	if rest, ok := strings.CutPrefix(target, "fd:"); ok {
+		fd, err := strconv.Atoi(rest)
+		if err != nil {
+			childDie(92, "unreadable descriptor "+target)
+		}
+		out = os.NewFile(uintptr(fd), target)
+	} else {
+		f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			childDie(91, err.Error())
+		}
+		out = f
+	}
+	if out == nil {
+		childDie(90, "no progress stream")
+	}
+	defer func() { _ = out.Close() }()
+
+	events := []progress.StreamEvent{
+		{Event: progress.EventScanStart, Version: progress.StreamVersion},
+		{Event: progress.EventDiscovered, Count: 1, Discovered: 1},
+		{Event: progress.EventAssetAdded, Index: childAssetIndex, Name: childAssetName, Platform: "debian", Num: 1},
+		{Event: progress.EventAssetProgress, Index: childAssetIndex, Num: 1, Percent: 0.5},
+		// A line the reader cannot fold has to be skipped rather than end the
+		// stream, so one goes down the wire on purpose; see below.
+		{Event: "a_future_event_this_launcher_has_never_heard_of", Index: childAssetIndex},
+		{Event: progress.EventAssetScore, Index: childAssetIndex, Num: 1, Score: childAssetScore},
+		{Event: progress.EventAssetDone, Index: childAssetIndex, Num: 1, State: progress.StateCompleted, Score: childAssetScore, Done: 1, Total: 1},
+		{Event: progress.EventScanDone, Total: 1, Done: 1, Completed: 1, Discovered: 1},
+	}
+
+	enc := json.NewEncoder(out)
+	for i, ev := range events {
+		ev.Seq = uint64(i)
+		ev.Time = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := enc.Encode(ev); err != nil {
+			childDie(89, err.Error())
+		}
+	}
+	// Not JSON at all: a corrupt line is a display problem and must not stop
+	// the parent watching a scan that is running perfectly well.
+	if _, err := fmt.Fprintln(out, "{this is not json"); err != nil {
+		childDie(88, err.Error())
+	}
+}
+
+// childFlag reads a flag's value off this process's own command line.
+func childFlag(name string) string {
+	for i, a := range os.Args {
+		if a == name && i+1 < len(os.Args) {
+			return os.Args[i+1]
+		}
+	}
+	return ""
+}
+
+// childRequest builds a request that runs the stand-in child instead of cnspec.
+func childRequest(t *testing.T, mode string, exit int) Request {
+	t.Helper()
+
+	real := Binary
+	Binary = func() string { return os.Args[0] }
+	t.Cleanup(func() { Binary = real })
+
+	return Request{
+		// Everything after -- is left for the child to read off os.Args, which
+		// is also where the reporting flags the session appends land.
+		Args: []string{"-test.run=TestScanChild", "--", "scan", "local"},
+		Env: []string{
+			childEnv + "=1",
+			childModeEnv + "=" + mode,
+			childExitEnv + "=" + strconv.Itoa(exit),
+		},
+		TrackTemp: func(fn func()) func() { return fn },
+	}
+}
+
+// runSession forks the child and waits for it, returning its outcome.
+func runSession(t *testing.T, s *Session) Outcome {
+	t.Helper()
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	select {
+	case out := <-s.Exit():
+		return out
+	case <-time.After(30 * time.Second):
+		t.Fatal("the child never exited")
+		return Outcome{}
+	}
+}
+
+// drained closes when the progress reader has seen the end of the stream.
+func drained(s *Session) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range s.Wake() { //revive:disable-line:empty-block
+		}
+	}()
+	return done
+}
+
+// A scan that found failing checks exits non-zero. That is the ordinary outcome
+// of a useful scan, and the caller tells it apart from a scan that broke by
+// reading the report rather than the exit status.
+func TestAFailingScanStillProducesAReadableReport(t *testing.T) {
+	s := NewSession(childRequest(t, childModeReport, 1))
+	defer s.Release()
+
+	out := runSession(t, s)
+	if out.Err == nil {
+		t.Fatal("the child was supposed to exit non-zero")
+	}
+
+	report, err := s.LoadReport()
+	if err != nil {
+		t.Fatalf("a non-zero exit must not stop the report being read: %v", err)
+	}
+	if len(report.GetAssets()) == 0 {
+		t.Fatal("the report carries no assets")
+	}
+}
+
+// A scan that wrote nothing is the only failure, and what there is to say about
+// it is on the child's own output: the loader's error is about a file and
+// explains nothing on its own.
+func TestAScanWithNoReportKeepsTheChildsLastWords(t *testing.T) {
+	s := NewSession(childRequest(t, childModeSilent, 3))
+	defer s.Release()
+
+	out := runSession(t, s)
+	if out.Err == nil {
+		t.Fatal("the child was supposed to exit non-zero")
+	}
+	if _, err := s.LoadReport(); err == nil {
+		t.Fatal("a scan that wrote no report must fail to load one")
+	}
+
+	lines := LastLines(out.Output, 1)
+	if len(lines) != 1 || !strings.Contains(lines[0], "MONDOO_AUTO_UPDATE") {
+		t.Errorf("the child's last words did not survive: %q", out.Output)
+	}
+}
+
+// The pin exists because the auto-update cache can hold a release that has
+// never heard of json-full and would write no report at all. The child reports
+// what it was given, so this asserts the value that actually reached it.
+func TestTheChildIsPinnedToThisBinary(t *testing.T) {
+	s := NewSession(childRequest(t, childModeSilent, 0))
+	defer s.Release()
+
+	out := runSession(t, s)
+	if !strings.Contains(out.Output, "MONDOO_AUTO_UPDATE=false") {
+		t.Errorf("the child was not pinned to this binary; it saw:\n%s", out.Output)
+	}
+}
+
+// The progress stream has to arrive over the descriptor the child inherited,
+// and the reader has to see the end of it. A pipe whose parent end is left open
+// never reaches EOF, which would hang the reader for the life of the launcher.
+func TestProgressArrivesOverTheInheritedDescriptor(t *testing.T) {
+	s := NewSession(childRequest(t, childModeReport, 1))
+	defer s.Release()
+
+	runSession(t, s)
+
+	select {
+	case <-drained(s):
+	case <-time.After(10 * time.Second):
+		t.Fatal("the progress stream never ended: the parent's write end is still open")
+	}
+
+	snap := s.Progress().Snapshot()
+	if snap.Total != 1 || snap.Done != 1 || snap.Completed != 1 {
+		t.Fatalf("the stream describes one completed asset, got %+v", snap)
+	}
+	if snap.Assets[0].Score != childAssetScore {
+		t.Errorf("the asset's score did not survive the stream: %q", snap.Assets[0].Score)
+	}
+	if snap.Assets[0].Percent != 1 {
+		t.Errorf("a finished asset is at 100%%, got %v", snap.Assets[0].Percent)
+	}
+	if snap.Assets[0].Label() != childAssetName {
+		t.Errorf("the asset is not named: %q", snap.Assets[0].Label())
+	}
+	if !snap.ScanDone {
+		t.Error("the summary event never arrived")
+	}
+	// The child sent one event this launcher has never heard of and one line
+	// that is not JSON. Neither is a reason to stop watching, and the summary
+	// above arriving after both is what proves it.
+}
+
+// A scan the user abandons has to die. The child here would sleep for two
+// minutes; if cancelling did not kill it, this test would sit there for two
+// minutes and then fail.
+func TestCancellingKillsTheChild(t *testing.T) {
+	s := NewSession(childRequest(t, childModeHang, 0))
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	reportDir := filepath.Dir(s.ReportPath())
+
+	s.Abort()
+
+	select {
+	case out := <-s.Exit():
+		if out.Err == nil {
+			t.Error("a killed child does not exit cleanly")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("cancel did not kill the child")
+	}
+
+	// And the abort releases what the child was reading, once it is gone.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(reportDir); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the report directory outlived the cancelled scan: %s", reportDir)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// A session ends exactly one way whatever happened. A fork that never happened
+// still has to close the progress stream and publish an outcome, or the caller
+// waits on two channels that will never answer.
+func TestAStartThatNeverForkedStillEndsTheSession(t *testing.T) {
+	real := Binary
+	Binary = func() string { return filepath.Join(t.TempDir(), "no-such-binary") }
+	t.Cleanup(func() { Binary = real })
+
+	s := NewSession(Request{Args: []string{"scan", "local"}})
+	defer s.Release()
+
+	if err := s.Start(); err == nil {
+		t.Fatal("starting a binary that is not there must fail")
+	}
+
+	select {
+	case out := <-s.Exit():
+		if out.Err == nil {
+			t.Error("the failure was not published as the outcome")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a fork that never happened never ended the session")
+	}
+
+	select {
+	case <-drained(s):
+	case <-time.After(5 * time.Second):
+		t.Fatal("the progress stream was left open with nothing to write to it")
+	}
+}
+
+// The plan's own temp files are released with the session, so that there is one
+// thing that ends a scan rather than two -- and a credential written for a
+// command that was cancelled does not outlive the launcher.
+func TestTheRequestsCleanupIsReleasedWithTheSession(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "inventory.yml")
+	if err := os.WriteFile(secret, []byte("password: <PLACEHOLDER-not-a-real-secret>\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tracked := 0
+	req := childRequest(t, childModeSilent, 0)
+	req.Cleanup = func() { _ = os.Remove(secret) }
+	req.TrackTemp = func(fn func()) func() { tracked++; return fn }
+
+	s := NewSession(req)
+	runSession(t, s)
+
+	reportDir := filepath.Dir(s.ReportPath())
+	s.Release()
+
+	if _, err := os.Stat(secret); !os.IsNotExist(err) {
+		t.Error("the credential the command was given outlived the scan")
+	}
+	if _, err := os.Stat(reportDir); !os.IsNotExist(err) {
+		t.Error("the report directory outlived the scan")
+	}
+	if tracked != 1 {
+		t.Errorf("the report directory was not registered with the caller's temp registry (%d)", tracked)
+	}
+}

--- a/cli/launcher/source/ambient.go
+++ b/cli/launcher/source/ambient.go
@@ -1,0 +1,470 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"os"
+	"strings"
+
+	tuiform "go.mondoo.com/cnspec/cli/tui/form"
+)
+
+// The ambient class: connectors whose entire credential is one token, taken
+// from one environment variable or handed over on the spot.
+//
+// Seven of them have nothing to enumerate. Treating them as value pickers is
+// what produced the empty box with no explanation that started this redesign:
+// a picker asks "which one", and there is no "which one" -- there is one token,
+// and the only questions worth asking about it are whether it is there and
+// where it came from.
+//
+// So an ambient credential gets two widgets instead of a list:
+//
+//   - a readout saying which variable supplied the token, or what to export if
+//     none did. It is a launcher-owned field (`special`), never a flag, and it
+//     holds a variable *name* -- never a token.
+//   - the connector's own --token flag, redrawn as a paste box, for the case
+//     where the shell the user has already left is not where they want to go.
+//
+// Neither ever puts a credential on the command line: the readout has nothing
+// to put there, and the paste box is secret, so args() skips it and delivery.go
+// decides which verified route the value travels by.
+
+// EnvLookup reads one environment variable.
+//
+// It is a parameter rather than a direct call to os.LookupEnv because these are
+// exactly the variables a developer running the tests is most likely to have
+// exported. A test that consulted the real environment would pass or fail
+// depending on whose machine it ran on, and would be reading that developer's
+// actual tokens to do it.
+type EnvLookup func(name string) (string, bool)
+
+// ambientEnv is the environment the launcher itself reads. Tests replace it
+// through SetAmbientEnv.
+var ambientEnv EnvLookup = os.LookupEnv
+
+// SetAmbientEnv replaces the environment the credential readouts are derived
+// from, and returns what it replaced so a test can put it back.
+//
+// It is exported because the tests that need it are the launcher's: a readout
+// is only observable on a built form, and the form engine and the connector
+// catalog are both on the other side of this package. The variables involved
+// are exactly the ones a developer running the suite is most likely to have
+// exported, so a test that read the real environment would pass or fail by
+// whose machine it ran on -- and would be reading that developer's actual
+// tokens to do it.
+func SetAmbientEnv(env EnvLookup) EnvLookup {
+	prev := ambientEnv
+	ambientEnv = env
+	return prev
+}
+
+// SpecialCredentialState marks the readout as a field the launcher owns rather
+// than one the provider declared, which is what keeps it off the command line:
+// args() skips a positional with a `special` marker, and this field has no flag
+// to be skipped by. A connector with a second ambient credential suffixes the
+// marker with the credential's Name, so the two readouts keep distinct
+// identities across a rebuild of the form.
+const SpecialCredentialState = "credential-state"
+
+// The reasons a readout gives for the value it is showing. They are what stops
+// carryOver from carrying a readout onto a rebuilt form: a prefilled value is
+// the rebuild's own business, and this one is re-derived from the environment
+// every time resolveSources runs.
+const (
+	AmbientWhyEnv   = "in your environment"
+	ambientWhyPaste = "typed here"
+)
+
+// AmbientCredential declares a connector whose credential is ambient.
+type AmbientCredential struct {
+	// Connector is the connector command word this credential belongs to.
+	Connector string
+	// Name distinguishes a second credential on the same connector from the
+	// main one, and is empty for the main one. Only digitalocean has a second.
+	Name string
+	// Source is the id of the ClassAmbient source registered for this
+	// credential, or "" for one the launcher can only report on. The source is
+	// what the model's own machinery re-checks the environment through; the
+	// readout does not depend on it having run.
+	Source string
+	// Flag is the connector's own flag carrying the same secret, or "" when
+	// the provider declares none. A credential with no flag is report-only:
+	// there is nowhere for a pasted value to go, and inventing a route for it
+	// is how a credential ends up somewhere the provider does not read.
+	Flag string
+	// Env are the variables the provider reads, in the order it reads them.
+	// The first one holding a value is the one that will be used, which is the
+	// one the readout names.
+	Env []string
+	// All says the provider needs every variable in Env rather than the first
+	// one that is set, so a partial set is not a credential.
+	All bool
+	// Label names the readout row, and must not collide with another field's
+	// label on the same form -- args() tracks visibility by label.
+	Label string
+	// Hint is what the readout says when nothing was found. "Empty" and
+	// "nothing here to fill in" look identical otherwise, which is the failure
+	// this whole widget exists to end, so it names the variable to export.
+	Hint string
+	// PasteHint is the placeholder on the paste box.
+	PasteHint string
+	// Compose fills a non-secret field the provider builds out of the
+	// environment rather than reading directly. Only okta needs one; see
+	// oktaOrganization for why it cannot simply mirror what the provider does.
+	Compose func(f *tuiform.Form, env EnvLookup)
+}
+
+// ambientCredentials holds every declared ambient credential, in registration
+// order. It is a registry rather than a literal for the same reason the source
+// and spec registries are: a connector curated later is an append in the file
+// that curates it.
+var ambientCredentials []AmbientCredential
+
+// RegisterAmbient declares ambient credentials and, for each that names one,
+// the ClassAmbient source behind it. Call it from the init of the file that
+// owns the connector.
+func RegisterAmbient(creds ...AmbientCredential) {
+	for _, a := range creds {
+		ambientCredentials = append(ambientCredentials, a)
+		if a.Source != "" {
+			Register(a.source())
+		}
+	}
+}
+
+// AmbientCredentials returns every declared ambient credential, in
+// registration order.
+//
+// It is the read-only view of the registry, for the launcher tests that hold
+// all of them to one property at a time -- that every paste box has a route,
+// that no two readouts share a label -- which is a form-level question and so
+// cannot be asked from here.
+func AmbientCredentials() []AmbientCredential {
+	return append([]AmbientCredential(nil), ambientCredentials...)
+}
+
+// ambientFor returns the credentials declared for a connector.
+func ambientFor(connector string) []AmbientCredential {
+	var out []AmbientCredential
+	for _, a := range ambientCredentials {
+		if a.Connector == connector {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func init() {
+	// The variables below are read out of each provider's own ParseCLI, not
+	// inferred from its prose. digitalocean and hetzner document theirs in the
+	// flag description as well, and both spellings agree.
+	RegisterAmbient(
+		AmbientCredential{
+			Connector: "github", Source: GitHubToken, Flag: "token",
+			Env: []string{"GITHUB_TOKEN"},
+		},
+		AmbientCredential{
+			Connector: "gitlab", Source: GitLabToken, Flag: "token",
+			Env: []string{"GITLAB_TOKEN"},
+		},
+		AmbientCredential{
+			Connector: "slack", Source: SlackToken, Flag: "token",
+			Env: []string{"SLACK_TOKEN"},
+		},
+		// The three the delivery registry did not already carry, so each
+		// declares its own paste route. Every one was read out of the provider
+		// that receives it: CLOUDFLARE_TOKEN in cloudflare's connection.go,
+		// and DIGITALOCEAN_TOKEN and HCLOUD_TOKEN in their own providers,
+		// which also name them in the --token descriptions. Without the route
+		// a pasted token has nowhere verified to go and the launcher refuses
+		// to run at all, so the paste box would be a dead end for three of the
+		// seven.
+		AmbientCredential{
+			Connector: "cloudflare", Source: CloudflareToken, Flag: "token",
+			Env: []string{"CLOUDFLARE_TOKEN"},
+		},
+		AmbientCredential{
+			Connector: "digitalocean", Source: DigitalOceanToken, Flag: "token",
+			Env: []string{"DIGITALOCEAN_TOKEN"},
+		},
+		AmbientCredential{
+			Connector: "hetzner", Source: HetznerToken, Flag: "token",
+			Env: []string{"HCLOUD_TOKEN"},
+		},
+		// okta reads three levels in this order: --token, OKTA_API_TOKEN, then
+		// OKTA_TOKEN. The readout names whichever one the provider will
+		// actually reach for, which is why Env order is load-bearing.
+		AmbientCredential{
+			Connector: "okta", Source: OktaToken, Flag: "token",
+			Env:     []string{"OKTA_API_TOKEN", "OKTA_TOKEN"},
+			Compose: composeOktaOrganization,
+		},
+
+		// digitalocean's Spaces credentials break the flag/env symmetry every
+		// other ambient connector has: DIGITALOCEAN_SPACES_KEY, _SECRET and
+		// _REGION are read from the environment and no flag carries any of
+		// them. They are surfaced as a readout and deliberately given no paste
+		// box, for two reasons.
+		//
+		// The first is that there is nowhere for a pasted value to go. Every
+		// credential now reaches the provider as a *flag* value, over its own
+		// ParseCLI, and these three name no flag: digitalocean's connection
+		// reads them straight out of the environment it inherits. A paste box
+		// would collect a value with nothing to hand it to.
+		//
+		// The second is that a readout is the whole of what is missing here.
+		// Without these variables `--discover spaces-buckets` finds nothing and
+		// says nothing about why, which is the same silent-empty failure the
+		// ambient class exists to end. Naming the variables in the row is the
+		// fix; carrying their values is not.
+		AmbientCredential{
+			Connector: "digitalocean", Name: "spaces",
+			Env:   []string{"DIGITALOCEAN_SPACES_KEY", "DIGITALOCEAN_SPACES_SECRET"},
+			All:   true,
+			Label: "spaces keys",
+			// Named in full rather than abbreviated to a shared prefix: this
+			// is the line a user copies into their shell, and _REGION is left
+			// out of it because the provider only insists on the other two.
+			Hint: "env only — export DIGITALOCEAN_SPACES_KEY and " +
+				"DIGITALOCEAN_SPACES_SECRET to scan buckets",
+		},
+	)
+}
+
+// Special is the launcher-owned marker on this credential's readout field.
+//
+// It is exported because the launcher keeps the allowlist of markers a form is
+// allowed to carry, and a marker that is not on it is how a launcher-owned
+// field would quietly become a positional argument.
+func (a AmbientCredential) Special() string {
+	if a.Name == "" {
+		return SpecialCredentialState
+	}
+	return SpecialCredentialState + "." + a.Name
+}
+
+// label names the readout row.
+func (a AmbientCredential) label() string {
+	if a.Label != "" {
+		return a.Label
+	}
+	return "credential"
+}
+
+// hint is what the readout says when it found nothing.
+func (a AmbientCredential) hint() string {
+	if a.Hint != "" {
+		return a.Hint
+	}
+	// "or" for the usual precedence chain, where any one of them will do;
+	// "and" where the provider insists on all of them.
+	join := " or "
+	if a.All {
+		join = " and "
+	}
+	hint := "not set — export " + strings.Join(a.Env, join)
+	if a.Flag != "" {
+		hint += ", or paste one below"
+	}
+	return hint
+}
+
+// pasteHint is the placeholder on the paste box. It is the guarantee rather
+// than an instruction, because the instruction ("paste a token") is already the
+// label's job and the guarantee is the part a user cannot check for themselves
+// without reading the command bar.
+func (a AmbientCredential) pasteHint() string {
+	if a.PasteHint != "" {
+		return a.PasteHint
+	}
+	return "paste a token — it never reaches the command line"
+}
+
+// present names the variables that hold a credential right now.
+//
+// It returns names and never values. A name is the whole of what the launcher
+// has to show, and a value it never holds is a value it cannot leak -- not into
+// a rendered row, not into a cached source result, not into a crash dump.
+func (a AmbientCredential) present(env EnvLookup) []string {
+	var out []string
+	for _, name := range a.Env {
+		if v, ok := env(name); ok && strings.TrimSpace(v) != "" {
+			out = append(out, name)
+		}
+	}
+	if a.All && len(out) != len(a.Env) {
+		// A partial set is not a credential: the provider needs all of them,
+		// and reporting "found" off the first one would be confidently wrong.
+		return nil
+	}
+	return out
+}
+
+// chosen turns what present found into the one line the readout shows.
+func (a AmbientCredential) chosen(found []string) string {
+	switch {
+	case len(found) == 0:
+		return ""
+	case a.All:
+		return strings.Join(found, " + ")
+	default:
+		return found[0]
+	}
+}
+
+// source is the ClassAmbient source behind this credential.
+//
+// Reading an environment variable does not need the model's asynchronous
+// machinery -- the readout is filled synchronously by RefreshAmbient, so it is
+// right on the first frame rather than a tick later. The source is declared
+// anyway because it is what makes this a source rather than a special case:
+// it gives the credential an Activity to name while anything waits on it, a
+// Cost that says when it may run, and a Prefer that agrees with the readout.
+func (a AmbientCredential) source() Source {
+	return Source{
+		ID:    a.Source,
+		Class: ClassAmbient,
+		// Checking a variable is cheaper than the file reads that share this
+		// cost, and it never leaves this process.
+		Cost:     CostInstant,
+		Activity: "checking " + strings.Join(a.Env, " and "),
+		Tool:     a.Env[0],
+		Prefer: func(values []string) (string, string) {
+			if v := a.chosen(values); v != "" {
+				return v, AmbientWhyEnv
+			}
+			return "", ""
+		},
+		Fetch: func([]string) ([]string, error) { return a.present(ambientEnv), nil },
+	}
+}
+
+// readout is the credential-state field for this credential.
+func (a AmbientCredential) readout() tuiform.Field {
+	fd := tuiform.NewField(tuiform.Decl{
+		Label:   a.label(),
+		Desc:    a.hint(),
+		Kind:    tuiform.KindCredentialState,
+		Special: a.Special(),
+		Section: tuiform.SectionCredential,
+	})
+	fd.SetSource(a.Source, tuiform.Emit(Emit(a.Source)))
+	return fd
+}
+
+// ApplyAmbient gives a connector's ambient credentials their widgets: a readout
+// for each, and the paste box that the connector's own token flag becomes.
+//
+// It runs after the curated overlay, so a spec's label and section for the
+// token flag survive and only its kind changes, and before resolveSources,
+// which is what fills the readouts in.
+//
+// It takes the connector's name rather than the connector, because the name is
+// all it ever reads and asking for the whole record would put the connector
+// catalog in this package's import list for one string.
+func ApplyAmbient(f *tuiform.Form, connector string) {
+	for _, a := range ambientFor(connector) {
+		a.apply(f)
+	}
+}
+
+func (a AmbientCredential) apply(f *tuiform.Form) {
+	// Where the readout goes: immediately above the paste box it describes,
+	// or at the end when the credential has no flag at all.
+	at := len(f.Fields())
+	if i := f.IndexOfFlag(a.Flag); i >= 0 {
+		fd := &f.Fields()[i]
+		fd.Kind = tuiform.KindPaste
+		// The classifier already reads --token as a secret for every one of
+		// these, but the launcher is not guessing here: this flag *is* the
+		// credential, so it is marked as one rather than left to a heuristic.
+		fd.Secret = true
+		fd.Section = tuiform.SectionCredential
+		fd.Desc = a.pasteHint()
+		at = i
+	}
+	// A flag the installed provider no longer declares leaves the readout
+	// standing on its own rather than taking the whole widget down with it:
+	// the environment still works, and saying so is still worth a row.
+	f.InsertField(at, a.readout())
+
+	if a.Compose != nil {
+		a.Compose(f, ambientEnv)
+	}
+}
+
+// RefreshAmbient recomputes every credential readout on the form.
+//
+// It runs from resolveSources, which is called when a form is built and after
+// every keystroke, so the readout is never stale: paste a token and the row
+// stops naming a variable, clear it and the row names the variable again.
+func RefreshAmbient(f *tuiform.Form) {
+	for _, a := range ambientFor(f.Subject()) {
+		i := f.IndexOfSpecial(a.Special())
+		if i < 0 {
+			continue
+		}
+		f.Fields()[i].Prefill(a.observe(f, ambientEnv))
+	}
+}
+
+// observe reports what the scan will actually use, and why.
+//
+// A pasted token wins, because that is the precedence every one of these
+// providers implements: the flag first, the variables after it. A readout that
+// named a variable while a pasted token was the thing about to be used would be
+// confidently wrong about the one fact it exists to state.
+func (a AmbientCredential) observe(f *tuiform.Form, env EnvLookup) (state, why string) {
+	if i := f.IndexOfFlag(a.Flag); i >= 0 && f.Fields()[i].IsSet() {
+		return "pasted", ambientWhyPaste
+	}
+	if v := a.chosen(a.present(env)); v != "" {
+		return v, AmbientWhyEnv
+	}
+	return "", ""
+}
+
+// oktaOrganization composes the okta organization the way the provider does,
+// minus the bug in how the provider does it.
+//
+// okta's ParseCLI builds `OKTA_ORG_NAME + "." + OKTA_BASE_URL` whenever
+// --organization is empty, and then guards with `if organization == ""`. With
+// both variables unset the composition is the literal ".", which is not "", so
+// the guard never fires: the connector proceeds with an organization of "." and
+// fails later as a connection error, nowhere near its cause.
+//
+// The launcher therefore special-cases both-empty rather than mirroring the
+// composition faithfully -- with nothing to compose from there is no
+// organization, and the field is left for the user to fill. A half-composed
+// value is mirrored, because that one the provider really will use, and showing
+// "dev-123." in an editable field is how the user gets to notice it.
+func oktaOrganization(env EnvLookup) string {
+	name := strings.TrimSpace(EnvValue(env, "OKTA_ORG_NAME"))
+	base := strings.TrimSpace(EnvValue(env, "OKTA_BASE_URL"))
+	if name == "" && base == "" {
+		return ""
+	}
+	return name + "." + base
+}
+
+// composeOktaOrganization prefills okta's --organization from the environment.
+func composeOktaOrganization(f *tuiform.Form, env EnvLookup) {
+	org := oktaOrganization(env)
+	if org == "" {
+		return
+	}
+	i := f.IndexOfFlag("organization")
+	if i < 0 || f.Fields()[i].IsSet() {
+		return
+	}
+	f.Fields()[i].SetValue(org)
+	f.Fields()[i].SetPrefilled(AmbientWhyEnv)
+}
+
+// EnvValue is the value of a variable, or "" when it is unset.
+func EnvValue(env EnvLookup, name string) string {
+	v, _ := env(name)
+	return v
+}

--- a/cli/launcher/source/ambient_test.go
+++ b/cli/launcher/source/ambient_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"testing"
+)
+
+// The environment is read through the injected lookup, never directly, or a
+// test would be reading the developer's own tokens.
+func TestAmbientStateReadsOnlyWhatItIsGiven(t *testing.T) {
+	a := AmbientCredential{Env: []string{"A", "B"}}
+	if got := a.present(mapEnv(map[string]string{"B": "x"})); len(got) != 1 || got[0] != "B" {
+		t.Errorf("present = %v, want [B]", got)
+	}
+	// A variable that is set but empty is not a credential.
+	if got := a.present(mapEnv(map[string]string{"A": "   "})); len(got) != 0 {
+		t.Errorf("a blank variable read as present: %v", got)
+	}
+	if got := a.present(mapEnv(nil)); len(got) != 0 {
+		t.Errorf("present = %v with nothing set", got)
+	}
+}
+
+// A partial set is not a credential either: with All, the provider needs every
+// variable, and reporting "found" off the first one would be confidently wrong.
+func TestAllOrNothingCredentialsNeedEveryVariable(t *testing.T) {
+	a := AmbientCredential{Env: []string{"A", "B"}, All: true}
+	if got := a.present(mapEnv(map[string]string{"A": "x"})); len(got) != 0 {
+		t.Errorf("half a credential read as present: %v", got)
+	}
+	got := a.present(mapEnv(map[string]string{"A": "x", "B": "y"}))
+	if len(got) != 2 {
+		t.Fatalf("present = %v, want both", got)
+	}
+	if chosen := a.chosen(got); chosen != "A + B" {
+		t.Errorf("chosen = %q, want both named", chosen)
+	}
+}
+
+// okta's ParseCLI composes OKTA_ORG_NAME + "." + OKTA_BASE_URL and then guards
+// with `if organization == ""`. With both unset the composition is the literal
+// ".", the guard never fires, and the connector proceeds with an organization
+// of "." -- so the launcher special-cases both-empty rather than mirroring the
+// composition faithfully. A half-composed value *is* mirrored, because that one
+// the provider really will use.
+func TestOktaOrganizationIsComposedFromTheEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		env  map[string]string
+		want string
+	}{
+		{nil, ""},
+		{map[string]string{"OKTA_ORG_NAME": "", "OKTA_BASE_URL": ""}, ""},
+		{map[string]string{"OKTA_ORG_NAME": "  ", "OKTA_BASE_URL": "\t"}, ""},
+		{map[string]string{"OKTA_ORG_NAME": "dev-123", "OKTA_BASE_URL": "okta.com"}, "dev-123.okta.com"},
+		{map[string]string{"OKTA_ORG_NAME": " dev-123 ", "OKTA_BASE_URL": "okta.com"}, "dev-123.okta.com"},
+		{map[string]string{"OKTA_ORG_NAME": "dev-123"}, "dev-123."},
+		{map[string]string{"OKTA_BASE_URL": "okta.com"}, ".okta.com"},
+	} {
+		if got := oktaOrganization(mapEnv(tc.env)); got != tc.want {
+			t.Errorf("oktaOrganization(%v) = %q, want %q", tc.env, got, tc.want)
+		}
+	}
+}
+
+// A paste box needs a flag to paste into.
+//
+// This used to check a second thing as well -- that the variable a pasted value
+// would travel in was one the provider actually reads -- because a pasted token
+// was delivered by exporting a variable, and inventing the name sent it
+// somewhere nothing read it. A pasted value now travels the same way a typed
+// one does, through the connector's own ParseCLI, so the only claim left is
+// that there is a flag for it to be the value of.
+func TestEveryPasteBoxHasAFlagToPasteInto(t *testing.T) {
+	checked := 0
+	for _, a := range ambientCredentials {
+		if a.All {
+			// A readout over a set of variables collects nothing: there is no
+			// paste box, deliberately. See the digitalocean Spaces note.
+			continue
+		}
+		checked++
+		if a.Flag == "" {
+			t.Errorf("%s: offers a paste box with no flag to paste into", a.Connector)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no ambient credential was checked, so this proved nothing")
+	}
+}
+
+func mapEnv(vars map[string]string) EnvLookup {
+	return func(name string) (string, bool) {
+		v, ok := vars[name]
+		return v, ok
+	}
+}

--- a/cli/launcher/source/declare.go
+++ b/cli/launcher/source/declare.go
@@ -1,0 +1,285 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"context"
+	"os"
+	"slices"
+)
+
+// Every pre-connection source, declared in one place: what can be offered
+// before any credential is used.
+//
+// The readers are elsewhere -- read.go for the kubeconfig, the ssh config and
+// the gcloud state, enumerated.go for the four credential files and the docker
+// context store -- because the file formats differ and no amount of declaring
+// makes an ini file parse like a kubeconfig. What is declared here is
+// everything around them: when each runs, what it says while running, what it
+// depends on, when a value is obvious, how its failures read, and where its
+// chosen value has to travel. That is the part that was being reinvented per
+// provider.
+//
+// It is one file because it used to be two idioms. Half of these sources were
+// declared here and implemented in read.go; the other half declared themselves
+// in the file that read their format, on the reasoning that what happens to
+// the chosen value -- a flag for oci and azure, an environment variable for
+// alicloud and docker, nothing at all for snowflake -- belonged next to the
+// reader. It does not: that is a property of the connector, which is what
+// Source.Env exists to state, and stating it in two places is how a subsystem
+// ends up with no owner. Adding a pre-connection source is an entry here and a
+// reader wherever its format belongs.
+
+func init() {
+	Register(
+		Source{
+			ID:       AWSProfile,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.aws",
+			Tool:     "~/.aws",
+			Emit:     awsProfileValue,
+			Prefer: func(values []string) (string, string) {
+				// The shared config calls the conventional one "default"; the
+				// picker may have labelled it with an account id.
+				for _, v := range values {
+					if awsProfileValue(v) == "default" {
+						return v, "default"
+					}
+				}
+				return "", ""
+			},
+			Fetch: func([]string) ([]string, error) { return awsProfiles(), nil },
+		},
+		Source{
+			ID:       KubeContext,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading your kubectl config",
+			Tool:     "kubectl",
+			Prefer: func(values []string) (string, string) {
+				if cur := kubeCurrentContext(); cur != "" && slices.Contains(values, cur) {
+					return cur, "current"
+				}
+				return "", ""
+			},
+			Fetch: func([]string) ([]string, error) { return kubeContexts(), nil },
+		},
+		Source{
+			ID:       SSHHost,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.ssh/config",
+			Tool:     "~/.ssh/config",
+			Fetch:    func([]string) ([]string, error) { return sshHosts(), nil },
+		},
+		Source{
+			ID:       GCPProject,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading gcloud config",
+			Tool:     "gcloud",
+			Prefer: func(values []string) (string, string) {
+				if cur := GCPActiveProject(); cur != "" && slices.Contains(values, cur) {
+					return cur, "active"
+				}
+				return "", ""
+			},
+			Fetch: func([]string) ([]string, error) { return gcpProjects(), nil },
+		},
+		Source{
+			ID:       GCPZone,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading gcloud config",
+			Tool:     "gcloud",
+			Fetch:    func([]string) ([]string, error) { return gcpZones(), nil },
+		},
+
+		// Local, but not free: a daemon on this machine, answering in about a
+		// second. Cheap enough to run when a form opens.
+		// Both of these ask a daemon, and which daemon is a question the form
+		// can now answer: the container spec offers a docker context, and
+		// listing the default daemon's containers while the child is pointed at
+		// another one would be exactly the confidently wrong answer the Source
+		// contract exists to prevent. Needs puts the chosen context into the
+		// cache key as well as into the call, so changing it re-runs the picker
+		// rather than reusing the previous daemon's list.
+		Source{
+			ID:       DockerContainer,
+			Class:    ClassEnumerated,
+			Cost:     CostLocal,
+			Activity: "asking docker for containers",
+			Tool:     "docker",
+			Needs:    []string{"s:" + SpecialDockerContext},
+			FetchCtx: func(ctx context.Context, params []string) ([]string, error) {
+				return dockerContainers(ctx, runnerWithEnv(nil, DockerContextEnvFrom(params)))
+			},
+		},
+		Source{
+			ID:       DockerImage,
+			Class:    ClassEnumerated,
+			Cost:     CostLocal,
+			Activity: "asking docker for images",
+			Tool:     "docker",
+			Needs:    []string{"s:" + SpecialDockerContext},
+			FetchCtx: func(ctx context.Context, params []string) ([]string, error) {
+				return dockerImages(ctx, runnerWithEnv(nil, DockerContextEnvFrom(params)))
+			},
+		},
+
+		// Remote: crosses a network, needs credentials, and can fail. Waits to
+		// be asked for.
+		Source{
+			ID:       GCPProjectAll,
+			Class:    ClassEnumerated,
+			Cost:     CostRemote,
+			Activity: "asking gcloud for projects",
+			Tool:     "gcloud",
+			Explain:  gcloudError,
+			FetchCtx: func(ctx context.Context, _ []string) ([]string, error) {
+				return gcpAllProjects(ctx, execRunner)
+			},
+		},
+		Source{
+			ID:       K8sNamespace,
+			Class:    ClassPostConnection,
+			Cost:     CostRemote,
+			Activity: "asking kubectl for namespaces",
+			Tool:     "kubectl",
+			// The namespaces belong to the chosen cluster. This is the
+			// dependency that used to be a hardcoded `if source != ...`.
+			Needs: []string{"context"},
+			FetchCtx: func(ctx context.Context, params []string) ([]string, error) {
+				// The connector's --context does not select a cluster, so the
+				// query is pointed at a kubeconfig copy instead. See
+				// kubeconfig.go.
+				env, cleanup, err := kubeEnvForContext(paramValue(params, "context"))
+				if cleanup != nil {
+					defer cleanup()
+				}
+				if err != nil {
+					return nil, err
+				}
+				return k8sNamespaces(ctx, execRunner, env)
+			},
+		},
+
+		// The four credential files and the docker context store. Each is a
+		// file this machine already has, read without a network or a
+		// credential, so all five are CostInstant. What differs between them
+		// is where the chosen value goes:
+		//
+		//   - oci and azure have a flag that carries it (--profile,
+		//     --subscription), both verified against the installed provider
+		//     metadata.
+		//   - alicloud has none. Its connector declares --access-key-id and
+		//     friends and no --profile at all, so the profile travels in
+		//     ALIBABA_CLOUD_PROFILE -- which is what Source.Env is for, and is
+		//     why guessing a flag name here would have produced a picker that
+		//     silently scanned the wrong account.
+		//   - snowflake has no flag that takes a *connection name* either, and
+		//     unlike alicloud there is no environment variable this connector
+		//     reads to accept one. So this source does not offer connection
+		//     names at all; see snowflakeAccountsFrom.
+		//   - docker has no --context on docker, container or local, so a
+		//     context travels in DOCKER_CONTEXT the way mql's own client
+		//     resolves it.
+		Source{
+			ID:       OCIProfile,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.oci/config",
+			Tool:     "~/.oci/config",
+			Prefer: func(values []string) (string, string) {
+				if slices.Contains(values, ociDefaultProfile) {
+					return ociDefaultProfile, "default"
+				}
+				return "", ""
+			},
+			Explain: missingFileExplain("~/.oci/config", "run: oci setup config"),
+			Fetch:   func([]string) ([]string, error) { return ociProfiles() },
+		},
+		Source{
+			ID:       AlicloudProfile,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.alibabacloud/credentials",
+			Tool:     "~/.alibabacloud/credentials",
+			// The connector declares no --profile. Verified against the
+			// installed alicloud provider metadata, which lists only
+			// --access-key-id, --access-key-secret, --sts-token, --role-arn,
+			// --role-session-name, --region, --regions and --filters.
+			Env: AlicloudProfileEnv,
+			Prefer: func(values []string) (string, string) {
+				// The environment already names one, and that is what the
+				// child would use whatever the picker showed.
+				if env := os.Getenv(AlicloudProfileEnv); env != "" && slices.Contains(values, env) {
+					return env, "from " + AlicloudProfileEnv
+				}
+				if slices.Contains(values, alicloudDefaultProfile) {
+					return alicloudDefaultProfile, "default"
+				}
+				return "", ""
+			},
+			Explain: missingFileExplain("~/.alibabacloud/credentials",
+				"pass --access-key-id and --access-key-secret instead"),
+			Fetch: func([]string) ([]string, error) { return alicloudProfiles() },
+		},
+		Source{
+			ID:       AzureSubscription,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.azure/azureProfile.json",
+			Tool:     "~/.azure/azureProfile.json",
+			Prefer: func(values []string) (string, string) {
+				// az marks exactly one subscription isDefault, which is the one
+				// `az account show` reports and the one a user means.
+				if id := azureDefaultSubscription(); id != "" && slices.Contains(values, id) {
+					return id, "default"
+				}
+				return "", ""
+			},
+			Explain: missingFileExplain("~/.azure/azureProfile.json", "run: az login"),
+			Fetch:   func([]string) ([]string, error) { return azureSubscriptions() },
+		},
+		Source{
+			ID:       SnowflakeConnection,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.snowflake/connections.toml",
+			Tool:     "~/.snowflake/connections.toml",
+			Prefer: func(values []string) (string, string) {
+				if acct := snowflakeDefaultAccount(); acct != "" && slices.Contains(values, acct) {
+					return acct, "default connection"
+				}
+				return "", ""
+			},
+			Explain: missingFileExplain("~/.snowflake/connections.toml",
+				"type the account identifier instead"),
+			Fetch: func([]string) ([]string, error) { return snowflakeAccounts() },
+		},
+		Source{
+			ID:       DockerContext,
+			Class:    ClassEnumerated,
+			Cost:     CostInstant,
+			Activity: "reading ~/.docker for contexts",
+			Tool:     "~/.docker",
+			// No --context on docker, container or local -- verified against
+			// the installed os provider metadata, which declares only --sudo,
+			// --id-detector, --disable-cache and --container-proxy for them.
+			// DOCKER_CONTEXT is what the docker CLI itself reads, and what
+			// mql's dockerclient honours when it builds a connection.
+			Env: DockerContextEnv,
+			Prefer: func(values []string) (string, string) {
+				if cur := dockerCurrentContext(); cur != "" && slices.Contains(values, cur) {
+					return cur, "current"
+				}
+				return "", ""
+			},
+			Explain: missingFileExplain("~/.docker", "type a context name instead"),
+			Fetch:   func([]string) ([]string, error) { return dockerContexts() },
+		},
+	)
+}

--- a/cli/launcher/source/discover.go
+++ b/cli/launcher/source/discover.go
@@ -1,0 +1,643 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Post-connection discovery: what is inside a target, asked through cnspec's
+// own discovery rather than through each vendor's CLI.
+//
+// A connector that can enumerate its own contents already has the answer the
+// launcher wants -- k8s knows its namespaces, github knows an organization's
+// repositories, azure knows its subscriptions -- and it also declares a flag
+// that consumes that answer back. `cnspec discover <connector> --discover
+// <target>` is the one call that covers all of them, so this file is one
+// implementation and a table, rather than a picker per provider. The bespoke
+// k8s namespace reader in sources_pre.go is what this replaces the *pattern*
+// of; see the note on DiscoverK8sNamespaces below for why that one source
+// stays where it is.
+//
+// Three properties of the underlying command shape everything here, and each
+// was established by running it rather than by reading about it:
+//
+//   - The payload flag is --output-full <path>, and it is a path, not a
+//     stream: there is no stdout mode for the assets. So the source writes to
+//     a temp file and reads it back. -f/--output-format json emits one
+//     inventory document, {"spec":{"assets":[...]}}, credentials redacted.
+//   - --discover is always passed explicitly. The default is `auto`, which is
+//     the expensive one -- providers gate on the target before enumerating.
+//   - `cnspec discover` connects into every discovered child, so this is slow
+//     even locally: `discover local --discover container` measured 3.9s
+//     against 0.6s for the bare host. Every source here is therefore
+//     CostRemote, and runs only when its picker is opened.
+//
+// And one that decides the whole empty-versus-failed story: **a refused
+// connection exits 0**. Asking github for repositories with no token prints
+// the connector's usage to stdout, writes the real reason to stderr, and
+// returns success. The output file is missing in that case -- but it is also
+// missing when the answer is genuinely nothing, because the command skips
+// writing when it discovered no assets. The two are told apart by stdout:
+// printPlatformSummary runs unconditionally once discovery has actually
+// happened, so its header is present for a real empty answer and absent for a
+// refusal. Without that distinction a picker showing nothing cannot say
+// whether the account is empty or unreachable, which is the single
+// most-repeated bug in this package's history.
+
+// discoveryMarker is what the child prints once discovery has run, including
+// when it discovered nothing. Its absence means the run never got that far.
+const discoveryMarker = "Discovered assets:"
+
+// discoverTool names what the wait is waiting for. It is the command the user
+// can run themselves, which is the point of naming a tool at all.
+const discoverTool = "cnspec discover"
+
+// discoverTimeout bounds the child. It is longer than the MQL query timeout
+// because discovery connects into every child it finds, and a large
+// organization legitimately takes minutes.
+const discoverTimeout = 2 * time.Minute
+
+// discoveredAsset is the part of an inventory asset a picker needs, and only
+// that part: the document also carries platform detail, capabilities and
+// relationships, none of which decides what goes on a command line. The
+// encoding is protojson with UseProtoNames, so the field names are the proto
+// ones -- platform_ids, not platformIds.
+type discoveredAsset struct {
+	Name        string   `json:"name"`
+	ID          string   `json:"id"`
+	PlatformIDs []string `json:"platform_ids"`
+	Platform    struct {
+		Name string `json:"name"`
+	} `json:"platform"`
+	Connections []struct {
+		Options map[string]string `json:"options"`
+	} `json:"connections"`
+}
+
+// assetValue pulls the value that goes on the command line out of one
+// discovered asset. It returns "" for an asset that carries none, which is
+// also how the root asset -- always present in the document, never a child --
+// is dropped.
+type assetValue func(a discoveredAsset) string
+
+// fromOption reads a connection option.
+//
+// This is the most reliable of the three, because it is the provider's own
+// round trip: ParseCLI maps --group to Options["group"], and discovery hands
+// each child a cloned config with that same option set. Where the names line
+// up, reading the option back is reading exactly what the flag would write.
+// They do not always line up -- github's --repos lands in Options["repository"]
+// -- so the key is declared per target rather than derived from the flag.
+func fromOption(keys ...string) assetValue {
+	return func(a discoveredAsset) string {
+		for _, c := range a.Connections {
+			for _, k := range keys {
+				if v := c.Options[k]; v != "" {
+					return v
+				}
+			}
+		}
+		return ""
+	}
+}
+
+// fromPlatformID reads the segment following a marker in an asset's platform
+// id -- the <ID> of //platformid.api.mondoo.app/runtime/neon/organization/<ID>.
+//
+// This is the fallback for the providers whose scoping flag takes an id: the
+// platform id is where that id is guaranteed to be, whereas the asset's name
+// is a display name and the connection option may not carry it at all.
+func fromPlatformID(marker string) assetValue {
+	sep := "/" + marker + "/"
+	return func(a discoveredAsset) string {
+		for _, id := range append([]string{a.ID}, a.PlatformIDs...) {
+			i := strings.Index(id, sep)
+			if i < 0 {
+				continue
+			}
+			rest := id[i+len(sep):]
+			if cut, _, found := strings.Cut(rest, "/"); found {
+				rest = cut
+			}
+			if rest != "" {
+				return rest
+			}
+		}
+		return ""
+	}
+}
+
+// fromName is the asset's own name, for the targets whose filter flag matches
+// on it -- a Kubernetes namespace is filtered by name, not by uid.
+func fromName() assetValue {
+	return func(a discoveredAsset) string { return a.Name }
+}
+
+// nameAfterSlash drops an owner prefix. github names a discovered repository
+// "<org>/<repo>" while --repos matches on the bare repository name.
+func nameAfterSlash() assetValue {
+	return func(a discoveredAsset) string {
+		if i := strings.LastIndex(a.Name, "/"); i >= 0 {
+			return a.Name[i+1:]
+		}
+		return a.Name
+	}
+}
+
+// firstValue takes the first extractor that yields anything.
+func firstValue(vs ...assetValue) assetValue {
+	return func(a discoveredAsset) string {
+		for _, v := range vs {
+			if got := v(a); got != "" {
+				return got
+			}
+		}
+		return ""
+	}
+}
+
+// platformNamed keeps only the assets of a declared platform.
+//
+// The names come from the provider's own metadata -- the Platforms block of
+// ~/.config/mondoo/providers/<name>/<name>.json -- so this is a check against
+// what the provider says it emits, not against a guess. It matters because the
+// document always contains the asset that was connected to as well as its
+// children, and a cluster is not one of its own namespaces.
+func platformNamed(names ...string) func(discoveredAsset) bool {
+	return func(a discoveredAsset) bool {
+		for _, n := range names {
+			if a.Platform.Name == n {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// discoverScope is one thing the discovery has to be pointed at before it
+// means anything: the cluster whose namespaces these are, the organization
+// whose repositories these are.
+//
+// The need is a field identity -- "p:1", "f:group" -- because every
+// interesting case here is keyed off a positional, which a flag name cannot
+// name. A positional scope carries no flag and is emitted in declaration
+// order, so it is always required: a hole in the middle of a positional list
+// would silently shift the arguments after it.
+type discoverScope struct {
+	// need names the field whose value scopes this discovery.
+	need string
+	// flag is the flag the value travels in. Empty means a positional.
+	flag string
+	// label is how the field is described when it has to be filled in first.
+	label string
+	// optional marks a scope that narrows the answer rather than enabling it.
+	optional bool
+	// equals gates the whole source on a selector's value: github lists
+	// repositories for an organization and for nothing else.
+	equals string
+	// unless is what to say when equals does not hold.
+	unless string
+}
+
+// discoverTarget declares one (connector, discovery target) pair and where its
+// answer lands.
+type discoverTarget struct {
+	// id is the source id; see source_ids.go.
+	id string
+	// connector and target are the two halves of
+	// `cnspec discover <connector> --discover <target>`.
+	connector, target string
+	// flag is the connector flag this answer is picked into. It is recorded
+	// rather than used, because the form owns the binding -- but a target
+	// whose answer has nowhere to go is a picker that wastes a network call,
+	// and TestEveryDiscoveryTargetHasSomewhereToPutIt checks this against the
+	// connector snapshot.
+	flag string
+	// activity says what is happening while it happens.
+	activity string
+	// scope is what has to be known before the question can be asked.
+	scope []discoverScope
+	// envFrom names a field whose value reaches the child through the
+	// environment instead of the command line, and envApply builds it. k8s is
+	// the case: --context is parsed and never reaches the client config, so
+	// the cluster travels as a kubeconfig copy.
+	envFrom  string
+	envApply func(value string) (env []string, cleanup func(), err error)
+	// keep decides which discovered assets are candidates.
+	keep func(discoveredAsset) bool
+	// value extracts the command-line value from one of them.
+	value assetValue
+}
+
+// needs is every field this target reads, derived from the declaration so the
+// two cannot drift apart.
+func (d discoverTarget) needs() []string {
+	out := make([]string, 0, len(d.scope)+1)
+	for _, s := range d.scope {
+		out = append(out, s.need)
+	}
+	if d.envFrom != "" {
+		out = append(out, d.envFrom)
+	}
+	return out
+}
+
+// commandLine is what the user would type to see this for themselves. It names
+// no values, only the shape, because it goes into an error message.
+func (d discoverTarget) commandLine() string {
+	return "cnspec discover " + d.connector + " --discover " + d.target
+}
+
+// args turns the scope into the child's arguments, or explains what is still
+// missing. Both halves matter: a picker that quietly discovers the wrong
+// thing is worse than one that says which field to fill in first.
+func (d discoverTarget) args(params []string) ([]string, error) {
+	var args []string
+	for _, s := range d.scope {
+		v := paramValue(params, s.need)
+		if s.equals != "" && v != s.equals {
+			return nil, errors.New(s.unless)
+		}
+		if v == "" {
+			if s.optional {
+				continue
+			}
+			return nil, errors.New("pick " + s.label + " first")
+		}
+		if s.flag == "" {
+			args = append(args, v)
+			continue
+		}
+		args = append(args, "--"+s.flag, v)
+	}
+	return args, nil
+}
+
+// discoverRun picks the runner for a child that may need extra environment.
+//
+// It exists because composing the two existing helpers loses the environment:
+// runWithEnv hands runnerWithEnv a base runner, and runnerWithEnv returns the
+// base unwrapped when one is set -- so `runWithEnv(ctx, execRunner, env, ...)`
+// runs the child with no env at all. execRunner is itself a runner, so the
+// production path takes that branch every time, and the value a source went to
+// the trouble of computing never reaches the process that needed it. For the
+// namespace picker that is KUBECONFIG, which is the *only* thing that selects
+// a cluster, so the answer would come back for whichever cluster the ambient
+// config happened to name.
+//
+// A nil base here means "the real thing", which is the one case that needs the
+// environment; a base is a test double, which never spawns anything and cannot
+// observe it. Fixing runnerWithEnv itself is the right repair and belongs to
+// the file that owns it.
+func discoverRun(base runner, env []string) runner {
+	if base != nil {
+		return base
+	}
+	return runnerWithEnv(nil, env)
+}
+
+// fetch runs the discovery and returns the candidates. A nil run is the real
+// child process; tests pass a double.
+//
+// The caller's context is what makes a picker abandonable: `cnspec discover`
+// connects into every asset it finds, so closing the picker has to kill it
+// rather than leave it running to completion for an answer nobody will read.
+func (d discoverTarget) fetch(ctx context.Context, run runner, params []string) ([]string, error) {
+	args, err := d.args(params)
+	if err != nil {
+		return nil, err
+	}
+
+	var env []string
+	if d.envApply != nil {
+		if v := paramValue(params, d.envFrom); v != "" {
+			more, cleanup, err := d.envApply(v)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err != nil {
+				return nil, err
+			}
+			env = more
+		}
+	}
+
+	// The assets have nowhere to go but a file, so one is made here and
+	// removed on the way out. The child truncates it; an unwritable temp dir
+	// is the only way this fails.
+	out, err := os.CreateTemp("", "cnspec-discover-*.json")
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot make room for the discovery output")
+	}
+	path := out.Name()
+	_ = out.Close()
+	defer func() { _ = os.Remove(path) }()
+
+	self, err := os.Executable()
+	if err != nil {
+		self = os.Args[0]
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, discoverTimeout)
+	defer cancel()
+
+	full := append([]string{"discover", d.connector}, args...)
+	full = append(full,
+		"--discover", d.target,
+		"--output-full", path,
+		"--output-format", "json",
+	)
+
+	stdout, runErr := discoverRun(run, env)(ctx, self, full...)
+
+	data, _ := os.ReadFile(path)
+	if len(bytes.TrimSpace(data)) == 0 {
+		// See the file comment: no file is both "nothing there" and "never
+		// got that far", and only stdout tells them apart.
+		if runErr == nil && bytes.Contains(stdout, []byte(discoveryMarker)) {
+			return nil, nil
+		}
+		if runErr != nil {
+			return nil, runErr
+		}
+		return nil, errors.New(d.commandLine() + " did not get far enough to answer")
+	}
+	return d.parse(data)
+}
+
+// parse pulls the candidates out of the inventory document discovery wrote.
+func (d discoverTarget) parse(data []byte) ([]string, error) {
+	var doc struct {
+		Spec struct {
+			Assets []discoveredAsset `json:"assets"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, errors.Wrap(err, "cannot read what "+discoverTool+" wrote")
+	}
+	var out []string
+	for _, a := range doc.Spec.Assets {
+		if d.keep != nil && !d.keep(a) {
+			continue
+		}
+		if v := d.value(a); v != "" {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		// An empty list from a document that parsed is a real answer: the
+		// connector has none of these. Returning nil rather than an empty
+		// slice keeps that indistinguishable from the marker path above,
+		// which means the same thing.
+		return nil, nil
+	}
+	return SortedUnique(out), nil
+}
+
+// explain turns whatever the child said into one sentence worth reading.
+//
+// The reason arrives twice removed: the provider speaks gRPC, cnspec logs that
+// through zerolog, and .Output() only surfaces stderr when the child exited
+// non-zero. So this unwraps as far as it can and, when there is nothing left
+// to unwrap, names the command instead -- because "could not reach it" with no
+// way to find out why is the failure this whole contract exists to prevent.
+func (d discoverTarget) explain(err error) error {
+	if err == nil {
+		return nil
+	}
+	if reason := discoverReason(err.Error()); reason != "" {
+		return errorString(reason)
+	}
+	return errors.New("cannot list " + d.target + " — run: " + d.commandLine())
+}
+
+// discoverReason digs the provider's own words out of the child's stderr.
+func discoverReason(text string) string {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	// The fatal line is the last thing written, and everything above it is
+	// startup noise about provider shorthands and the like.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		// zerolog's console writer renders the error as error="..." after the
+		// message, and the message is ours, not the provider's.
+		if _, after, ok := strings.Cut(line, `error="`); ok {
+			if inner, _, ok := strings.Cut(after, `"`); ok && inner != "" {
+				line = inner
+			}
+		}
+		line = strings.TrimSpace(strings.TrimLeft(line, "x!*-> "))
+		if line == "" {
+			continue
+		}
+		return stripRPCPrefix(errorString(line)).Error()
+	}
+	return ""
+}
+
+// source turns the declaration into the contract the launcher consumes.
+func (d discoverTarget) source() Source {
+	return Source{
+		ID:       d.id,
+		Class:    ClassPostConnection,
+		Cost:     CostRemote,
+		Activity: d.activity,
+		Tool:     discoverTool,
+		Needs:    d.needs(),
+		Explain:  d.explain,
+		FetchCtx: func(ctx context.Context, params []string) ([]string, error) {
+			return d.fetch(ctx, nil, params)
+		},
+	}
+}
+
+// discoverTargets is the table.
+//
+// A pair earns a row by satisfying both halves, checked against the installed
+// providers rather than assumed:
+//
+//   - the connector declares the discovery target (its Discovery list), and
+//   - it declares a flag that consumes the answer, whose description says so.
+//
+// Forty connectors declare discovery targets and most of them fail the second
+// half, which is why this table is shorter than the count of things cnspec can
+// discover. The exclusions are recorded in the test file rather than here, so
+// that a future pass can see what was considered and why it was left out.
+var discoverTargets = []discoverTarget{
+	{
+		id:        DiscoverK8sNamespaces,
+		connector: "k8s",
+		target:    "namespaces",
+		flag:      "namespaces",
+		activity:  "asking cnspec discover for the cluster's namespaces",
+		// The connector's --context is parsed and then never reaches the
+		// client config, so the cluster travels as a kubeconfig copy. That
+		// plumbing already exists in kubeconfig.go and is not duplicated here.
+		envFrom:  "f:context",
+		envApply: kubeEnvForContext,
+		// The document also holds the cluster that was connected to, and a
+		// cluster is not one of its own namespaces.
+		keep:  platformNamed("k8s-namespace"),
+		value: fromName(),
+	},
+	{
+		id:        DiscoverGitHubRepos,
+		connector: "github",
+		target:    "repos",
+		flag:      "repos",
+		activity:  "asking cnspec discover for the organization's repositories",
+		scope: []discoverScope{
+			{
+				need: "p:0", equals: "org",
+				unless: "repositories are only listed for an organization",
+			},
+			{need: "p:1", label: "the organization"},
+		},
+		keep: platformNamed("github-repo"),
+		// The connector names a discovered repository "<org>/<repo>" while
+		// --repos matches the bare name, which is also what the child's own
+		// Options["repository"] carries.
+		value: firstValue(fromOption("repository"), nameAfterSlash()),
+	},
+	{
+		id:        DiscoverGitLabGroups,
+		connector: "gitlab",
+		target:    "groups",
+		flag:      "group",
+		activity:  "asking cnspec discover for your GitLab groups",
+		keep:      platformNamed("gitlab-group"),
+		// --group takes the full path, which is what discovery writes into
+		// the child's own Options["group"].
+		value: fromOption("group"),
+	},
+	{
+		id:        DiscoverGitLabProjects,
+		connector: "gitlab",
+		target:    "projects",
+		flag:      "project",
+		activity:  "asking cnspec discover for the group's projects",
+		// Without a group this walks every group the token can see, which is
+		// slow but not wrong, so the scope narrows rather than gates.
+		scope: []discoverScope{
+			{need: "f:group", flag: "group", label: "a group", optional: true},
+		},
+		keep:  platformNamed("gitlab-project"),
+		value: fromOption("project"),
+	},
+	{
+		id:        DiscoverAzureSubscriptions,
+		connector: "azure",
+		target:    "subscriptions",
+		flag:      "subscriptions",
+		activity:  "asking cnspec discover for your Azure subscriptions",
+		// --subscriptions is matched against the subscription id and nothing
+		// else, so the display name the asset is called by would silently
+		// match no subscription at all.
+		value: firstValue(
+			fromOption("subscription-id"),
+			fromPlatformID("subscriptions"),
+		),
+	},
+	{
+		id:        DiscoverSourceID("neon", "organizations"),
+		connector: "neon",
+		target:    "organizations",
+		flag:      "organization",
+		activity:  "asking cnspec discover for your Neon organizations",
+		keep:      platformNamed("neon-organization"),
+		value:     fromPlatformID("organization"),
+	},
+	{
+		id:        DiscoverSourceID("netlify", "accounts"),
+		connector: "netlify",
+		target:    "accounts",
+		flag:      "account",
+		activity:  "asking cnspec discover for your Netlify accounts",
+		keep:      platformNamed("netlify-account"),
+		value:     fromPlatformID("account"),
+	},
+	{
+		id:        DiscoverSourceID("vercel", "teams"),
+		connector: "vercel",
+		target:    "teams",
+		flag:      "team",
+		activity:  "asking cnspec discover for your Vercel teams",
+		keep:      platformNamed("vercel-team"),
+		value:     fromPlatformID("team"),
+	},
+	{
+		id:        DiscoverAtlasProjects,
+		connector: "mongodbatlas",
+		target:    "projects",
+		flag:      "project-id",
+		activity:  "asking cnspec discover for your Atlas projects",
+		scope: []discoverScope{
+			{need: "f:org-id", flag: "org-id", label: "an organization", optional: true},
+		},
+		keep:  platformNamed("mongodbatlas-project"),
+		value: fromPlatformID("project"),
+	},
+	{
+		id:        DiscoverClaudeWorkspaces,
+		connector: "claude",
+		target:    "workspaces",
+		flag:      "workspace-id",
+		activity:  "asking cnspec discover for your Claude workspaces",
+		keep:      platformNamed("claude-workspace"),
+		value:     fromPlatformID("workspace"),
+	},
+}
+
+func init() {
+	sources := make([]Source, 0, len(discoverTargets))
+	for _, d := range discoverTargets {
+		sources = append(sources, d.source())
+	}
+	Register(sources...)
+}
+
+// DiscoverPair is one row of the table above, reduced to the claims it makes
+// about a connector: that the connector declares this discovery target, and
+// that it declares a flag the answer can be picked into.
+type DiscoverPair struct {
+	ID        string
+	Connector string
+	Target    string
+	// Flag is where the answer lands.
+	Flag string
+	// ScopeFlags are the flags the discovery is narrowed by, which have to
+	// exist too.
+	ScopeFlags []string
+}
+
+// DiscoverPairs is the table, flattened.
+//
+// It exists so those claims can be confronted with the recorded connector
+// metadata, which lives with the launcher because that is where the catalog
+// that produced it lives. Both halves have to be checked against the provider
+// rather than against what a flag name suggests: aws --filters looks exactly
+// like the place a discovered account goes, and is not.
+func DiscoverPairs() []DiscoverPair {
+	out := make([]DiscoverPair, 0, len(discoverTargets))
+	for _, d := range discoverTargets {
+		p := DiscoverPair{ID: d.id, Connector: d.connector, Target: d.target, Flag: d.flag}
+		for _, s := range d.scope {
+			if s.flag != "" {
+				p.ScopeFlags = append(p.ScopeFlags, s.flag)
+			}
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/cli/launcher/source/discover_test.go
+++ b/cli/launcher/source/discover_test.go
@@ -1,0 +1,441 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Everything here runs against a recorded inventory document, so none of it
+// needs credentials, a network, or an installed provider.
+// testdata/discover_local_container.json is not written by hand: it is the
+// output of a real `cnspec discover local --discover container`, with the
+// machine it named scrubbed. The rest are hand-built to carry the one thing
+// their connector taught -- github's owner prefix, azure's display name -- and
+// a fixture that omits the catch tests nothing.
+
+// targetByID finds a declaration to exercise.
+func targetByID(t *testing.T, id string) discoverTarget {
+	t.Helper()
+	for _, d := range discoverTargets {
+		if d.id == id {
+			return d
+		}
+	}
+	t.Fatalf("no discovery target declared for %q", id)
+	return discoverTarget{}
+}
+
+// fixtureRunner stands in for the child process: it records the command line
+// it was handed and writes a recorded document to whatever path --output-full
+// named. stdout is what the real command prints, which is the only thing that
+// tells an empty answer from a refused one.
+func fixtureRunner(t *testing.T, fixture, stdout string, runErr error) (runner, *[]string) {
+	t.Helper()
+	var got []string
+	return func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		got = args
+		if fixture != "" {
+			data, err := os.ReadFile("testdata/" + fixture)
+			if err != nil {
+				t.Fatalf("cannot read the fixture: %v", err)
+			}
+			for i, a := range args {
+				if a == "--output-full" && i+1 < len(args) {
+					if err := os.WriteFile(args[i+1], data, 0o600); err != nil {
+						t.Fatalf("cannot stage the fixture: %v", err)
+					}
+				}
+			}
+		}
+		return []byte(stdout), runErr
+	}, &got
+}
+
+const summary = "Discovered assets:\nalpine: 8\n"
+
+// The document a real run produces, parsed as it actually arrives.
+//
+// It carries the property every other case here depends on: the asset that was
+// connected to is in the document alongside its children. A picker that took
+// every asset would offer the machine it was asked about as one of the things
+// inside it.
+func TestTheRecordedDocumentParses(t *testing.T) {
+	containers := discoverTarget{
+		connector: "local", target: "container",
+		value: fromPlatformID("containers"),
+	}
+	run, _ := fixtureRunner(t, "discover_local_container.json", summary, nil)
+
+	got, err := containers.fetch(context.Background(), run, nil)
+	if err != nil {
+		t.Fatalf("parsing a real discovery document failed: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d containers from the recording, want 4: %v", len(got), got)
+	}
+	for _, v := range got {
+		if len(v) != 64 {
+			t.Errorf("%q is not a container id", v)
+		}
+	}
+
+	// The host the command was pointed at has no container id, so it drops out
+	// of the answer rather than being offered as one of its own containers.
+	byName := discoverTarget{connector: "local", target: "container", value: fromName()}
+	all, err := byName.fetch(context.Background(), run, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(all, "workstation") {
+		t.Fatal("the recording no longer holds the connected root; the keep/value rules below are untested")
+	}
+}
+
+func TestNamespacesAreTheClustersNotTheCluster(t *testing.T) {
+	d := targetByID(t, DiscoverK8sNamespaces)
+	run, args := fixtureRunner(t, "discover_k8s_namespaces.json", summary, nil)
+
+	got, err := d.fetch(context.Background(), run, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"default", "kube-system", "payments"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("namespaces = %v, want %v", got, want)
+	}
+	if slices.Contains(got, "kind-demo") {
+		t.Error("the cluster was offered as one of its own namespaces")
+	}
+
+	// --discover is never left to default to auto, which is the expensive one.
+	line := strings.Join(*args, " ")
+	if !strings.Contains(line, "--discover namespaces") {
+		t.Errorf("the target was not named explicitly: %s", line)
+	}
+	if !strings.Contains(line, "--output-format json") {
+		t.Errorf("the payload format was not pinned: %s", line)
+	}
+}
+
+// github names a discovered repository "<org>/<repo>" and --repos matches the
+// bare name, so emitting the display name would filter to nothing at all.
+func TestGitHubReposEmitTheBareName(t *testing.T) {
+	d := targetByID(t, DiscoverGitHubRepos)
+	run, args := fixtureRunner(t, "discover_github_repos.json", summary, nil)
+
+	got, err := d.fetch(context.Background(), run, []string{"p:0=org", "p:1=mondoohq"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"cnquery", "cnspec", "policy-bundles"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("repos = %v, want %v", got, want)
+	}
+	for _, v := range got {
+		if strings.Contains(v, "/") {
+			t.Errorf("%q still carries its owner prefix", v)
+		}
+	}
+	// The organization and the user in the same document are not repositories.
+	if slices.Contains(got, "mondoohq") || slices.Contains(got, "octocat") {
+		t.Errorf("a non-repository reached the picker: %v", got)
+	}
+	// The scope reaches the child as the positional pair the connector wants.
+	if line := strings.Join(*args, " "); !strings.Contains(line, "discover github org mondoohq") {
+		t.Errorf("the organization did not scope the discovery: %s", line)
+	}
+}
+
+// A subscription is filtered by id and by nothing else, so the display name
+// the asset is called by would match no subscription at all.
+func TestAzureSubscriptionsEmitTheIDNotTheName(t *testing.T) {
+	d := targetByID(t, DiscoverAzureSubscriptions)
+	run, _ := fixtureRunner(t, "discover_azure_subscriptions.json", summary, nil)
+
+	got, err := d.fetch(context.Background(), run, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"0d7c6b5a-4e3f-2a1b-9c8d-7e6f5a4b3c2d",
+		"f1f9a0d1-9c2e-4a5b-8f3e-1c2d3e4f5a6b",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("subscriptions = %v, want %v", got, want)
+	}
+	for _, v := range got {
+		if strings.Contains(v, " ") {
+			t.Errorf("%q is a display name, not a subscription id", v)
+		}
+	}
+	// The second entry carries no connection option, so it is only findable
+	// through the platform id -- which is the fallback this pair needs.
+}
+
+// A team picker offers teams. The projects inside them are in the same
+// document and are a different flag's business.
+func TestVercelOffersTeamsOnly(t *testing.T) {
+	d := targetByID(t, DiscoverSourceID("vercel", "teams"))
+	run, _ := fixtureRunner(t, "discover_vercel_teams.json", summary, nil)
+
+	got, err := d.fetch(context.Background(), run, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"team_3xKd9RvBnM", "team_7fLp2QmXyZ"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("teams = %v, want %v", got, want)
+	}
+	for _, v := range got {
+		if strings.HasPrefix(v, "prj_") {
+			t.Errorf("a project reached the team picker: %q", v)
+		}
+	}
+}
+
+// The rule this whole file is organised around.
+//
+// `cnspec discover` writes no asset file for an account with nothing in it and
+// no asset file for a connection it refused -- and it exits 0 either way, so
+// the exit code does not separate them. Only stdout does: the per-platform
+// summary is printed once discovery has actually run.
+func TestEmptyAndFailedDoNotLookTheSame(t *testing.T) {
+	d := targetByID(t, DiscoverAzureSubscriptions)
+
+	// Nothing there: discovery ran and found none.
+	ran, _ := fixtureRunner(t, "", "Discovered assets:\n", nil)
+	values, err := d.fetch(context.Background(), ran, nil)
+	if err != nil {
+		t.Errorf("an empty subscription list reported an error: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("values from nothing: %v", values)
+	}
+
+	// Refused: the connector printed its usage and still exited 0.
+	refused, _ := fixtureRunner(t, "", "Use the azure provider to query...\n\nUsage:\n", nil)
+	if _, err := d.fetch(context.Background(), refused, nil); err == nil {
+		t.Fatal("a refused connection reported an empty subscription list")
+	} else if got := d.explain(err).Error(); !strings.Contains(got, "cnspec discover azure") {
+		t.Errorf("explained as %q, want the command the user can run", got)
+	}
+
+	// Refused loudly: the child exited non-zero and its stderr came back.
+	stderr := errors.New(`! provider flag shorthand already in use, ignoring shorthand conflicts-with=user flag=username shorthand=u
+x failed to parse cli arguments error="rpc error: code = Unknown desc = a valid GitHub authentication is required, pass --token '<yourtoken>', set GITHUB_TOKEN environment variable or provide GitHub App credentials"`)
+	loud, _ := fixtureRunner(t, "", "", stderr)
+	_, err = d.fetch(context.Background(), loud, nil)
+	if err == nil {
+		t.Fatal("a failed child reported success")
+	}
+	got := d.explain(err).Error()
+	if strings.Contains(got, "\n") {
+		t.Errorf("a picker gets one line, got %q", got)
+	}
+	if strings.HasPrefix(got, "rpc error:") || strings.Contains(got, "desc = ") {
+		t.Errorf("the gRPC envelope survived: %q", got)
+	}
+	if strings.HasPrefix(got, "x ") || strings.Contains(got, `error="`) {
+		t.Errorf("the log decoration survived: %q", got)
+	}
+	if !strings.Contains(got, "GITHUB_TOKEN") {
+		t.Errorf("the provider's own instruction was lost: %q", got)
+	}
+}
+
+// A discovery that has not been told what it is discovering inside says which
+// field to fill in, rather than answering for something else.
+func TestScopeIsRequiredBeforeAsking(t *testing.T) {
+	d := targetByID(t, DiscoverGitHubRepos)
+
+	if _, err := d.args([]string{"p:0=repo", "p:1=mondoohq/cnspec"}); err == nil {
+		t.Error("a single-repo scan was offered a list of the org's repositories")
+	} else if !strings.Contains(err.Error(), "organization") {
+		t.Errorf("explained as %q, want it to name what this needs", err)
+	}
+
+	if _, err := d.args([]string{"p:0=org"}); err == nil {
+		t.Error("the organization was never asked for")
+	} else if !strings.Contains(err.Error(), "first") {
+		t.Errorf("explained as %q, want it to say what to fill in first", err)
+	}
+
+	args, err := d.args([]string{"p:0=org", "p:1=mondoohq"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(args, " ") != "org mondoohq" {
+		t.Errorf("args = %v, want the positional pair the connector takes", args)
+	}
+
+	// An optional scope narrows the answer and never blocks it.
+	projects := targetByID(t, DiscoverGitLabProjects)
+	if args, err := projects.args(nil); err != nil || len(args) != 0 {
+		t.Errorf("unscoped gitlab projects = %v, %v; want an unscoped run", args, err)
+	}
+	if args, err := projects.args([]string{"f:group=acme/platform"}); err != nil ||
+		strings.Join(args, " ") != "--group acme/platform" {
+		t.Errorf("scoped gitlab projects = %v, %v", args, err)
+	}
+}
+
+// A source depends on a field by identity, and the dependency it declares has
+// to be the one it actually reads -- otherwise the model caches one cluster's
+// answer under another's key.
+func TestNeedsMatchTheScope(t *testing.T) {
+	for _, d := range discoverTargets {
+		needs := d.needs()
+		for _, s := range d.scope {
+			if !slices.Contains(needs, s.need) {
+				t.Errorf("%s: reads %q but does not declare it", d.id, s.need)
+			}
+		}
+		if d.envFrom != "" && !slices.Contains(needs, d.envFrom) {
+			t.Errorf("%s: takes %q through the environment but does not declare it", d.id, d.envFrom)
+		}
+		s, ok := ByID(d.id)
+		if !ok {
+			t.Errorf("%s: declared but never registered", d.id)
+			continue
+		}
+		if strings.Join(s.Needs, ",") != strings.Join(needs, ",") {
+			t.Errorf("%s: registered Needs %v, declared %v", d.id, s.Needs, needs)
+		}
+	}
+
+	// The namespace list belongs to one cluster, and that cluster is chosen in
+	// a flag field -- the identity form, not the bare name, because a bare
+	// name is only shorthand for a flag and this one has to keep working when
+	// the field moves.
+	d := targetByID(t, DiscoverK8sNamespaces)
+	if !slices.Contains(d.needs(), "f:context") {
+		t.Errorf("namespaces do not depend on the cluster: %v", d.needs())
+	}
+}
+
+// Discovery connects into everything it finds, so none of these may run when a
+// form opens.
+func TestDiscoverySourcesWaitToBeAskedFor(t *testing.T) {
+	for _, d := range discoverTargets {
+		s, ok := ByID(d.id)
+		if !ok {
+			t.Errorf("%s is not registered", d.id)
+			continue
+		}
+		if s.Class != ClassPostConnection {
+			t.Errorf("%s: class %v, want ClassPostConnection", d.id, s.Class)
+		}
+		if s.Cost != CostRemote || !Deferred(d.id) {
+			t.Errorf("%s: cost %v, want CostRemote so the picker opens it", d.id, s.Cost)
+		}
+		if s.Tool != discoverTool || !strings.Contains(s.Activity, discoverTool) {
+			t.Errorf("%s: %q does not name %q", d.id, s.Activity, discoverTool)
+		}
+	}
+}
+
+// The pairs that were considered and left out, and why.
+//
+// Each of these has a discovery target that sounds like it feeds a flag, and
+// none of them does. Writing them down as a test rather than as a comment is
+// what stops the next pass re-deriving the same plausible mapping: an invented
+// flag mapping is the documented failure mode on this branch, and it survived
+// review last time because it read perfectly well.
+func TestExcludedPairsStayExcluded(t *testing.T) {
+	excluded := []struct {
+		connector, target, why string
+	}{
+		{"aws", "accounts", "--filters takes regions, tags and per-service ids; the provider's prefix allowlist has no account key, so a discovered account would be silently dropped"},
+		{"alicloud", "accounts", "--filters takes regions and tags only, and there is no account flag"},
+		{"digitalocean", "databases", "--filters takes regions and tags only, and there is no database flag"},
+		{"oci", "tenancy", "--tenancy exists, but the tenancy is what you connect with rather than what you find, and the discovered asset's shape could not be verified"},
+		{"gcp", "projects", "the answer's only destination is the positional the discovery is already scoped by, so the picker would replace what it needed to run"},
+		{"databricks", "workspaces", "--host takes a workspace URL, which is not the workspace id the platform id carries; the mapping could not be verified"},
+		{"hcp", "projects", "--project-id exists, but the project asset's id is composed at runtime and neither the provider metadata nor the binary shows where it lands"},
+		{"snowflake", "databases", "snowflake declares the databases target and no flag that takes a database name"},
+		{"mssql", "databases", "--database exists, but discovery needs the password, and this launcher does not put a secret on a child's command line"},
+		{"mysqldb", "databases", "as mssql"},
+		{"postgresdb", "databases", "as mssql"},
+	}
+	for _, e := range excluded {
+		id := DiscoverSourceID(e.connector, e.target)
+		if _, ok := ByID(id); ok {
+			t.Errorf("%s was registered; it was excluded because %s", id, e.why)
+		}
+		for _, d := range discoverTargets {
+			if d.connector == e.connector && d.target == e.target {
+				t.Errorf("%s %s was declared; it was excluded because %s", e.connector, e.target, e.why)
+			}
+		}
+	}
+}
+
+// The chosen cluster has to reach the child, and this is the one dimension of
+// it that a double cannot check: the value travels in the environment, so a
+// recorded command line proves nothing about whether it arrived.
+//
+// It is worth a real process because composing the two existing runner helpers
+// silently drops the environment -- runnerWithEnv returns its base unwrapped
+// when one is set, and the production base is never nil -- which would leave
+// the namespace list answering for whatever cluster the ambient kubeconfig
+// named. See discoverRun.
+func TestTheEnvironmentReachesTheChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /bin/sh to ask")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	run := discoverRun(nil, []string{"KUBECONFIG=/tmp/picked-cluster"})
+	out, err := run(ctx, "/bin/sh", "-c", "printenv KUBECONFIG")
+	if err != nil {
+		t.Fatalf("could not ask the child what it was given: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "/tmp/picked-cluster" {
+		t.Errorf("the child saw KUBECONFIG=%q, want the chosen cluster's copy", got)
+	}
+
+	// A double is used as it stands, so a test never spawns anything.
+	fake, _ := fixtureRunner(t, "", summary, nil)
+	if discoverRun(fake, []string{"KUBECONFIG=/tmp/ignored"}) == nil {
+		t.Error("an injected runner was discarded")
+	}
+}
+
+// The k8s namespace picker that predates this file is left where it is.
+//
+// It answers the same question through kubectl rather than through discovery,
+// it is what the shipped k8s form names, and its behaviour is asserted in
+// three test files this one does not own. Registering the generic version
+// under a second id is an append; replacing the old one would have been an
+// edit to a form and to tests belonging to someone else, for no behaviour the
+// user can see.
+func TestTheKubectlNamespaceSourceIsUntouched(t *testing.T) {
+	old, ok := ByID(K8sNamespace)
+	if !ok {
+		t.Fatal("the kubectl namespace source is gone")
+	}
+	if old.Tool != "kubectl" {
+		t.Errorf("the kubectl source now asks %q", old.Tool)
+	}
+	generic, ok := ByID(DiscoverK8sNamespaces)
+	if !ok {
+		t.Fatal("the discovery namespace source is not registered")
+	}
+	if generic.Tool == old.Tool {
+		t.Error("both namespace sources claim the same tool, so a wait cannot say which is running")
+	}
+	if Key(K8sNamespace, nil) == Key(DiscoverK8sNamespaces, nil) {
+		t.Error("the two namespace sources share a cache entry")
+	}
+}

--- a/cli/launcher/source/doc.go
+++ b/cli/launcher/source/doc.go
@@ -1,0 +1,7 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package source holds the launcher's value pickers: what a form field can be
+// filled from, and everything a picker has to declare about itself before it
+// is allowed to fill one.
+package source

--- a/cli/launcher/source/enumerated.go
+++ b/cli/launcher/source/enumerated.go
@@ -1,0 +1,424 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// The readers behind five of the enumerated sources: five local files that
+// already name the thing the user is about to be asked for -- ~/.oci/config,
+// ~/.alibabacloud/credentials, ~/.azure/azureProfile.json,
+// ~/.snowflake/connections.toml and the docker context store.
+//
+// What they have in common is the shape, not the format. Each is a file this
+// machine already has, read without a network or a credential. The Source
+// declarations that use them are in declare.go with every other pre-connection
+// declaration; this file is the part that differs per format, which is the
+// part no amount of declaring can make uniform.
+//
+// Every reader takes a path so it is testable without a $HOME, and every reader
+// distinguishes "nothing configured" from "could not read": a picker that shows
+// an empty list for a file it never opened is the failure this contract exists
+// to stop.
+
+const (
+	// The literal DEFAULT is the OCI convention, in capitals, and is what the
+	// connector's own --profile help names. Lowercasing it here would prefill a
+	// profile that does not exist.
+	ociDefaultProfile = "DEFAULT"
+
+	// AlicloudProfileEnv carries the chosen profile, since the connector has no
+	// flag for it. Verified in aliyun/credentials-go's ProfileCredentialsProvider,
+	// whose precedence is: explicit name, then this variable, then "default".
+	AlicloudProfileEnv = "ALIBABA_CLOUD_PROFILE"
+	// alicloudCredentialsEnv relocates the credentials file itself.
+	alicloudCredentialsEnv  = "ALIBABA_CLOUD_CREDENTIALS_FILE"
+	alicloudDefaultProfile  = "default"
+	snowflakeHomeEnv        = "SNOWFLAKE_HOME"
+	snowflakeConnectionFile = "connections.toml"
+	// snowflakeDefaultConnection is the table Snowflake's tooling falls back to
+	// when no connection is named.
+	snowflakeDefaultConnection = "default"
+	// azureConfigDirEnv relocates the az CLI's whole config directory, and so
+	// the profile file inside it.
+	azureConfigDirEnv = "AZURE_CONFIG_DIR"
+	azureProfileFile  = "azureProfile.json"
+
+	// The docker names, spelled as docker/cli spells them: DOCKER_CONFIG for
+	// the config directory, "contexts" for the store inside it, and the context
+	// named "default" for the CLI's own env-and-default-socket resolution.
+	dockerConfigDirEnv    = "DOCKER_CONFIG"
+	dockerConfigFile      = "config.json"
+	dockerContextsDir     = "contexts"
+	dockerContextMetaDir  = "meta"
+	dockerContextMetaFile = "meta.json"
+	DockerContextEnv      = "DOCKER_CONTEXT"
+	DockerHostEnv         = "DOCKER_HOST"
+	DockerDefaultContext  = "default"
+)
+
+// missingFileExplain turns a file-read failure into the one sentence that says
+// what to do about it.
+//
+// A picker backed by a file has exactly two failures worth telling apart, and
+// neither of them reads well raw: os wraps both in a path and a syscall name,
+// which says where the launcher looked but not what the user should do. Anything
+// else -- a malformed file, a truncated read -- keeps its own words, because a
+// message of ours would say less.
+func missingFileExplain(what, remedy string) ExplainFunc {
+	return func(err error) error {
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			return errors.New("no " + what + " — " + remedy)
+		case errors.Is(err, fs.ErrPermission):
+			return errors.New("cannot read " + what + " — check its permissions")
+		}
+		return stripRPCPrefix(err)
+	}
+}
+
+// profileNamesFrom reads the section names, and nothing else, out of a
+// credentials file.
+//
+// One function for OCI and for Alibaba Cloud, because it was one function
+// twice: the two readers were byte-identical, and the only thing that ever
+// differed was the sentence above them explaining why each could not use a
+// library. Both reasons are the same reason. ~/.oci/config is ini-*like*
+// rather than ini -- Oracle's SDK hand-rolls the parse and is not in cnspec's
+// module graph -- and ~/.alibabacloud/credentials is a true ini that
+// gopkg.in/ini.v1 would read in a line. What settles both is what is next to
+// the names: private keys and their passphrases in one, an access key secret
+// in every section of the other. See ini.go.
+func profileNamesFrom(path string) ([]string, error) {
+	names, _, err := iniSections(iniScan{files: iniPath(path)})
+	if len(names) == 0 && err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// ociProfiles lists the profiles in the OCI config file.
+func ociProfiles() ([]string, error) { return profileNamesFrom(home(".oci", "config")) }
+
+// alicloudProfiles lists the profiles in the Alibaba Cloud credentials file.
+func alicloudProfiles() ([]string, error) {
+	return profileNamesFrom(alicloudCredentialsPath())
+}
+
+// alicloudCredentialsPath is the credentials file the SDK would read.
+func alicloudCredentialsPath() string {
+	if path := os.Getenv(alicloudCredentialsEnv); path != "" {
+		return path
+	}
+	return home(".alibabacloud", "credentials")
+}
+
+// snowflakeConnectionsPath is the connections file the Snowflake tooling reads.
+func snowflakeConnectionsPath() string {
+	if dir := os.Getenv(snowflakeHomeEnv); dir != "" {
+		return filepath.Join(dir, snowflakeConnectionFile)
+	}
+	return home(".snowflake", snowflakeConnectionFile)
+}
+
+// snowflakeAccountKey is the one key the connections file may be read for.
+var snowflakeAccountKey = map[string]bool{"account": true}
+
+func snowflakeAccounts() ([]string, error) {
+	return snowflakeAccountsFrom(snowflakeConnectionsPath())
+}
+
+// snowflakeAccountsFrom offers the account identifiers named in
+// connections.toml -- not the connection names.
+//
+// This is the decision the id SnowflakeConnection does not make for itself.
+// connections.toml is a table per connection, and the obvious picker would list
+// those table names. But nothing in cnspec accepts one: the connector declares
+// --user, --account, --role, --region, --token, --password and --identity-file,
+// and no flag and no variable it reads takes a connection name. Offering "audit"
+// as a value would put `--account audit` on the command line, which is a
+// confidently wrong answer of exactly the kind this contract exists to prevent.
+//
+// So the picker offers the one thing in that file the connector can use. Attach
+// it to --account.
+//
+// `account` is a locator, not a credential, which is what makes reading it
+// allowable at all: the allowlist is one key wide, and the passwords, tokens and
+// key paths in the same table are never held. That is the same shape as the AWS
+// reader's sso_account_id, and the reason neither file goes through a TOML or
+// ini library.
+func snowflakeAccountsFrom(path string) ([]string, error) {
+	_, values, err := iniSections(iniScan{files: iniPath(path), want: snowflakeAccountKey})
+	if len(values) == 0 && err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(values))
+	for _, keys := range values {
+		out = append(out, keys.last("account"))
+	}
+	return SortedUnique(out), nil
+}
+
+// snowflakeDefaultAccount is the account of the connection named "default".
+func snowflakeDefaultAccount() string {
+	return snowflakeDefaultAccountFrom(snowflakeConnectionsPath())
+}
+
+func snowflakeDefaultAccountFrom(path string) string {
+	_, values, err := iniSections(iniScan{files: iniPath(path), want: snowflakeAccountKey})
+	if err != nil && len(values) == 0 {
+		return ""
+	}
+	return values[snowflakeDefaultConnection].last("account")
+}
+
+// utf8BOM is what the az CLI writes at the start of azureProfile.json. Go's
+// encoding/json refuses a document that begins with it -- "invalid character
+// 'ï' looking for beginning of value" -- so it comes off before the decode.
+var utf8BOM = []byte{0xef, 0xbb, 0xbf}
+
+// azureProfileDoc is the part of the az CLI's profile this launcher reads.
+//
+// It is not internal/onboarding's AzAccount, which describes the JSON `az
+// account list` prints rather than the JSON `az` stores. The two differ in one
+// field that matters: the command emits `cloudName`, the file writes
+// `environmentName`, so decoding this file into AzAccount leaves the cloud empty
+// and says nothing about it.
+type azureProfileDoc struct {
+	Subscriptions []azureProfileSubscription `json:"subscriptions"`
+}
+
+type azureProfileSubscription struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// State is "Enabled" or "Disabled". A disabled subscription is still
+	// listed, and is not scannable.
+	State           string `json:"state"`
+	IsDefault       bool   `json:"isDefault"`
+	TenantID        string `json:"tenantId"`
+	EnvironmentName string `json:"environmentName"`
+}
+
+// azureProfilePath is the az CLI's profile file.
+func azureProfilePath() string {
+	if dir := os.Getenv(azureConfigDirEnv); dir != "" {
+		return filepath.Join(dir, azureProfileFile)
+	}
+	return home(".azure", azureProfileFile)
+}
+
+func azureProfileFrom(path string) (azureProfileDoc, error) {
+	var doc azureProfileDoc
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return doc, err
+	}
+	if err := json.Unmarshal(bytes.TrimPrefix(data, utf8BOM), &doc); err != nil {
+		return doc, errors.Wrap(err, "cannot read the az CLI profile")
+	}
+	return doc, nil
+}
+
+func azureSubscriptions() ([]string, error) { return azureSubscriptionsFrom(azureProfilePath()) }
+
+// azureSubscriptionsFrom lists the ids of the subscriptions az knows about.
+//
+// Ids rather than names, because --subscription takes an id: the connector's own
+// help says so and its provider reads flags["subscription"] straight through. A
+// name would look better in the list and would not connect.
+func azureSubscriptionsFrom(path string) ([]string, error) {
+	doc, err := azureProfileFrom(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(doc.Subscriptions))
+	for _, sub := range doc.Subscriptions {
+		// A disabled subscription cannot be scanned, so offering it would only
+		// produce a failure the launcher could have predicted.
+		if !strings.EqualFold(sub.State, "Enabled") {
+			continue
+		}
+		out = append(out, sub.ID)
+	}
+	return SortedUnique(out), nil
+}
+
+// azureDefaultSubscription is the id az would use with no --subscription.
+func azureDefaultSubscription() string { return azureDefaultSubscriptionFrom(azureProfilePath()) }
+
+func azureDefaultSubscriptionFrom(path string) string {
+	doc, err := azureProfileFrom(path)
+	if err != nil {
+		return ""
+	}
+	for _, sub := range doc.Subscriptions {
+		if sub.IsDefault && strings.EqualFold(sub.State, "Enabled") {
+			return sub.ID
+		}
+	}
+	return ""
+}
+
+// dockerConfigDir is the directory the docker CLI keeps its config in.
+func dockerConfigDir() string {
+	if dir := os.Getenv(dockerConfigDirEnv); dir != "" {
+		return dir
+	}
+	return home(".docker")
+}
+
+func dockerContexts() ([]string, error) { return dockerContextsFrom(dockerConfigDir()) }
+
+// dockerContextsFrom lists the contexts in a docker config directory.
+//
+// The store keys each context by the sha256 of its name, so the directory names
+// are digests and the name itself is the `Name` field inside each meta.json --
+// the one field read here. docker/cli's own store.ContextStore.List() does
+// exactly this and is the reader mql's dockerclient goes through, but it is an
+// indirect dependency: importing it directly promotes it in go.mod, and this
+// phase owns no existing file. Reading the one field keeps the launcher's list
+// and mql's connection talking about the same set of contexts without that.
+//
+// "default" is always offered. It is not in the store -- it is the docker CLI's
+// name for its own DOCKER_HOST-and-default-socket resolution -- but it is a
+// context a user can choose, and DOCKER_CONTEXT=default selects it.
+func dockerContextsFrom(configDir string) ([]string, error) {
+	names := []string{DockerDefaultContext}
+
+	metaRoot := filepath.Join(configDir, dockerContextsDir, dockerContextMetaDir)
+	entries, err := os.ReadDir(metaRoot)
+	if err != nil {
+		// A machine that has never run `docker context create` has no store,
+		// and that is not a failure: it still has the default context.
+		if errors.Is(err, fs.ErrNotExist) {
+			return names, nil
+		}
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(metaRoot, entry.Name(), dockerContextMetaFile))
+		if err != nil {
+			continue
+		}
+		// Capitalised, because that is how the store writes it: the docker/cli
+		// type has no json tag on Name beyond ",omitempty".
+		var meta struct {
+			Name string `json:"Name"`
+		}
+		if json.Unmarshal(data, &meta) != nil {
+			continue
+		}
+		names = append(names, meta.Name)
+	}
+	return SortedUnique(names), nil
+}
+
+// dockerCurrentContext reports the context the docker CLI would use.
+// DockerContextEnvFrom turns a picker's source parameters into the environment
+// the enumeration has to run under.
+//
+// A picker that ignored the chosen context would offer the default daemon's
+// containers for a scan pointed at another one -- a list that looks right and
+// names nothing the child can reach. The neutralisation is the same one the
+// launch applies, and for the same reason: DOCKER_HOST outranks DOCKER_CONTEXT
+// in the docker CLI and in mql's dockerclient, so leaving an inherited one in
+// place would pin the enumeration back to the default while the variable said
+// otherwise.
+func DockerContextEnvFrom(params []string) []string {
+	const want = "s:" + SpecialDockerContext + "="
+	for _, p := range params {
+		if !strings.HasPrefix(p, want) {
+			continue
+		}
+		value := strings.TrimPrefix(p, want)
+		if value == "" {
+			return nil
+		}
+		return append([]string{DockerContextEnv + "=" + value},
+			NeutralisedBy(DockerContextEnv, value)...)
+	}
+	return nil
+}
+
+// NeutralisedBy returns the entries that stop an inherited variable from
+// overriding one that is being set deliberately.
+//
+// DOCKER_HOST is the case, and it is the silent kind. The docker CLI resolves
+// its target as DOCKER_HOST first, then DOCKER_CONTEXT, then the config file --
+// mql's own dockerclient follows the same order -- so a DOCKER_HOST already in
+// the environment pins the child to the `default` context and the context the
+// user picked in the launcher does nothing at all. Nothing fails: the scan runs
+// against a host the user did not choose and reports on it confidently.
+//
+// Clearing it rather than warning about it is the choice, for two reasons. The
+// launcher's whole contract is that what you pick is what gets scanned, and a
+// warning that says "your choice will be ignored" is an admission that it is
+// not. And the clearing is scoped as narrowly as it can be: one child process,
+// one variable, only when the user actively chose a context, and only in the
+// direction of honouring that choice.
+//
+// The `default` context is deliberately exempt. It is not a host of its own --
+// it *is* the DOCKER_HOST-and-default-socket resolution, which is why
+// dockerCurrentContextFrom prefills it when DOCKER_HOST is set -- so clearing
+// the variable there would retarget the scan away from the daemon the user was
+// already pointed at, which is the very bug this is fixing.
+//
+// It lives here rather than with the launch it is applied to. It is a fact
+// about how docker resolves a target, spelled in the same three constants as
+// the picker that offers one, and both callers -- the enumeration above and
+// the launch -- need exactly the same answer. Split across the two files it
+// was two halves of one rule with the constants on one side and the use on the
+// other.
+func NeutralisedBy(envVar, value string) []string {
+	if envVar != DockerContextEnv || value == "" || value == DockerDefaultContext {
+		return nil
+	}
+	// An empty value, not an absent one: os/exec keeps the last entry for a
+	// repeated key, and every reader of DOCKER_HOST -- the docker CLI, mql's
+	// dockerclient -- treats empty as unset.
+	return []string{DockerHostEnv + "="}
+}
+
+func dockerCurrentContext() string { return dockerCurrentContextFrom(dockerConfigDir()) }
+
+// dockerCurrentContextFrom mirrors the docker CLI's own precedence, which mql's
+// dockerclient follows too: an explicit DOCKER_HOST pins the CLI to the default
+// context whatever else is configured, then DOCKER_CONTEXT, then the
+// currentContext in config.json.
+//
+// The DOCKER_HOST case is the one worth having: with it set, choosing any other
+// context changes nothing, and a launcher that offered one anyway would be
+// promising a target it cannot reach.
+func dockerCurrentContextFrom(configDir string) string {
+	if os.Getenv(DockerHostEnv) != "" {
+		return DockerDefaultContext
+	}
+	if ctx := os.Getenv(DockerContextEnv); ctx != "" {
+		return ctx
+	}
+	data, err := os.ReadFile(filepath.Join(configDir, dockerConfigFile))
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		CurrentContext string `json:"currentContext"`
+	}
+	if json.Unmarshal(data, &cfg) != nil {
+		return ""
+	}
+	return cfg.CurrentContext
+}

--- a/cli/launcher/source/enumerated_test.go
+++ b/cli/launcher/source/enumerated_test.go
@@ -1,0 +1,449 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Each fixture under testdata carries the catch its reader exists for -- a BOM,
+// a capitalised DEFAULT, a sha256 directory name -- because a fixture without it
+// proves only that the happy path parses, which was never in doubt.
+
+const (
+	ociFixture       = "testdata/oci_config"
+	alicloudFixture  = "testdata/alicloud_credentials"
+	azureFixtureDir  = "testdata/azure"
+	snowflakeFixture = "testdata/snowflake"
+	dockerFixtureDir = "testdata/docker"
+)
+
+// The OCI default profile is the literal DEFAULT. Reading it case-insensitively,
+// or normalising it to the AWS spelling, prefills a profile the connector will
+// not find.
+func TestOCIProfilesKeepTheOracleSpelling(t *testing.T) {
+	got, err := profileNamesFrom(ociFixture)
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	want := []string{"DEFAULT", "SANDBOX", "eu-audit"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("profiles = %v, want %v", got, want)
+	}
+
+	// The last one is there because a header with a trailing comment is what an
+	// edited config file actually looks like.
+	if slices.Contains(got, "eu-audit]  ; read-only auditor") {
+		t.Error("a trailing comment became part of the profile name")
+	}
+
+	if v, why := PreferredValue(OCIProfile, got); v != "DEFAULT" || why != "default" {
+		t.Errorf("prefilled %q/%q, want DEFAULT", v, why)
+	}
+	if v, _ := PreferredValue(OCIProfile, []string{"SANDBOX", "eu-audit"}); v != "" {
+		t.Errorf("prefilled %q with no DEFAULT profile present", v)
+	}
+}
+
+// The whole reason these are scanners and not ini libraries: the files hold live
+// credentials, and answering "what are the profiles called" must not pull them
+// into this process.
+func TestTheIniReadersHoldNoValues(t *testing.T) {
+	for _, path := range []string{ociFixture, alicloudFixture} {
+		names, values, err := iniSections(iniScan{files: iniPath(path)})
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if len(names) == 0 {
+			t.Fatalf("%s: no sections read, so this proves nothing", path)
+		}
+		if len(values) != 0 {
+			t.Errorf("%s: the reader kept %d sections' values", path, len(values))
+		}
+	}
+
+	// And with an allowlist, it keeps only what is on it. The snowflake fixture
+	// has a password in every table it has an account in.
+	_, values, err := iniSections(iniScan{
+		files: iniPath(filepath.Join(snowflakeFixture, "connections.toml")),
+		want:  map[string]bool{"account": true},
+	})
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	if len(values) == 0 {
+		t.Fatal("no tables read, so this proves nothing")
+	}
+	for section, keys := range values {
+		for _, kv := range keys {
+			if kv.key != "account" {
+				t.Errorf("[%s] kept %q, which is not on the allowlist", section, kv.key)
+			}
+		}
+	}
+}
+
+// A missing file is not an empty list, and the difference is the only thing a
+// user can act on.
+func TestAMissingFileIsExplainedRatherThanShownAsEmpty(t *testing.T) {
+	cases := []struct {
+		id    string
+		fetch func(string) ([]string, error)
+		want  string
+	}{
+		{OCIProfile, profileNamesFrom, "oci setup config"},
+		{AlicloudProfile, profileNamesFrom, "--access-key-id"},
+		{AzureSubscription, azureSubscriptionsFrom, "az login"},
+		{SnowflakeConnection, snowflakeAccountsFrom, "account identifier"},
+	}
+	for _, c := range cases {
+		values, err := c.fetch(filepath.Join(t.TempDir(), "absent"))
+		if err == nil {
+			t.Errorf("%s: a missing file read as %v with no error", c.id, values)
+			continue
+		}
+		if len(values) != 0 {
+			t.Errorf("%s: a missing file produced values %v", c.id, values)
+		}
+		got := explainFailure(c.id, err).Error()
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: explained as %q, want it to mention %q", c.id, got, c.want)
+		}
+		if strings.Contains(got, "\n") {
+			t.Errorf("%s: a picker gets one line, got %q", c.id, got)
+		}
+		// The raw error names a syscall and a temp path; neither is useful.
+		if strings.Contains(got, "no such file or directory") {
+			t.Errorf("%s: the os error survived: %q", c.id, got)
+		}
+	}
+
+	// Anything that is not a missing or unreadable file keeps its own words.
+	own := errors.New("unexpected end of JSON input")
+	if got := explainFailure(AzureSubscription, own).Error(); got != own.Error() {
+		t.Errorf("an unrecognised failure was rewritten to %q", got)
+	}
+	if got := explainFailure(OCIProfile, fs.ErrPermission).Error(); !strings.Contains(got, "permissions") {
+		t.Errorf("a permission failure explained as %q", got)
+	}
+}
+
+// alicloud is the case Source.Env exists for. The claim is checked against the
+// connector's own declaration rather than asserted in prose, because the whole
+// failure mode is a picker wired to a flag that does not exist.
+func TestAlicloudProfilesTravelInTheEnvironment(t *testing.T) {
+	s, ok := ByID(AlicloudProfile)
+	if !ok {
+		t.Fatal("the alicloud profile source is not registered")
+	}
+	if s.Env != "ALIBABA_CLOUD_PROFILE" {
+		t.Errorf("Env = %q, want the variable the SDK reads", s.Env)
+	}
+
+	// That alicloud really declares no --profile is checked against the
+	// recorded connector metadata, which lives with the launcher: see
+	// TestTheEnvBackedPickersFillNoFlag.
+}
+
+func TestAlicloudProfilesEnumerateEverySection(t *testing.T) {
+	got, err := profileNamesFrom(alicloudFixture)
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	want := []string{"default", "ecs", "ram-role", "staging"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("profiles = %v, want %v", got, want)
+	}
+
+	if v, why := PreferredValue(AlicloudProfile, got); v != "default" || why != "default" {
+		t.Errorf("prefilled %q/%q, want the conventional profile", v, why)
+	}
+	// What the environment already names wins, because that is what the child
+	// would use whatever the list showed.
+	t.Setenv("ALIBABA_CLOUD_PROFILE", "staging")
+	if v, why := PreferredValue(AlicloudProfile, got); v != "staging" || !strings.Contains(why, "ALIBABA_CLOUD_PROFILE") {
+		t.Errorf("prefilled %q/%q, want the profile the environment names", v, why)
+	}
+	// A variable naming something not in the file is not an opinion.
+	t.Setenv("ALIBABA_CLOUD_PROFILE", "not-in-the-file")
+	if v, why := PreferredValue(AlicloudProfile, got); v != "default" || why != "default" {
+		t.Errorf("prefilled %q/%q for an unknown ALIBABA_CLOUD_PROFILE", v, why)
+	}
+}
+
+func TestAlicloudCredentialsFileFollowsItsVariable(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", alicloudFixture)
+	got, err := alicloudProfiles()
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	if !slices.Contains(got, "ram-role") {
+		t.Errorf("ALIBABA_CLOUD_CREDENTIALS_FILE was not honoured: %v", got)
+	}
+}
+
+// The az CLI writes azureProfile.json with a UTF-8 BOM, and encoding/json
+// refuses a document that starts with one. This asserts the fixture still has
+// the BOM first, so the reader is not being congratulated on parsing a file the
+// az CLI would never write.
+func TestTheAzureFixtureStillHasItsBOM(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(azureFixtureDir, "azureProfile.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	if len(data) < 3 || data[0] != 0xef || data[1] != 0xbb || data[2] != 0xbf {
+		t.Fatalf("the fixture no longer starts with a UTF-8 BOM: % x", data[:min(3, len(data))])
+	}
+	// And the catch is real: without the trim this is what happens.
+	var doc azureProfileDoc
+	if err := json.Unmarshal(data, &doc); err == nil {
+		t.Error("encoding/json accepted a BOM, so the trim is no longer load-bearing")
+	}
+}
+
+func TestAzureSubscriptionsSurviveTheBOM(t *testing.T) {
+	path := filepath.Join(azureFixtureDir, "azureProfile.json")
+	got, err := azureSubscriptionsFrom(path)
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	want := []string{
+		"00000000-0000-0000-0000-00000000aaaa",
+		"00000000-0000-0000-0000-00000000bbbb",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("subscriptions = %v, want the enabled ones %v", got, want)
+	}
+	// A disabled subscription is listed by az and cannot be scanned.
+	if slices.Contains(got, "00000000-0000-0000-0000-00000000cccc") {
+		t.Error("a Disabled subscription was offered")
+	}
+
+	// Exactly one entry is isDefault, which is the one `az account show` reports.
+	if id := azureDefaultSubscriptionFrom(path); id != want[1] {
+		t.Errorf("default subscription = %q, want %q", id, want[1])
+	}
+	t.Setenv("AZURE_CONFIG_DIR", azureFixtureDir)
+	if v, why := PreferredValue(AzureSubscription, got); v != want[1] || why != "default" {
+		t.Errorf("prefilled %q/%q, want the default subscription", v, why)
+	}
+}
+
+// The file the az CLI stores and the JSON `az account list` prints are not the
+// same document, and onboarding's AzAccount describes the second one. Decoding
+// this file with it loses the cloud silently.
+func TestTheAzureProfileFileNamesItsCloudDifferently(t *testing.T) {
+	doc, err := azureProfileFrom(filepath.Join(azureFixtureDir, "azureProfile.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	if len(doc.Subscriptions) == 0 {
+		t.Fatal("no subscriptions, so this proves nothing")
+	}
+	if doc.Subscriptions[0].EnvironmentName == "" {
+		t.Error("environmentName did not decode; the field the file actually uses is empty")
+	}
+
+	var withCloudName struct {
+		Subscriptions []struct {
+			CloudName string `json:"cloudName"`
+		} `json:"subscriptions"`
+	}
+	data, err := os.ReadFile(filepath.Join(azureFixtureDir, "azureProfile.json"))
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	if err := json.Unmarshal(data[3:], &withCloudName); err != nil {
+		t.Fatalf("decoding the fixture: %v", err)
+	}
+	if withCloudName.Subscriptions[0].CloudName != "" {
+		t.Error("this file does carry cloudName after all; reusing AzAccount would be fine")
+	}
+}
+
+// The picker offers accounts, not connection names, because no flag and no
+// variable this connector reads takes a connection name.
+func TestSnowflakeOffersAccountsNotConnectionNames(t *testing.T) {
+	path := filepath.Join(snowflakeFixture, "connections.toml")
+	got, err := snowflakeAccountsFrom(path)
+	if err != nil {
+		t.Fatalf("reading the fixture: %v", err)
+	}
+	// Three tables, two distinct accounts: "default" and "legacy" share one.
+	want := []string{"myorg-audit_account", "myorg-prod_account"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("accounts = %v, want %v", got, want)
+	}
+	for _, name := range []string{"default", "audit", "legacy"} {
+		if slices.Contains(got, name) {
+			t.Errorf("the connection name %q was offered as a value; --account would reject it", name)
+		}
+	}
+
+	if acct := snowflakeDefaultAccountFrom(path); acct != "myorg-prod_account" {
+		t.Errorf("the default connection's account = %q", acct)
+	}
+	t.Setenv("SNOWFLAKE_HOME", snowflakeFixture)
+	if v, why := PreferredValue(SnowflakeConnection, got); v != "myorg-prod_account" || why == "" {
+		t.Errorf("prefilled %q/%q, want the default connection's account", v, why)
+	}
+
+	// That --account exists and --connection does not is checked against the
+	// recorded connector metadata; see TestTheFlagBackedPickersNameRealFlags.
+	if s, _ := ByID(SnowflakeConnection); s.Env != "" {
+		t.Errorf("Env = %q, but --account carries the value", s.Env)
+	}
+}
+
+// The context store keys each context by the sha256 of its name, and the name
+// itself is inside the file. A fixture whose directory name is anything else
+// would still be read by a hand-rolled walk and would prove nothing about the
+// store this actually goes through.
+func TestTheDockerFixtureUsesRealDigests(t *testing.T) {
+	metaRoot := filepath.Join(dockerFixtureDir, "contexts", "meta")
+	entries, err := os.ReadDir(metaRoot)
+	if err != nil {
+		t.Fatalf("reading the fixture store: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("the fixture store is empty, so this proves nothing")
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(filepath.Join(metaRoot, e.Name(), "meta.json"))
+		if err != nil {
+			t.Fatalf("%s: %v", e.Name(), err)
+		}
+		var meta struct {
+			Name string `json:"Name"`
+		}
+		if err := json.Unmarshal(data, &meta); err != nil {
+			t.Fatalf("%s: %v", e.Name(), err)
+		}
+		sum := sha256.Sum256([]byte(meta.Name))
+		if want := hex.EncodeToString(sum[:]); want != e.Name() {
+			t.Errorf("context %q lives in %s, want %s", meta.Name, e.Name(), want)
+		}
+	}
+}
+
+func TestDockerContextsComeFromTheStore(t *testing.T) {
+	got, err := dockerContextsFrom(dockerFixtureDir)
+	if err != nil {
+		t.Fatalf("reading the fixture store: %v", err)
+	}
+	want := []string{"colima", "default", "remote-prod"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("contexts = %v, want %v", got, want)
+	}
+
+	// A machine with no context store still has the default context, and that
+	// is not an error.
+	only, err := dockerContextsFrom(t.TempDir())
+	if err != nil {
+		t.Fatalf("an absent store failed: %v", err)
+	}
+	if !reflect.DeepEqual(only, []string{"default"}) {
+		t.Errorf("an absent store gave %v, want just the default context", only)
+	}
+}
+
+func TestDockerContextPrecedence(t *testing.T) {
+	// Nothing in the environment: config.json decides.
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "")
+	if got := dockerCurrentContextFrom(dockerFixtureDir); got != "colima" {
+		t.Errorf("currentContext = %q, want the one in config.json", got)
+	}
+
+	// DOCKER_CONTEXT overrides the config file.
+	t.Setenv("DOCKER_CONTEXT", "remote-prod")
+	if got := dockerCurrentContextFrom(dockerFixtureDir); got != "remote-prod" {
+		t.Errorf("with DOCKER_CONTEXT set, currentContext = %q", got)
+	}
+
+	// An explicit DOCKER_HOST pins the CLI to the default context whatever else
+	// is configured, so offering another one would promise a target the child
+	// will not use.
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:2375")
+	if got := dockerCurrentContextFrom(dockerFixtureDir); got != "default" {
+		t.Errorf("with DOCKER_HOST set, currentContext = %q, want default", got)
+	}
+
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "")
+	t.Setenv("DOCKER_CONFIG", dockerFixtureDir)
+	values, err := dockerContexts()
+	if err != nil {
+		t.Fatalf("DOCKER_CONFIG was not honoured: %v", err)
+	}
+	if v, why := PreferredValue(DockerContext, values); v != "colima" || why != "current" {
+		t.Errorf("prefilled %q/%q, want the current context", v, why)
+	}
+}
+
+// Neither docker, container nor local declares --context, which is why the
+// chosen context travels in DOCKER_CONTEXT.
+func TestDockerContextsTravelInTheEnvironment(t *testing.T) {
+	s, ok := ByID(DockerContext)
+	if !ok {
+		t.Fatal("the docker context source is not registered")
+	}
+	if s.Env != "DOCKER_CONTEXT" {
+		t.Errorf("Env = %q, want the variable the docker CLI reads", s.Env)
+	}
+	// That none of docker, container and local declares --context is checked
+	// against the recorded connector metadata; see
+	// TestTheEnvBackedPickersFillNoFlag.
+}
+
+// Every one of the five reads a file on this machine, so none of them may defer
+// and none of them may claim to be leaving the process. The generic contract
+// tests cover the registry as a whole; this pins the five to the class and cost
+// their ids were declared with.
+func TestTheFiveLocalPickersAreInstantAndEnumerated(t *testing.T) {
+	for _, id := range []string{
+		OCIProfile, AlicloudProfile, AzureSubscription,
+		SnowflakeConnection, DockerContext,
+	} {
+		s, ok := ByID(id)
+		if !ok {
+			t.Errorf("%s is declared but never registered", id)
+			continue
+		}
+		if s.Class != ClassEnumerated {
+			t.Errorf("%s: class %v, want ClassEnumerated", id, s.Class)
+		}
+		if s.Cost != CostInstant {
+			t.Errorf("%s: cost %v, want CostInstant for a file read", id, s.Cost)
+		}
+		if len(s.Needs) != 0 {
+			t.Errorf("%s: depends on %v, but reads a file that depends on nothing", id, s.Needs)
+		}
+		if s.Fetch == nil {
+			t.Errorf("%s: no Fetch, so the picker is empty", id)
+		}
+		if s.Explain == nil {
+			t.Errorf("%s: no Explain, so a missing file reads as a syscall", id)
+		}
+	}
+
+	// The two with a flag must not also set a variable: a value delivered twice
+	// is a value the child resolves by a precedence nobody chose.
+	for _, id := range []string{OCIProfile, AzureSubscription} {
+		if s, _ := ByID(id); s.Env != "" {
+			t.Errorf("%s: Env = %q, but its connector declares a flag for the value", id, s.Env)
+		}
+	}
+}

--- a/cli/launcher/source/ids.go
+++ b/cli/launcher/source/ids.go
@@ -1,0 +1,121 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+// The whole source-ID namespace, in one place.
+//
+// A source id is a string, so nothing technically requires it to be declared
+// before it is used. What requires it is the order the launcher gets built in:
+// a curated form names its pickers by id, and the form files and the source
+// files are written by different people at the same time. Declaring the names
+// here first means a form can reference a picker that does not exist yet and
+// still compile, and means two source files cannot quietly invent two spellings
+// of the same thing.
+//
+// The rule for adding one: put the constant here, Register the Source in the
+// file that owns its class, and name it from a form. A constant with no
+// registration is caught by TestEverySourceNamedByASpecExists the moment a form
+// reaches for it; an id spelled inline rather than declared here is caught by
+// nothing, which is why this file exists.
+
+// Enumerated: a local file lists the candidates.
+const (
+	AWSProfile      = "aws.profile"
+	KubeContext     = "k8s.context"
+	SSHHost         = "ssh.host"
+	DockerContainer = "docker.container"
+	DockerImage     = "docker.image"
+	GCPProject      = "gcp.project"
+	GCPProjectAll   = "gcp.project.all"
+	GCPZone         = "gcp.zone"
+
+	// AzureSubscription reads ~/.azure/azureProfile.json, which the Azure
+	// CLI writes with a UTF-8 BOM.
+	AzureSubscription = "azure.subscription"
+	// OCIProfile reads ~/.oci/config, whose conventional first section is
+	// the literal DEFAULT rather than the lowercase "default" the AWS
+	// convention would suggest.
+	OCIProfile = "oci.profile"
+	// AlicloudProfile reads ~/.alibabacloud/credentials. The connector
+	// declares no --profile, so the chosen value travels in the environment.
+	AlicloudProfile = "alicloud.profile"
+	// SnowflakeConnection reads ~/.snowflake/connections.toml. No flag
+	// takes a connection name either.
+	SnowflakeConnection = "snowflake.connection"
+	// DockerContext reads ~/.docker/config.json and the context store
+	// beside it. docker, container and local all lack a --context flag.
+	DockerContext = "docker.context"
+)
+
+// K8sNamespace is post-connection but predates cnspec's own discovery being
+// wired into the launcher: it asks kubectl directly, against a kubeconfig copy
+// pointed at the chosen cluster. It sits here rather than with the discovery
+// ids below because it is a different mechanism, not a different target.
+const K8sNamespace = "k8s.namespace"
+
+// Ambient: one credential from the environment. There is nothing to enumerate,
+// so what these answer is "is it present, and where did it come from".
+const (
+	GitHubToken       = "github.token"
+	GitLabToken       = "gitlab.token"
+	SlackToken        = "slack.token"
+	CloudflareToken   = "cloudflare.token"
+	DigitalOceanToken = "digitalocean.token"
+	HetznerToken      = "hetzner.token"
+	// OktaToken covers okta's three-level precedence: --token, then
+	// OKTA_API_TOKEN, then OKTA_TOKEN.
+	OktaToken = "okta.token"
+)
+
+// Post-connection: what is inside a target, asked through cnspec's own
+// discovery once a credential is in hand. Always CostRemote.
+//
+// The id names the connector and the discovery target together, because a
+// connector has several and they feed different flags: github's repos go to
+// --repos while its organization goes to a positional. DiscoverSourceID builds
+// the same string for a pair not named here, so a source file can Register one
+// without editing this one.
+const (
+	DiscoverK8sNamespaces      = "discover.k8s.namespaces"
+	DiscoverGitHubRepos        = "discover.github.repos"
+	DiscoverGitLabProjects     = "discover.gitlab.projects"
+	DiscoverGitLabGroups       = "discover.gitlab.groups"
+	DiscoverAzureSubscriptions = "discover.azure.subscriptions"
+	DiscoverGCPProjects        = "discover.gcp.projects"
+	DiscoverAWSAccounts        = "discover.aws.accounts"
+	DiscoverOCITenancy         = "discover.oci.tenancy"
+	DiscoverAlicloudAccounts   = "discover.alicloud.accounts"
+	DiscoverDigitalOceanDBs    = "discover.digitalocean.databases"
+	DiscoverNeonProjects       = "discover.neon.projects"
+	DiscoverNetlifySites       = "discover.netlify.sites"
+	DiscoverVercelProjects     = "discover.vercel.projects"
+	DiscoverAtlasProjects      = "discover.mongodbatlas.projects"
+	DiscoverHCPProjects        = "discover.hcp.projects"
+	DiscoverClaudeWorkspaces   = "discover.claude.workspaces"
+	DiscoverMSSQLDatabases     = "discover.mssql.databases"
+	DiscoverMySQLDatabases     = "discover.mysqldb.databases"
+	DiscoverPostgresDatabases  = "discover.postgresdb.databases"
+	DiscoverSnowflakeDatabases = "discover.snowflake.databases"
+)
+
+// DiscoverSourceID names the source that asks cnspec's discovery for one
+// target inside one connector. The constants above are the pairs the launcher
+// already knows it wants; this is how a source file names a pair it does not
+// yet have a constant for, without editing this file to get it.
+func DiscoverSourceID(connector, target string) string {
+	return "discover." + connector + "." + target
+}
+
+// SpecialDockerContext is the identity of the launcher-owned field holding a
+// docker context.
+//
+// It is a field name rather than a source id, and it is here because two
+// things have to spell it the same way: the form spec that creates the field,
+// and the Needs of the two sources that read it. A literal in both places is a
+// typo waiting to be silent -- the identity simply never matches, the
+// enumeration runs against the default daemon, and the list looks right.
+//
+// docker, container and local declare no --context, so a chosen one travels in
+// DOCKER_CONTEXT; see DockerContextEnvFrom.
+const SpecialDockerContext = "docker-context"

--- a/cli/launcher/source/ids_test.go
+++ b/cli/launcher/source/ids_test.go
@@ -1,0 +1,125 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+// declaredSourceIDs is the whole namespace from source_ids.go, listed once so
+// the checks below are about the set rather than about any one id.
+//
+// Keeping the list here rather than deriving it is the point: a constant that
+// is declared and then never registered, named or spelled consistently is
+// exactly what this catches, and deriving the list from the registry would make
+// the test agree with whatever happened to be there.
+var declaredSourceIDs = []string{
+	AWSProfile,
+	KubeContext,
+	SSHHost,
+	DockerContainer,
+	DockerImage,
+	GCPProject,
+	GCPProjectAll,
+	GCPZone,
+	AzureSubscription,
+	OCIProfile,
+	AlicloudProfile,
+	SnowflakeConnection,
+	DockerContext,
+	K8sNamespace,
+	GitHubToken,
+	GitLabToken,
+	SlackToken,
+	CloudflareToken,
+	DigitalOceanToken,
+	HetznerToken,
+	OktaToken,
+	DiscoverK8sNamespaces,
+	DiscoverGitHubRepos,
+	DiscoverGitLabProjects,
+	DiscoverGitLabGroups,
+	DiscoverAzureSubscriptions,
+	DiscoverGCPProjects,
+	DiscoverAWSAccounts,
+	DiscoverOCITenancy,
+	DiscoverAlicloudAccounts,
+	DiscoverDigitalOceanDBs,
+	DiscoverNeonProjects,
+	DiscoverNetlifySites,
+	DiscoverVercelProjects,
+	DiscoverAtlasProjects,
+	DiscoverHCPProjects,
+	DiscoverClaudeWorkspaces,
+	DiscoverMSSQLDatabases,
+	DiscoverMySQLDatabases,
+	DiscoverPostgresDatabases,
+	DiscoverSnowflakeDatabases,
+}
+
+// Two constants with the same value are two names for one cache entry, and the
+// second source registered under it silently replaces the first.
+func TestSourceIDsAreUnique(t *testing.T) {
+	seen := map[string]int{}
+	for _, id := range declaredSourceIDs {
+		seen[id]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("%q is declared %d times", id, n)
+		}
+	}
+}
+
+// A source id is a cache key prefix and appears in test failures, so it has to
+// read as one thing: dotted, lowercase, no spaces.
+func TestSourceIDsAreWellFormed(t *testing.T) {
+	for _, id := range declaredSourceIDs {
+		if id == "" {
+			t.Error("an empty source id matches every unregistered lookup")
+			continue
+		}
+		if id != strings.ToLower(id) || strings.ContainsAny(id, " \t") {
+			t.Errorf("%q should be lowercase with no spaces", id)
+		}
+		if !strings.Contains(id, ".") {
+			t.Errorf("%q should name its provider, e.g. \"aws.profile\"", id)
+		}
+	}
+}
+
+// The discovery constants and the builder must agree, or a source registered
+// through one is invisible to a form naming the other.
+func TestDiscoverSourceIDMatchesTheConstants(t *testing.T) {
+	cases := []struct {
+		connector, target, want string
+	}{
+		{"k8s", "namespaces", DiscoverK8sNamespaces},
+		{"github", "repos", DiscoverGitHubRepos},
+		{"gitlab", "projects", DiscoverGitLabProjects},
+		{"gitlab", "groups", DiscoverGitLabGroups},
+		{"azure", "subscriptions", DiscoverAzureSubscriptions},
+		{"gcp", "projects", DiscoverGCPProjects},
+		{"aws", "accounts", DiscoverAWSAccounts},
+		{"oci", "tenancy", DiscoverOCITenancy},
+		{"alicloud", "accounts", DiscoverAlicloudAccounts},
+		{"digitalocean", "databases", DiscoverDigitalOceanDBs},
+		{"neon", "projects", DiscoverNeonProjects},
+		{"netlify", "sites", DiscoverNetlifySites},
+		{"vercel", "projects", DiscoverVercelProjects},
+		{"mongodbatlas", "projects", DiscoverAtlasProjects},
+		{"hcp", "projects", DiscoverHCPProjects},
+		{"claude", "workspaces", DiscoverClaudeWorkspaces},
+		{"mssql", "databases", DiscoverMSSQLDatabases},
+		{"mysqldb", "databases", DiscoverMySQLDatabases},
+		{"postgresdb", "databases", DiscoverPostgresDatabases},
+		{"snowflake", "databases", DiscoverSnowflakeDatabases},
+	}
+	for _, c := range cases {
+		if got := DiscoverSourceID(c.connector, c.target); got != c.want {
+			t.Errorf("DiscoverSourceID(%q, %q) = %q, want %q", c.connector, c.target, got, c.want)
+		}
+	}
+}

--- a/cli/launcher/source/ini.go
+++ b/cli/launcher/source/ini.go
@@ -1,0 +1,180 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// The one ini scanner, for the four credential files the launcher reads names
+// out of: ~/.aws/config, ~/.aws/credentials, ~/.oci/config,
+// ~/.alibabacloud/credentials and ~/.snowflake/connections.toml.
+//
+// There used to be two, hand-rolled a few months apart, and the second one
+// carefully re-derived the first one's rule: **read the section headers, hold
+// no values**. Every file this is pointed at keeps live access keys, private
+// key passphrases or bearer tokens next to the names being read, and an ini or
+// TOML library would pull all of them into this process to answer a question
+// about headers. That is why this is a scanner rather than a parse, and why
+// the keys it will read at all are an allowlist the caller passes in --
+// sso_account_id, account_id, account -- each of which is a locator rather
+// than a credential.
+//
+// It is tolerant enough for every dialect involved: the AWS `[profile name]`
+// spelling, a TOML `[[table]]`, a quoted table name, and a trailing `; comment`
+// after a header all resolve to the name. What it does not model is a TOML
+// multi-line string whose body contains a line starting with `[`, which would
+// be read as a section -- harmless here, because a section invented that way
+// has no allowlisted key under it and so contributes nothing.
+//
+// Two of those tolerances are wider than the AWS reader used to be, and both
+// only show on a file the AWS CLI would itself reject:
+//
+//   - A header with anything after its closing bracket used to be no header at
+//     all, which left the section pointer on the *previous* profile and
+//     attached that profile's account id to the wrong name. Now it resolves to
+//     the name, the way ~/.oci/config's `[eu-audit]  ; read-only auditor`
+//     always had to.
+//   - A quoted value loses its quotes, which TOML requires and which an AWS
+//     file has no reason to carry.
+//
+// A well-formed shared config parses identically either way: a header that
+// ends in `]` has one closing bracket, and an account id is not quoted.
+
+// iniFile is one file to walk, and what its section headers spell.
+type iniFile struct {
+	path string
+	// strip comes off the front of a section name, and is a per-file property
+	// rather than a per-scan one: ~/.aws/config spells its sections
+	// `[profile prod]` while ~/.aws/credentials spells the same profile
+	// `[prod]`, and it is the same profile.
+	strip string
+}
+
+// iniScan says which files to walk and what may be read out of them.
+type iniScan struct {
+	// files are read in order, and a section already named by an earlier file
+	// keeps its first position. Only the AWS reader passes more than one:
+	// ~/.aws/config and ~/.aws/credentials are one namespace split across two
+	// files, and reading either alone hides profiles the CLI can see.
+	files []iniFile
+	// want is the whole of what may be read from inside a section. An empty
+	// allowlist means headers only, which is what three of the four readers
+	// need.
+	want map[string]bool
+}
+
+// iniPath is the common case: one file whose headers are spelled plainly.
+func iniPath(path string) []iniFile { return []iniFile{{path: path}} }
+
+// iniAssign is one allowlisted key=value, kept in the order the file made it.
+//
+// Order is why this is a slice and not a map. The AWS reader treats
+// sso_account_id and account_id as two spellings of one fact and takes
+// whichever the file stated last; a map keyed by name cannot answer that, and
+// the reader that used to do this by hand got it right by accident of writing
+// both keys into the same slot.
+type iniAssign struct {
+	key, value string
+}
+
+// iniValues are the allowlisted assignments under one section.
+type iniValues []iniAssign
+
+// last returns the value of the last assignment to any of keys, or "".
+func (v iniValues) last(keys ...string) string {
+	for i := len(v) - 1; i >= 0; i-- {
+		for _, k := range keys {
+			if v[i].key == k {
+				return v[i].value
+			}
+		}
+	}
+	return ""
+}
+
+// iniSections walks the declared files and returns the section names in file
+// order, plus the allowlisted values under each.
+//
+// A file that cannot be opened is reported rather than skipped, because "no
+// such file" and "nothing configured" are different answers and a picker that
+// shows an empty list for a file it never opened is the failure the Source
+// contract exists to stop. With several paths, the first failure is what is
+// returned and the rest are still read: ~/.aws/credentials alone is a working
+// setup, and so is ~/.aws/config alone.
+func iniSections(scan iniScan) ([]string, map[string]iniValues, error) {
+	var names []string
+	values := map[string]iniValues{}
+	seen := map[string]bool{}
+	var firstErr error
+
+	for _, file := range scan.files {
+		if file.path == "" {
+			if firstErr == nil {
+				firstErr = fs.ErrNotExist
+			}
+			continue
+		}
+		f, err := os.Open(file.path)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		section := ""
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+				continue
+			}
+			if strings.HasPrefix(line, "[") {
+				name, ok := iniSectionName(line, file.strip)
+				if !ok {
+					continue
+				}
+				section = name
+				if section != "" && !seen[section] {
+					seen[section] = true
+					names = append(names, section)
+				}
+				continue
+			}
+			if section == "" || len(scan.want) == 0 {
+				continue
+			}
+			key, value, ok := strings.Cut(line, "=")
+			if key = strings.TrimSpace(key); !ok || !scan.want[key] {
+				continue
+			}
+			values[section] = append(values[section], iniAssign{
+				key:   key,
+				value: strings.Trim(strings.TrimSpace(value), `"'`),
+			})
+		}
+		f.Close()
+		// A read that died part way still knows about the sections it
+		// reached, and a short list is more use than none.
+		if err := sc.Err(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return names, values, firstErr
+}
+
+// iniSectionName reads a section header. The name runs to the first closing
+// bracket, so a trailing comment does not become part of it; the extra Trim
+// handles TOML's `[[array]]`, whose first `]` leaves one bracket behind.
+func iniSectionName(line, strip string) (string, bool) {
+	end := strings.IndexByte(line, ']')
+	if end < 0 {
+		return "", false
+	}
+	name := strings.Trim(strings.TrimSpace(strings.Trim(line[1:end], "[]")), `"'`)
+	return strings.TrimPrefix(name, strip), true
+}

--- a/cli/launcher/source/ini_test.go
+++ b/cli/launcher/source/ini_test.go
@@ -1,0 +1,274 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// The scanner was two scanners, written a few months apart, and merging them is
+// only safe if the merged one still parses everything either of them did. Each
+// test below is a property one of the originals had; together they are the
+// whole of what was merged.
+
+func write(t *testing.T, name, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The AWS reader's property: the two files are one namespace, and the section
+// spelling differs between them.
+//
+// `strip` is per file rather than per scan for exactly this reason. Stripping
+// "profile " from the credentials file as well would mangle a profile whose
+// name begins with those eight characters, which is a thing an ini file may
+// legally contain.
+func TestTheProfilePrefixIsStrippedFromOnlyTheFileThatUsesIt(t *testing.T) {
+	config := write(t, "config", "[profile prod]\n[default]\n")
+	creds := write(t, "credentials", "[profile weirdly-named]\n[staging]\n")
+
+	names, _ := awsProfileSections(config, creds)
+	want := []string{"default", "prod", "profile weirdly-named", "staging"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("profiles = %v, want %v", names, want)
+	}
+}
+
+// The AWS reader's other property: sso_account_id and account_id are two
+// spellings of one fact, and the file's last word on it wins.
+//
+// This is the case that decided the shape of iniValues. The original wrote both
+// keys into one map slot, so "last wins" was a property of the loop; a map
+// keyed by name cannot express it, and reading sso_account_id in preference
+// would flip the answer for the file below.
+func TestTheLastAccountKeyWins(t *testing.T) {
+	config := write(t, "config", strings.Join([]string{
+		"[profile both]",
+		"sso_account_id = 111111111111",
+		"account_id = 222222222222",
+		"[profile sso-first]",
+		"account_id = 333333333333",
+		"sso_account_id = 444444444444",
+	}, "\n"))
+
+	_, accounts := awsProfileSections(config, "")
+	if got := accounts["both"].last(awsAccountKeys...); got != "222222222222" {
+		t.Errorf("account = %q, want the one the file stated last", got)
+	}
+	if got := accounts["sso-first"].last(awsAccountKeys...); got != "444444444444" {
+		t.Errorf("account = %q, want the one the file stated last", got)
+	}
+}
+
+// And across the two files: the credentials file is read second, so it has the
+// last word.
+func TestTheCredentialsFileHasTheLastWordOnAnAccount(t *testing.T) {
+	config := write(t, "config", "[profile prod]\naccount_id = 111111111111\n")
+	creds := write(t, "credentials", "[prod]\naccount_id = 222222222222\n")
+
+	_, accounts := awsProfileSections(config, creds)
+	if got := accounts["prod"].last(awsAccountKeys...); got != "222222222222" {
+		t.Errorf("account = %q, want the credentials file's", got)
+	}
+}
+
+// The other original's property: the dialects. A TOML `[[table]]`, a quoted
+// name and a trailing comment all resolve to the name.
+func TestEveryDialectResolvesToTheName(t *testing.T) {
+	for _, tc := range []struct{ line, want string }{
+		{"[default]", "default"},
+		{"[profile prod]", "profile prod"},
+		{"[[connections.audit]]", "connections.audit"},
+		{`["quoted name"]`, "quoted name"},
+		{"[eu-audit]  ; read-only auditor", "eu-audit"},
+		{"[  spaced  ]", "spaced"},
+	} {
+		got, ok := iniSectionName(tc.line, "")
+		if !ok || got != tc.want {
+			t.Errorf("iniSectionName(%q) = %q/%v, want %q", tc.line, got, ok, tc.want)
+		}
+	}
+	// A header with no closing bracket is not a header, and must not become
+	// one: a TOML multi-line string can start a line with `[`.
+	if _, ok := iniSectionName("[unterminated", ""); ok {
+		t.Error("an unterminated header was accepted")
+	}
+}
+
+// The allowlist is the whole point, and it is what makes reading these files
+// allowable at all: every one of them keeps live key material beside the names.
+func TestNothingOutsideTheAllowlistIsHeld(t *testing.T) {
+	path := write(t, "credentials", strings.Join([]string{
+		"[prod]",
+		"aws_secret_access_key = <PLACEHOLDER-must-never-be-held>",
+		"account_id = 123456789012",
+		"aws_session_token = <PLACEHOLDER-must-never-be-held-either>",
+	}, "\n"))
+
+	_, values, err := iniSections(iniScan{
+		files: iniPath(path),
+		want:  map[string]bool{"account_id": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for section, kvs := range values {
+		for _, kv := range kvs {
+			if kv.key != "account_id" {
+				t.Errorf("[%s] kept %q, which is not on the allowlist", section, kv.key)
+			}
+			if strings.Contains(kv.value, "must-never-be-held") {
+				t.Fatalf("[%s] holds key material: %q", section, kv.value)
+			}
+		}
+	}
+
+	// With no allowlist at all, nothing inside a section is read.
+	_, values, err = iniSections(iniScan{files: iniPath(path)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 0 {
+		t.Errorf("a headers-only scan kept %d sections' values", len(values))
+	}
+}
+
+// Comments never become sections or values, in either dialect's comment
+// character.
+func TestCommentsAreNotContent(t *testing.T) {
+	path := write(t, "config", strings.Join([]string{
+		"# [profile commented-out]",
+		"; [profile also-commented]",
+		"[profile real]",
+		"# account_id = 999999999999",
+		"account_id = 123456789012",
+	}, "\n"))
+
+	names, values, err := iniSections(iniScan{
+		files: []iniFile{{path: path, strip: "profile "}},
+		want:  map[string]bool{"account_id": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"real"}) {
+		t.Errorf("sections = %v, want just the uncommented one", names)
+	}
+	if got := values["real"].last("account_id"); got != "123456789012" {
+		t.Errorf("account = %q", got)
+	}
+}
+
+// A file that could not be opened is reported, because "no such file" and
+// "nothing configured" are different answers and only one of them is something
+// the user can act on.
+func TestAnUnopenableFileIsReportedRatherThanEmpty(t *testing.T) {
+	_, _, err := iniSections(iniScan{files: iniPath(filepath.Join(t.TempDir(), "absent"))})
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("a missing file gave %v", err)
+	}
+	// An empty path is the same answer, and is what a reader gets when there
+	// is no home directory to resolve against.
+	if _, _, err := iniSections(iniScan{files: iniPath("")}); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("an empty path gave %v", err)
+	}
+}
+
+// One readable file among several is a working setup: ~/.aws/credentials alone
+// is one, and so is ~/.aws/config alone.
+func TestOneReadableFileIsEnough(t *testing.T) {
+	creds := write(t, "credentials", "[staging]\n")
+	names, _, err := iniSections(iniScan{files: []iniFile{
+		{path: filepath.Join(t.TempDir(), "absent"), strip: "profile "},
+		{path: creds},
+	}})
+	if err == nil {
+		t.Error("the unreadable file was not reported")
+	}
+	if !reflect.DeepEqual(names, []string{"staging"}) {
+		t.Errorf("sections = %v, want the readable file's", names)
+	}
+}
+
+// The two profile readers were byte-identical and are now one, so the one has
+// to answer for both dialects: the OCI file is ini-like and capitalises its
+// conventional section, the Alibaba Cloud file is a true ini and does not.
+func TestOneProfileReaderAnswersForBothFiles(t *testing.T) {
+	oci, err := profileNamesFrom(ociFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ali, err := profileNamesFrom(alicloudFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(oci, []string{"DEFAULT", "SANDBOX", "eu-audit"}) {
+		t.Errorf("oci profiles = %v", oci)
+	}
+	if !reflect.DeepEqual(ali, []string{"default", "ecs", "ram-role", "staging"}) {
+		t.Errorf("alicloud profiles = %v", ali)
+	}
+	// Neither reader ever held a value, which is why one function can serve
+	// both without a decision about what to keep.
+	for _, path := range []string{ociFixture, alicloudFixture} {
+		_, values, err := iniSections(iniScan{files: iniPath(path)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(values) != 0 {
+			t.Errorf("%s: the reader kept %d sections' values", path, len(values))
+		}
+	}
+}
+
+// The one place the merged scanner is wider than the AWS reader it replaced,
+// pinned so the widening is a decision rather than a surprise.
+//
+// A header with anything after its closing bracket used to be no header at
+// all, which left the section pointer on the previous profile -- so the keys
+// under the malformed header were filed against the wrong name. The OCI
+// dialect requires the other reading, and both readers are now one.
+func TestAHeaderWithATrailingCommentNamesItsSection(t *testing.T) {
+	config := write(t, "config", strings.Join([]string{
+		"[profile prod]",
+		"account_id = 111111111111",
+		"[profile audit]  ; read-only",
+		"account_id = 222222222222",
+	}, "\n"))
+
+	names, accounts := awsProfileSections(config, "")
+	if !reflect.DeepEqual(names, []string{"audit", "prod"}) {
+		t.Fatalf("profiles = %v, want both named", names)
+	}
+	if got := accounts["prod"].last(awsAccountKeys...); got != "111111111111" {
+		t.Errorf("prod account = %q; the second profile's id leaked into it", got)
+	}
+	if got := accounts["audit"].last(awsAccountKeys...); got != "222222222222" {
+		t.Errorf("audit account = %q", got)
+	}
+}
+
+// A quoted value loses its quotes, which TOML requires. An AWS account id is
+// never quoted, so nothing well-formed changes.
+func TestQuotedValuesLoseTheirQuotes(t *testing.T) {
+	path := write(t, "connections.toml", "[default]\naccount = \"myorg-prod\"\n")
+	_, values, err := iniSections(iniScan{files: iniPath(path), want: snowflakeAccountKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := values["default"].last("account"); got != "myorg-prod" {
+		t.Errorf("account = %q, want it unquoted", got)
+	}
+}

--- a/cli/launcher/source/launcher.go
+++ b/cli/launcher/source/launcher.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import "github.com/cockroachdb/errors"
+
+// The launcher-side seam: the two things this package needs that it cannot yet
+// import.
+//
+// cli/launcher/source is meant to sit on top of cli/launcher/delivery, which
+// owns both of them -- the kubeconfig copy that points a child at one cluster,
+// and the registry saying which environment variable a pasted secret travels
+// in. That package is being extracted from the same commit as this one and
+// does not exist yet, so both still live in apps/cnspec/cmd/interactive, which
+// imports this package. The dependency therefore cannot be written as an
+// import in this direction without a cycle.
+//
+// What is written down instead is the shape of it: one function value the
+// launcher installs, and one list the launcher drains. Neither is a second
+// copy of anything, and both are one commit's work to delete once delivery
+// exists -- `KubeEnvApply` becomes a direct call, and the drain becomes an
+// init in this package.
+
+// EnvApplyFunc builds the environment a child needs to reach one chosen value,
+// plus the cleanup for whatever had to be written to get it there.
+type EnvApplyFunc func(value string) (env []string, cleanup func(), err error)
+
+// KubeEnvApply points a child process at one Kubernetes context.
+//
+// The k8s connector's --context is parsed and then never reaches the client
+// config, so the only thing that selects a cluster is a KUBECONFIG whose
+// current-context is the wanted one -- which means writing a copy of the
+// user's kubeconfig first and removing it afterwards. That is the launcher's
+// kubeconfig.go.
+//
+// The default refuses rather than returning nothing, which is the whole reason
+// it is written out rather than left nil. A source that quietly ran with no
+// environment would answer for whichever cluster the ambient kubeconfig
+// happened to name: a confidently wrong answer with no error attached, which
+// is the exact failure the Source contract exists to prevent. An empty context
+// is still nothing to do, exactly as the real one treats it.
+var KubeEnvApply EnvApplyFunc = func(context string) ([]string, func(), error) {
+	if context == "" {
+		return nil, nil, nil
+	}
+	return nil, nil, errors.New("cannot target a Kubernetes context — " +
+		"the launcher did not install a kubeconfig writer")
+}
+
+// kubeEnvForContext is KubeEnvApply, read when it is called rather than when a
+// source is declared.
+//
+// The indirection is what makes the seam safe. Sources are declared in this
+// package's init, which runs before the importing package's, so a declaration
+// that named KubeEnvApply directly would capture the refusal above and keep it
+// for the life of the process.
+func kubeEnvForContext(context string) ([]string, func(), error) {
+	return KubeEnvApply(context)
+}

--- a/cli/launcher/source/proc_unix.go
+++ b/cli/launcher/source/proc_unix.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package source
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// A picker's child is often a shell, and a shell that forks rather than execs
+// leaves the real work running when only the shell is killed. `sh -c "sleep
+// 30"` is the case that proved it: macOS execs the sleep, so killing the child
+// ends it, while Linux forks, so the sleep outlived its context and kept the
+// stdout pipe open -- and Wait, which waits for the pipe rather than for the
+// process, blocked for the full thirty seconds.
+//
+// Putting the child in its own process group makes the whole tree killable by
+// one signal, so cancelling stops the work rather than only stopping the wait.
+
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killTree signals the child's whole group. The negative pid is the group.
+func killTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		// The group is gone if the child already exited, which is not a
+		// failure to cancel. Fall back to the process itself in case the
+		// group was never established.
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/cli/launcher/source/proc_windows.go
+++ b/cli/launcher/source/proc_windows.go
@@ -1,0 +1,23 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package source
+
+import "os/exec"
+
+// Windows has no process groups to signal the way Unix does, and killing a
+// tree needs a job object. No picker source spawns a shell on Windows -- the
+// file-backed ones read files and the rest run a vendor CLI directly -- so the
+// default, killing the process itself, is what these callers need. WaitDelay
+// in execRunner is the backstop that keeps a held pipe from blocking Wait.
+
+func setProcessGroup(cmd *exec.Cmd) {}
+
+func killTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/cli/launcher/source/read.go
+++ b/cli/launcher/source/read.go
@@ -1,0 +1,648 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/kevinburke/ssh_config"
+	"gopkg.in/yaml.v3"
+)
+
+// Value pickers. These turn a text field into a list of the things actually
+// present on this machine -- the AWS profiles you have, the clusters in your
+// kubeconfig -- so the launcher can answer "which account?" instead of asking
+// the user to remember.
+//
+// Every source is best-effort and non-fatal: a missing file or an absent binary
+// yields no suggestions and the field stays free text. They read *names only*.
+// None of them ever reads, holds or returns credential material.
+
+// kubeCurrentContext reports the context kubectl would use.
+func kubeCurrentContext() string {
+	var paths []string
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		paths = filepath.SplitList(env)
+	} else {
+		paths = []string{home(".kube", "config")}
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var cfg struct {
+			CurrentContext string `yaml:"current-context"`
+		}
+		if yaml.Unmarshal(data, &cfg) == nil && cfg.CurrentContext != "" {
+			return cfg.CurrentContext
+		}
+	}
+	return ""
+}
+
+// home is a path under the user's home directory, or "" when there is no home
+// to be under.
+//
+// It is exported because the readers here are not the only thing that has to
+// find a dotted config directory -- the kubeconfig copy the launcher writes
+// resolves the same ~/.kube/config -- and two spellings of "where the user's
+// config lives" is how a picker and a launch end up talking about different
+// files.
+func home(rel ...string) string {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(append([]string{dir}, rel...)...)
+}
+
+// awsAccountKeys are the two spellings of the account an AWS profile names.
+// They are one fact, so the file's last word on it is the answer -- see
+// iniValues.last.
+var awsAccountKeys = []string{"sso_account_id", "account_id"}
+
+// awsProfiles lists the profile names in the shared AWS config files.
+//
+// It reads section headers and the account keys only, through the shared ini
+// scanner: ~/.aws/credentials holds live access keys, and there is no reason
+// for this process to pull them into memory to answer "what are the profiles
+// called". See ini.go.
+func awsProfiles() []string {
+	return awsProfilesFrom(home(".aws", "config"), home(".aws", "credentials"))
+}
+
+func awsProfilesFrom(configPath, credentialsPath string) []string {
+	profiles, accounts := awsProfileSections(configPath, credentialsPath)
+
+	out := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		// Where the config already names the account -- SSO profiles carry
+		// sso_account_id -- show it, because "which account is that?" is the
+		// question a profile name rarely answers. Resolving the rest would
+		// mean an STS call per profile, which is not something a picker should
+		// do behind the user's back.
+		if id := accounts[p].last(awsAccountKeys...); id != "" && !strings.Contains(p, id) {
+			out = append(out, p+"  ("+id+")")
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// awsProfileValue strips the account annotation back off, so what reaches the
+// command line is the profile name AWS knows.
+func awsProfileValue(display string) string {
+	if i := strings.Index(display, "  ("); i > 0 {
+		return display[:i]
+	}
+	return display
+}
+
+// awsProfileSections reads profile names, and any account id declared beside
+// them, from the shared config files.
+//
+// The two files are one namespace: ~/.aws/config spells a profile
+// `[profile prod]`, ~/.aws/credentials spells the same one `[prod]`, and a
+// machine commonly has only one of the two. Both are therefore scanned into a
+// single set of names, and the account id is whichever of the two keys either
+// file stated last.
+func awsProfileSections(configPath, credentialsPath string) ([]string, map[string]iniValues) {
+	names, accounts, _ := iniSections(iniScan{
+		files: []iniFile{
+			{path: configPath, strip: "profile "},
+			{path: credentialsPath},
+		},
+		want: map[string]bool{"sso_account_id": true, "account_id": true},
+	})
+	// A read failure is not reported: an absent ~/.aws is a machine with no
+	// profiles, and the field stays free text either way.
+	sort.Strings(names)
+	return names, accounts
+}
+
+// kubeContexts lists the context names in the active kubeconfig, current one
+// first. The file is read with a minimal schema rather than through client-go's
+// loader, which would pull a very large dependency in for two field reads.
+func kubeContexts() []string {
+	// KUBECONFIG lists files the way PATH lists directories, and kubectl merges
+	// all of them. Reading only the first hides clusters the user can see.
+	var paths []string
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		paths = filepath.SplitList(env)
+	} else {
+		paths = []string{home(".kube", "config")}
+	}
+	return kubeContextsFrom(paths...)
+}
+
+func kubeContextsFrom(paths ...string) []string {
+	var names []string
+	var current string
+	seen := map[string]bool{}
+
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var cfg struct {
+			CurrentContext string `yaml:"current-context"`
+			Contexts       []struct {
+				Name string `yaml:"name"`
+			} `yaml:"contexts"`
+		}
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			continue
+		}
+		// kubectl takes current-context from the first file that sets one.
+		if current == "" {
+			current = cfg.CurrentContext
+		}
+		for _, c := range cfg.Contexts {
+			if c.Name != "" && !seen[c.Name] {
+				seen[c.Name] = true
+				names = append(names, c.Name)
+			}
+		}
+	}
+
+	sort.Strings(names)
+	if current != "" && seen[current] {
+		// The current context is the one most likely meant, so it leads.
+		out := make([]string, 0, len(names))
+		out = append(out, current)
+		for _, n := range names {
+			if n != current {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+	return names
+}
+
+// sshHosts lists the Host aliases in the SSH client config. Wildcard patterns
+// are skipped: `Host *` sets defaults for every host and is not itself a target.
+func sshHosts() []string {
+	return sshHostsFrom(home(".ssh", "config"))
+}
+
+func sshHostsFrom(path string) []string {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	cfg, err := ssh_config.Decode(f)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, host := range cfg.Hosts {
+		for _, pattern := range host.Patterns {
+			p := pattern.String()
+			if p == "" || strings.ContainsAny(p, "*?!") {
+				continue
+			}
+			out = append(out, p)
+		}
+	}
+	return SortedUnique(out)
+}
+
+// gcloud keeps its state the way kubectl does: a pointer to the active
+// configuration and one file per configuration. So the project picker is a
+// file read, like the kube contexts and the AWS profiles, and needs neither the
+// network nor working credentials.
+//
+// Enumerating every project the account can see is a different matter --
+// `gcloud projects list` is an API call that fails outright when the auth token
+// has expired, which on a developer machine is the usual state. The launcher
+// therefore offers what is configured locally and lets anything else be typed.
+
+// gcloudDir is the directory gcloud keeps its configurations in.
+//
+// It is the one config path in this file that is not simply a dotted directory
+// under $HOME. The aws, kubectl and ssh readers all use ~/.aws, ~/.kube and
+// ~/.ssh on Windows exactly as they do elsewhere -- those tools resolve $HOME
+// themselves -- so those stay as they are. gcloud does not: on Windows it puts
+// its configuration under %APPDATA%, which is where `gcloud config
+// configurations list` reads from and where ~/.config/gcloud does not exist.
+// Looking in the wrong place there is silent, because a missing directory is
+// indistinguishable from a machine with no configurations.
+func gcloudDir() string { return gcloudDirFor(runtime.GOOS, os.Getenv) }
+
+// gcloudDirFor is gcloudDir with the platform and the environment injected, so
+// the Windows answer is checkable from any machine. It follows the resolution
+// in the SDK's own core/config.py (_GetGlobalConfigDir).
+func gcloudDirFor(goos string, getenv func(string) string) string {
+	// CLOUDSDK_CONFIG relocates the whole directory, and does so on every
+	// platform, so it is checked before anything else.
+	if dir := getenv("CLOUDSDK_CONFIG"); dir != "" {
+		return dir
+	}
+	if goos != "windows" {
+		return home(".config", "gcloud")
+	}
+	if appdata := getenv("APPDATA"); appdata != "" {
+		return filepath.Join(appdata, "gcloud")
+	}
+	// gcloud's own last resort, for a Windows profile that carries no APPDATA.
+	drive := getenv("SystemDrive")
+	if drive == "" {
+		drive = "C:"
+	}
+	return filepath.Join(drive, string(filepath.Separator), "gcloud")
+}
+
+// gcpConfigurations returns each gcloud configuration's name and the settings
+// the launcher cares about.
+func gcpConfigurations(dir string) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	entries, err := os.ReadDir(filepath.Join(dir, "configurations"))
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		name, ok := strings.CutPrefix(e.Name(), "config_")
+		if !ok || e.IsDir() {
+			continue
+		}
+		f, err := os.Open(filepath.Join(dir, "configurations", e.Name()))
+		if err != nil {
+			continue
+		}
+		settings := map[string]string{}
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			key, value, ok := strings.Cut(sc.Text(), "=")
+			if !ok {
+				continue
+			}
+			settings[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+		f.Close()
+		out[name] = settings
+	}
+	return out
+}
+
+// gcpActiveConfig is the configuration gcloud would use.
+func gcpActiveConfig(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "active_config"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func gcpProjects() []string { return gcpProjectsFrom(gcloudDir()) }
+
+func gcpProjectsFrom(dir string) []string {
+	var out []string
+	for _, settings := range gcpConfigurations(dir) {
+		if p := settings["project"]; p != "" {
+			out = append(out, p)
+		}
+	}
+	return SortedUnique(out)
+}
+
+// GCPActiveProject is the project of the active configuration.
+func GCPActiveProject() string { return gcpActiveProjectFrom(gcloudDir()) }
+
+func gcpActiveProjectFrom(dir string) string {
+	active := gcpActiveConfig(dir)
+	if active == "" {
+		return ""
+	}
+	return gcpConfigurations(dir)[active]["project"]
+}
+
+func gcpZones() []string { return gcpZonesFrom(gcloudDir()) }
+
+// gcpZonesFrom offers the zones the configurations name. It is a suggestion,
+// not a list of valid zones: a zone gcloud has never been told about is still
+// perfectly scannable, so the field stays free text.
+func gcpZonesFrom(dir string) []string {
+	var out []string
+	for _, settings := range gcpConfigurations(dir) {
+		if z := settings["zone"]; z != "" {
+			out = append(out, z)
+		}
+	}
+	return SortedUnique(out)
+}
+
+// gcpAllProjects lists every project the signed-in account can see.
+//
+// This is the GCP counterpart of the kubeconfig read, and it has to be a live
+// call because there is no local equivalent: gcloud keeps named configurations,
+// not a project list, so the config gives one project where a kubeconfig gives
+// every cluster you have ever fetched credentials for.
+//
+// It goes through gcloud rather than MQL because `cnspec run gcp` needs a scope
+// before it will connect, and `gcp.projects` comes back empty from a
+// project-scoped connection -- listing projects needs an organization id, which
+// is the thing the user is usually trying to avoid having to know. gcloud
+// already holds the credentials for this, and the same shape is used elsewhere
+// in cnspec to enumerate Azure subscriptions.
+func gcpAllProjects(ctx context.Context, run runner) ([]string, error) {
+	// The timeout is a backstop on a call that can hang; the context under it
+	// comes from the picker, so closing the picker kills the gcloud this
+	// started rather than leaving it to run to completion unwatched.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	out, err := run(ctx, "gcloud", "projects", "list", "--format=value(projectId)")
+	if err != nil {
+		return nil, gcloudError(err)
+	}
+	var projects []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			projects = append(projects, line)
+		}
+	}
+	return SortedUnique(projects), nil
+}
+
+// gcloudError turns what gcloud printed into something worth acting on.
+//
+// Its own message is four lines of prose wrapped around the one instruction
+// that matters, and a picker has room for a sentence. Everything it says about
+// refreshing tokens and non-interactive execution amounts to: log in again.
+func gcloudError(err error) error {
+	text := err.Error()
+	switch {
+	case strings.Contains(text, "Reauthentication failed"),
+		strings.Contains(text, "problem refreshing"),
+		strings.Contains(text, "gcloud auth login"),
+		strings.Contains(text, "invalid_grant"):
+		return errors.New("gcloud needs signing in again — run: gcloud auth login")
+	case strings.Contains(text, "executable file not found"),
+		strings.Contains(text, "no such file"):
+		return errors.New("gcloud is not installed — type a project id instead")
+	case strings.Contains(text, "does not have permission"),
+		strings.Contains(text, "PERMISSION_DENIED"):
+		return errors.New("this account cannot list projects — type a project id instead")
+	}
+	// Anything unrecognised keeps gcloud's own first line, which is more use
+	// than a message of ours that says nothing.
+	if line, _, _ := strings.Cut(text, "\n"); line != "" {
+		return errors.New(strings.TrimPrefix(line, "ERROR: "))
+	}
+	return err
+}
+
+// runner runs a command and returns its stdout. Injectable so the MQL-backed
+// sources are testable without spawning anything.
+type runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// The environment a runner has to apply travels on the context rather than in
+// the signature, and that is a deliberate choice rather than a shortcut.
+//
+// The obvious shape -- wrap the runner and let the wrapper set cmd.Env -- is
+// what this code used to do, and it dropped the environment on the floor for
+// every caller that supplied a base runner. Production always supplies one
+// (k8sNamespaces -> mqlQuery -> runWithEnv -> runnerWithEnv(execRunner, env)),
+// so the KUBECONFIG that selects the chosen cluster never reached the child
+// and the namespace picker answered for whatever cluster the ambient
+// kubeconfig named. Nothing failed; the answer was simply about a different
+// cluster.
+//
+// Putting it on the context fixes that in the one place it can be fixed for
+// every runner at once: whoever finally spawns the process reads it back, and
+// a substituted runner -- which spawns nothing and therefore cannot be
+// observed through a process -- can read the same value and assert on it. See
+// TestTheEnvironmentReachesTheChild and TestASubstitutedRunnerSeesTheEnv.
+type runEnvKey struct{}
+
+// withRunEnv adds environment entries for the eventual child. Entries already
+// on the context are kept, and later ones win the way os/exec resolves a
+// duplicated key.
+func withRunEnv(ctx context.Context, env []string) context.Context {
+	if len(env) == 0 {
+		return ctx
+	}
+	prev := runEnvFrom(ctx)
+	merged := make([]string, 0, len(prev)+len(env))
+	merged = append(merged, prev...)
+	merged = append(merged, env...)
+	return context.WithValue(ctx, runEnvKey{}, merged)
+}
+
+// runEnvFrom reports the environment a runner has been asked to apply.
+func runEnvFrom(ctx context.Context) []string {
+	env, _ := ctx.Value(runEnvKey{}).([]string)
+	return env
+}
+
+// execRunner is the real thing: it spawns the process and applies whatever
+// environment the context carries.
+func execRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	// Cancelling has to stop the work, not just stop waiting for it. See
+	// proc_unix.go: the child gets its own process group and Cancel signals
+	// the group, and WaitDelay bounds the case where something still holds
+	// the output pipe after the group is gone.
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error { return killTree(cmd) }
+	cmd.WaitDelay = 2 * time.Second
+	// The launcher is already the current binary. Letting the child hand
+	// off to whatever release sits in the auto-update cache costs a second
+	// and answers the question from a different version than the one being
+	// used.
+	cmd.Env = append(os.Environ(), "MONDOO_AUTO_UPDATE=false")
+	// os/exec keeps the last entry for a repeated key, so this overrides an
+	// inherited KUBECONFIG rather than sitting behind it.
+	cmd.Env = append(cmd.Env, runEnvFrom(ctx)...)
+	out, err := cmd.Output()
+	if err != nil {
+		// The reason a CLI refused is on stderr, and .Output() files it
+		// away on the error rather than returning it. Without this a
+		// picker can only report that something went wrong.
+		var exit *exec.ExitError
+		if errors.As(err, &exit) && len(exit.Stderr) > 0 {
+			return out, errors.New(strings.TrimSpace(string(exit.Stderr)))
+		}
+	}
+	return out, err
+}
+
+// runnerWithEnv builds a runner that applies env to whatever eventually runs.
+// base is used when set, so tests can substitute their own; a nil base is the
+// real child process.
+func runnerWithEnv(base runner, env []string) runner {
+	if base == nil {
+		base = execRunner
+	}
+	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return base(withRunEnv(ctx, env), name, args...)
+	}
+}
+
+// mqlQuery runs an MQL query against the local system and returns the raw JSON.
+//
+// Asking cnspec rather than the tool underneath it is what makes this
+// generalize: the same call shape enumerates anything MQL can express, on any
+// platform where cnspec already works, without the launcher growing a
+// dependency on each vendor's CLI. It costs a subprocess -- about 0.7s -- so it
+// only ever runs from a tea.Cmd.
+func mqlQuery(ctx context.Context, run runner, connector, query string, env []string) ([]byte, error) {
+	self, err := os.Executable()
+	if err != nil {
+		self = os.Args[0]
+	}
+	// A picker wants one resource, not an inventory. Without --discover none
+	// the query is run against every discovered asset, which on a real cluster
+	// meant 36 seconds instead of 6.
+	//
+	// The timeout is a backstop, not the only way out: the context comes from
+	// whoever opened the picker, so pressing esc kills this child instead of
+	// abandoning the answer and leaving it running.
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	// The child must not hand off to a newer installed binary mid-query.
+	return runWithEnv(ctx, run, env, self,
+		"run", connector, "--discover", "none", "-c", query, "-j")
+}
+
+// runWithEnv threads extra environment into a runner. Sources that target a
+// specific cluster do it this way, because the connector's own --context flag
+// does not select one (see kubeconfig.go).
+func runWithEnv(ctx context.Context, run runner, env []string, name string, args ...string) ([]byte, error) {
+	return runnerWithEnv(run, env)(ctx, name, args...)
+}
+
+// dockerContainers lists the containers on this host, running ones first,
+// labelled with the image they came from.
+func dockerContainers(ctx context.Context, run runner) ([]string, error) {
+	data, err := mqlQuery(ctx, run, "local", "docker.containers { names image state }", nil)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		Names []string `json:"names"`
+		Image string   `json:"image"`
+		State string   `json:"state"`
+	}
+	if err := decodeMQLList(data, "docker.containers", &rows); err != nil {
+		return nil, err
+	}
+
+	var running, stopped []string
+	for _, r := range rows {
+		if len(r.Names) == 0 {
+			continue
+		}
+		if r.State == "running" {
+			running = append(running, r.Names[0])
+			continue
+		}
+		stopped = append(stopped, r.Names[0])
+	}
+	sort.Strings(running)
+	sort.Strings(stopped)
+	return append(running, stopped...), nil
+}
+
+// dockerImages lists the image references held on this host.
+func dockerImages(ctx context.Context, run runner) ([]string, error) {
+	data, err := mqlQuery(ctx, run, "local", "docker.images { tags }", nil)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		Tags []string `json:"tags"`
+	}
+	if err := decodeMQLList(data, "docker.images", &rows); err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, r := range rows {
+		for _, tag := range r.Tags {
+			// An untagged image shows as "<none>:<none>" and cannot be scanned
+			// by reference.
+			if tag != "" && !strings.Contains(tag, "<none>") {
+				out = append(out, tag)
+			}
+		}
+	}
+	return SortedUnique(out), nil
+}
+
+// k8sNamespaces lists the namespaces of the cluster the env targets.
+func k8sNamespaces(ctx context.Context, run runner, env []string) ([]string, error) {
+	data, err := mqlQuery(ctx, run, "k8s", "k8s.namespaces { name }", env)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		Name string `json:"name"`
+	}
+	if err := decodeMQLList(data, "k8s.namespaces", &rows); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if r.Name != "" {
+			out = append(out, r.Name)
+		}
+	}
+	return SortedUnique(out), nil
+}
+
+// decodeMQLList pulls one resource's rows out of `cnspec run -j` output, which
+// is an array of result objects keyed by the queried resource.
+func decodeMQLList(data []byte, resource string, out any) error {
+	var envelope []map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	for _, entry := range envelope {
+		if raw, ok := entry[resource]; ok {
+			return json.Unmarshal(raw, out)
+		}
+	}
+	return errors.New("no " + resource + " in the query result")
+}
+
+func SortedUnique(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/launcher/source/read_test.go
+++ b/cli/launcher/source/read_test.go
@@ -1,0 +1,420 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func eq(t *testing.T, got, want []string, what string) {
+	t.Helper()
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("%s = %v, want %v", what, got, want)
+	}
+}
+
+// Both AWS shared-config spellings have to work: ~/.aws/config prefixes
+// sections with "profile ", ~/.aws/credentials does not. Machines commonly
+// have only one of the two files.
+func TestAWSProfiles(t *testing.T) {
+	got := awsProfilesFrom("testdata/aws_config", "testdata/aws_credentials")
+	eq(t, got, []string{"default", "prod", "sso-prod  (123456789012)", "staging"}, "profiles from both files")
+
+	got = awsProfilesFrom("testdata/aws_config", "testdata/does-not-exist")
+	eq(t, got, []string{"default", "prod", "sso-prod  (123456789012)"}, "profiles with no credentials file")
+
+	got = awsProfilesFrom("testdata/nope", "testdata/aws_credentials")
+	eq(t, got, []string{"default", "staging"}, "profiles with no config file")
+
+	if got := awsProfilesFrom("", ""); len(got) != 0 {
+		t.Errorf("expected no profiles with no paths, got %v", got)
+	}
+}
+
+// The profile reader must never surface key material, whatever the file holds.
+func TestAWSProfilesNeverReturnSecrets(t *testing.T) {
+	for _, p := range awsProfilesFrom("testdata/aws_config", "testdata/aws_credentials") {
+		if strings.Contains(p, "AKIA") || strings.Contains(p, "EXAMPLEKEY") || strings.Contains(p, "=") {
+			t.Fatalf("profile list leaked credential material: %q", p)
+		}
+	}
+}
+
+// The current context sorts first because it is the one the user most likely
+// means; the rest are alphabetical.
+func TestKubeContexts(t *testing.T) {
+	got := kubeContextsFrom("testdata/kubeconfig")
+	want := []string{
+		"arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster",
+		"aks-trial",
+		"chris-dev",
+	}
+	eq(t, got, want, "kube contexts")
+
+	if got := kubeContextsFrom("testdata/nope"); got != nil {
+		t.Errorf("expected nil for a missing kubeconfig, got %v", got)
+	}
+	if got := kubeContextsFrom("testdata/aws_config"); len(got) != 0 {
+		t.Errorf("expected nothing from a non-kubeconfig file, got %v", got)
+	}
+}
+
+// `Host *` and `Host web-*` set defaults for other hosts; they are not targets.
+func TestSSHHostsSkipWildcards(t *testing.T) {
+	got := sshHostsFrom("testdata/ssh_config")
+	eq(t, got, []string{"bastion.example.com", "jump", "prod-web"}, "ssh hosts")
+
+	if got := sshHostsFrom("testdata/nope"); len(got) != 0 {
+		t.Errorf("expected nothing for a missing ssh config, got %v", got)
+	}
+}
+
+// Containers and images are enumerated by asking cnspec, not the docker CLI,
+// so the launcher works wherever cnspec does and gets richer data: running
+// containers sort ahead of stopped ones.
+func TestDockerContainers(t *testing.T) {
+	fake := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte(`[{"docker.containers":[
+			{"names":["web"],"image":"nginx:1.27","state":"running"},
+			{"names":["old-job"],"image":"alpine:3","state":"exited"},
+			{"names":["db"],"image":"postgres:16","state":"running"}
+		]}]`), nil
+	}
+	got, err := dockerContainers(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq(t, got, []string{"db", "web", "old-job"}, "containers, running first")
+}
+
+func TestDockerImages(t *testing.T) {
+	fake := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte(`[{"docker.images":[
+			{"tags":["alpine:3","alpine:latest"]},
+			{"tags":["<none>:<none>"]},
+			{"tags":["ubuntu:22.04"]}
+		]}]`), nil
+	}
+	got, err := dockerImages(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq(t, got, []string{"alpine:3", "alpine:latest", "ubuntu:22.04"}, "image tags")
+}
+
+// A missing docker daemon, or any other query failure, must leave the field
+// usable rather than error out.
+func TestMQLSourcesFailSoft(t *testing.T) {
+	broken := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return nil, errors.New("connection refused")
+	}
+	// The error must come back too: an unreachable daemon and a host with no
+	// containers are not the same thing, and the field says so differently.
+	got, err := dockerContainers(context.Background(), broken)
+	if len(got) != 0 || err == nil {
+		t.Errorf("expected no containers and an error, got %v / %v", got, err)
+	}
+	if got, err := dockerImages(context.Background(), broken); len(got) != 0 || err == nil {
+		t.Errorf("expected no images and an error, got %v / %v", got, err)
+	}
+
+	garbage := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("not json"), nil
+	}
+	if got, err := dockerImages(context.Background(), garbage); len(got) != 0 || err == nil {
+		t.Errorf("expected no images and an error from unparseable output, got %v / %v", got, err)
+	}
+}
+
+// kubectl merges every file KUBECONFIG names; reading only the first hides
+// clusters the user can see.
+func TestKubeContextsMergeEveryFile(t *testing.T) {
+	got := kubeContextsFrom("testdata/kubeconfig", "testdata/kubeconfig2")
+	want := []string{
+		// current-context comes from the first file that sets one, and leads.
+		"arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster",
+		"aks-trial", "chris-dev", "staging",
+	}
+	eq(t, got, want, "merged contexts")
+
+	// chris-dev appears in both files and must not be listed twice.
+	seen := map[string]int{}
+	for _, c := range got {
+		seen[c]++
+	}
+	if seen["chris-dev"] != 1 {
+		t.Errorf("chris-dev listed %d times, want 1", seen["chris-dev"])
+	}
+}
+
+// A profile name rarely answers "which account is that?", so where the config
+// already says, the picker shows it.
+func TestAWSProfilesLabelTheirAccount(t *testing.T) {
+	got := awsProfilesFrom("testdata/aws_config", "testdata/aws_credentials")
+	if !slices.Contains(got, "sso-prod  (123456789012)") {
+		t.Errorf("expected the sso profile labelled with its account, got %v", got)
+	}
+	// A profile with no declared account stays as it is.
+	if !slices.Contains(got, "prod") {
+		t.Errorf("expected plain profiles untouched, got %v", got)
+	}
+}
+
+// Only the profile name is a command-line argument; the label is for reading.
+func TestAWSProfileLabelIsStrippedBeforeUse(t *testing.T) {
+	if got := awsProfileValue("sso-prod  (123456789012)"); got != "sso-prod" {
+		t.Fatalf("awsProfileValue = %q, want %q", got, "sso-prod")
+	}
+	if got := awsProfileValue("plain"); got != "plain" {
+		t.Fatalf("awsProfileValue = %q, want %q", got, "plain")
+	}
+	// The source declares the mapping, and a field attached to it emits
+	// through that declaration. That the launcher's own form does so is
+	// TestAWSProfileLabelNeverReachesArgv.
+	s, ok := ByID(AWSProfile)
+	if !ok || s.Emit == nil {
+		t.Fatal("the aws profile source declares no Emit, so the label would reach argv")
+	}
+	if got := s.Emit("sso-prod  (123456789012)"); got != "sso-prod" {
+		t.Fatalf("Emit = %q, want the bare profile name", got)
+	}
+}
+
+// gcloud keeps its state the way kubectl does, so the project picker is a file
+// read: no network, and no dependence on an auth token that has usually
+// expired by the time anyone opens the launcher.
+func TestGCPProjectsFromGcloudConfig(t *testing.T) {
+	eq(t, gcpProjectsFrom("testdata/gcloud"),
+		[]string{"attack-surface-scanner", "mondoo-staging"}, "configured projects")
+
+	if got := gcpActiveProjectFrom("testdata/gcloud"); got != "attack-surface-scanner" {
+		t.Errorf("active project = %q, want the one active_config names", got)
+	}
+	eq(t, gcpZonesFrom("testdata/gcloud"),
+		[]string{"europe-west1-b", "us-central1-c"}, "configured zones")
+
+	// No gcloud at all is not an error, just no suggestions.
+	if got := gcpProjectsFrom("testdata/does-not-exist"); len(got) != 0 {
+		t.Errorf("expected nothing without a gcloud config, got %v", got)
+	}
+	if got := gcpActiveProjectFrom("testdata/does-not-exist"); got != "" {
+		t.Errorf("expected no active project, got %q", got)
+	}
+}
+
+// The project list must carry no credential material, the same guarantee the
+// AWS profile reader gives.
+func TestGCPProjectsNeverReturnSecrets(t *testing.T) {
+	for _, p := range gcpProjectsFrom("testdata/gcloud") {
+		if strings.ContainsAny(p, "=@") {
+			t.Fatalf("project list leaked a setting: %q", p)
+		}
+	}
+}
+
+// gcloud keeps configurations, not a project list, so the full list is a live
+// call.
+func TestGCPAllProjects(t *testing.T) {
+	ok := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name != "gcloud" {
+			t.Errorf("expected gcloud, got %q", name)
+		}
+		return []byte("attack-surface-scanner\nmondoo-demo\n\nmondoo-staging\n"), nil
+	}
+	got, err := gcpAllProjects(context.Background(), ok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq(t, got, []string{"attack-surface-scanner", "mondoo-demo", "mondoo-staging"}, "listed projects")
+}
+
+// gcloud's own message is four lines of prose around the one instruction that
+// matters. A picker has room for a sentence, so it gets the instruction.
+func TestGcloudErrorsSayWhatToDo(t *testing.T) {
+	// Verbatim from `gcloud projects list` with an expired token.
+	stale := `ERROR: (gcloud.projects.list) There was a problem refreshing your current auth tokens: Reauthentication failed. cannot prompt during non-interactive execution.
+Please run:
+
+  $ gcloud auth login
+
+to obtain new credentials.`
+
+	cases := []struct{ in, want string }{
+		{stale, "gcloud auth login"},
+		{"exec: \"gcloud\": executable file not found in $PATH", "not installed"},
+		{"ERROR: (gcloud.projects.list) User does not have permission", "cannot list projects"},
+	}
+	for _, c := range cases {
+		got := gcloudError(errors.New(c.in)).Error()
+		if !strings.Contains(got, c.want) {
+			t.Errorf("gcloudError(%.40q…) = %q, want it to mention %q", c.in, got, c.want)
+		}
+		if strings.Count(got, "\n") != 0 {
+			t.Errorf("a picker gets one line, got %q", got)
+		}
+	}
+
+	// Something unrecognised keeps gcloud's own first line, which beats a
+	// message of ours that says nothing.
+	got := gcloudError(errors.New("ERROR: (gcloud.projects.list) quota exceeded\nsee docs")).Error()
+	if got != "(gcloud.projects.list) quota exceeded" {
+		t.Errorf("unrecognised error = %q", got)
+	}
+}
+
+// The chosen cluster has to reach the child process, and this is the one
+// dimension of it a double cannot check: KUBECONFIG travels in the
+// environment, so a recorded command line proves nothing about whether it
+// arrived.
+//
+// It is worth a real process because the composition used to lose it silently.
+// runnerWithEnv returned its base unwrapped whenever one was set, and the
+// production path always sets one -- k8sNamespaces hands mqlQuery execRunner,
+// mqlQuery hands it to runWithEnv, runWithEnv to runnerWithEnv -- so the
+// KUBECONFIG that selects the cluster the user picked was dropped on every
+// real call and kept on none. Nothing failed: the namespace picker simply
+// answered for whatever cluster the ambient kubeconfig named.
+func TestRunWithEnvReachesTheChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /bin/sh to ask")
+	}
+	// Set in this process too, so this also proves the child's value wins over
+	// an inherited one rather than sitting behind it.
+	t.Setenv("KUBECONFIG", "/tmp/ambient-cluster")
+
+	out, err := runWithEnv(context.Background(), execRunner,
+		[]string{"KUBECONFIG=/tmp/chosen-cluster"},
+		"/bin/sh", "-c", "printenv KUBECONFIG || echo MISSING")
+	if err != nil {
+		t.Fatalf("could not ask the child what it was given: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "/tmp/chosen-cluster" {
+		t.Errorf("the child saw KUBECONFIG=%q, want the chosen cluster's copy", got)
+	}
+}
+
+// The seam stays a seam: a substituted runner spawns nothing, so the only way
+// it can assert what it was asked to apply is to be told. It is told on the
+// context, which is also how the real runner learns it.
+func TestASubstitutedRunnerIsToldWhichEnvironmentToApply(t *testing.T) {
+	var seen []string
+	double := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		seen = runEnvFrom(ctx)
+		return []byte(`[{"k8s.namespaces":[{"name":"kube-system"}]}]`), nil
+	}
+
+	// Through the whole production shape, not just the last hop: this is the
+	// call chain that used to drop it.
+	got, err := k8sNamespaces(context.Background(), double, []string{"KUBECONFIG=/tmp/picked"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq(t, got, []string{"kube-system"}, "namespaces")
+	eq(t, seen, []string{"KUBECONFIG=/tmp/picked"}, "environment the runner was asked to apply")
+
+	// And nothing is invented when there is nothing to apply.
+	if _, err := k8sNamespaces(context.Background(), double, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 0 {
+		t.Errorf("a query with no environment was given %v", seen)
+	}
+}
+
+// gcloud is the one tool here that does not keep its configuration under a
+// dotted directory in $HOME. Getting this wrong is silent: a directory that
+// does not exist reads as a machine with no configurations, so the gcp pickers
+// would offer nothing and say nothing.
+func TestGcloudConfigDirIsPlatformAware(t *testing.T) {
+	windows := func(name string) string {
+		switch name {
+		case "APPDATA":
+			return `C:\Users\chris\AppData\Roaming`
+		}
+		return ""
+	}
+	if got, want := gcloudDirFor("windows", windows),
+		filepath.Join(`C:\Users\chris\AppData\Roaming`, "gcloud"); got != want {
+		t.Errorf("on Windows gcloudDir = %q, want %q", got, want)
+	}
+
+	// A Windows profile with no APPDATA falls back the way the SDK does, and
+	// must not silently answer with a POSIX path that cannot exist there.
+	if got := gcloudDirFor("windows", func(string) string { return "" }); strings.Contains(got, ".config") {
+		t.Errorf("with no APPDATA gcloudDir = %q, which is the POSIX answer", got)
+	}
+
+	// Everywhere else is unchanged, and so are the aws, kube and ssh paths --
+	// those tools do resolve ~ on Windows, and were not touched.
+	if got, want := gcloudDirFor("darwin", func(string) string { return "" }),
+		home(".config", "gcloud"); got != want {
+		t.Errorf("gcloudDir = %q, want %q", got, want)
+	}
+
+	// CLOUDSDK_CONFIG relocates the whole thing, on every platform.
+	env := func(name string) string {
+		if name == "CLOUDSDK_CONFIG" {
+			return "/opt/gcloud-config"
+		}
+		return `C:\Users\chris\AppData\Roaming`
+	}
+	for _, goos := range []string{"windows", "linux"} {
+		if got := gcloudDirFor(goos, env); got != "/opt/gcloud-config" {
+			t.Errorf("%s: CLOUDSDK_CONFIG was ignored, got %q", goos, got)
+		}
+	}
+}
+
+// Cancelling really does stop the work, rather than only stop waiting for it.
+// This is the mechanism the picker relies on; the model's half is
+// TestClosingAPickerStopsWhatItStarted.
+func TestACancelledContextKillsTheChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /bin/sh to ask")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if _, err := runnerWithEnv(nil, nil)(ctx, "/bin/sh", "-c", "sleep 30"); err == nil {
+		t.Fatal("a cancelled run reported success")
+	}
+	if waited := time.Since(start); waited > 10*time.Second {
+		t.Fatalf("the child outlived its context by %s", waited)
+	}
+}
+
+// The shell above is allowed to exec the sleep, replacing itself, in which case
+// killing the child is enough. A trailing command forces it to fork instead, so
+// the sleep is a grandchild that survives its parent and keeps the output pipe
+// open -- and Wait waits on the pipe, not on the process. macOS execs and Linux
+// forks, which is why this only ever failed in CI.
+func TestACancelledContextKillsAGrandchild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /bin/sh to ask")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if _, err := runnerWithEnv(nil, nil)(ctx, "/bin/sh", "-c", "sleep 30; :"); err == nil {
+		t.Fatal("a cancelled run reported success")
+	}
+	if waited := time.Since(start); waited > 10*time.Second {
+		t.Fatalf("the grandchild outlived its context by %s", waited)
+	}
+}

--- a/cli/launcher/source/source.go
+++ b/cli/launcher/source/source.go
@@ -1,0 +1,329 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// A Source produces the candidate values for a field.
+//
+// It exists because the launcher's pickers were written one provider at a time,
+// and each one answered the same handful of questions in its own place: when to
+// run, what to say while running, what to say when it fails, what it depends on,
+// and when a value is obvious enough to fill in. Those answers lived as
+// conditionals scattered across three files, so every new provider rediscovered
+// the same bugs -- a list that shows nothing when it means "cannot reach", a
+// cache key that hides a complete answer, a live list left attached to the wrong
+// selector.
+//
+// Declaring them here is the point. A new source gets the behaviour by
+// construction rather than by remembering.
+type Source struct {
+	// ID is what a form field names to use this source.
+	ID string
+	// Class is what kind of question this source can answer at all. It decides
+	// which widget the field gets, not merely how it is filled.
+	Class Class
+	// Cost decides when the source runs. Not the mechanism: docker is a
+	// subprocess like the k8s namespace list, but one asks a socket on this
+	// machine and the other crosses a network.
+	Cost Cost
+	// Activity says what is happening while it happens, naming the tool being
+	// asked -- "asking gcloud for projects". "Loading" tells the user nothing
+	// they cannot see; the tool's name tells them whose credentials matter and
+	// what to run themselves.
+	Activity string
+	// Tool is what Activity names: the command being run or the file being
+	// read -- "gcloud", "kubectl", "~/.aws". It is declared rather than
+	// inferred because the contract test that checks Activity actually names
+	// something used to hold its own list of tool names, which meant every new
+	// source failed a test in a file it did not own. Naming it here makes that
+	// a per-source property instead.
+	Tool string
+	// Env names the environment variable this source's chosen value travels
+	// in, for the targets that have no flag to carry them. Empty for the
+	// common case, where the value is a command-line argument. See
+	// formEnvironment: a field whose spec names a variable wins over this, and
+	// the general case -- a value that has to become a file first -- is an
+	// EnvSpec instead.
+	Env string
+	// Needs names the fields whose values this source depends on. A namespace
+	// list belongs to one cluster, and serving another's is the kind of
+	// confidently wrong answer worth designing against.
+	Needs []string
+	// Emit maps a value as this source shows it to the value a command line
+	// takes. Empty for the common case, where a picker offers exactly the words
+	// the connector accepts.
+	//
+	// A picker is free to annotate what it found -- an AWS profile is listed
+	// with the account id its config names, because "which account is that?" is
+	// the question a profile name rarely answers -- and the annotation is not
+	// something any provider will accept. Until this existed, the form engine
+	// carried the one source that does it: emitted(), the function every field
+	// of every connector passes through on its way to argv, opened with a test
+	// for "aws.profile". The second annotated picker would have added a second.
+	Emit EmitFunc
+	// Prefer picks the one obvious value, or returns "" for no opinion. A guess
+	// the user has to notice and undo is worse than an empty field.
+	Prefer PreferFunc
+	// Explain turns whatever the underlying tool said into one actionable
+	// sentence. Providers speak gRPC, CLIs speak prose; a picker has room for
+	// neither.
+	Explain ExplainFunc
+	// Fetch returns the values and, separately, why there are none. Both:
+	// "empty" and "failed" look identical on screen unless the source
+	// distinguishes them.
+	Fetch FetchFunc
+	// FetchCtx is Fetch for a source that spawns something, and exists because
+	// abandoning a result is not the same as stopping the work.
+	//
+	// A picker the user closes used to leave its `gcloud projects list` or its
+	// `cnspec run k8s` running to completion, holding a connection and a
+	// process nobody was waiting for. The context comes from the model and is
+	// cancelled when the picker closes, so the child is killed rather than
+	// orphaned; the source's own timeout stays as the backstop for the case
+	// where the picker is left open.
+	//
+	// A source declares one or the other. The file-backed sources answer in
+	// microseconds and have nothing to cancel, so Fetch is right for them and
+	// stays the simpler shape.
+	FetchCtx FetchCtxFunc
+}
+
+// Class is what kind of discovery is possible for a provider at all.
+//
+// Sorting providers this way is what stops the launcher building a picker for
+// something that can never be enumerated. Seven of the eighteen providers
+// surveyed have exactly one env var and one flag: there is no list, and offering
+// an empty box was a category error rather than a missing feature.
+type Class int
+
+const (
+	// ClassEnumerated: a local file lists the candidates. Cheap, offline, and
+	// the answer is a set of credentials or addresses.
+	ClassEnumerated Class = iota
+	// ClassAmbient: one credential from the environment. Nothing to enumerate;
+	// the useful thing to show is whether it is present and where it came from.
+	ClassAmbient
+	// ClassPostConnection: what is inside a target, once connected. Feeds the
+	// connector's own filter flags.
+	ClassPostConnection
+	// ClassRequired: there is nothing ambient and nothing to enumerate. The
+	// user has to supply the value, and the honest thing a launcher can do is
+	// say so rather than offer a box that will never fill itself in. The
+	// provider survey found three connectors in exactly this position, and the
+	// enum could not previously express it.
+	ClassRequired
+)
+
+// Cost decides when a source runs, and is the whole of that policy.
+type Cost int
+
+const (
+	// CostInstant: a file read. Runs when a form opens.
+	CostInstant Cost = iota
+	// CostLocal: something on this machine that is not free -- a daemon, a
+	// subprocess -- but answers in about a second. Also runs when a form opens,
+	// asynchronously.
+	CostLocal
+	// CostRemote: crosses a network, needs credentials, and can fail. Runs only
+	// when its picker is opened, with a spinner and a way out.
+	CostRemote
+)
+
+// deferred reports whether a cost waits to be asked for.
+func (c Cost) Deferred() bool { return c == CostRemote }
+
+type (
+	// PreferFunc picks the obvious value and says why, or returns "" twice.
+	PreferFunc func(values []string) (value, why string)
+	// ExplainFunc maps a failure to one sentence the user can act on.
+	ExplainFunc func(err error) error
+	// FetchFunc returns candidates for the given parameters.
+	FetchFunc func(params []string) ([]string, error)
+	// FetchCtxFunc is FetchFunc for a source with something to cancel.
+	FetchCtxFunc func(ctx context.Context, params []string) ([]string, error)
+	// EmitFunc turns one of a source's displayed values into the value a
+	// command line takes.
+	EmitFunc func(display string) string
+)
+
+// registry holds every declared source, keyed by ID.
+var registry = map[string]Source{}
+
+// Register adds a source, and is called from each source file's init.
+func Register(sources ...Source) {
+	for _, s := range sources {
+		registry[s.ID] = s
+	}
+}
+
+// ByID returns a declared source.
+func ByID(id string) (Source, bool) {
+	s, ok := registry[id]
+	return s, ok
+}
+
+// Registry is every declared source keyed by id, and is the live map rather
+// than a copy.
+//
+// It exists for the tests that install a source, drive a screen with it and
+// take it away again -- a picker's behaviour is only observable through a form
+// that names one, and inventing a real provider to observe it with would tie
+// the test to whatever is installed. Both of those are on the launcher's side
+// of this boundary, which is why this is exported and Register is not enough.
+// Nothing outside a test should reach for it.
+func Registry() map[string]Source { return registry }
+
+// all returns every declared source, in id order.
+//
+// It is what the contract test walks, and returning a sorted slice rather than
+// ranging the map is what makes a failure name the same source every run.
+func all() []Source {
+	out := make([]Source, 0, len(registry))
+	for _, s := range registry {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// ActivityFor is what to say while a source runs.
+func ActivityFor(id string) string {
+	if s, ok := ByID(id); ok && s.Activity != "" {
+		return s.Activity
+	}
+	return "looking"
+}
+
+// Deferred reports whether a source waits until its picker is opened.
+func Deferred(id string) bool {
+	s, ok := ByID(id)
+	return ok && s.Cost.Deferred()
+}
+
+// PreferredValue asks a source for the one obvious value.
+func PreferredValue(id string, values []string) (value, why string) {
+	if len(values) == 0 {
+		return "", ""
+	}
+	if s, ok := ByID(id); ok && s.Prefer != nil {
+		if v, w := s.Prefer(values); v != "" {
+			return v, w
+		}
+	}
+	// A single candidate is unambiguous whatever the source, so this does not
+	// need declaring nine times.
+	if len(values) == 1 {
+		return values[0], "only one"
+	}
+	return "", ""
+}
+
+// Emit is how a source's displayed values reach a command line, or nil
+// when they reach it unchanged. It is what a form field is handed when a picker
+// is attached to it, so the field can answer what it emits without knowing that
+// pickers exist.
+func Emit(id string) EmitFunc {
+	if s, ok := ByID(id); ok {
+		return s.Emit
+	}
+	return nil
+}
+
+// explainFailure turns a source's error into something worth reading.
+func explainFailure(id string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if s, ok := ByID(id); ok && s.Explain != nil {
+		return s.Explain(err)
+	}
+	return stripRPCPrefix(err)
+}
+
+// Result is one source's answer: what it found, why there is nothing, and
+// whether anyone is still waiting for it.
+//
+// The three are separate on purpose. "Empty" and "failed" look identical on
+// screen unless the source distinguishes them, and a cancelled answer is
+// neither -- a killed child reports "signal: killed", which is true and
+// useless, because the user closed the picker and reporting that their gcloud
+// died is blaming them for their own esc key.
+type Result struct {
+	// Values are the candidates, and may be empty for a real empty answer.
+	Values []string
+	// Err explains an empty list, already put through the source's own
+	// Explain.
+	Err error
+	// Cancelled marks the answer to a question nobody is waiting for any more.
+	Cancelled bool
+}
+
+// Load runs a source and returns its answer.
+//
+// ctx belongs to whoever asked. A source that spawns a child declares FetchCtx
+// and receives it, so closing the picker kills what the picker started; the
+// file-backed sources answer too quickly for it to matter and declare Fetch.
+//
+// This is the whole of the fetch policy, and it is deliberately not a tea.Cmd:
+// the launcher wraps it in one, so the rule about which of the two fetch
+// shapes runs -- and what a cancelled context means -- is testable without a
+// UI.
+func Load(ctx context.Context, id string, params []string) Result {
+	var r Result
+	s, ok := ByID(id)
+	if !ok || (s.Fetch == nil && s.FetchCtx == nil) {
+		return r
+	}
+	var err error
+	if s.FetchCtx != nil {
+		r.Values, err = s.FetchCtx(ctx, params)
+	} else {
+		r.Values, err = s.Fetch(params)
+	}
+	if ctx.Err() != nil {
+		return Result{Cancelled: true}
+	}
+	r.Err = explainFailure(id, err)
+	return r
+}
+
+// stripRPCPrefix removes the gRPC envelope that providers' errors arrive in.
+// The useful part is what the provider said; "rpc error: code = Unknown desc ="
+// is noise in a box this size.
+func stripRPCPrefix(err error) error {
+	text := err.Error()
+	if i := strings.Index(text, "desc = "); i >= 0 && strings.HasPrefix(text, "rpc error:") {
+		return errorString(text[i+len("desc = "):])
+	}
+	return err
+}
+
+// errorString is an error that is just its message.
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+// Key identifies a source's cached values. The parameters are part of it:
+// two clusters have two namespace lists, and serving one for the other is
+// exactly the kind of confidently wrong answer worth avoiding. It must be
+// stable -- keying on anything generated makes a load and its lookup disagree,
+// and a full answer then never reaches the screen.
+func Key(id string, params []string) string {
+	return id + "\x00" + strings.Join(params, " ")
+}
+
+// paramValue reads one of a source's parameters.
+func paramValue(params []string, name string) string {
+	for _, p := range params {
+		if v, ok := strings.CutPrefix(p, name+"="); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/cli/launcher/source/source_test.go
+++ b/cli/launcher/source/source_test.go
@@ -1,0 +1,172 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package source
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// The contract is enforced here rather than described in a comment. Every rule
+// below was learned by shipping its violation for one provider; applying it to
+// every registered source is the whole point of having a contract.
+//
+// Each of these walks all(), so a source declared tomorrow is held to the rules
+// written today without either file being edited. That is deliberate and is the
+// thing to preserve: the previous shape kept its own list of source ids and its
+// own list of tool names here, which meant a source declared in one file failed
+// a test in another, and every author of a new source edited the same line to
+// get green.
+
+// Naming the tool is what makes a wait useful: it says whose credentials matter
+// and what the user could run themselves.
+//
+// The claim lives on the declaration rather than in a list here. This test used
+// to hold its own `tools := []string{"gcloud", "kubectl", ...}`, which meant a
+// source declared in one file failed a test in another, and every author of a
+// new source edited the same line to get green. Source.Tool makes it a property
+// of each source instead, and a new source is an append in its own file.
+func TestEverySourceSaysWhatItIsDoing(t *testing.T) {
+	for _, s := range all() {
+		id := s.ID
+		if s.Activity == "" {
+			t.Errorf("%s: no Activity, so a wait on it would say nothing", id)
+			continue
+		}
+		if strings.EqualFold(s.Activity, "loading") {
+			t.Errorf("%s: %q tells the user nothing they cannot see", id, s.Activity)
+		}
+		if s.Tool == "" {
+			t.Errorf("%s: no Tool, so nothing says whose credentials this needs", id)
+			continue
+		}
+		if !strings.Contains(strings.ToLower(s.Activity), strings.ToLower(s.Tool)) {
+			t.Errorf("%s: Activity %q does not name its Tool %q", id, s.Activity, s.Tool)
+		}
+	}
+}
+
+// Cost is a claim about what a source does, and a wrong claim means it runs at
+// the wrong time -- eagerly blocking a form, or lazily hiding a free answer.
+//
+// The claim the source already makes in prose is the one checked: an Activity
+// that says it is *asking* another program has left this process, and a source
+// that has left this process cannot be instant. Reading a file says "reading",
+// and checking an environment variable says neither. This replaces a hand-kept
+// map of source ids, for the same reason as above.
+//
+// The other half of the contract -- that only a remote cost defers -- is
+// TestOnlyRemoteSourcesAreDeferred below.
+func TestSourceCostMatchesWhatItDoes(t *testing.T) {
+	for _, s := range all() {
+		id := s.ID
+		asking := strings.HasPrefix(strings.ToLower(strings.TrimSpace(s.Activity)), "asking")
+		if asking && s.Cost == CostInstant {
+			t.Errorf("%s: %q leaves this process but claims CostInstant", id, s.Activity)
+		}
+	}
+}
+
+// Only what crosses a network waits to be asked for. A file read that deferred
+// would leave a form empty for no reason; a network call that did not would
+// block opening one.
+func TestOnlyRemoteSourcesAreDeferred(t *testing.T) {
+	for _, s := range all() {
+		id := s.ID
+		if got, want := Deferred(id), s.Cost == CostRemote; got != want {
+			t.Errorf("%s: deferred=%v, want %v for cost %v", id, got, want, s.Cost)
+		}
+	}
+}
+
+// A source that can fail in a way the user could act on has to say so in one
+// sentence. Anything else is either unrecognised -- where the tool's own words
+// are kept -- or cannot fail.
+func TestFailuresExplainThemselves(t *testing.T) {
+	// Verbatim from gcloud with an expired token.
+	stale := errors.New(`ERROR: (gcloud.projects.list) There was a problem refreshing your current auth tokens: Reauthentication failed.
+Please run:
+
+  $ gcloud auth login`)
+
+	got := explainFailure(GCPProjectAll, stale).Error()
+	if !strings.Contains(got, "gcloud auth login") {
+		t.Errorf("explained as %q, want the command to run", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("a picker gets one line, got %q", got)
+	}
+
+	// A source with no Explain still loses the gRPC envelope, which is the
+	// shape provider errors arrive in.
+	wrapped := errors.New("rpc error: code = Unknown desc = dial tcp 127.0.0.1:22: connect: connection refused")
+	if got := explainFailure(SSHHost, wrapped).Error(); strings.HasPrefix(got, "rpc error:") {
+		t.Errorf("the gRPC envelope survived: %q", got)
+	} else if !strings.Contains(got, "connection refused") {
+		t.Errorf("the provider's own words were lost: %q", got)
+	}
+
+	if explainFailure(SSHHost, nil) != nil {
+		t.Error("no error should explain to nothing")
+	}
+}
+
+// Prefilling a guess the user must notice and undo is worse than an empty
+// field, so an opinion is only offered when the answer is unambiguous.
+func TestPrefillOnlyWhenUnambiguous(t *testing.T) {
+	// A sole candidate is unambiguous for every source, and is handled once
+	// rather than declared nine times.
+	for _, s := range all() {
+		id := s.ID
+		if v, why := PreferredValue(id, []string{"only"}); v != "only" || why == "" {
+			t.Errorf("%s: single candidate gave %q/%q", id, v, why)
+		}
+		if v, _ := PreferredValue(id, nil); v != "" {
+			t.Errorf("%s: prefilled %q from nothing", id, v)
+		}
+	}
+
+	// Several candidates with nothing to distinguish them is not.
+	if v, _ := PreferredValue(SSHHost, []string{"a", "b"}); v != "" {
+		t.Errorf("two ssh hosts prefilled %q", v)
+	}
+	if v, why := PreferredValue(AWSProfile, []string{"prod", "default"}); v != "default" || why != "default" {
+		t.Errorf("aws = %q/%q, want the conventional profile", v, why)
+	}
+}
+
+// A cache key must be stable across lookups and must vary with the parameters.
+// Violating the first hid a complete answer behind a key that changed every
+// time it was asked for.
+func TestCacheKeysAreStableAndScoped(t *testing.T) {
+	a := Key(K8sNamespace, []string{"context=prod"})
+	if a != Key(K8sNamespace, []string{"context=prod"}) {
+		t.Fatal("the same question produced two keys")
+	}
+	if a == Key(K8sNamespace, []string{"context=staging"}) {
+		t.Fatal("two clusters share a key")
+	}
+	if !strings.HasPrefix(a, K8sNamespace) {
+		t.Errorf("key %q does not name its source", a)
+	}
+}
+
+// A source that depends on another field says so, rather than the model
+// carrying a hardcoded exception for it.
+func TestDependenciesAreDeclared(t *testing.T) {
+	s, ok := ByID(K8sNamespace)
+	if !ok {
+		t.Fatal("the namespace source is not registered")
+	}
+	if !slices.Contains(s.Needs, "context") {
+		t.Fatalf("namespaces depend on the cluster, Needs = %v", s.Needs)
+	}
+	// And a source that depends on nothing declares nothing.
+	if s, _ := ByID(AWSProfile); len(s.Needs) != 0 {
+		t.Errorf("aws profiles depend on nothing, Needs = %v", s.Needs)
+	}
+}

--- a/cli/launcher/source/testdata/alicloud_credentials
+++ b/cli/launcher/source/testdata/alicloud_credentials
@@ -1,0 +1,22 @@
+; ~/.alibabacloud/credentials, as aliyun/credentials-go reads it. Several
+; sections, and the conventional one is the lowercase "default".
+[default]
+type = access_key
+access_key_id = LTAI5tNOTAREALKEYID
+access_key_secret = NOTAREALSECRETVALUEATALLxxxxxxxxxx
+
+[staging]
+type = access_key
+access_key_id = LTAI5tSTAGINGKEYID
+access_key_secret = STAGINGSECRETVALUExxxxxxxxxxxxxxxx
+
+[ram-role]
+type = ram_role_arn
+access_key_id = LTAI5tROLEKEYID
+access_key_secret = ROLESECRETVALUExxxxxxxxxxxxxxxxxxx
+role_arn = acs:ram::1234567890123456:role/auditor
+role_session_name = cnspec
+
+[ecs]
+type = ecs_ram_role
+role_name = cnspec-scanner

--- a/cli/launcher/source/testdata/aws_config
+++ b/cli/launcher/source/testdata/aws_config
@@ -1,0 +1,11 @@
+[default]
+region = us-east-1
+
+# a comment
+[profile prod]
+region = eu-west-1
+role_arn = arn:aws:iam::123456789012:role/Admin
+
+[profile sso-prod]
+sso_account_id = 123456789012
+sso_role_name = AdministratorAccess

--- a/cli/launcher/source/testdata/aws_credentials
+++ b/cli/launcher/source/testdata/aws_credentials
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[staging]
+aws_access_key_id = AKIAI44QH8DHBEXAMPLE
+aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY

--- a/cli/launcher/source/testdata/azure/azureProfile.json
+++ b/cli/launcher/source/testdata/azure/azureProfile.json
@@ -1,0 +1,47 @@
+﻿{
+  "installationId": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+  "subscriptions": [
+    {
+      "id": "00000000-0000-0000-0000-00000000aaaa",
+      "name": "Production",
+      "state": "Enabled",
+      "user": {
+        "name": "chris@example.com",
+        "type": "user"
+      },
+      "isDefault": false,
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "11111111-1111-1111-1111-111111111111",
+      "managedByTenants": []
+    },
+    {
+      "id": "00000000-0000-0000-0000-00000000bbbb",
+      "name": "Sandbox",
+      "state": "Enabled",
+      "user": {
+        "name": "chris@example.com",
+        "type": "user"
+      },
+      "isDefault": true,
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "11111111-1111-1111-1111-111111111111",
+      "managedByTenants": []
+    },
+    {
+      "id": "00000000-0000-0000-0000-00000000cccc",
+      "name": "Retired",
+      "state": "Disabled",
+      "user": {
+        "name": "chris@example.com",
+        "type": "user"
+      },
+      "isDefault": false,
+      "tenantId": "11111111-1111-1111-1111-111111111111",
+      "environmentName": "AzureCloud",
+      "homeTenantId": "11111111-1111-1111-1111-111111111111",
+      "managedByTenants": []
+    }
+  ]
+}

--- a/cli/launcher/source/testdata/discover_azure_subscriptions.json
+++ b/cli/launcher/source/testdata/discover_azure_subscriptions.json
@@ -1,0 +1,54 @@
+{
+  "spec": {
+    "assets": [
+      {
+        "id": "//platformid.api.mondoo.app/runtime/azure/subscriptions/f1f9a0d1-9c2e-4a5b-8f3e-1c2d3e4f5a6b",
+        "name": "Azure subscription Production",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/azure/subscriptions/f1f9a0d1-9c2e-4a5b-8f3e-1c2d3e4f5a6b"
+        ],
+        "platform": {
+          "name": "azure",
+          "title": "Azure Subscription",
+          "kind": "api",
+          "runtime": "azure",
+          "technology_url_segments": [
+            "azure",
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "f1f9a0d1-9c2e-4a5b-8f3e-1c2d3e4f5a6b",
+            "account"
+          ]
+        },
+        "connections": [
+          {
+            "id": 1,
+            "type": "azure",
+            "options": {
+              "subscription-id": "f1f9a0d1-9c2e-4a5b-8f3e-1c2d3e4f5a6b",
+              "tenant-id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+            }
+          }
+        ]
+      },
+      {
+        "id": "//platformid.api.mondoo.app/runtime/azure/subscriptions/0d7c6b5a-4e3f-2a1b-9c8d-7e6f5a4b3c2d",
+        "name": "Azure subscription Sandbox",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/azure/subscriptions/0d7c6b5a-4e3f-2a1b-9c8d-7e6f5a4b3c2d"
+        ],
+        "platform": {
+          "name": "azure",
+          "title": "Azure Subscription",
+          "kind": "api",
+          "runtime": "azure"
+        },
+        "connections": [
+          {
+            "id": 2,
+            "type": "azure"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli/launcher/source/testdata/discover_github_repos.json
+++ b/cli/launcher/source/testdata/discover_github_repos.json
@@ -1,0 +1,122 @@
+{
+  "spec": {
+    "assets": [
+      {
+        "name": "mondoohq",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/github/organization/mondoohq"
+        ],
+        "platform": {
+          "name": "github-org",
+          "title": "GitHub Organization",
+          "family": ["github"],
+          "kind": "api",
+          "runtime": "github"
+        },
+        "connections": [
+          {
+            "id": 1,
+            "type": "github",
+            "options": {
+              "organization": "mondoohq"
+            },
+            "discover": {
+              "targets": ["repos"]
+            }
+          }
+        ]
+      },
+      {
+        "name": "mondoohq/cnspec",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/github/owner/mondoohq/repository/cnspec"
+        ],
+        "platform": {
+          "name": "github-repo",
+          "title": "GitHub Repository",
+          "family": ["github"],
+          "kind": "api",
+          "runtime": "github"
+        },
+        "connections": [
+          {
+            "id": 2,
+            "type": "github",
+            "options": {
+              "organization": "mondoohq",
+              "repository": "cnspec"
+            },
+            "parent_connection_id": 1
+          }
+        ]
+      },
+      {
+        "name": "mondoohq/cnquery",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/github/owner/mondoohq/repository/cnquery"
+        ],
+        "platform": {
+          "name": "github-repo",
+          "title": "GitHub Repository",
+          "family": ["github"],
+          "kind": "api",
+          "runtime": "github"
+        },
+        "connections": [
+          {
+            "id": 3,
+            "type": "github",
+            "options": {
+              "organization": "mondoohq",
+              "repository": "cnquery"
+            },
+            "parent_connection_id": 1
+          }
+        ]
+      },
+      {
+        "name": "mondoohq/policy-bundles",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/github/owner/mondoohq/repository/policy-bundles"
+        ],
+        "platform": {
+          "name": "github-repo",
+          "title": "GitHub Repository",
+          "family": ["github"],
+          "kind": "api",
+          "runtime": "github"
+        },
+        "connections": [
+          {
+            "id": 4,
+            "type": "github",
+            "parent_connection_id": 1
+          }
+        ]
+      },
+      {
+        "name": "octocat",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/github/user/octocat"
+        ],
+        "platform": {
+          "name": "github-user",
+          "title": "GitHub User",
+          "family": ["github"],
+          "kind": "api",
+          "runtime": "github"
+        },
+        "connections": [
+          {
+            "id": 5,
+            "type": "github",
+            "options": {
+              "user": "octocat"
+            },
+            "parent_connection_id": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli/launcher/source/testdata/discover_k8s_namespaces.json
+++ b/cli/launcher/source/testdata/discover_k8s_namespaces.json
@@ -1,0 +1,95 @@
+{
+  "spec": {
+    "assets": [
+      {
+        "name": "kind-demo",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/k8s/uid/9f0a5c2c-4b2b-4d0e-9d1c-2f9b6f6b1111"
+        ],
+        "platform": {
+          "name": "k8s-cluster",
+          "title": "Kubernetes Cluster",
+          "family": ["k8s"],
+          "kind": "api",
+          "runtime": "k8s-cluster",
+          "version": "v1.31.0"
+        },
+        "connections": [
+          {
+            "id": 1,
+            "type": "k8s",
+            "options": {
+              "context": "kind-demo"
+            },
+            "discover": {
+              "targets": ["namespaces"]
+            }
+          }
+        ]
+      },
+      {
+        "name": "default",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/k8s/uid/9f0a5c2c-4b2b-4d0e-9d1c-2f9b6f6b1111/namespace/default"
+        ],
+        "platform": {
+          "name": "k8s-namespace",
+          "title": "Kubernetes Namespace",
+          "family": ["k8s", "k8s-namespace"],
+          "kind": "k8s-object",
+          "runtime": "k8s-cluster"
+        },
+        "labels": {
+          "kubernetes.io/metadata.name": "default"
+        },
+        "connections": [
+          {
+            "id": 2,
+            "type": "k8s",
+            "parent_connection_id": 1
+          }
+        ]
+      },
+      {
+        "name": "kube-system",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/k8s/uid/9f0a5c2c-4b2b-4d0e-9d1c-2f9b6f6b1111/namespace/kube-system"
+        ],
+        "platform": {
+          "name": "k8s-namespace",
+          "title": "Kubernetes Namespace",
+          "family": ["k8s", "k8s-namespace"],
+          "kind": "k8s-object",
+          "runtime": "k8s-cluster"
+        },
+        "connections": [
+          {
+            "id": 3,
+            "type": "k8s",
+            "parent_connection_id": 1
+          }
+        ]
+      },
+      {
+        "name": "payments",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/k8s/uid/9f0a5c2c-4b2b-4d0e-9d1c-2f9b6f6b1111/namespace/payments"
+        ],
+        "platform": {
+          "name": "k8s-namespace",
+          "title": "Kubernetes Namespace",
+          "family": ["k8s", "k8s-namespace"],
+          "kind": "k8s-object",
+          "runtime": "k8s-cluster"
+        },
+        "connections": [
+          {
+            "id": 4,
+            "type": "k8s",
+            "parent_connection_id": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli/launcher/source/testdata/discover_local_container.json
+++ b/cli/launcher/source/testdata/discover_local_container.json
@@ -1,0 +1,229 @@
+{
+  "spec": {
+    "assets": [
+      {
+        "name": "workstation",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/hostname/workstation.local",
+          "//platformid.api.mondoo.app/serialnumber/SERIAL0000"
+        ],
+        "platform": {
+          "name": "macos",
+          "arch": "arm64",
+          "title": "macOS",
+          "family": [
+            "darwin",
+            "bsd",
+            "unix",
+            "os"
+          ],
+          "version": "26.5",
+          "kind": "baremetal",
+          "technology_url_segments": [
+            "os",
+            "darwin",
+            "macos",
+            "26.5"
+          ],
+          "metadata": {
+            "mondoo.com/device-type": "workstation"
+          }
+        },
+        "connections": [
+          {
+            "id": 1,
+            "type": "local",
+            "options": {
+              "device-names": "",
+              "staged-discovery": ""
+            },
+            "discover": {
+              "targets": [
+                "container"
+              ]
+            },
+            "capabilities": [
+              "run-command",
+              "file"
+            ]
+          }
+        ],
+        "id_detector": [
+          "cloud-detect",
+          "hostname",
+          "serialnumber"
+        ],
+        "kind_string": "baremetal"
+      },
+      {
+        "name": "mondoomdm-install-garage-1",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/docker/containers/ddf69867f71a4e6f0dd3c9d59992acdbaa1927db2c4f1f0602bdc78104e1675c"
+        ],
+        "platform": {
+          "name": "scratch",
+          "arch": "arm64",
+          "family": [
+            "os"
+          ],
+          "version": "unknown",
+          "kind": "container",
+          "technology_url_segments": [
+            "os",
+            "other",
+            "scratch",
+            "unknown"
+          ],
+          "runtime": "docker-container",
+          "metadata": {
+            "mondoo.com/device-type": "container"
+          }
+        },
+        "connections": [
+          {
+            "host": "ddf69867f71a4e6f0dd3c9d59992acdbaa1927db2c4f1f0602bdc78104e1675c",
+            "id": 2,
+            "type": "docker-container",
+            "capabilities": [
+              "run-command",
+              "file"
+            ]
+          }
+        ],
+        "kind_string": "container"
+      },
+      {
+        "name": "mondooattacksurface-temporal-1",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/docker/containers/10f2fbd87dcb2c56862793802b7f0855f22df4f92dd7cbd95033288842fc4c31"
+        ],
+        "platform": {
+          "name": "alpine",
+          "arch": "arm64",
+          "title": "Alpine Linux v3.23",
+          "family": [
+            "linux",
+            "unix",
+            "os"
+          ],
+          "version": "3.23.4",
+          "kind": "container",
+          "technology_url_segments": [
+            "os",
+            "linux",
+            "alpine",
+            "3.23.4"
+          ],
+          "runtime": "docker-container",
+          "labels": {
+            "distro-id": "alpine"
+          },
+          "metadata": {
+            "distro-id": "alpine",
+            "mondoo.com/device-type": "container"
+          }
+        },
+        "connections": [
+          {
+            "host": "10f2fbd87dcb2c56862793802b7f0855f22df4f92dd7cbd95033288842fc4c31",
+            "id": 3,
+            "type": "docker-container",
+            "capabilities": [
+              "run-command",
+              "file"
+            ]
+          }
+        ],
+        "kind_string": "container"
+      },
+      {
+        "name": "mondooattacksurface-meilisearch-1",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/docker/containers/1d3ed9f99e49bc3c3dcd10b86d79d55872e98b3a797346cf12fbd84d64085874"
+        ],
+        "platform": {
+          "name": "alpine",
+          "arch": "arm64",
+          "title": "Alpine Linux v3.16",
+          "family": [
+            "linux",
+            "unix",
+            "os"
+          ],
+          "version": "3.16.9",
+          "kind": "container",
+          "technology_url_segments": [
+            "os",
+            "linux",
+            "alpine",
+            "3.16.9"
+          ],
+          "runtime": "docker-container",
+          "labels": {
+            "distro-id": "alpine"
+          },
+          "metadata": {
+            "distro-id": "alpine",
+            "mondoo.com/device-type": "container"
+          }
+        },
+        "connections": [
+          {
+            "host": "1d3ed9f99e49bc3c3dcd10b86d79d55872e98b3a797346cf12fbd84d64085874",
+            "id": 4,
+            "type": "docker-container",
+            "capabilities": [
+              "run-command",
+              "file"
+            ]
+          }
+        ],
+        "kind_string": "container"
+      },
+      {
+        "name": "mondooattacksurface-valkey-1",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/docker/containers/d03c03140394d00f875e7fda6db364ac014716506d8208c86192a52651f09e5d"
+        ],
+        "platform": {
+          "name": "alpine",
+          "arch": "arm64",
+          "title": "Alpine Linux v3.24",
+          "family": [
+            "linux",
+            "unix",
+            "os"
+          ],
+          "version": "3.24.1",
+          "kind": "container",
+          "technology_url_segments": [
+            "os",
+            "linux",
+            "alpine",
+            "3.24.1"
+          ],
+          "runtime": "docker-container",
+          "labels": {
+            "distro-id": "alpine"
+          },
+          "metadata": {
+            "distro-id": "alpine",
+            "mondoo.com/device-type": "container"
+          }
+        },
+        "connections": [
+          {
+            "host": "d03c03140394d00f875e7fda6db364ac014716506d8208c86192a52651f09e5d",
+            "id": 5,
+            "type": "docker-container",
+            "capabilities": [
+              "run-command",
+              "file"
+            ]
+          }
+        ],
+        "kind_string": "container"
+      }
+    ]
+  }
+}

--- a/cli/launcher/source/testdata/discover_vercel_teams.json
+++ b/cli/launcher/source/testdata/discover_vercel_teams.json
@@ -1,0 +1,67 @@
+{
+  "spec": {
+    "assets": [
+      {
+        "name": "Acme Engineering",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/vercel/team/team_7fLp2QmXyZ"
+        ],
+        "platform": {
+          "name": "vercel-team",
+          "title": "Vercel Team",
+          "family": ["vercel"],
+          "kind": "api",
+          "runtime": "vercel"
+        },
+        "connections": [
+          {
+            "id": 1,
+            "type": "vercel",
+            "discover": {
+              "targets": ["teams"]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Acme Labs",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/vercel/team/team_3xKd9RvBnM"
+        ],
+        "platform": {
+          "name": "vercel-team",
+          "title": "Vercel Team",
+          "family": ["vercel"],
+          "kind": "api",
+          "runtime": "vercel"
+        },
+        "connections": [
+          {
+            "id": 2,
+            "type": "vercel"
+          }
+        ]
+      },
+      {
+        "name": "acme-marketing-site",
+        "platform_ids": [
+          "//platformid.api.mondoo.app/runtime/vercel/project/prj_QwErTy123456"
+        ],
+        "platform": {
+          "name": "vercel-project",
+          "title": "Vercel Project",
+          "family": ["vercel"],
+          "kind": "api",
+          "runtime": "vercel"
+        },
+        "connections": [
+          {
+            "id": 3,
+            "type": "vercel",
+            "parent_connection_id": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli/launcher/source/testdata/docker/config.json
+++ b/cli/launcher/source/testdata/docker/config.json
@@ -1,0 +1,5 @@
+{
+  "auths": {},
+  "currentContext": "colima",
+  "credsStore": "osxkeychain"
+}

--- a/cli/launcher/source/testdata/docker/contexts/meta/25bb03dbd1e8a543c45410f200c67df5154df65b89dd690f147976886b0b245c/meta.json
+++ b/cli/launcher/source/testdata/docker/contexts/meta/25bb03dbd1e8a543c45410f200c67df5154df65b89dd690f147976886b0b245c/meta.json
@@ -1,0 +1,1 @@
+{"Name":"remote-prod","Metadata":{"Description":"production build host"},"Endpoints":{"docker":{"Host":"ssh://build@prod.example.com","SkipTLSVerify":false}}}

--- a/cli/launcher/source/testdata/docker/contexts/meta/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16/meta.json
+++ b/cli/launcher/source/testdata/docker/contexts/meta/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16/meta.json
@@ -1,0 +1,1 @@
+{"Name":"colima","Metadata":{"Description":"colima"},"Endpoints":{"docker":{"Host":"unix:///Users/chris/.colima/default/docker.sock","SkipTLSVerify":false}}}

--- a/cli/launcher/source/testdata/gcloud/active_config
+++ b/cli/launcher/source/testdata/gcloud/active_config
@@ -1,0 +1,1 @@
+default

--- a/cli/launcher/source/testdata/gcloud/configurations/config_default
+++ b/cli/launcher/source/testdata/gcloud/configurations/config_default
@@ -1,0 +1,8 @@
+[core]
+account = chris@mondoo.com
+project = attack-surface-scanner
+disable_usage_reporting = False
+
+[compute]
+zone = us-central1-c
+region = us-central1

--- a/cli/launcher/source/testdata/gcloud/configurations/config_staging
+++ b/cli/launcher/source/testdata/gcloud/configurations/config_staging
@@ -1,0 +1,4 @@
+[core]
+project = mondoo-staging
+[compute]
+zone = europe-west1-b

--- a/cli/launcher/source/testdata/kubeconfig
+++ b/cli/launcher/source/testdata/kubeconfig
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Config
+current-context: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+contexts:
+  - name: aks-trial
+    context: {cluster: aks, user: aks}
+  - name: arn:aws:eks:us-east-2:921877552404:cluster/patrick-container-escape-demo-azql-cluster
+    context: {cluster: eks, user: eks}
+  - name: chris-dev
+    context: {cluster: dev, user: dev}

--- a/cli/launcher/source/testdata/kubeconfig2
+++ b/cli/launcher/source/testdata/kubeconfig2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Config
+current-context: staging
+contexts:
+  - name: staging
+    context: {cluster: s, user: s}
+  - name: chris-dev
+    context: {cluster: d, user: d}

--- a/cli/launcher/source/testdata/oci_config
+++ b/cli/launcher/source/testdata/oci_config
@@ -1,0 +1,24 @@
+# The OCI CLI writes this file. Its conventional first section is the literal
+# DEFAULT, in capitals -- not the lowercase "default" the AWS shared config uses.
+[DEFAULT]
+user=ocid1.user.oc1..aaaaaaaaexampleuniqueid
+fingerprint=20:3b:97:13:55:1c:5b:0d:d3:37:d8:50:4e:c5:3a:34
+key_file=~/.oci/oci_api_key.pem
+tenancy=ocid1.tenancy.oc1..aaaaaaaaexampleuniqueid
+region=us-ashburn-1
+pass_phrase=not-a-real-passphrase-but-it-must-not-be-read
+
+[SANDBOX]
+user=ocid1.user.oc1..aaaaaaaasandboxuniqueid
+fingerprint=aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99
+key_file=~/.oci/sandbox.pem
+tenancy=ocid1.tenancy.oc1..aaaaaaaasandboxuniqueid
+region=eu-frankfurt-1
+
+; a trailing comment after the header, which some editors leave behind
+[eu-audit]  ; read-only auditor
+user=ocid1.user.oc1..aaaaaaaaauditoruniqueid
+fingerprint=99:88:77:66:55:44:33:22:11:00:ff:ee:dd:cc:bb:aa
+key_file=~/.oci/audit.pem
+tenancy=ocid1.tenancy.oc1..aaaaaaaaexampleuniqueid
+region=eu-frankfurt-1

--- a/cli/launcher/source/testdata/snowflake/connections.toml
+++ b/cli/launcher/source/testdata/snowflake/connections.toml
@@ -1,0 +1,23 @@
+# ~/.snowflake/connections.toml, one TOML table per connection. The table named
+# "default" is the one Snowflake's own tooling falls back to.
+#
+# Note what else is in here: passwords and private key paths. That is why the
+# reader takes section headers and the single `account` key and nothing else.
+[default]
+account = "myorg-prod_account"
+user = "chris"
+password = "not-a-real-password-and-must-not-be-read"
+role = "SECURITYADMIN"
+warehouse = "COMPUTE_WH"
+
+[audit]
+account = "myorg-audit_account"
+user = "auditor"
+authenticator = "SNOWFLAKE_JWT"
+private_key_file = "/Users/chris/.snowflake/audit_key.p8"
+private_key_file_pwd = "also-not-real"
+
+[legacy]
+account = "myorg-prod_account"
+user = "legacy_svc"
+password = "still-not-real"

--- a/cli/launcher/source/testdata/ssh_config
+++ b/cli/launcher/source/testdata/ssh_config
@@ -1,0 +1,12 @@
+Host *
+  ServerAliveInterval 60
+
+Host jump prod-web
+  HostName 10.0.0.4
+  User chris
+
+Host bastion.example.com
+  User admin
+
+Host web-*
+  User deploy

--- a/cli/progress/stream.go
+++ b/cli/progress/stream.go
@@ -1,0 +1,383 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package progress
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// StreamEnvVar names the destination for the machine-readable scan progress
+// stream. It is read by the scanner when it builds its progress reporter.
+//
+// A parent process that runs `cnspec scan` as a child sets it to either:
+//
+//	/path/to/file    an absolute or relative path. A named pipe (FIFO) works
+//	                 and is usually what a live consumer wants; a regular file
+//	                 is truncated on open.
+//	fd:3             a file descriptor the parent passed down, e.g. via
+//	                 exec.Cmd.ExtraFiles (the first extra file is fd 3).
+//
+// It is deliberately an environment variable rather than a flag: the whole
+// point is that a supervising process can turn the stream on for a child it
+// spawns without having to reach into how that child's command line is built,
+// and env is what a child already inherits. It also keeps the stream orthogonal
+// to `-o`/`--output-target`, which describe the *report*, not progress.
+const StreamEnvVar = "MONDOO_PROGRESS_STREAM"
+
+// StreamVersion is the schema version reported by the scan_start event.
+// Bump it when the meaning of an existing field changes; adding a new field
+// or a new event type is backwards compatible and does not need a bump.
+const StreamVersion = 1
+
+// Event names emitted on the stream.
+const (
+	EventScanStart     = "scan_start"
+	EventDiscovered    = "discovered"
+	EventFiltered      = "filtered"
+	EventAssetAdded    = "asset_added"
+	EventAssetProgress = "asset_progress"
+	EventAssetScore    = "asset_score"
+	EventAssetDone     = "asset_done"
+	EventScanDone      = "scan_done"
+)
+
+// Terminal states reported by an asset_done event.
+const (
+	StateCompleted     = "completed"
+	StateErrored       = "errored"
+	StateNotApplicable = "not_applicable"
+)
+
+// StreamEvent is one line of the NDJSON progress stream.
+//
+// Every line is a complete JSON object followed by a single newline, so a
+// consumer can read it with a line scanner as the scan runs. Fields are
+// omitted when empty; a consumer must read an absent field as the zero value
+// (0 for numbers, "" for strings) rather than as "unknown".
+//
+//	scan_start      version
+//	discovered      count, discovered   (count = this batch, discovered = running total)
+//	filtered        count, filtered
+//	asset_added     index, name, platform, num
+//	asset_progress  index, num, percent (0..1, emitted when the whole percent changes)
+//	asset_score     index, num, score
+//	asset_done      index, num, state, score, done, total, duration_ms
+//	scan_done       total, done, completed, errored, not_applicable,
+//	                discovered, filtered, duration_ms
+//
+// `index` is the asset's primary platform ID — the same key the scanner uses
+// internally — and `num` is its 1-based position in the order assets were
+// announced. `total` is the number of assets known at the time of the event;
+// assets are discovered while the scan runs, so it can grow.
+type StreamEvent struct {
+	Seq   uint64 `json:"seq"`
+	Time  string `json:"time"`
+	Event string `json:"event"`
+
+	Version int `json:"version,omitempty"`
+
+	Index    string  `json:"index,omitempty"`
+	Name     string  `json:"name,omitempty"`
+	Platform string  `json:"platform,omitempty"`
+	Num      int     `json:"num,omitempty"`
+	Percent  float64 `json:"percent,omitempty"`
+	Score    string  `json:"score,omitempty"`
+	State    string  `json:"state,omitempty"`
+
+	Count         int `json:"count,omitempty"`
+	Total         int `json:"total,omitempty"`
+	Done          int `json:"done,omitempty"`
+	Completed     int `json:"completed,omitempty"`
+	Errored       int `json:"errored,omitempty"`
+	NotApplicable int `json:"not_applicable,omitempty"`
+	Discovered    int `json:"discovered,omitempty"`
+	Filtered      int `json:"filtered,omitempty"`
+
+	DurationMs int64 `json:"duration_ms,omitempty"`
+}
+
+type streamTask struct {
+	num         int
+	startedAt   time.Time
+	lastPercent int // whole percent last emitted, -1 before the first progress event
+	done        bool
+}
+
+// streamProgress is a MultiProgress that writes NDJSON events instead of
+// drawing a terminal UI. It is safe for concurrent use: the scanner runs a
+// pipeline with configurable parallelism, so every method can be called from
+// a different goroutine at the same time.
+type streamProgress struct {
+	mu     sync.Mutex
+	out    io.Writer
+	closer io.Closer
+	now    func() time.Time
+
+	seq       uint64
+	startedAt time.Time
+	order     []string
+	tasks     map[string]*streamTask
+
+	discovered    int
+	filtered      int
+	completed     int
+	errored       int
+	notApplicable int
+
+	closed   bool
+	writeErr error
+}
+
+// NewStream opens the progress stream target described by `target` (see
+// StreamEnvVar for the accepted forms) and returns a MultiProgress that emits
+// NDJSON to it.
+func NewStream(target string) (*streamProgress, error) {
+	w, err := openStreamTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	s := NewStreamWriter(w)
+	s.closer = w
+	return s, nil
+}
+
+// NewStreamWriter returns an NDJSON progress reporter writing to w. The writer
+// is not closed by Close; use NewStream when the stream owns its destination.
+func NewStreamWriter(w io.Writer) *streamProgress {
+	s := &streamProgress{
+		out:   w,
+		now:   time.Now,
+		tasks: map[string]*streamTask{},
+	}
+	s.startedAt = s.now()
+	// The scan_start event is written here rather than in Open because the
+	// scanner calls Open from its own goroutine, which would race with the
+	// first AddTask and could put scan_start in the middle of the stream.
+	s.emit(StreamEvent{Event: EventScanStart, Version: StreamVersion})
+	return s
+}
+
+func openStreamTarget(target string) (*os.File, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, errors.New("empty progress stream target")
+	}
+
+	if rest, ok := strings.CutPrefix(target, "fd:"); ok {
+		fd, err := strconv.Atoi(rest)
+		if err != nil || fd < 0 {
+			return nil, errors.Newf("invalid progress stream file descriptor %q", target)
+		}
+		return os.NewFile(uintptr(fd), target), nil
+	}
+
+	// Not buffered on purpose: a consumer reads this while the scan runs, so
+	// every event has to reach the destination as it happens.
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open progress stream %q", target)
+	}
+	return f, nil
+}
+
+// emit serializes and writes one event. The whole line is handed to a single
+// Write call while the lock is held, so events never interleave and a line is
+// never written in halves.
+func (s *streamProgress) emit(e StreamEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.emitLocked(e)
+}
+
+func (s *streamProgress) emitLocked(e StreamEvent) {
+	if s.closed || s.out == nil || s.writeErr != nil {
+		return
+	}
+
+	s.seq++
+	e.Seq = s.seq
+	e.Time = s.now().UTC().Format(time.RFC3339Nano)
+
+	line, err := json.Marshal(&e)
+	if err != nil {
+		s.fail(errors.Wrap(err, "failed to encode progress event"))
+		return
+	}
+	line = append(line, '\n')
+
+	if _, err := s.out.Write(line); err != nil {
+		s.fail(errors.Wrap(err, "failed to write progress event"))
+	}
+}
+
+// fail records the first write failure and stops emitting. A broken progress
+// stream — the consumer went away, the disk filled up — must never take the
+// scan down with it.
+func (s *streamProgress) fail(err error) {
+	s.writeErr = err
+	log.Warn().Err(err).Msg("progress stream disabled")
+}
+
+// taskLocked returns the tracked task for index, announcing it first if the
+// scanner reports on an asset it never added. Every index that appears on the
+// stream has an asset_added event before it.
+func (s *streamProgress) taskLocked(index string, asset *inventory.Asset) *streamTask {
+	if t, ok := s.tasks[index]; ok {
+		return t
+	}
+
+	s.order = append(s.order, index)
+	t := &streamTask{num: len(s.order), lastPercent: -1}
+	s.tasks[index] = t
+
+	added := StreamEvent{Event: EventAssetAdded, Index: index, Num: t.num}
+	if asset != nil {
+		added.Name = asset.Name
+		if asset.Platform != nil {
+			added.Platform = asset.Platform.Name
+		}
+	}
+	s.emitLocked(added)
+	return t
+}
+
+func (s *streamProgress) Open() error {
+	// Nothing to do: the destination is opened by NewStream and scan_start is
+	// already on the wire. The scanner runs Open in a goroutine and waits for
+	// it after Close, so returning immediately is correct here.
+	return nil
+}
+
+func (s *streamProgress) Discovered(count int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discovered += count
+	s.emitLocked(StreamEvent{Event: EventDiscovered, Count: count, Discovered: s.discovered})
+}
+
+func (s *streamProgress) Filtered(count int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.filtered += count
+	s.emitLocked(StreamEvent{Event: EventFiltered, Count: count, Filtered: s.filtered})
+}
+
+func (s *streamProgress) AddTask(index string, asset *inventory.Asset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.taskLocked(index, asset)
+}
+
+func (s *streamProgress) OnProgress(index string, percent float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	percent = min(max(percent, 0), 1)
+	t := s.taskLocked(index, nil)
+	if t.startedAt.IsZero() {
+		t.startedAt = s.now()
+	}
+
+	// The executor reports progress per query, which on a large policy is
+	// thousands of calls per asset. One event per whole percent keeps the
+	// stream readable without losing anything a display could show.
+	whole := int(percent * 100)
+	if whole == t.lastPercent {
+		return
+	}
+	t.lastPercent = whole
+
+	// Rounded: the executor's raw ratio carries 17 digits of precision that no
+	// display can use and that only makes the line harder to read.
+	rounded := math.Round(percent*10000) / 10000
+	s.emitLocked(StreamEvent{Event: EventAssetProgress, Index: index, Num: t.num, Percent: rounded})
+}
+
+func (s *streamProgress) Score(index string, score string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t := s.taskLocked(index, nil)
+	s.emitLocked(StreamEvent{Event: EventAssetScore, Index: index, Num: t.num, Score: score})
+}
+
+func (s *streamProgress) Errored(index string) { s.finish(index, StateErrored) }
+
+func (s *streamProgress) NotApplicable(index string) { s.finish(index, StateNotApplicable) }
+
+func (s *streamProgress) Completed(index string) { s.finish(index, StateCompleted) }
+
+func (s *streamProgress) finish(index string, state string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t := s.taskLocked(index, nil)
+	if t.done {
+		return
+	}
+	t.done = true
+
+	switch state {
+	case StateErrored:
+		s.errored++
+	case StateNotApplicable:
+		s.notApplicable++
+	default:
+		s.completed++
+	}
+
+	e := StreamEvent{
+		Event: EventAssetDone,
+		Index: index,
+		Num:   t.num,
+		State: state,
+		Done:  s.completed + s.errored + s.notApplicable,
+		Total: len(s.order),
+	}
+	if !t.startedAt.IsZero() {
+		e.DurationMs = s.now().Sub(t.startedAt).Milliseconds()
+	}
+	s.emitLocked(e)
+}
+
+// Close writes the summary event and releases the destination. The scanner
+// calls it both explicitly and from a defer, so it has to be idempotent.
+func (s *streamProgress) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+
+	s.emitLocked(StreamEvent{
+		Event:         EventScanDone,
+		Total:         len(s.order),
+		Done:          s.completed + s.errored + s.notApplicable,
+		Completed:     s.completed,
+		Errored:       s.errored,
+		NotApplicable: s.notApplicable,
+		Discovered:    s.discovered,
+		Filtered:      s.filtered,
+		DurationMs:    s.now().Sub(s.startedAt).Milliseconds(),
+	})
+
+	s.closed = true
+	if s.closer != nil {
+		if err := s.closer.Close(); err != nil {
+			log.Warn().Err(err).Msg("failed to close progress stream")
+		}
+	}
+}

--- a/cli/progress/stream_test.go
+++ b/cli/progress/stream_test.go
@@ -1,0 +1,357 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package progress
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keepFilesAlive holds files whose descriptor was handed off to a stream, so
+// that the descriptor is closed exactly once — by the stream.
+var keepFilesAlive []*os.File
+
+// lineWriter records every individual Write call so a test can prove the
+// stream never emits a partial line.
+type lineWriter struct {
+	mu     sync.Mutex
+	writes []string
+}
+
+func (l *lineWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.writes = append(l.writes, string(p))
+	return len(p), nil
+}
+
+func (l *lineWriter) all() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string{}, l.writes...)
+}
+
+func parseEvents(t *testing.T, raw string) []StreamEvent {
+	t.Helper()
+
+	var events []StreamEvent
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var e StreamEvent
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &e), "unparseable line: %q", line)
+		events = append(events, e)
+	}
+	require.NoError(t, scanner.Err())
+	return events
+}
+
+func eventNames(events []StreamEvent) []string {
+	names := make([]string, len(events))
+	for i, e := range events {
+		names[i] = e.Event
+	}
+	return names
+}
+
+func TestStreamSingleAsset(t *testing.T) {
+	w := &lineWriter{}
+	s := NewStreamWriter(w)
+
+	s.Discovered(3)
+	s.Filtered(1)
+	s.AddTask("id-1", testAsset("test1", "linux"))
+	s.OnProgress("id-1", 0.0)
+	s.OnProgress("id-1", 0.5)
+	s.OnProgress("id-1", 0.503) // same whole percent, must not emit again
+	s.OnProgress("id-1", 1.0)
+	s.Score("id-1", "A")
+	s.Completed("id-1")
+	s.Close()
+
+	events := parseEvents(t, strings.Join(w.all(), ""))
+	assert.Equal(t, []string{
+		EventScanStart,
+		EventDiscovered,
+		EventFiltered,
+		EventAssetAdded,
+		EventAssetProgress, // 0%
+		EventAssetProgress, // 50%
+		EventAssetProgress, // 100%
+		EventAssetScore,
+		EventAssetDone,
+		EventScanDone,
+	}, eventNames(events))
+
+	// seq is monotonic and gapless, and every event is timestamped.
+	for i, e := range events {
+		assert.Equal(t, uint64(i+1), e.Seq)
+		assert.NotEmpty(t, e.Time)
+	}
+
+	assert.Equal(t, StreamVersion, events[0].Version)
+	assert.Equal(t, 3, events[1].Count)
+	assert.Equal(t, 3, events[1].Discovered)
+	assert.Equal(t, 1, events[2].Filtered)
+
+	added := events[3]
+	assert.Equal(t, "id-1", added.Index)
+	assert.Equal(t, "test1", added.Name)
+	assert.Equal(t, "linux", added.Platform)
+	assert.Equal(t, 1, added.Num)
+
+	assert.Equal(t, 0.5, events[5].Percent)
+	assert.Equal(t, 1.0, events[6].Percent)
+	assert.Equal(t, "A", events[7].Score)
+
+	done := events[8]
+	assert.Equal(t, StateCompleted, done.State)
+	assert.Equal(t, 1, done.Num)
+	assert.Equal(t, 1, done.Done)
+	assert.Equal(t, 1, done.Total)
+
+	summary := events[9]
+	assert.Equal(t, EventScanDone, summary.Event)
+	assert.Equal(t, 1, summary.Total)
+	assert.Equal(t, 1, summary.Completed)
+	assert.Equal(t, 0, summary.Errored)
+	assert.Equal(t, 3, summary.Discovered)
+	assert.Equal(t, 1, summary.Filtered)
+}
+
+func TestStreamTerminalStates(t *testing.T) {
+	w := &lineWriter{}
+	s := NewStreamWriter(w)
+
+	s.AddTask("ok", testAsset("ok", "linux"))
+	s.AddTask("bad", testAsset("bad", "linux"))
+	s.AddTask("na", testAsset("na", ""))
+
+	s.Completed("ok")
+	s.Errored("bad")
+	s.NotApplicable("na")
+	s.Completed("ok") // duplicate, must not double count
+	s.Close()
+
+	events := parseEvents(t, strings.Join(w.all(), ""))
+
+	var states []string
+	var summary StreamEvent
+	for _, e := range events {
+		switch e.Event {
+		case EventAssetDone:
+			states = append(states, e.State)
+		case EventScanDone:
+			summary = e
+		}
+	}
+
+	assert.Equal(t, []string{StateCompleted, StateErrored, StateNotApplicable}, states)
+	assert.Equal(t, 3, summary.Total)
+	assert.Equal(t, 3, summary.Done)
+	assert.Equal(t, 1, summary.Completed)
+	assert.Equal(t, 1, summary.Errored)
+	assert.Equal(t, 1, summary.NotApplicable)
+}
+
+// An asset the scanner never announced still gets an asset_added event before
+// anything else references it, so the stream stays self-describing.
+func TestStreamAnnouncesUnknownAssets(t *testing.T) {
+	w := &lineWriter{}
+	s := NewStreamWriter(w)
+
+	s.OnProgress("ghost", 0.25)
+	s.Completed("ghost")
+	s.Close()
+
+	events := parseEvents(t, strings.Join(w.all(), ""))
+	assert.Equal(t, []string{
+		EventScanStart, EventAssetAdded, EventAssetProgress, EventAssetDone, EventScanDone,
+	}, eventNames(events))
+	assert.Equal(t, "ghost", events[1].Index)
+	assert.Equal(t, 1, events[1].Num)
+}
+
+func TestStreamCloseIsIdempotent(t *testing.T) {
+	w := &lineWriter{}
+	s := NewStreamWriter(w)
+
+	s.AddTask("id-1", testAsset("test1", "linux"))
+	s.Close()
+	s.Close()
+
+	// Events after Close are dropped rather than trailing the summary.
+	s.AddTask("id-2", testAsset("test2", "linux"))
+	s.Completed("id-2")
+
+	events := parseEvents(t, strings.Join(w.all(), ""))
+	assert.Equal(t, []string{EventScanStart, EventAssetAdded, EventScanDone}, eventNames(events))
+}
+
+// The scanner runs its pipeline with configurable parallelism, so every method
+// can be called from a different goroutine at once. Run with -race.
+func TestStreamConcurrentWriters(t *testing.T) {
+	w := &lineWriter{}
+	s := NewStreamWriter(w)
+
+	const assets = 16
+	var wg sync.WaitGroup
+	for i := range assets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			index := fmt.Sprintf("asset-%d", i)
+			s.AddTask(index, testAsset(index, "linux"))
+			for p := range 10 {
+				s.OnProgress(index, float64(p)/10)
+			}
+			s.Score(index, "A")
+			if i%4 == 0 {
+				s.Errored(index)
+			} else {
+				s.Completed(index)
+			}
+			s.Discovered(1)
+		}()
+	}
+	wg.Wait()
+	s.Close()
+
+	// Every Write call is exactly one complete line: a consumer reading the
+	// stream can never see two events spliced together or half of one.
+	writes := w.all()
+	for _, line := range writes {
+		assert.Truef(t, strings.HasSuffix(line, "\n"), "write did not end a line: %q", line)
+		assert.Equalf(t, 1, strings.Count(line, "\n"), "write held more than one line: %q", line)
+	}
+
+	events := parseEvents(t, strings.Join(writes, ""))
+	require.Len(t, events, len(writes))
+	for i, e := range events {
+		assert.Equal(t, uint64(i+1), e.Seq)
+	}
+
+	summary := events[len(events)-1]
+	assert.Equal(t, EventScanDone, summary.Event)
+	assert.Equal(t, assets, summary.Total)
+	assert.Equal(t, assets, summary.Done)
+	assert.Equal(t, assets/4, summary.Errored)
+	assert.Equal(t, assets-assets/4, summary.Completed)
+	assert.Equal(t, assets, summary.Discovered)
+
+	// Each asset was announced exactly once, with a unique 1-based num.
+	nums := map[int]string{}
+	for _, e := range events {
+		if e.Event != EventAssetAdded {
+			continue
+		}
+		_, dup := nums[e.Num]
+		assert.Falsef(t, dup, "num %d used twice", e.Num)
+		nums[e.Num] = e.Index
+	}
+	assert.Len(t, nums, assets)
+}
+
+func TestStreamToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "progress.ndjson")
+
+	s, err := NewStream(path)
+	require.NoError(t, err)
+
+	s.AddTask("id-1", testAsset("test1", "linux"))
+	s.Completed("id-1")
+	s.Close()
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		EventScanStart, EventAssetAdded, EventAssetDone, EventScanDone,
+	}, eventNames(parseEvents(t, string(raw))))
+}
+
+// A file descriptor handed down by a parent process (exec.Cmd.ExtraFiles) is
+// the form the launcher uses: no temp file to clean up, and the reader sees
+// EOF when the child exits.
+func TestStreamToFileDescriptor(t *testing.T) {
+	r, wf, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	// Ownership of the descriptor moves to the stream, which closes it. The
+	// pipe's own *os.File must therefore outlive the test: if it were
+	// collected, its cleanup would close the same descriptor a second time,
+	// and by then the number can already belong to something else.
+	fd := wf.Fd()
+	keepFilesAlive = append(keepFilesAlive, wf)
+
+	s, err := NewStream(fmt.Sprintf("fd:%d", fd))
+	require.NoError(t, err)
+
+	lines := make(chan []StreamEvent, 1)
+	go func() {
+		var events []StreamEvent
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			var e StreamEvent
+			if err := json.Unmarshal(scanner.Bytes(), &e); err == nil {
+				events = append(events, e)
+			}
+		}
+		lines <- events
+	}()
+
+	s.AddTask("id-1", testAsset("test1", "linux"))
+	s.Completed("id-1")
+	s.Close() // closes the write end, so the reader sees EOF
+
+	assert.Equal(t, []string{
+		EventScanStart, EventAssetAdded, EventAssetDone, EventScanDone,
+	}, eventNames(<-lines))
+}
+
+func TestStreamTargetErrors(t *testing.T) {
+	_, err := NewStream("")
+	assert.Error(t, err)
+
+	_, err = NewStream("fd:not-a-number")
+	assert.Error(t, err)
+
+	_, err = NewStream(filepath.Join(t.TempDir(), "missing-dir", "progress.ndjson"))
+	assert.Error(t, err)
+}
+
+// A destination that goes away mid-scan must not take the scan down with it.
+func TestStreamSurvivesABrokenDestination(t *testing.T) {
+	w := &failingWriter{}
+	s := NewStreamWriter(w)
+
+	assert.NotPanics(t, func() {
+		s.AddTask("id-1", testAsset("test1", "linux"))
+		s.OnProgress("id-1", 0.5)
+		s.Completed("id-1")
+		s.Close()
+	})
+	assert.Equal(t, 1, w.calls, "writing stopped after the first failure")
+	assert.Error(t, s.writeErr)
+}
+
+type failingWriter struct{ calls int }
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.calls++
+	return 0, errors.New("destination is gone")
+}

--- a/cli/progress/todolist.go
+++ b/cli/progress/todolist.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/components"
 	"go.mondoo.com/mql/logger"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
@@ -237,18 +238,6 @@ var (
 	styleSuccess    = lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
 	styleError      = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4672"))
 	styleInProgress = lipgloss.NewStyle().Foreground(lipgloss.Color("#7571F9"))
-
-	// scoreColors maps score rating text to lipgloss colors, matching
-	// the ScoreRatingLipglossColorMapping in cli/components/rating.go.
-	scoreColors = map[string]lipgloss.Color{
-		"UNRATED":  lipgloss.Color("231"),
-		"NONE":     lipgloss.Color("78"),
-		"LOW":      lipgloss.Color("117"),
-		"MEDIUM":   lipgloss.Color("75"),
-		"HIGH":     lipgloss.Color("212"),
-		"CRITICAL": lipgloss.Color("204"),
-		"ERROR":    lipgloss.Color("210"),
-	}
 )
 
 func (m *modelTodoList) View() string {
@@ -395,7 +384,15 @@ func (m *modelTodoList) renderTask(t *task) string {
 
 	if m.includeScore && t.score != "" {
 		scoreStr := t.score
-		if c, ok := scoreColors[t.score]; ok {
+		// Straight out of the rating palette rather than out of a copy of it.
+		// The copy that used to live in this file carried a comment saying it
+		// matched cli/components/rating.go, which is an import's job: two of
+		// the launcher's three hand-picked colours had already drifted by the
+		// time anyone checked. The lookup stays a map read rather than
+		// LipglossColor because the miss matters here -- a score this palette
+		// has never heard of falls through to the error style below rather than
+		// being painted as unrated.
+		if c, ok := components.DefaultScoreRatingColors.ScoreRatingLipglossColorMapping[t.score]; ok {
 			scoreStr = lipgloss.NewStyle().Foreground(c).Render(t.score)
 		} else if t.state == taskStateErrored {
 			scoreStr = styleError.Render(t.score)

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -161,6 +161,8 @@ func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollectio
 		}
 		_, err = r.out.Write(data)
 		return err
+	case FormatJSONFull:
+		return WriteCollection(data, r.out)
 	case FormatJUnit:
 		writer := iox.IOWriter{Writer: r.out}
 		return ConvertToJunit(data, &writer, r.Conf.detailed)
@@ -212,6 +214,10 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, target string) error {
 		return ocsfconvert.ConvertVulnReport(target, data, r.Conf.ocsfVersion, r.out)
 	case FormatOcsfParquet:
 		return errors.New("'ocsf-parquet' is not supported for vuln reports, please use 'ocsf-json'")
+	case FormatJSONFull:
+		// json-full is a serialized policy.ReportCollection; a standalone vuln
+		// report is not one, so there is nothing faithful to write here.
+		return errors.New("'json-full' is not supported for vuln reports, please use one of the other formats")
 	case FormatCSV:
 		writer := iox.IOWriter{Writer: r.out}
 		return VulnReportToCSV(data, &writer)

--- a/cli/reporter/collection.go
+++ b/cli/reporter/collection.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Every other output format in this package is a reduction: json-v1 and
+// json-v2 keep scores and status, sarif and junit keep findings, the compact
+// printers keep whatever fits on a terminal. None of them carry the bundle,
+// the resolved policies, the query documentation or the raw llx results, so
+// none of them can be read back into the structure a scan produced.
+//
+// json-full is that missing artifact. It is the whole *policy.ReportCollection
+// and nothing else, so a consumer -- a report viewer, a diff, a re-render in
+// another format -- gets exactly what the scanner had.
+//
+// Encoding is encoding/json rather than protojson, deliberately:
+//
+//   - It is the shape the rest of the repo already produces and consumes.
+//     internal/scandump writes collections with json.MarshalIndent, and the
+//     fixtures under testdata/ are read straight into policy.ReportCollection
+//     with json.Unmarshal. Choosing protojson would fork the artifact away
+//     from every collection dump that already exists.
+//   - It round-trips losslessly for this message tree. The only oneof in
+//     cnspec_policy.proto is on Metric, which ReportCollection does not
+//     reference, and neither ReportCollection nor anything it reaches uses a
+//     well-known type whose Go representation differs from its JSON one.
+//     []byte fields (llx.Primitive.Value) go out as base64 and come back
+//     byte-identical. TestCollectionRoundTrip proves this against both
+//     fixtures with proto.Equal.
+//   - protojson would additionally rename every field to lowerCamel, which
+//     would make the artifact unreadable by the existing loaders above for no
+//     gain in fidelity.
+//
+// Do not route this through (*ReportCollection).ToJSON(): it nils out
+// Reports[k].Data on its own receiver, which is precisely the fidelity this
+// format exists to keep.
+
+// WriteCollection serializes the complete report collection to out.
+func WriteCollection(data *policy.ReportCollection, out io.Writer) error {
+	if data == nil {
+		data = &policy.ReportCollection{}
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	// keep MQL snippets, URLs and markdown remediation readable instead of
+	// escaping <, > and & into \u00xx sequences
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(data); err != nil {
+		return errors.Wrap(err, "failed to write report collection")
+	}
+	return nil
+}
+
+// LoadCollection reads a json-full artifact back into a report collection.
+//
+// It also reads any other plain JSON serialization of a policy.ReportCollection,
+// which includes the collections written by internal/scandump.
+func LoadCollection(in io.Reader) (*policy.ReportCollection, error) {
+	raw, err := io.ReadAll(in)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read report collection")
+	}
+	return UnmarshalCollection(raw)
+}
+
+// LoadCollectionFile reads a json-full artifact from a file path.
+func LoadCollectionFile(path string) (*policy.ReportCollection, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read report collection from %s", path)
+	}
+
+	res, err := UnmarshalCollection(raw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load report collection from %s", path)
+	}
+	return res, nil
+}
+
+// UnmarshalCollection decodes a json-full artifact.
+func UnmarshalCollection(raw []byte) (*policy.ReportCollection, error) {
+	if err := rejectReducedReport(raw); err != nil {
+		return nil, err
+	}
+
+	res := &policy.ReportCollection{}
+	if err := json.Unmarshal(raw, res); err != nil {
+		return nil, errors.Wrap(err, "failed to parse report collection")
+	}
+	return res, nil
+}
+
+// rejectReducedReport fails fast on the reduced json-v1 / json-v2 artifacts.
+//
+// Both of those are JSON objects whose keys partially overlap with
+// ReportCollection's ("assets", "errors"), so decoding one would succeed and
+// silently yield a collection with no reports rather than an error. A viewer
+// cannot tell that apart from a scan where every asset failed, so the loader
+// has to say so here.
+func rejectReducedReport(raw []byte) error {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return errors.Wrap(err, "failed to parse report collection")
+	}
+
+	// neither key exists on ReportCollection; both exist on the reduced reports
+	for _, key := range []string{"scores", "data"} {
+		if _, ok := doc[key]; ok {
+			return errors.New("this is a reduced report (json-v1/json-v2), not a full report collection; re-run the scan with --output json-full")
+		}
+	}
+	return nil
+}

--- a/cli/reporter/collection_test.go
+++ b/cli/reporter/collection_test.go
@@ -1,0 +1,314 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+	"google.golang.org/protobuf/proto"
+)
+
+// 15 assets, 0 reports, 15 errors -- every asset failed to scan. A viewer must
+// be able to tell this apart from "assets with no findings", so the artifact has
+// to carry the errors map through untouched.
+const fixtureK8s = "./testdata/report-k8s.json"
+
+func loadFixture(t *testing.T, path string) *policy.ReportCollection {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	res := &policy.ReportCollection{}
+	require.NoError(t, json.Unmarshal(raw, res))
+	return res
+}
+
+// loadUbuntu is the recorded scan of one Ubuntu host: 1 asset, 1 report, 0
+// errors -- the single-asset happy path, carrying a bundle, resolved policies,
+// raw llx data and a vuln report. It is shared with the other reporters through
+// internal/reportfixture rather than read from a path here.
+func loadUbuntu(t *testing.T) *policy.ReportCollection {
+	t.Helper()
+	res, err := reportfixture.UbuntuScan()
+	require.NoError(t, err)
+	return res
+}
+
+func loadK8s(t *testing.T) *policy.ReportCollection {
+	t.Helper()
+	return loadFixture(t, fixtureK8s)
+}
+
+// TestCollectionRoundTrip is the proof that json-full is lossless: load the
+// fixture, write it, load it back, and require the two collections to be equal
+// as protobuf messages -- not merely similar-looking JSON.
+func TestCollectionRoundTrip(t *testing.T) {
+	fixtures := map[string]func(*testing.T) *policy.ReportCollection{
+		"report-ubuntu": loadUbuntu,
+		"report-k8s":    loadK8s,
+	}
+	for name, load := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			orig := load(t)
+
+			var first bytes.Buffer
+			require.NoError(t, WriteCollection(orig, &first))
+
+			back, err := LoadCollection(bytes.NewReader(first.Bytes()))
+			require.NoError(t, err)
+
+			require.True(t, proto.Equal(orig, back),
+				"collection changed across a write/load round-trip")
+
+			// writing the reloaded collection must reproduce the same bytes,
+			// so the artifact is stable across repeated re-serialization
+			var second bytes.Buffer
+			require.NoError(t, WriteCollection(back, &second))
+			require.Equal(t, first.String(), second.String())
+
+			// and the shape survives a second full round-trip
+			again, err := LoadCollection(bytes.NewReader(second.Bytes()))
+			require.NoError(t, err)
+			require.True(t, proto.Equal(orig, again))
+		})
+	}
+}
+
+// TestCollectionKeepsErroredAssets pins the property the k8s fixture exists
+// for. All fifteen assets failed to scan; none of them produced a report.
+func TestCollectionKeepsErroredAssets(t *testing.T) {
+	orig := loadK8s(t)
+	require.Len(t, orig.Assets, 15)
+	require.Len(t, orig.Errors, 15)
+	require.Empty(t, orig.Reports)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteCollection(orig, &buf))
+
+	back, err := LoadCollection(&buf)
+	require.NoError(t, err)
+
+	assert.Len(t, back.Assets, 15)
+	assert.Len(t, back.Errors, 15)
+	assert.Empty(t, back.Reports)
+
+	// the error strings themselves are what a viewer renders, so compare them
+	// verbatim rather than counting them
+	for mrn, msg := range orig.Errors {
+		require.Contains(t, back.Errors, mrn)
+		assert.Equal(t, msg, back.Errors[mrn])
+		assert.NotEmpty(t, msg)
+	}
+
+	// every errored asset is still identifiable
+	for mrn := range orig.Assets {
+		require.Contains(t, back.Assets, mrn)
+		assert.Equal(t, orig.Assets[mrn].Name, back.Assets[mrn].Name)
+	}
+}
+
+// TestCollectionKeepsFullFidelity checks the specific things the reduced
+// formats drop, since proto.Equal on an accidentally-empty pair would pass.
+func TestCollectionKeepsFullFidelity(t *testing.T) {
+	orig := loadUbuntu(t)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteCollection(orig, &buf))
+	back, err := LoadCollection(&buf)
+	require.NoError(t, err)
+
+	require.NotNil(t, back.Bundle, "bundle is dropped by every other format")
+	assert.NotEmpty(t, back.Bundle.Policies)
+	assert.NotEmpty(t, back.Bundle.Queries)
+	assert.NotEmpty(t, back.ResolvedPolicies)
+	assert.NotEmpty(t, back.VulnReports)
+	require.Len(t, back.Reports, 1)
+
+	// query documentation: titles, docs, remediation, impact
+	var withDocs, withRemediation, withImpact int
+	for _, q := range back.Bundle.Queries {
+		if q.Title != "" {
+			withDocs++
+		}
+		if q.Docs != nil && q.Docs.Remediation != nil {
+			withRemediation++
+		}
+		if q.Impact != nil {
+			withImpact++
+		}
+	}
+	assert.NotZero(t, withDocs)
+	assert.NotZero(t, withRemediation)
+	assert.NotZero(t, withImpact)
+
+	for mrn, report := range back.Reports {
+		// (*ReportCollection).ToJSON() nils this out; json-full must not
+		assert.NotEmpty(t, report.Data, "report data was dropped for %s", mrn)
+		assert.NotEmpty(t, report.Scores)
+		assert.Equal(t, len(orig.Reports[mrn].Data), len(report.Data))
+		assert.Equal(t, len(orig.Reports[mrn].Scores), len(report.Scores))
+	}
+
+	// the resolved policies carry the collector job the traversal walks
+	for mrn, rp := range back.ResolvedPolicies {
+		require.NotNil(t, rp.CollectorJob, "collector job dropped for %s", mrn)
+		assert.NotEmpty(t, rp.CollectorJob.ReportingJobs)
+		assert.NotEmpty(t, rp.ExecutionJob.Queries)
+	}
+}
+
+// TestCollectionRawLlxData proves the base64-encoded llx primitives survive,
+// which is the part encoding/json handles differently from protojson.
+func TestCollectionRawLlxData(t *testing.T) {
+	orig := loadUbuntu(t)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteCollection(orig, &buf))
+	back, err := LoadCollection(&buf)
+	require.NoError(t, err)
+
+	var compared, nils int
+	for mrn, report := range orig.Reports {
+		for id, res := range report.Data {
+			require.Contains(t, back.Reports[mrn].Data, id)
+			got := back.Reports[mrn].Data[id]
+			require.True(t, proto.Equal(res, got), "llx result %s changed", id)
+
+			// the fixture contains map entries whose value is literally null;
+			// a key that exists with no result is not the same as an absent
+			// key, so the artifact has to keep both
+			if res == nil {
+				assert.Nil(t, got, "null llx result %s came back non-nil", id)
+				nils++
+				continue
+			}
+			if len(res.GetData().GetValue()) > 0 {
+				assert.Equal(t, res.GetData().GetValue(), got.GetData().GetValue())
+				compared++
+			}
+		}
+	}
+	assert.NotZero(t, compared, "fixture carried no raw llx values to compare")
+	assert.NotZero(t, nils, "fixture carried no null llx results to compare")
+}
+
+// TestCollectionDoesNotMutateReceiver guards against the ToJSON() trap: it
+// nils Reports[k].Data on its own input.
+func TestCollectionDoesNotMutateReceiver(t *testing.T) {
+	orig := loadUbuntu(t)
+	before := loadUbuntu(t)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteCollection(orig, &buf))
+
+	require.True(t, proto.Equal(before, orig), "WriteCollection mutated its input")
+}
+
+func TestWriteCollectionNil(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteCollection(nil, &buf))
+
+	back, err := LoadCollection(&buf)
+	require.NoError(t, err)
+	assert.Empty(t, back.Assets)
+	assert.Empty(t, back.Reports)
+	assert.Empty(t, back.Errors)
+}
+
+func TestLoadCollectionFile(t *testing.T) {
+	orig := loadK8s(t)
+
+	path := filepath.Join(t.TempDir(), "report.json")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, WriteCollection(orig, f))
+	require.NoError(t, f.Close())
+
+	back, err := LoadCollectionFile(path)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(orig, back))
+
+	_, err = LoadCollectionFile(filepath.Join(t.TempDir(), "missing.json"))
+	require.Error(t, err)
+}
+
+// TestLoadCollectionRejectsReducedReports is what stops a viewer from
+// rendering a json-v2 file as "15 assets, no findings".
+func TestLoadCollectionRejectsReducedReports(t *testing.T) {
+	t.Run("json-v2 file", func(t *testing.T) {
+		_, err := LoadCollectionFile(filepath.Join("testdata", "cnspec_report_pass.json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reduced report")
+	})
+
+	t.Run("json-v1 shape", func(t *testing.T) {
+		// json-v1 puts per-asset results under a top-level "data" key, which
+		// ReportCollection does not have
+		_, err := LoadCollection(strings.NewReader(`{"assets":{},"data":{}}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reduced report")
+	})
+
+	t.Run("garbage", func(t *testing.T) {
+		_, err := LoadCollection(strings.NewReader("not json"))
+		require.Error(t, err)
+	})
+}
+
+// TestReporterJSONFullFormat exercises the wiring: the alias, the WriteReport
+// switch, and PrintVulns.
+func TestReporterJSONFullFormat(t *testing.T) {
+	format, ok := Formats["json-full"]
+	require.True(t, ok, "json-full alias is not registered")
+	require.Equal(t, FormatJSONFull, format)
+	assert.Contains(t, AllFormats(), "json-full")
+
+	conf, err := ParseConfig("json-full")
+	require.NoError(t, err)
+	require.Equal(t, FormatJSONFull, conf.format)
+
+	orig := loadUbuntu(t)
+
+	var buf bytes.Buffer
+	r := NewReporter(conf, false).WithOutput(&buf)
+	require.NoError(t, r.WriteReport(context.Background(), orig))
+
+	back, err := LoadCollection(&buf)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(orig, back))
+
+	// vuln reports are not report collections; the format must say so rather
+	// than emit something a loader would choke on
+	vulnErr := NewReporter(conf, false).WithOutput(&bytes.Buffer{}).PrintVulns(nil, "target")
+	require.Error(t, vulnErr)
+	assert.Contains(t, vulnErr.Error(), "json-full")
+}
+
+// TestJSONFullToFileTarget verifies --output-target routing works for the new
+// format, since localFileHandler reuses WriteReport with a file writer.
+func TestJSONFullToFileTarget(t *testing.T) {
+	orig := loadK8s(t)
+
+	conf, err := ParseConfig("json-full")
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "out.json")
+	handler := &localFileHandler{file: path, conf: conf}
+	require.NoError(t, handler.WriteReport(context.Background(), orig))
+
+	back, err := LoadCollectionFile(path)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(orig, back))
+	assert.Len(t, back.Errors, 15)
+}

--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -194,26 +194,31 @@ const (
 	FormatHDF
 	FormatOcsfJson
 	FormatOcsfParquet
+	// FormatJSONFull writes the entire policy.ReportCollection. Unlike every
+	// other format it is not a reduction, so it can be loaded back with
+	// LoadCollection. See collection.go.
+	FormatJSONFull
 )
 
 // Formats that are supported by the reporter
 var Formats = map[string]Format{
-	"compact": FormatCompact,
-	"summary": FormatSummary,
-	"full":    FormatFull,
-	"":        FormatCompact,
-	"report":  FormatReport,
-	"yaml-v1": FormatYAMLv1,
-	"yaml-v2": FormatYAMLv2,
-	"yaml":    FormatYAMLv1,
-	"yml":     FormatYAMLv2,
-	"json-v1": FormatJSONv1,
-	"json-v2": FormatJSONv2,
-	"json":    FormatJSONv2,
-	"junit":   FormatJUnit,
-	"csv":     FormatCSV,
-	"sarif":   FormatSarif,
-	"hdf":     FormatHDF,
+	"compact":   FormatCompact,
+	"summary":   FormatSummary,
+	"full":      FormatFull,
+	"":          FormatCompact,
+	"report":    FormatReport,
+	"yaml-v1":   FormatYAMLv1,
+	"yaml-v2":   FormatYAMLv2,
+	"yaml":      FormatYAMLv1,
+	"yml":       FormatYAMLv2,
+	"json-v1":   FormatJSONv1,
+	"json-v2":   FormatJSONv2,
+	"json":      FormatJSONv2,
+	"json-full": FormatJSONFull,
+	"junit":     FormatJUnit,
+	"csv":       FormatCSV,
+	"sarif":     FormatSarif,
+	"hdf":       FormatHDF,
 	// OCSF, for security data lakes. "ocsf" is an alias for the JSON flavor.
 	"ocsf":         FormatOcsfJson,
 	"ocsf-json":    FormatOcsfJson,

--- a/cli/reporter/summary.go
+++ b/cli/reporter/summary.go
@@ -27,56 +27,79 @@ func NewSummaryRenderer(print *printer.Printer) *summaryPrinter {
 	}
 }
 
-type summaryStats struct {
-	assetScores map[string]*policy.Score
-	assetNames  map[string]string
-	policyStats map[string][]*policy.Score
-	policyNames map[string]string
+// SummaryStats is the per-asset and per-policy view of a report collection: the
+// score of every asset (synthesized for assets that errored or were never
+// reported on) and, per policy, one score per asset. It is what the summary
+// renderer draws and what the report viewer filters on.
+type SummaryStats struct {
+	// AssetScores maps an asset MRN to its overall score.
+	AssetScores map[string]*policy.Score
+	// AssetNames maps an asset MRN to its human-readable name.
+	AssetNames map[string]string
+	// PolicyStats maps a policy MRN to the score it got on each asset, in the
+	// order the assets were visited.
+	PolicyStats map[string][]*policy.Score
+	// PolicyNames maps a policy MRN to its human-readable name.
+	PolicyNames map[string]string
 }
 
-func (s *summaryPrinter) GenerateStats(report *policy.ReportCollection) summaryStats {
+// GenerateStats extracts the per-asset and per-policy scores from a report
+// collection. An asset with no report is not an asset without findings: it gets
+// a synthesized ScoreType_Error score carrying the scan error, or a
+// ScoreType_Unknown score when there is no error either.
+func GenerateStats(report *policy.ReportCollection) SummaryStats {
 	// stats data
-	stats := summaryStats{
-		assetScores: map[string]*policy.Score{},
-		assetNames:  map[string]string{},
-		policyStats: map[string][]*policy.Score{},
-		policyNames: map[string]string{},
+	stats := SummaryStats{
+		AssetScores: map[string]*policy.Score{},
+		AssetNames:  map[string]string{},
+		PolicyStats: map[string][]*policy.Score{},
+		PolicyNames: map[string]string{},
 	}
 
 	// extract statistics from scan report
-	pbm := report.Bundle.ToMap()
+	//
+	// A collection can arrive without a bundle: a scan where every asset failed
+	// to connect never resolves policies, so there is nothing to attach. That is
+	// the case a caller most wants stats for -- it is the difference between
+	// "no findings" and "nothing ran" -- so it must not be the case that panics.
+	// An empty map rather than a nil one: the policy loop below then simply
+	// finds nothing, instead of every caller needing its own guard.
+	pbm := &policy.PolicyBundleMap{}
+	if report.Bundle != nil {
+		pbm = report.Bundle.ToMap()
+	}
 	for assetMrn := range report.Assets {
-		stats.assetNames[assetMrn] = report.Assets[assetMrn].Name
+		stats.AssetNames[assetMrn] = report.Assets[assetMrn].Name
 		assetReport, ok := report.Reports[assetMrn]
 		if !ok {
 			if errMsg := report.Errors[assetMrn]; errMsg != "" {
-				stats.assetScores[assetMrn] = &policy.Score{
+				stats.AssetScores[assetMrn] = &policy.Score{
 					QrId:    assetMrn,
 					Type:    policy.ScoreType_Error,
 					Message: errMsg,
 				}
 			} else {
-				stats.assetScores[assetMrn] = &policy.Score{
+				stats.AssetScores[assetMrn] = &policy.Score{
 					QrId: assetMrn,
 					Type: policy.ScoreType_Unknown,
 				}
 			}
 			continue
 		} else {
-			stats.assetScores[assetMrn] = assetReport.Scores[assetMrn]
+			stats.AssetScores[assetMrn] = assetReport.Scores[assetMrn]
 		}
-		// stats.assetNames[assetMrn] = report.Assets[assetMrn].Name
+		// stats.AssetNames[assetMrn] = report.Assets[assetMrn].Name
 
 		// iterate over each policy to get the score results per assets
 		for k := range pbm.Policies {
 			p := pbm.Policies[k]
-			stats.policyNames[k] = p.Name
+			stats.PolicyNames[k] = p.Name
 
 			score := assetReport.Scores[k]
-			if stats.policyStats[k] == nil {
-				stats.policyStats[k] = []*policy.Score{}
+			if stats.PolicyStats[k] == nil {
+				stats.PolicyStats[k] = []*policy.Score{}
 			}
-			stats.policyStats[k] = append(stats.policyStats[k], score)
+			stats.PolicyStats[k] = append(stats.PolicyStats[k], score)
 		}
 	}
 
@@ -84,7 +107,7 @@ func (s *summaryPrinter) GenerateStats(report *policy.ReportCollection) summaryS
 }
 
 func (s *summaryPrinter) Render(report *policy.ReportCollection) string {
-	summaryStats := s.GenerateStats(report)
+	stats := GenerateStats(report)
 
 	var res bytes.Buffer
 	res.WriteString(s.print.H1("Summary"))
@@ -95,12 +118,12 @@ func (s *summaryPrinter) Render(report *policy.ReportCollection) string {
 
 	// render policy list
 	microScoreCard := components.NewMicroScoreCard()
-	for k := range summaryStats.assetScores {
-		score := summaryStats.assetScores[k]
+	for k := range stats.AssetScores {
+		score := stats.AssetScores[k]
 		res.WriteString("■ ")
 		res.WriteString(microScoreCard.Render(score))
 		res.WriteString(" ")
-		res.WriteString(summaryStats.assetNames[k])
+		res.WriteString(stats.AssetNames[k])
 		res.WriteString(NewLineCharacter)
 	}
 	res.WriteString(NewLineCharacter)
@@ -122,19 +145,19 @@ func (s *summaryPrinter) Render(report *policy.ReportCollection) string {
 		Entries: []components.StackBarDataEntry{},
 	}
 
-	if len(summaryStats.policyStats) > 0 {
+	if len(stats.PolicyStats) > 0 {
 
 		entries := []components.StackBarDataEntry{}
 		ratings := []map[string]int{}
 
-		for k := range summaryStats.policyNames {
+		for k := range stats.PolicyNames {
 			// We are looking for MRNs that are policies only. Everything else
 			// may be filtered
 			if err := policy.IsPolicyMrn(k); err != nil {
 				continue
 			}
 
-			scores := summaryStats.policyStats[k]
+			scores := stats.PolicyStats[k]
 			total := 0
 			r := map[string]int{}
 			for i := range scores {
@@ -166,7 +189,7 @@ func (s *summaryPrinter) Render(report *policy.ReportCollection) string {
 			ratings = append(ratings, r)
 
 			entry := components.StackBarDataEntry{
-				Key:    summaryStats.policyNames[k],
+				Key:    stats.PolicyNames[k],
 				Values: []float64{0, 0, 0, 0, 0, 0},
 			}
 

--- a/cli/reporter/summary_nilbundle_test.go
+++ b/cli/reporter/summary_nilbundle_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"go.mondoo.com/cnspec/policy"
+)
+
+// A scan where every asset failed to connect never resolves a policy, so the
+// collection arrives with no bundle at all. That is the case stats are most
+// wanted for -- it separates "nothing ran" from "nothing was found" -- so it is
+// the one case that must not panic.
+func TestGenerateStatsWithoutABundle(t *testing.T) {
+	raw, err := os.ReadFile("testdata/report-k8s.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var collection policy.ReportCollection
+	if err := json.Unmarshal(raw, &collection); err != nil {
+		t.Fatal(err)
+	}
+	if collection.Bundle != nil {
+		t.Fatal("fixture is meant to have no bundle; it now has one")
+	}
+
+	stats := GenerateStats(&collection)
+
+	if len(stats.AssetScores) != len(collection.Assets) {
+		t.Errorf("scored %d assets, want %d", len(stats.AssetScores), len(collection.Assets))
+	}
+	for mrn, score := range stats.AssetScores {
+		if score.Type != policy.ScoreType_Error {
+			t.Errorf("%s: type %d, want error -- an asset that could not be scanned is not a clean one", mrn, score.Type)
+		}
+	}
+}

--- a/cli/reportmodel/detail.go
+++ b/cli/reportmodel/detail.go
@@ -1,0 +1,156 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportmodel
+
+import (
+	"strings"
+
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/cnspec/reports/reportdoc"
+	"go.mondoo.com/mql/cli/printer"
+)
+
+// RemediationItem is one way to fix a check. Id names the platform or tool the
+// fix applies to ("terraform", "cli", …) and is empty or "default" for a
+// platform-agnostic one. Desc is markdown source: this package does not render
+// it, so a viewer either prints it plainly or runs it through a renderer of its
+// choice.
+type RemediationItem struct {
+	Id   string
+	Desc string
+}
+
+// Reference is a link a check cites.
+type Reference struct {
+	Title string
+	Url   string
+}
+
+// CheckDetail is everything a detail view shows about one check on one asset. It
+// carries the same sections, in the same order, as the JUnit reporter's
+// detailedCheckBody - description, MQL, assessment, failing locations, error,
+// remediation, references - but as fields rather than as one formatted string,
+// so a pane can lay them out itself.
+//
+// Every field may be empty; a viewer skips the sections that are.
+type CheckDetail struct {
+	// Title, Status and Severity repeat the Check they came from, so a detail
+	// pane needs nothing else to draw its header.
+	Title    string
+	Status   Status
+	Severity string
+	// Impact is the configured impact (0-100), HasImpact whether it is set.
+	Impact    int32
+	HasImpact bool
+	// Description is the prose explaining what the check looks for.
+	Description string
+	// Mql is the query source.
+	Mql string
+	// Audit is the manual verification instructions, when the check has any.
+	Audit string
+	// Assessment is the rendered expected-vs-actual of the check, colour-free.
+	// It is only available for assertion checks that executed.
+	Assessment string
+	// FailingLocations are the "path:line" locations of the resources that made
+	// the check fail. It is populated for resources that carry source context
+	// (Terraform/HCL) and empty for scalar checks.
+	FailingLocations []string
+	// Error is the reason an errored check could not run. It is empty for every
+	// other status.
+	Error string
+	// Remediation are the fixes that apply to this asset's platform.
+	Remediation []RemediationItem
+	// References are the links the check cites.
+	References []Reference
+	// Compliance maps a framework tag to the control the check satisfies, e.g.
+	// "compliance/iso-27001-2022" -> "iso-27001-2022-a-8-24".
+	Compliance map[string]string
+	// Policies are the policies of this asset that include the check.
+	Policies []PolicyRef
+}
+
+// Detail composes the full detail of a check on its asset.
+//
+// It is computed on demand rather than when the model is built: rendering an
+// assessment compiles nothing but does walk the raw results, and a large scan
+// has thousands of checks of which a viewer opens one at a time.
+func (c *Check) Detail() CheckDetail {
+	if c == nil {
+		return CheckDetail{Status: StatusUnknown}
+	}
+
+	res := CheckDetail{
+		Title:     c.Title,
+		Status:    c.Status,
+		Severity:  c.Severity,
+		Impact:    c.Impact,
+		HasImpact: c.HasImpact,
+		Policies:  c.Policies,
+	}
+	if c.Query == nil {
+		return res
+	}
+	query := c.Query
+
+	res.Description = strings.TrimSpace(normalizeNewlines(reportdoc.QueryDescription(query)))
+	res.Mql = strings.TrimSpace(normalizeNewlines(reportdoc.QueryMql(query)))
+	res.Audit = normalizeNewlines(reportdoc.QueryAudit(query))
+	res.Compliance = reportdoc.QueryComplianceTags(query)
+
+	platformKeys := map[string]bool{"": true, "default": true}
+	if c.asset != nil {
+		platformKeys = c.asset.platformKeys
+	}
+	for _, item := range reportdoc.RemediationItems(query, platformKeys) {
+		res.Remediation = append(res.Remediation, RemediationItem{
+			Id:   item.Id,
+			Desc: strings.TrimSpace(normalizeNewlines(item.Desc)),
+		})
+	}
+
+	for _, ref := range reportdoc.QueryRefs(query) {
+		res.References = append(res.References, Reference{Title: ref.Title, Url: ref.Url})
+	}
+
+	res.Assessment, res.FailingLocations = c.assessment()
+
+	// For an errored check the score message carries the failure reason.
+	if c.Score != nil && c.Score.Type == policy.ScoreType_Error {
+		res.Error = strings.TrimSpace(normalizeNewlines(c.Score.MessageLine()))
+	}
+
+	return res
+}
+
+// assessment renders the expected-vs-actual of the check and the source
+// locations of the resources that failed it.
+//
+// The guards matter: ResolvedPolicy.GetCodeBundle dereferences ExecutionJob and
+// panics when it is nil, which is the state of a resolved policy that never
+// executed.
+func (c *Check) assessment() (string, []string) {
+	asset := c.asset
+	if asset == nil || asset.report == nil || asset.resolved == nil || asset.resolved.ExecutionJob == nil {
+		return "", nil
+	}
+
+	cb := asset.resolved.GetCodeBundle(c.Query)
+	if cb == nil {
+		return "", nil
+	}
+
+	assessment := policy.Query2Assessment(cb, asset.report)
+	if assessment == nil {
+		return "", nil
+	}
+
+	text := strings.TrimSpace(normalizeNewlines(printer.PlainNoColorPrinter.Assessment(cb, assessment)))
+
+	var locations []string
+	if locs := reportdoc.FailingResourceLocations(cb, assessment); locs != "" {
+		locations = strings.Split(normalizeNewlines(locs), "\n")
+	}
+
+	return text, locations
+}

--- a/cli/reportmodel/model.go
+++ b/cli/reportmodel/model.go
@@ -1,0 +1,659 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package reportmodel turns a scan result (*policy.ReportCollection) into a
+// navigable asset -> policy -> check tree.
+//
+// It is a data model, not a renderer: nothing here writes to a terminal, picks a
+// color or knows about bubbletea. A viewer walks Report.Assets, then
+// Asset.Policies, then Policy.Checks, and asks a Check for its Detail when the
+// user opens it.
+//
+// Two things this package exists to get right, because both are easy to get
+// wrong when reading a report collection directly:
+//
+//   - The checks that ran on an asset are not the entries of Report.Scores. That
+//     map mixes policy scores, control scores, check scores (keyed by MRN) and
+//     execution-query scores (keyed by code id). The checks come from the
+//     asset's ResolvedPolicy: the CHECK / CHECK_AND_DATA_QUERY reporting jobs,
+//     each confirmed against CollectorJob.ReportingQueries so we only surface
+//     checks that actually ran on this asset's platform.
+//
+//   - "Failed" is not a score type. It is a result score whose value is below
+//     100, so failing, errored, skipped and unscored checks are four distinct
+//     outcomes (see Status). An asset that failed to scan is likewise not an
+//     asset without findings: it has no report and no resolved policy at all,
+//     and surfaces here as StatusError with its ScanError set.
+package reportmodel
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/cnspec/reports/reportdoc"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// UngroupedPolicyName is the name of the synthetic policy node that collects the
+// checks of an asset whose reporting job does not lead up to any policy in the
+// bundle. It is always sorted last and has an empty Mrn.
+const UngroupedPolicyName = "Other checks"
+
+// Status is the outcome of a check, a policy or an asset. The six values mirror
+// reportdoc.Outcome, which is the single place in cnspec that collapses the
+// seven score types into an outcome.
+//
+// Note that StatusFail and StatusPass share a score type (ScoreType_Result) and
+// are told apart by the score value, while StatusError, StatusSkipped and
+// StatusUnscored are score types of their own. A viewer must not collapse them:
+// a check that could not run is not a check that passed.
+type Status string
+
+const (
+	StatusPass     Status = "PASS"
+	StatusFail     Status = "FAIL"
+	StatusError    Status = "ERROR"
+	StatusSkipped  Status = "SKIPPED"
+	StatusUnscored Status = "UNSCORED"
+	StatusUnknown  Status = "UNKNOWN"
+)
+
+// StatusOf maps a score to its outcome. It is nil-safe: a missing score is
+// StatusUnknown, never StatusPass.
+func StatusOf(score *policy.Score) Status {
+	return Status(reportdoc.OutcomeOf(score).Label())
+}
+
+// Icon is the emoji for a status. It matches the SARIF reporter's icons.
+func (s Status) Icon() string {
+	switch s {
+	case StatusPass:
+		return "✅"
+	case StatusFail:
+		return "❌"
+	case StatusError:
+		return "⚠️"
+	case StatusSkipped:
+		return "⏭️"
+	default:
+		return "ℹ️"
+	}
+}
+
+// IsFinding reports whether the status is something the user has to act on: a
+// check that failed, or one that errored and therefore proved nothing.
+func (s Status) IsFinding() bool {
+	return s == StatusFail || s == StatusError
+}
+
+// Counts is the tally of outcomes over a set of checks or assets. Total is the
+// number counted, not the sum of the other fields, so an unrecognized status is
+// still counted once.
+type Counts struct {
+	Total    int
+	Passed   int
+	Failed   int
+	Errored  int
+	Skipped  int
+	Unscored int
+	Unknown  int
+}
+
+// Add counts one outcome.
+func (c *Counts) Add(s Status) {
+	c.Total++
+	switch s {
+	case StatusPass:
+		c.Passed++
+	case StatusFail:
+		c.Failed++
+	case StatusError:
+		c.Errored++
+	case StatusSkipped:
+		c.Skipped++
+	case StatusUnscored:
+		c.Unscored++
+	default:
+		c.Unknown++
+	}
+}
+
+// Findings is the number of outcomes that need action: failed plus errored.
+func (c Counts) Findings() int {
+	return c.Failed + c.Errored
+}
+
+// PolicyRef names a policy a check belongs to.
+type PolicyRef struct {
+	// Mrn is the policy MRN, empty for the synthetic UngroupedPolicyName node.
+	Mrn string
+	// Name is the human-readable policy title, falling back to the MRN.
+	Name string
+}
+
+// Report is the root of the model: every asset the scan touched, whether or not
+// it produced a report.
+type Report struct {
+	// Assets are all assets of the scan, sorted by name and then MRN.
+	Assets []*Asset
+	// AssetCounts tallies the outcome of each asset.
+	AssetCounts Counts
+	// CheckCounts tallies the outcome of every check on every asset. A check
+	// that ran on two assets is counted twice.
+	CheckCounts Counts
+
+	collection *policy.ReportCollection
+	byMrn      map[string]*Asset
+}
+
+// Asset is one scanned entity, with the policies and checks that ran on it.
+type Asset struct {
+	// Mrn identifies the asset and is the key into the report collection.
+	Mrn string
+	// Name is the human-readable asset name, falling back to the MRN.
+	Name string
+	// Platform is the platform the asset was detected as. It is nil for an
+	// asset that failed to scan before detection completed.
+	Platform *inventory.Platform
+	// PlatformName is the platform title, falling back to its name.
+	PlatformName string
+	// Score is the asset's overall score. For an asset that never produced a
+	// report it is synthesized: a ScoreType_Error score carrying ScanError, or
+	// a ScoreType_Unknown score when there is no error either.
+	Score *policy.Score
+	// Status is the asset's outcome.
+	Status Status
+	// ScanError is the scan failure of this asset, empty when it scanned. An
+	// asset with a ScanError has no policies and no checks - that is a scan
+	// that did not happen, not a scan without findings.
+	ScanError string
+	// Policies are the policies that ran on this asset, sorted by name; the
+	// synthetic UngroupedPolicyName node, if any, is last.
+	Policies []*Policy
+	// Checks are all checks of this asset, each once, sorted by title and then
+	// MRN. A check that belongs to two policies appears once here and in both
+	// Policy.Checks.
+	Checks []*Check
+	// Counts tallies Checks.
+	Counts Counts
+
+	report   *policy.Report
+	resolved *policy.ResolvedPolicy
+	// platformKeys filters remediation down to this asset's platform.
+	platformKeys map[string]bool
+}
+
+// Scanned reports whether the asset produced a report at all.
+func (a *Asset) Scanned() bool {
+	return a != nil && a.report != nil
+}
+
+// Policy is one policy as it applied to a single asset.
+type Policy struct {
+	// Mrn is the policy MRN, empty for the synthetic UngroupedPolicyName node.
+	Mrn string
+	// Name is the policy title, falling back to the MRN.
+	Name string
+	// Score is the policy's score on this asset; nil when it has none.
+	Score *policy.Score
+	// Status is the policy's outcome on this asset.
+	Status Status
+	// Checks are the checks of this policy on this asset, sorted by title and
+	// then MRN.
+	Checks []*Check
+	// Counts tallies Checks.
+	Counts Counts
+}
+
+// Check is one check as it ran on a single asset.
+type Check struct {
+	// Mrn is the check MRN. It is empty only for a check that has no MRN at
+	// all, in which case CodeId identifies it.
+	Mrn string
+	// CodeId is the checksum of the compiled MQL. It is what the collector job
+	// keys reporting queries by.
+	CodeId string
+	// Title is the check title, falling back to the MRN or the code id.
+	Title string
+	// Score is the check's score on this asset, nil when the check reported
+	// nothing.
+	Score *policy.Score
+	// Status is the check's outcome: PASS, FAIL, ERROR, SKIPPED, UNSCORED or
+	// UNKNOWN.
+	Status Status
+	// Impact is the configured impact of the check (0-100, 100 being the most
+	// impactful) and HasImpact says whether it is configured at all.
+	Impact    int32
+	HasImpact bool
+	// Severity is the label of Impact (CRITICAL/HIGH/MEDIUM/LOW/NONE). It is
+	// what the check is worth, not how it did - use Risk for the latter.
+	Severity string
+	// Risk is the realized risk of the score (100 - value): 0 for a check that
+	// passed, 100 for one that failed outright. A score type that carries no
+	// value - error, skip, unscored - has value 0 and therefore risk 100, so
+	// read Risk together with Status rather than on its own.
+	Risk int32
+	// Policies are the policies of this asset that include the check, sorted by
+	// name.
+	Policies []PolicyRef
+	// Query is the check itself. It is never nil.
+	Query *policy.Mquery
+
+	asset *Asset
+}
+
+// New builds the model from a report collection. The collection is not
+// modified and may be nil, in which case the result is an empty report.
+func New(collection *policy.ReportCollection) *Report {
+	res := &Report{
+		collection: collection,
+		byMrn:      map[string]*Asset{},
+	}
+	if collection == nil {
+		return res
+	}
+
+	b := newBuilder(collection)
+	for _, mrn := range b.assetMrns() {
+		asset := b.buildAsset(mrn)
+		res.Assets = append(res.Assets, asset)
+		res.byMrn[mrn] = asset
+		res.AssetCounts.Add(asset.Status)
+		for _, check := range asset.Checks {
+			res.CheckCounts.Add(check.Status)
+		}
+	}
+
+	sort.SliceStable(res.Assets, func(i, j int) bool {
+		if res.Assets[i].Name != res.Assets[j].Name {
+			return res.Assets[i].Name < res.Assets[j].Name
+		}
+		return res.Assets[i].Mrn < res.Assets[j].Mrn
+	})
+
+	return res
+}
+
+// Collection returns the report collection the model was built from, so a
+// viewer can reach data the model does not cover (vulnerability reports, raw
+// results). It may be nil.
+func (r *Report) Collection() *policy.ReportCollection {
+	return r.collection
+}
+
+// Asset looks an asset up by MRN, returning nil when there is none.
+func (r *Report) Asset(mrn string) *Asset {
+	return r.byMrn[mrn]
+}
+
+// builder carries the bundle-derived lookups shared by every asset.
+type builder struct {
+	collection *policy.ReportCollection
+	bundle     *policy.PolicyBundleMap
+	// queriesByMrn is the bundle's queries keyed by MRN, which is what a
+	// reporting job's QrId normally is.
+	queriesByMrn map[string]*policy.Mquery
+	// queriesByCodeID is the same set keyed by code id. It resolves the jobs of
+	// an unsigned bundle, whose QrId is a code id rather than an MRN.
+	queriesByCodeID map[string]*policy.Mquery
+	policyNames     map[string]string
+}
+
+func newBuilder(collection *policy.ReportCollection) *builder {
+	b := &builder{
+		collection:      collection,
+		queriesByMrn:    map[string]*policy.Mquery{},
+		queriesByCodeID: map[string]*policy.Mquery{},
+		policyNames:     map[string]string{},
+	}
+
+	// Bundle is nil for a scan that failed before resolving policies - the
+	// all-errored k8s report is exactly that - so this cannot be unconditional.
+	if collection.Bundle == nil {
+		return b
+	}
+
+	b.bundle = collection.Bundle.ToMap()
+	b.queriesByMrn = b.bundle.Queries
+	// DeterministicQueryMap rather than PolicyBundleMap.QueryMap: the latter
+	// picks an arbitrary query when variants share a code id.
+	b.queriesByCodeID = reportdoc.QueryMap(b.bundle)
+	for mrn, p := range b.bundle.Policies {
+		if p == nil {
+			continue
+		}
+		name := p.Name
+		if name == "" {
+			name = mrn
+		}
+		b.policyNames[mrn] = name
+	}
+
+	return b
+}
+
+// assetMrns is every asset the collection knows about: the inventory, plus any
+// MRN that only shows up as a report or as an error, so an asset can never go
+// missing from the model.
+func (b *builder) assetMrns() []string {
+	seen := map[string]struct{}{}
+	for mrn := range b.collection.Assets {
+		seen[mrn] = struct{}{}
+	}
+	for mrn := range b.collection.Reports {
+		seen[mrn] = struct{}{}
+	}
+	for mrn := range b.collection.Errors {
+		seen[mrn] = struct{}{}
+	}
+	return sortedKeys(seen)
+}
+
+func (b *builder) buildAsset(mrn string) *Asset {
+	asset := &Asset{
+		Mrn:       mrn,
+		Name:      mrn,
+		ScanError: plainError(b.collection.Errors[mrn]),
+		report:    b.collection.Reports[mrn],
+		resolved:  b.collection.ResolvedPolicies[mrn],
+	}
+
+	if inv := b.collection.Assets[mrn]; inv != nil {
+		if inv.Name != "" {
+			asset.Name = inv.Name
+		}
+		asset.Platform = inv.Platform
+		if p := inv.Platform; p != nil {
+			asset.PlatformName = p.Title
+			if asset.PlatformName == "" {
+				asset.PlatformName = p.Name
+			}
+		}
+	}
+	asset.platformKeys = reportdoc.PlatformRemediationKeys(asset.Platform)
+
+	asset.Score = b.assetScore(mrn, asset.report)
+	asset.Status = StatusOf(asset.Score)
+
+	b.buildChecks(asset)
+	return asset
+}
+
+// assetScore is the asset's overall score, synthesized when the asset produced
+// no report. This mirrors reporter.GenerateStats: an asset that failed to scan
+// gets a ScoreType_Error score carrying the scan error, so a single code path
+// covers reports, errors and assets with neither. (GenerateStats itself is not
+// called here because it dereferences ReportCollection.Bundle, which is nil for
+// precisely the all-errored collections this has to handle.)
+func (b *builder) assetScore(mrn string, report *policy.Report) *policy.Score {
+	if report != nil {
+		if score, ok := report.Scores[mrn]; ok && score != nil {
+			return score
+		}
+		if report.Score != nil {
+			return report.Score
+		}
+	}
+	if msg := plainError(b.collection.Errors[mrn]); msg != "" {
+		return &policy.Score{
+			QrId:    mrn,
+			Type:    policy.ScoreType_Error,
+			Message: msg,
+		}
+	}
+	return &policy.Score{
+		QrId: mrn,
+		Type: policy.ScoreType_Unknown,
+	}
+}
+
+// buildChecks fills in the asset's checks and policies from its resolved policy.
+//
+// The checks of an asset are the CHECK and CHECK_AND_DATA_QUERY reporting jobs
+// of its collector job - not the entries of Report.Scores, which also hold
+// policy, control and execution-query scores. Each job's QrId is resolved
+// against the bundle and then confirmed against ReportingQueries, because the
+// bundle holds queries that do not match this asset's platform.
+func (b *builder) buildChecks(asset *Asset) {
+	if asset.resolved == nil || asset.resolved.CollectorJob == nil {
+		return
+	}
+	jobs := asset.resolved.CollectorJob.ReportingJobs
+	reportingQueries := asset.resolved.CollectorJob.ReportingQueries
+
+	byKey := map[string]*Check{}
+	policies := map[string]*Policy{}
+
+	for _, uuid := range sortedKeys(jobs) {
+		job := jobs[uuid]
+		if job == nil {
+			continue
+		}
+		if job.Type != policy.ReportingJob_CHECK && job.Type != policy.ReportingJob_CHECK_AND_DATA_QUERY {
+			continue
+		}
+
+		query := b.query(job.QrId)
+		if query == nil || query.CodeId == "" {
+			continue
+		}
+		// Confirm the check actually ran on this asset.
+		if _, ok := reportingQueries[query.CodeId]; !ok {
+			continue
+		}
+
+		key := query.Mrn
+		if key == "" {
+			key = query.CodeId
+		}
+
+		check, ok := byKey[key]
+		if !ok {
+			check = b.buildCheck(asset, job, query)
+			byKey[key] = check
+			asset.Checks = append(asset.Checks, check)
+			asset.Counts.Add(check.Status)
+		}
+
+		for _, policyMrn := range b.policyAncestors(jobs, job) {
+			b.attach(policies, policyMrn, check)
+		}
+	}
+
+	// A check whose reporting job leads up to no policy in the bundle still has
+	// to be reachable in the tree.
+	for _, check := range asset.Checks {
+		if len(check.Policies) == 0 {
+			b.attach(policies, "", check)
+		}
+	}
+
+	sortChecks(asset.Checks)
+	for _, check := range asset.Checks {
+		refs := check.Policies
+		sort.SliceStable(refs, func(i, j int) bool {
+			if refs[i].Name != refs[j].Name {
+				return refs[i].Name < refs[j].Name
+			}
+			return refs[i].Mrn < refs[j].Mrn
+		})
+	}
+
+	for _, mrn := range sortedKeys(policies) {
+		p := policies[mrn]
+		sortChecks(p.Checks)
+		for _, check := range p.Checks {
+			p.Counts.Add(check.Status)
+		}
+		if asset.report != nil && p.Mrn != "" {
+			p.Score = asset.report.Scores[p.Mrn]
+		}
+		p.Status = StatusOf(p.Score)
+		asset.Policies = append(asset.Policies, p)
+	}
+
+	sort.SliceStable(asset.Policies, func(i, j int) bool {
+		a, c := asset.Policies[i], asset.Policies[j]
+		// the synthetic node sorts last
+		if (a.Mrn == "") != (c.Mrn == "") {
+			return c.Mrn == ""
+		}
+		if a.Name != c.Name {
+			return a.Name < c.Name
+		}
+		return a.Mrn < c.Mrn
+	})
+}
+
+func (b *builder) attach(policies map[string]*Policy, policyMrn string, check *Check) {
+	p, ok := policies[policyMrn]
+	if !ok {
+		name := b.policyNames[policyMrn]
+		if name == "" {
+			name = policyMrn
+		}
+		if policyMrn == "" {
+			name = UngroupedPolicyName
+		}
+		p = &Policy{Mrn: policyMrn, Name: name}
+		policies[policyMrn] = p
+	}
+	p.Checks = append(p.Checks, check)
+	check.Policies = append(check.Policies, PolicyRef{Mrn: p.Mrn, Name: p.Name})
+}
+
+func (b *builder) buildCheck(asset *Asset, job *policy.ReportingJob, query *policy.Mquery) *Check {
+	score := b.checkScore(asset.report, job, query)
+
+	title := query.Title
+	if title == "" {
+		title = query.Mrn
+	}
+	if title == "" {
+		title = query.CodeId
+	}
+
+	check := &Check{
+		Mrn:    query.Mrn,
+		CodeId: query.CodeId,
+		Title:  title,
+		Score:  score,
+		Status: StatusOf(score),
+		Risk:   reportdoc.ScoreRisk(score),
+		Query:  query,
+		asset:  asset,
+	}
+	check.Impact, check.HasImpact = reportdoc.QueryImpact(query)
+	check.Severity = reportdoc.RiskSeverityLabel(check.Impact)
+	return check
+}
+
+// checkScore looks a check's score up. Both keys are in use depending on how the
+// score was collected, so try the MRN first and fall back to the code id.
+//
+// The score is returned as it is stored. The compact reporter raises the value
+// of a low-impact failing check in place (a documented FIXME v12 workaround);
+// this model does not mutate scores, so a viewer sees what the scan recorded.
+func (b *builder) checkScore(report *policy.Report, job *policy.ReportingJob, query *policy.Mquery) *policy.Score {
+	if report == nil {
+		return nil
+	}
+	for _, key := range []string{query.Mrn, job.QrId, query.CodeId} {
+		if key == "" {
+			continue
+		}
+		if score, ok := report.Scores[key]; ok && score != nil {
+			return score
+		}
+	}
+	return nil
+}
+
+// query resolves a reporting job's QrId to a check. A signed bundle keys its
+// queries by MRN, which is what QrId holds; an unsigned one has no MRNs and uses
+// the code id, hence the second lookup.
+func (b *builder) query(qrID string) *policy.Mquery {
+	if qrID == "" {
+		return nil
+	}
+	if query, ok := b.queriesByMrn[qrID]; ok && query != nil {
+		return query
+	}
+	return b.queriesByCodeID[qrID]
+}
+
+// policyAncestors walks up the reporting graph from a check and returns the MRNs
+// of the nearest policies that own it. It stops at the first policy job on each
+// branch, so a check of a policy that is itself bundled into a parent policy (or
+// into the space) is attributed to the policy that declares it, not to every
+// ancestor of it.
+func (b *builder) policyAncestors(jobs map[string]*policy.ReportingJob, job *policy.ReportingJob) []string {
+	var res []string
+	seen := map[string]struct{}{}
+	queue := append([]string{}, job.Notify...)
+
+	for i := 0; i < len(queue); i++ {
+		uuid := queue[i]
+		if _, ok := seen[uuid]; ok {
+			continue
+		}
+		seen[uuid] = struct{}{}
+
+		parent := jobs[uuid]
+		if parent == nil {
+			continue
+		}
+		if parent.Type == policy.ReportingJob_POLICY {
+			if _, known := b.policyNames[parent.QrId]; known {
+				res = append(res, parent.QrId)
+				continue
+			}
+		}
+		queue = append(queue, parent.Notify...)
+	}
+
+	sort.Strings(res)
+	return res
+}
+
+func sortChecks(checks []*Check) {
+	sort.SliceStable(checks, func(i, j int) bool {
+		if checks[i].Title != checks[j].Title {
+			return checks[i].Title < checks[j].Title
+		}
+		return checks[i].Mrn < checks[j].Mrn
+	})
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	res := make([]string, 0, len(m))
+	for k := range m {
+		res = append(res, k)
+	}
+	sort.Strings(res)
+	return res
+}
+
+// normalizeNewlines strips carriage returns so a string carried into a
+// width-sensitive renderer cannot corrupt its line maths. Reporter output uses
+// NewLineCharacter, which is "\r\n" on Windows.
+func normalizeNewlines(s string) string {
+	if !strings.Contains(s, "\r") {
+		return s
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// rpcEnvelope matches the wrapper gRPC puts around a provider's own words:
+// "rpc error: code = InvalidArgument desc = asset doesn't support any
+// policies". The code is a transport detail; the sentence after desc= is the
+// part a reader can act on, and in the fixtures every single scan error
+// carries this prefix.
+var rpcEnvelope = regexp.MustCompile(`^rpc error: code = \S+ desc = `)
+
+// plainError strips that envelope, leaving the message the provider wrote.
+func plainError(msg string) string {
+	return strings.TrimSpace(rpcEnvelope.ReplaceAllString(strings.TrimSpace(msg), ""))
+}

--- a/cli/reportmodel/model_test.go
+++ b/cli/reportmodel/model_test.go
@@ -1,0 +1,472 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportmodel
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// The fixtures are named rather than pathed, because the two no longer come from
+// the same place. report-ubuntu is one asset that scanned, and it is shared with
+// every reporter through internal/reportfixture; report-k8s is fifteen that did
+// not, and it still lives with the reporter tests.
+const (
+	fixtureUbuntu = "report-ubuntu"
+	fixtureK8s    = "report-k8s"
+)
+
+func loadCollection(t *testing.T, fixture string) *policy.ReportCollection {
+	t.Helper()
+	if fixture == fixtureUbuntu {
+		res, err := reportfixture.UbuntuScan()
+		require.NoError(t, err)
+		return res
+	}
+
+	raw, err := os.ReadFile("../reporter/testdata/" + fixture + ".json")
+	require.NoError(t, err)
+
+	res := &policy.ReportCollection{}
+	require.NoError(t, json.Unmarshal(raw, res))
+	return res
+}
+
+func TestNilCollection(t *testing.T) {
+	report := New(nil)
+	require.NotNil(t, report)
+	assert.Empty(t, report.Assets)
+	assert.Nil(t, report.Collection())
+	assert.Nil(t, report.Asset("//no/such/asset"))
+}
+
+func TestEmptyCollection(t *testing.T) {
+	report := New(&policy.ReportCollection{})
+	require.NotNil(t, report)
+	assert.Empty(t, report.Assets)
+	assert.Equal(t, 0, report.AssetCounts.Total)
+	assert.Equal(t, 0, report.CheckCounts.Total)
+}
+
+// The happy path: one asset, one report, no errors.
+func TestUbuntuAsset(t *testing.T) {
+	report := New(loadCollection(t, fixtureUbuntu))
+
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+
+	assert.Equal(t, "ubuntu:24.04", asset.Name)
+	assert.True(t, asset.Scanned())
+	assert.Empty(t, asset.ScanError)
+	require.NotNil(t, asset.Platform)
+	assert.Equal(t, "ubuntu", asset.Platform.Name)
+	assert.Equal(t, "Ubuntu 24.04.2 LTS", asset.PlatformName)
+
+	require.NotNil(t, asset.Score)
+	assert.Equal(t, policy.ScoreType_Result, asset.Score.Type)
+	assert.Equal(t, StatusFail, asset.Status)
+
+	assert.Same(t, asset, report.Asset(asset.Mrn))
+
+	// The checks come from the reporting jobs, not from Report.Scores. The
+	// score map is much larger than the check set because it also holds policy,
+	// control and execution-query scores.
+	require.NotEmpty(t, asset.Checks)
+	rawScores := len(report.Collection().Reports[asset.Mrn].Scores)
+	assert.Greater(t, rawScores, len(asset.Checks),
+		"Report.Scores holds more than the asset's checks; the model must not equate them")
+
+	// Every check resolved to a real query, ran on this asset and is only
+	// listed once.
+	resolved := report.Collection().ResolvedPolicies[asset.Mrn]
+	require.NotNil(t, resolved)
+	seen := map[string]bool{}
+	for _, check := range asset.Checks {
+		require.NotNil(t, check.Query, "check %q has no query", check.Title)
+		assert.NotEmpty(t, check.CodeId)
+		assert.Contains(t, resolved.CollectorJob.ReportingQueries, check.CodeId,
+			"check %q did not run on this asset", check.Title)
+		assert.False(t, seen[check.Mrn], "check %q listed twice", check.Mrn)
+		seen[check.Mrn] = true
+		assert.NotEmpty(t, check.Policies, "check %q is not reachable from any policy", check.Title)
+	}
+
+	assert.Equal(t, len(asset.Checks), asset.Counts.Total)
+	assert.Equal(t, asset.Counts, report.CheckCounts)
+	assert.Equal(t, 1, report.AssetCounts.Total)
+	assert.Equal(t, 1, report.AssetCounts.Failed)
+}
+
+// The reporting-job traversal must agree with the reference implementation in
+// print_compact.go: CHECK / CHECK_AND_DATA_QUERY jobs, resolved through the
+// bundle and confirmed against ReportingQueries.
+func TestChecksMatchReportingJobs(t *testing.T) {
+	collection := loadCollection(t, fixtureUbuntu)
+	report := New(collection)
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+
+	resolved := collection.ResolvedPolicies[asset.Mrn]
+	require.NotNil(t, resolved)
+	bundle := collection.Bundle.ToMap()
+
+	expected := map[string]bool{}
+	for _, job := range resolved.CollectorJob.ReportingJobs {
+		if job.Type != policy.ReportingJob_CHECK && job.Type != policy.ReportingJob_CHECK_AND_DATA_QUERY {
+			continue
+		}
+		query, ok := bundle.Queries[job.QrId]
+		if !ok || query == nil || query.CodeId == "" {
+			continue
+		}
+		if _, ok := resolved.CollectorJob.ReportingQueries[query.CodeId]; !ok {
+			continue
+		}
+		expected[query.Mrn] = true
+	}
+	require.NotEmpty(t, expected)
+
+	got := map[string]bool{}
+	for _, check := range asset.Checks {
+		got[check.Mrn] = true
+	}
+	assert.Equal(t, expected, got)
+}
+
+// Failed and errored are two outcomes, not one: the ubuntu fixture has both,
+// plus passes. (Skipped and unscored checks are covered by
+// TestFourScoreStatesAreDistinguished, which builds them explicitly - the ubuntu
+// scan has skipped and unscored *scores*, but they belong to policies and data
+// queries, not to any of its 24 checks.)
+func TestUbuntuCheckStates(t *testing.T) {
+	report := New(loadCollection(t, fixtureUbuntu))
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+
+	byStatus := map[Status][]*Check{}
+	for _, check := range asset.Checks {
+		byStatus[check.Status] = append(byStatus[check.Status], check)
+	}
+
+	for _, status := range []Status{StatusPass, StatusFail, StatusError} {
+		assert.NotEmpty(t, byStatus[status], "no check with status %s in the fixture", status)
+	}
+
+	// A failing check is a result score below 100 - not a score type of its own.
+	for _, check := range byStatus[StatusFail] {
+		require.NotNil(t, check.Score)
+		assert.Equal(t, policy.ScoreType_Result, check.Score.Type)
+		assert.NotEqual(t, uint32(100), check.Score.Value)
+	}
+	for _, check := range byStatus[StatusPass] {
+		require.NotNil(t, check.Score)
+		assert.Equal(t, policy.ScoreType_Result, check.Score.Type)
+		assert.Equal(t, uint32(100), check.Score.Value)
+	}
+	// An errored check has a score type of its own, so it can never be mistaken
+	// for a pass - the score value of an error is 0, which alone would look
+	// like a total failure rather than a check that proved nothing.
+	for _, check := range byStatus[StatusError] {
+		assert.Equal(t, policy.ScoreType_Error, check.Score.Type)
+	}
+
+	assert.Equal(t, len(byStatus[StatusPass]), asset.Counts.Passed)
+	assert.Equal(t, len(byStatus[StatusFail]), asset.Counts.Failed)
+	assert.Equal(t, len(byStatus[StatusError]), asset.Counts.Errored)
+	assert.Equal(t, len(byStatus[StatusSkipped]), asset.Counts.Skipped)
+	assert.Equal(t, len(byStatus[StatusUnscored]), asset.Counts.Unscored)
+	assert.Equal(t, len(byStatus[StatusFail])+len(byStatus[StatusError]), asset.Counts.Findings())
+
+	// A skipped or unscored check is not a finding; a failed or errored one is.
+	assert.True(t, StatusFail.IsFinding())
+	assert.True(t, StatusError.IsFinding())
+	assert.False(t, StatusSkipped.IsFinding())
+	assert.False(t, StatusUnscored.IsFinding())
+	assert.False(t, StatusPass.IsFinding())
+	assert.False(t, StatusUnknown.IsFinding())
+}
+
+func TestPolicyTree(t *testing.T) {
+	report := New(loadCollection(t, fixtureUbuntu))
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+
+	require.NotEmpty(t, asset.Policies)
+
+	names := []string{}
+	inTree := map[string]bool{}
+	total := 0
+	for _, p := range asset.Policies {
+		names = append(names, p.Name)
+		assert.NotEmpty(t, p.Checks, "policy %q has no checks", p.Name)
+		assert.Equal(t, len(p.Checks), p.Counts.Total)
+		total += len(p.Checks)
+		for _, check := range p.Checks {
+			inTree[check.Mrn] = true
+		}
+		// A policy of a scanned asset carries its own per-asset score.
+		if p.Mrn != "" {
+			assert.NotNil(t, p.Score, "policy %q has no score", p.Name)
+		}
+	}
+
+	assert.Contains(t, names, "Mondoo Linux Security")
+	assert.Contains(t, names, "Mondoo SSH Server Security")
+	// The space is a policy in the bundle too, but a check is attributed to the
+	// policy that declares it, never to an ancestor of that policy.
+	assert.NotContains(t, names, "test-infallible-taussig-796596")
+
+	// Every check of the asset is reachable through the tree, and the tree
+	// introduces none the asset does not have.
+	assert.Len(t, inTree, len(asset.Checks))
+	assert.GreaterOrEqual(t, total, len(asset.Checks))
+	for _, check := range asset.Checks {
+		assert.True(t, inTree[check.Mrn], "check %q unreachable in the policy tree", check.Title)
+	}
+}
+
+func TestSeverityAndRisk(t *testing.T) {
+	report := New(loadCollection(t, fixtureUbuntu))
+	asset := report.Assets[0]
+
+	withImpact := 0
+	for _, check := range asset.Checks {
+		assert.Contains(t,
+			[]string{
+				policy.ScoreRatingTextCritical, policy.ScoreRatingTextHigh,
+				policy.ScoreRatingTextMedium, policy.ScoreRatingTextLow,
+				policy.ScoreRatingTextNone,
+			},
+			check.Severity, "check %q has an unexpected severity", check.Title)
+
+		if check.HasImpact {
+			withImpact++
+			assert.NotEqual(t, policy.ScoreRatingTextNone, check.Severity)
+		}
+
+		// Risk is the realized risk of the score, not the declared severity.
+		if check.Status == StatusPass {
+			assert.Equal(t, int32(0), check.Risk)
+		}
+	}
+	assert.NotZero(t, withImpact, "no check in the fixture declares an impact")
+}
+
+func TestDeterministicOrder(t *testing.T) {
+	collection := loadCollection(t, fixtureUbuntu)
+
+	first := New(collection)
+	for i := 0; i < 5; i++ {
+		other := New(collection)
+		require.Len(t, other.Assets, len(first.Assets))
+		for a := range first.Assets {
+			assert.Equal(t, first.Assets[a].Mrn, other.Assets[a].Mrn)
+			assert.Equal(t, checkTitles(first.Assets[a].Checks), checkTitles(other.Assets[a].Checks))
+			assert.Equal(t, policyNames(first.Assets[a].Policies), policyNames(other.Assets[a].Policies))
+		}
+	}
+}
+
+func TestDetail(t *testing.T) {
+	report := New(loadCollection(t, fixtureUbuntu))
+	asset := report.Assets[0]
+
+	var failing, errored *Check
+	for _, check := range asset.Checks {
+		if failing == nil && check.Status == StatusFail {
+			failing = check
+		}
+		if errored == nil && check.Status == StatusError {
+			errored = check
+		}
+	}
+	require.NotNil(t, failing, "the fixture has no failing check")
+	require.NotNil(t, errored, "the fixture has no errored check")
+
+	detail := failing.Detail()
+	assert.Equal(t, failing.Title, detail.Title)
+	assert.Equal(t, StatusFail, detail.Status)
+	assert.Equal(t, policy.ScoreRatingTextCritical, detail.Severity)
+	assert.NotEmpty(t, detail.Description, "check %q has no description", failing.Title)
+	assert.NotEmpty(t, detail.Mql)
+	assert.NotEmpty(t, detail.Remediation, "check %q has no remediation", failing.Title)
+	assert.NotEmpty(t, detail.Policies)
+	assert.Empty(t, detail.Error, "a failing check is not an errored one")
+
+	// An errored check explains itself through the score message.
+	errDetail := errored.Detail()
+	assert.Equal(t, StatusError, errDetail.Status)
+	assert.NotEmpty(t, errDetail.Error, "errored check %q has no error message", errored.Title)
+
+	// Remediation, references and the assessment are exposed structurally, not
+	// as one formatted string.
+	assessed, remediated, referenced, audited := 0, 0, 0, 0
+	for _, check := range asset.Checks {
+		d := check.Detail()
+		if d.Assessment != "" {
+			assessed++
+		}
+		if d.Audit != "" {
+			audited++
+		}
+		for _, item := range d.Remediation {
+			assert.NotEmpty(t, item.Desc)
+			remediated++
+		}
+		for _, ref := range d.References {
+			assert.NotEmpty(t, ref.Url)
+			referenced++
+		}
+		for k := range d.Compliance {
+			assert.True(t, strings.HasPrefix(k, "compliance/"))
+		}
+		for _, s := range []string{d.Description, d.Mql, d.Assessment, d.Audit, d.Error} {
+			assert.NotContains(t, s, "\r", "detail of %q carries a carriage return into the renderer", check.Title)
+		}
+	}
+	assert.Equal(t, 15, assessed, "expected 15 of the 24 checks to have an assessment")
+	assert.Equal(t, 2, audited, "expected 2 checks with manual audit steps")
+	assert.NotZero(t, remediated, "no check in the fixture has remediation")
+	assert.NotZero(t, referenced, "no check in the fixture has references")
+}
+
+func TestDetailOfNilCheck(t *testing.T) {
+	var check *Check
+	assert.Equal(t, CheckDetail{Status: StatusUnknown}, check.Detail())
+}
+
+// The model must not rewrite the scan's scores. print_compact.go raises the
+// value of a low-impact failing check in place as a documented workaround; doing
+// that here would leak a mutated collection back to whoever loaded it.
+func TestScoresAreNotMutated(t *testing.T) {
+	collection := loadCollection(t, fixtureUbuntu)
+
+	before := map[string]uint32{}
+	for mrn, score := range collection.Reports {
+		for k, v := range score.Scores {
+			before[mrn+"/"+k] = v.Value
+		}
+	}
+
+	report := New(collection)
+	for _, asset := range report.Assets {
+		for _, check := range asset.Checks {
+			_ = check.Detail()
+		}
+	}
+
+	for mrn, score := range collection.Reports {
+		for k, v := range score.Scores {
+			assert.Equal(t, before[mrn+"/"+k], v.Value, "score %s/%s was mutated", mrn, k)
+		}
+	}
+}
+
+// Fifteen assets, no reports, fifteen errors. An asset that failed to scan is
+// not an asset without findings.
+func TestErroredAssets(t *testing.T) {
+	collection := loadCollection(t, fixtureK8s)
+	require.Len(t, collection.Assets, 15)
+	require.Empty(t, collection.Reports)
+	require.Len(t, collection.Errors, 15)
+	require.Nil(t, collection.Bundle, "the k8s fixture has no bundle; the model must not require one")
+
+	report := New(collection)
+	require.Len(t, report.Assets, 15)
+
+	assert.Equal(t, 15, report.AssetCounts.Total)
+	assert.Equal(t, 15, report.AssetCounts.Errored)
+	assert.Equal(t, 0, report.AssetCounts.Passed)
+	assert.Equal(t, 0, report.AssetCounts.Failed)
+	assert.Equal(t, 0, report.CheckCounts.Total)
+
+	for _, asset := range report.Assets {
+		assert.Equal(t, StatusError, asset.Status, "asset %q should be errored", asset.Name)
+		assert.True(t, asset.Status.IsFinding(), "an errored asset is something to act on")
+		assert.NotEmpty(t, asset.ScanError, "asset %q lost its scan error", asset.Name)
+		assert.False(t, asset.Scanned())
+
+		// The synthesized score carries the failure, exactly like the summary
+		// renderer's.
+		require.NotNil(t, asset.Score)
+		assert.Equal(t, policy.ScoreType_Error, asset.Score.Type)
+		assert.Equal(t, asset.ScanError, asset.Score.Message)
+		assert.Equal(t, asset.Mrn, asset.Score.QrId)
+
+		assert.Empty(t, asset.Checks)
+		assert.Empty(t, asset.Policies)
+		assert.Equal(t, 0, asset.Counts.Total)
+	}
+
+	// Names and platforms survive even though nothing scanned, so the viewer can
+	// tell the user which assets failed, and the assets come out sorted.
+	assert.Equal(t, "K8s Cluster minikube", report.Assets[0].Name)
+	assert.Equal(t, "kube-system/coredns", report.Assets[1].Name)
+	assert.True(t, sort.SliceIsSorted(report.Assets, func(i, j int) bool {
+		return report.Assets[i].Name < report.Assets[j].Name
+	}), "assets are not sorted by name")
+	for _, asset := range report.Assets {
+		assert.NotEqual(t, asset.Mrn, asset.Name, "asset %q lost its name", asset.Mrn)
+		assert.NotEmpty(t, asset.PlatformName)
+	}
+}
+
+// An asset that has neither a report nor an error is unknown, not passing.
+func TestAssetWithNeitherReportNorError(t *testing.T) {
+	report := New(&policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			"//assets/silent": {Mrn: "//assets/silent", Name: "silent"},
+		},
+	})
+
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+	assert.Equal(t, "silent", asset.Name)
+	assert.Equal(t, StatusUnknown, asset.Status)
+	assert.Empty(t, asset.ScanError)
+	require.NotNil(t, asset.Score)
+	assert.Equal(t, policy.ScoreType_Unknown, asset.Score.Type)
+	assert.Equal(t, 1, report.AssetCounts.Unknown)
+	assert.Equal(t, 0, report.AssetCounts.Passed)
+}
+
+func TestAssetOnlyKnownByItsError(t *testing.T) {
+	// An error for an MRN that is not in the inventory still produces an asset:
+	// dropping it would report a failed scan as a scan of nothing.
+	report := New(&policy.ReportCollection{
+		Errors: map[string]string{"//assets/ghost": "could not connect"},
+	})
+
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+	assert.Equal(t, "//assets/ghost", asset.Mrn)
+	assert.Equal(t, "//assets/ghost", asset.Name)
+	assert.Equal(t, StatusError, asset.Status)
+	assert.Equal(t, "could not connect", asset.ScanError)
+}
+
+func checkTitles(checks []*Check) []string {
+	res := make([]string, 0, len(checks))
+	for _, check := range checks {
+		res = append(res, check.Title)
+	}
+	return res
+}
+
+func policyNames(policies []*Policy) []string {
+	res := make([]string, 0, len(policies))
+	for _, p := range policies {
+		res = append(res, p.Name)
+	}
+	return res
+}

--- a/cli/reportmodel/plainerror_test.go
+++ b/cli/reportmodel/plainerror_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportmodel
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/policy"
+)
+
+// gRPC wraps a provider's own sentence in a transport envelope. The code is a
+// detail of how the message travelled; what a reader can act on is the part
+// after desc=. Every scan error in the fixtures carries the wrapper, so this is
+// the normal case rather than an edge one.
+func TestScanErrorsLoseTheirRPCEnvelope(t *testing.T) {
+	raw, err := os.ReadFile("../reporter/testdata/report-k8s.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var collection policy.ReportCollection
+	if err := json.Unmarshal(raw, &collection); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapped := 0
+	for _, msg := range collection.Errors {
+		if strings.HasPrefix(msg, "rpc error:") {
+			wrapped++
+		}
+	}
+	if wrapped == 0 {
+		t.Fatal("fixture no longer carries wrapped errors; this test proves nothing")
+	}
+	t.Logf("%d of %d fixture errors arrive wrapped", wrapped, len(collection.Errors))
+
+	report := New(&collection)
+	for _, asset := range report.Assets {
+		if strings.HasPrefix(asset.ScanError, "rpc error:") {
+			t.Errorf("%s: still wrapped: %q", asset.Name, asset.ScanError)
+		}
+		if asset.ScanError == "" {
+			t.Errorf("%s: the reason was lost entirely", asset.Name)
+		}
+	}
+}
+
+func TestPlainErrorKeepsWhatItCannotImprove(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"rpc error: code = InvalidArgument desc = asset doesn't support any policies", "asset doesn't support any policies"},
+		{"connection refused", "connection refused"},
+		{"", ""},
+		{"rpc error: malformed", "rpc error: malformed"},
+	} {
+		if got := plainError(tc.in); got != tc.want {
+			t.Errorf("plainError(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cli/reportmodel/states_test.go
+++ b/cli/reportmodel/states_test.go
@@ -1,0 +1,260 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+const stateAssetMrn = "//assets/states"
+
+// stateCase is one check of the hand-built collection below, together with the
+// outcome the model must report for it.
+type stateCase struct {
+	name  string
+	score *policy.Score
+	want  Status
+}
+
+// stateCollection builds a collection with one check per outcome. The ubuntu
+// fixture proves the traversal against real data but only carries passing,
+// failing and errored checks; skipped and unscored checks need a scan whose
+// filters excluded a query, so they are constructed here.
+func stateCollection(cases []stateCase) *policy.ReportCollection {
+	bundle := &policy.Bundle{}
+	group := &policy.PolicyGroup{}
+	jobs := map[string]*policy.ReportingJob{
+		"policy-job": {
+			Uuid: "policy-job",
+			QrId: "//policies/states",
+			Type: policy.ReportingJob_POLICY,
+		},
+	}
+	reportingQueries := map[string]*policy.StringArray{}
+	scores := map[string]*policy.Score{}
+
+	for _, c := range cases {
+		mrn := "//queries/" + c.name
+		codeID := "code-" + c.name
+
+		bundle.Queries = append(bundle.Queries, &policy.Mquery{
+			Mrn:    mrn,
+			CodeId: codeID,
+			Title:  c.name,
+			Mql:    "true",
+			Impact: &policy.Impact{Value: &policy.ImpactValue{Value: 80}},
+		})
+		group.Checks = append(group.Checks, &policy.Mquery{Mrn: mrn})
+
+		jobs["job-"+c.name] = &policy.ReportingJob{
+			Uuid:   "job-" + c.name,
+			QrId:   mrn,
+			Type:   policy.ReportingJob_CHECK,
+			Notify: []string{"policy-job"},
+		}
+		reportingQueries[codeID] = &policy.StringArray{Items: []string{"job-" + c.name}}
+
+		if c.score != nil {
+			c.score.QrId = mrn
+			scores[mrn] = c.score
+		}
+	}
+
+	bundle.Policies = []*policy.Policy{{
+		Mrn:    "//policies/states",
+		Name:   "States",
+		Groups: []*policy.PolicyGroup{group},
+	}}
+
+	return &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			stateAssetMrn: {
+				Mrn:      stateAssetMrn,
+				Name:     "states",
+				Platform: &inventory.Platform{Name: "ubuntu", Title: "Ubuntu", Family: []string{"linux"}},
+			},
+		},
+		Bundle: bundle,
+		Reports: map[string]*policy.Report{
+			stateAssetMrn: {
+				EntityMrn: stateAssetMrn,
+				Score:     &policy.Score{QrId: stateAssetMrn, Type: policy.ScoreType_Result, Value: 40},
+				Scores:    scores,
+			},
+		},
+		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
+			stateAssetMrn: {
+				CollectorJob: &policy.CollectorJob{
+					ReportingJobs:    jobs,
+					ReportingQueries: reportingQueries,
+				},
+			},
+		},
+	}
+}
+
+// The point of the model: failed, errored, skipped and unscored are four
+// distinct outcomes. Collapsing any of them into "not passing" - or worse into
+// "passing", which a bare score value of 100 on an unscored check invites -
+// would tell the user something untrue.
+func TestFourScoreStatesAreDistinguished(t *testing.T) {
+	cases := []stateCase{
+		{"pass", &policy.Score{Type: policy.ScoreType_Result, Value: 100}, StatusPass},
+		{"fail", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+		{"partial", &policy.Score{Type: policy.ScoreType_Result, Value: 99}, StatusFail},
+		{"error", &policy.Score{Type: policy.ScoreType_Error, Message: "boom"}, StatusError},
+		{"skip", &policy.Score{Type: policy.ScoreType_Skip}, StatusSkipped},
+		{"outofscope", &policy.Score{Type: policy.ScoreType_OutOfScope}, StatusSkipped},
+		{"disabled", &policy.Score{Type: policy.ScoreType_Disabled}, StatusSkipped},
+		{"unscored", &policy.Score{Type: policy.ScoreType_Unscored, Value: 100}, StatusUnscored},
+		{"missing", nil, StatusUnknown},
+	}
+
+	report := New(stateCollection(cases))
+	require.Len(t, report.Assets, 1)
+	asset := report.Assets[0]
+	require.Len(t, asset.Checks, len(cases))
+
+	got := map[string]Status{}
+	for _, check := range asset.Checks {
+		got[check.Title] = check.Status
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, got[c.name], "check %q", c.name)
+	}
+
+	assert.Equal(t, Counts{
+		Total:    9,
+		Passed:   1,
+		Failed:   2,
+		Errored:  1,
+		Skipped:  3,
+		Unscored: 1,
+		Unknown:  1,
+	}, asset.Counts)
+	assert.Equal(t, 3, asset.Counts.Findings())
+	assert.Equal(t, asset.Counts, report.CheckCounts)
+
+	// The four are never the same value, so a viewer switching on Status cannot
+	// accidentally merge them.
+	distinct := map[Status]bool{}
+	for _, s := range []Status{StatusPass, StatusFail, StatusError, StatusSkipped, StatusUnscored, StatusUnknown} {
+		assert.False(t, distinct[s])
+		distinct[s] = true
+	}
+	assert.Len(t, distinct, 6)
+}
+
+// A check whose code id is not in ReportingQueries did not run on this asset -
+// the bundle holds queries for platforms other than the one scanned - and must
+// not show up as a check of it.
+func TestChecksThatDidNotRunAreDropped(t *testing.T) {
+	collection := stateCollection([]stateCase{
+		{"ran", &policy.Score{Type: policy.ScoreType_Result, Value: 100}, StatusPass},
+		{"other-platform", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+	})
+	delete(collection.ResolvedPolicies[stateAssetMrn].CollectorJob.ReportingQueries, "code-other-platform")
+
+	report := New(collection)
+	require.Len(t, report.Assets, 1)
+	require.Len(t, report.Assets[0].Checks, 1)
+	assert.Equal(t, "ran", report.Assets[0].Checks[0].Title)
+}
+
+// Only CHECK and CHECK_AND_DATA_QUERY jobs are checks. Report.Scores also holds
+// policy, control and execution-query scores, which is why iterating it instead
+// of the reporting jobs is wrong.
+func TestOnlyCheckJobsBecomeChecks(t *testing.T) {
+	collection := stateCollection([]stateCase{
+		{"check", &policy.Score{Type: policy.ScoreType_Result, Value: 100}, StatusPass},
+		{"data", &policy.Score{Type: policy.ScoreType_Unscored}, StatusUnscored},
+		{"control", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+	})
+	jobs := collection.ResolvedPolicies[stateAssetMrn].CollectorJob.ReportingJobs
+	jobs["job-data"].Type = policy.ReportingJob_DATA_QUERY
+	jobs["job-control"].Type = policy.ReportingJob_CONTROL
+
+	report := New(collection)
+	require.Len(t, report.Assets, 1)
+	require.Len(t, report.Assets[0].Checks, 1)
+	assert.Equal(t, "check", report.Assets[0].Checks[0].Title)
+
+	// A CHECK_AND_DATA_QUERY job is still a check.
+	jobs["job-data"].Type = policy.ReportingJob_CHECK_AND_DATA_QUERY
+	report = New(collection)
+	assert.Len(t, report.Assets[0].Checks, 2)
+}
+
+// A check whose reporting job leads to no policy in the bundle is still
+// reachable in the tree, under the synthetic node.
+func TestChecksWithoutAPolicyAreStillReachable(t *testing.T) {
+	collection := stateCollection([]stateCase{
+		{"orphan", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+	})
+	collection.ResolvedPolicies[stateAssetMrn].CollectorJob.ReportingJobs["job-orphan"].Notify = nil
+
+	report := New(collection)
+	asset := report.Assets[0]
+	require.Len(t, asset.Checks, 1)
+	require.Len(t, asset.Policies, 1)
+	assert.Equal(t, UngroupedPolicyName, asset.Policies[0].Name)
+	assert.Empty(t, asset.Policies[0].Mrn)
+	assert.Len(t, asset.Policies[0].Checks, 1)
+}
+
+// The score of a check can be keyed by MRN or by code id depending on how the
+// scan collected it; both have to resolve.
+func TestScoreKeyedByCodeID(t *testing.T) {
+	collection := stateCollection([]stateCase{
+		{"byCode", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+	})
+	report := collection.Reports[stateAssetMrn]
+	score := report.Scores["//queries/byCode"]
+	delete(report.Scores, "//queries/byCode")
+	report.Scores["code-byCode"] = score
+
+	model := New(collection)
+	require.Len(t, model.Assets[0].Checks, 1)
+	assert.Equal(t, StatusFail, model.Assets[0].Checks[0].Status)
+}
+
+// A check that appears in two policies is one check, listed under both.
+func TestCheckSharedByTwoPolicies(t *testing.T) {
+	collection := stateCollection([]stateCase{
+		{"shared", &policy.Score{Type: policy.ScoreType_Result, Value: 0}, StatusFail},
+	})
+	collection.Bundle.Policies = append(collection.Bundle.Policies, &policy.Policy{
+		Mrn:  "//policies/second",
+		Name: "Second",
+		Groups: []*policy.PolicyGroup{{
+			Checks: []*policy.Mquery{{Mrn: "//queries/shared"}},
+		}},
+	})
+	jobs := collection.ResolvedPolicies[stateAssetMrn].CollectorJob.ReportingJobs
+	jobs["second-policy-job"] = &policy.ReportingJob{
+		Uuid: "second-policy-job",
+		QrId: "//policies/second",
+		Type: policy.ReportingJob_POLICY,
+	}
+	jobs["job-shared"].Notify = append(jobs["job-shared"].Notify, "second-policy-job")
+
+	report := New(collection)
+	asset := report.Assets[0]
+
+	require.Len(t, asset.Checks, 1, "a check in two policies is still one check")
+	assert.Equal(t, 1, asset.Counts.Total, "a shared check must not be counted twice")
+
+	require.Len(t, asset.Policies, 2)
+	assert.Equal(t, []string{"Second", "States"}, policyNames(asset.Policies))
+	for _, p := range asset.Policies {
+		require.Len(t, p.Checks, 1)
+		assert.Same(t, asset.Checks[0], p.Checks[0])
+	}
+	assert.Len(t, asset.Checks[0].Policies, 2)
+}

--- a/cli/reportview/copy.go
+++ b/cli/reportview/copy.go
@@ -1,0 +1,387 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Copying a check's code to the clipboard.
+//
+// A remediation is not prose. It is a `yum remove`, an ansible play, a `defaults
+// write` -- things whose only use is to be run somewhere else. Until this, the
+// only way to get one out of the viewer was to select it with the mouse, and the
+// pane had already folded it at the right edge and set it in two columns from
+// the left, so what landed in the clipboard was not a command any more.
+//
+// So the thing that is copied is the *source*: the bytes between the fences,
+// exactly as the policy author wrote them. Not what is on screen. No wrap, no
+// indent, no ANSI, nothing glamour did to it. A pasted command runs.
+//
+// # What is copyable
+//
+// Everything the detail pane draws as a code block:
+//
+//   - the QUERY section, which is d.Mql -- a snippet in its own right, because
+//     pasting it into `cnspec shell` is how you find out what the check saw;
+//   - every fenced code block in the DESCRIPTION, the AUDIT and each
+//     REMEDIATION body, all three of which are markdown source.
+//
+// The assessment is deliberately not on that list. It is the check's output,
+// not something anybody runs.
+//
+// The blocks come from goldmark (fencedCodes), not from a scan for backticks.
+// A fence may be written with tildes, may be indented, may carry no language and
+// may never be closed at all, and CommonMark says something specific about each;
+// goldmark is already in the module graph underneath glamour and already knows.
+//
+// # The clipboard
+//
+// github.com/atotto/clipboard, which shells out to pbcopy, xclip or wl-copy --
+// already in the module graph, via bubbles/textinput. The reason to prefer it
+// over an OSC 52 escape sequence is that it **returns an error**: it either put
+// the text on the clipboard or it said why it could not, and the footer can
+// therefore state a fact rather than a hope. An escape sequence is
+// fire-and-forget -- many terminals ignore it by default, tmux and screen need
+// explicit passthrough, and there is no reply -- so a viewer built on one would
+// have to say "copied" without knowing.
+//
+// cnspec runs on the machine the user is sitting at, and that machine's
+// clipboard is the one they will paste from, so the native clipboard is also the
+// one that reaches the right place. Where there is no clipboard tool installed,
+// WriteAll says so, and copyNotice shows that reason.
+
+// Snippet is one copyable piece of a check: a code block, with enough about
+// where it came from to name it in the footer afterwards.
+//
+// A check often has several -- the same fix as a CLI command, an ansible play
+// and a bash script -- so "copied" on its own would not say which one.
+type Snippet struct {
+	// From is the section it came from, spelled the way the footer says it:
+	// "description", "the query", "audit", "remediation [ansible]".
+	From string
+	// Lang is the fence's info word ("bash", "yaml"), empty when the fence
+	// carried none. The query's is "mql".
+	Lang string
+	// Text is the source, exactly. This is what goes on the clipboard.
+	Text string
+	// Nth and Of place the snippet among the blocks of its own section, one
+	// based. Of is 1 when the section had a single block, and Label leaves the
+	// ordinal off in that case -- "remediation [cli]" needs no "#1 of 1".
+	Nth, Of int
+}
+
+// Label names the snippet in a sentence: "remediation [cli] #2".
+func (s Snippet) Label() string {
+	if s.Of > 1 {
+		return s.From + " #" + strconv.Itoa(s.Nth)
+	}
+	return s.From
+}
+
+// Describe is Label plus what it is and how much of it there is, which is the
+// whole of what the footer needs to say: "remediation [cli] #2 (bash, 94 B)".
+func (s Snippet) Describe() string {
+	size := humanSize(int64(len(s.Text)))
+	if s.Lang == "" {
+		return s.Label() + " (" + size + ")"
+	}
+	return s.Label() + " (" + s.Lang + ", " + size + ")"
+}
+
+// checkSnippets is every copyable block of a check, in the order the detail pane
+// draws them: description, query, audit, remediation. The order matters -- it is
+// what lets the pane number the buttons it renders against this list rather than
+// keeping a second one of its own.
+func checkSnippets(c *reportmodel.Check) []Snippet {
+	if c == nil {
+		return nil
+	}
+	return detailSnippets(c.Detail())
+}
+
+// detailSnippets is checkSnippets over an already-composed detail. Detail()
+// walks the raw results, so the pane computes it once per selection and passes
+// it here rather than paying for it twice.
+func detailSnippets(d reportmodel.CheckDetail) []Snippet {
+	var res []Snippet
+	res = append(res, markdownSnippets("description", d.Description)...)
+	if mql := strings.TrimSpace(tui.Clean(d.Mql)); mql != "" {
+		res = append(res, Snippet{From: "the query", Lang: "mql", Text: mql, Nth: 1, Of: 1})
+	}
+	res = append(res, markdownSnippets("audit", d.Audit)...)
+	for _, item := range d.Remediation {
+		res = append(res, markdownSnippets(remediationLabel(item.Id), item.Desc)...)
+	}
+	return res
+}
+
+// remediationLabel names a fix by its platform id, which is what tells three
+// otherwise identical rows apart. "default" is reportmodel's stand-in for a fix
+// with no platform, and is not a name worth showing.
+func remediationLabel(id string) string {
+	if id == "" || id == "default" {
+		return "remediation"
+	}
+	return "remediation [" + id + "]"
+}
+
+// markdownSnippets is the fenced blocks of one markdown source, labelled.
+func markdownSnippets(from, src string) []Snippet {
+	codes := fencedCodes(mdSource(src))
+	if len(codes) == 0 {
+		return nil
+	}
+	res := make([]Snippet, 0, len(codes))
+	for i, c := range codes {
+		res = append(res, Snippet{
+			From: from, Lang: c.Lang, Text: c.Text,
+			Nth: i + 1, Of: len(codes),
+		})
+	}
+	return res
+}
+
+// --- the clipboard -----------------------------------------------------------
+
+// clipboardWrite is what puts text on the system clipboard.
+//
+// It is a variable so the tests can watch it. A test that called the real one
+// would overwrite whatever the developer running it had copied, and on a build
+// box with no pbcopy, xclip or wl-copy it would fail for a reason that has
+// nothing to do with this viewer.
+var clipboardWrite = clipboard.WriteAll
+
+// copyDoneMsg is the outcome of a clipboard write on its way back to the frame.
+//
+// Unlike ExportDoneMsg this is not exported. A write to the clipboard is a
+// subprocess that returns in milliseconds, not a multi-megabyte render, so there
+// is no window in which the viewer is closed and the result still matters -- and
+// exporting it would advertise a message an embedding program has to handle.
+type copyDoneMsg struct {
+	Snippet Snippet
+	Err     error
+}
+
+// copyCmd is the write, as a command.
+//
+// Off the event loop for the same reason exportCmd is: clipboard.WriteAll forks
+// pbcopy (or xclip, or wl-copy) and waits for it, and a fork-and-wait inside
+// Update is a viewer that stops repainting mid-keystroke. Nothing here touches
+// the terminal -- the escape-sequence route would have, and racing bubbletea's
+// renderer from a command goroutine is exactly the thing this avoids.
+func copyCmd(s Snippet) tea.Cmd {
+	return func() tea.Msg {
+		if s.Text == "" {
+			return copyDoneMsg{Snippet: s, Err: errors.New("there is nothing in this block to copy")}
+		}
+		if err := clipboardWrite(s.Text); err != nil {
+			return copyDoneMsg{Snippet: s, Err: errors.Wrap(err, "the system clipboard refused it")}
+		}
+		return copyDoneMsg{Snippet: s}
+	}
+}
+
+// copyNotice is the one line the footer shows afterwards.
+//
+// Success says "copied", flatly, because clipboard.WriteAll returning nil means
+// the text is on the clipboard -- there is nothing to hedge. Failure says why,
+// in the words of whatever refused: a missing xclip and a wl-copy that exited
+// non-zero are different problems and the user is the one who can fix either.
+func copyNotice(msg copyDoneMsg) string {
+	if msg.Err != nil {
+		return "copy failed: " + tui.OneLine(msg.Err.Error())
+	}
+	return "copied " + msg.Snippet.Describe() + " to the clipboard"
+}
+
+// --- the button --------------------------------------------------------------
+
+// The affordance is a web page's, on purpose: a small COPY at the top right of
+// every code block, and you take the one you want. Clicking it copies that
+// block.
+//
+// # The arming rule
+//
+// The keyboard needs a way to say *which* button, and the answer is the accent
+// band: exactly one COPY on screen wears it, and y takes that block. The rule
+// that decides which one, in full:
+//
+//  1. n and p move the arm to the next and previous code block of the check, and
+//     scroll it into view. This is a real selection -- it is the reason the band
+//     is worth drawing.
+//  2. A plain scroll (the arrows, j/k, the page keys, g/G, the wheel) that
+//     carries the armed block off the screen gives the arm back: it reverts to
+//     the topmost block currently in view. Scrolling was the only way to aim
+//     before n and p existed, and it is still an aim -- what it must not do is
+//     leave the band somewhere the user cannot see it.
+//  3. When no code block is on screen at all -- a long check opens on its
+//     description, and the first fence may be forty rows down -- nothing is
+//     armed. y says so and names n as the way to reach one.
+//  4. A new selection resets the arm. The block you picked on the last check is
+//     not on this one; the implicit rule takes over, and at the top of a fresh
+//     page that is the check's first block.
+//
+// The invariant underneath all four: **y never copies a block that is not on
+// screen**. It is enforced structurally rather than by agreement -- armedIn will
+// not return a block outside the viewport, whatever put it there -- so a scroll,
+// a resize or a reflow cannot leave y aimed at something invisible.
+//
+// The one exception is a terminal too narrow for two panes with the tree
+// focused, where the detail pane is not drawn at all. There is no viewport to
+// aim with and no band to have seen, and y still has to work from the tree, so
+// it takes the check's first block. See detailPane.CopyTarget.
+//
+// A click is not arming and never has been: the button under the pointer is the
+// answer to which block the user meant, so a click copies that one and leaves
+// the arm where it was.
+
+// copyLabel is the button. It is a constant width so that a column of them lines
+// up down the pane and so the geometry can reserve exactly one strip for them.
+const copyLabel = " COPY "
+
+const (
+	// copyLabelW is the rendered width of copyLabel.
+	copyLabelW = 6
+	// copyGutter is what a code block gives up to the button: the label plus one
+	// space between it and the code. The block is *rendered* narrower by this
+	// much rather than being overwritten by the button, so a button never hides
+	// a character of the command it copies.
+	copyGutter = copyLabelW + 1
+	// copyMinCode is the narrowest strip of code worth keeping. Below
+	// copyGutter+copyMinCode cells the pane draws no buttons at all: a terminal
+	// where the button is wider than the command is one where the button is the
+	// bug.
+	copyMinCode = 8
+)
+
+// copyWidth is the width to render a code block at inside w cells, and whether
+// there is room for a button beside it.
+func copyWidth(w int) (int, bool) {
+	if w < copyGutter+copyMinCode {
+		return w, false
+	}
+	return w - copyGutter, true
+}
+
+// copyButtonRow puts the button at the right edge of a row w cells wide.
+//
+// Every button is drawn as a band, so every button reads as a button. The
+// armed one -- the block y would take -- wears the accent band; the rest wear
+// the inactive one. Drawing the unarmed ones as faint text instead was the
+// first attempt and it read as *disabled*: a user seeing one lit button and one
+// grey label concludes the second does not work, when in fact clicking it
+// copies that block just as well.
+//
+// The armed one stays banded whether or not the detail pane has focus, because
+// y is a frame binding -- it copies that block from the tree as well.
+//
+// The row is padded rather than overwritten: copyWidth already took the gutter
+// out of the width the block was rendered at, so there is nothing under the
+// button to lose.
+func copyButtonRow(row string, w int, armed bool) string {
+	if w < copyLabelW+1 {
+		return row
+	}
+	style := tui.BandInactive
+	if armed {
+		style = tui.BandSelected
+	}
+	head := tui.PadRight(tui.Truncate(row, w-copyLabelW-1), w-copyLabelW-1)
+	return head + " " + style.Render(copyLabel)
+}
+
+// copyZoneTag marks a Zone as a COPY button. The zone's Idx is the index of the
+// snippet it copies.
+const copyZoneTag = "copy"
+
+// --- frame integration -------------------------------------------------------
+
+// CopySource is the optional interface for a pane that can hand the frame
+// something to put on the clipboard. It is optional in the same way SizedPane is:
+// a pane that has no code in it simply does not implement it.
+type CopySource interface {
+	// CopyTarget is the snippet a copy key would take right now, and whether
+	// there is one at all. It must not depend on having been rendered since the
+	// last resize: below tui.MinTwoPaneWidth only the focused pane is drawn, and
+	// the key still works from the other one.
+	CopyTarget(st *State) (Snippet, bool)
+
+	// ArmCopy moves the armed block delta places -- +1 for n, -1 for p -- and
+	// scrolls it into view, which is not optional: an arm the user cannot see is
+	// worse than no arm at all. It reports whether the pane had a block to arm;
+	// at either end of the list it stays put and still reports true.
+	ArmCopy(st *State, delta int) bool
+}
+
+// copySnippet is the frame's y binding: ask each pane for a target, and say so
+// plainly when there is none. An empty picker is not offered -- this package has
+// a rule against those.
+func (m Model) copySnippet() (tea.Model, tea.Cmd) {
+	for _, p := range m.panes() {
+		cs, ok := p.(CopySource)
+		if !ok {
+			continue
+		}
+		if snip, ok := cs.CopyTarget(m.state); ok {
+			return m, copyCmd(snip)
+		}
+	}
+	m.state.Notice = "nothing to copy: " + noCopyReason(m.state)
+	return m, nil
+}
+
+// armCopy is the frame's n and p binding: move the arm one block on.
+//
+// It is frame-level for the same reason y is, and the reason matters more than
+// the line it saves. y copies while the tree has focus, which is where the
+// cursor spends most of its time; a pane-local n and p would be dead in exactly
+// that spot, so the key that aims would work in fewer places than the key that
+// fires. It also never reaches the frame while the header's search field is
+// open, because that field consumes every rune.
+func (m Model) armCopy(delta int) (tea.Model, tea.Cmd) {
+	for _, p := range m.panes() {
+		cs, ok := p.(CopySource)
+		if !ok {
+			continue
+		}
+		if cs.ArmCopy(m.state, delta) {
+			return m, nil
+		}
+	}
+	// Silence would be indistinguishable from a key that does not exist, which is
+	// the same reason y says something rather than nothing.
+	m.state.Notice = "nothing to highlight: " + noCopyReason(m.state)
+	return m, nil
+}
+
+// noCopyReason is why no pane offered a block, in the words the footer uses.
+// It is only ever reached on the failing path, so recomputing the snippets to
+// tell an empty check from a check scrolled away from costs nothing that the
+// user is waiting on.
+func noCopyReason(st *State) string {
+	switch {
+	case st.Sel.Check == nil:
+		return "no check is selected"
+	case len(checkSnippets(st.Sel.Check)) == 0:
+		return "this check has no code blocks"
+	default:
+		return "no code block is in view (press n for the next one)"
+	}
+}
+
+// copyDone puts the outcome in the footer. There is no box to keep open on a
+// failure the way export has: the copy was one keystroke and the reason it
+// failed fits on the line.
+func (m Model) copyDone(msg copyDoneMsg) (tea.Model, tea.Cmd) {
+	m.state.Notice = copyNotice(msg)
+	return m, nil
+}

--- a/cli/reportview/copy_test.go
+++ b/cli/reportview/copy_test.go
@@ -1,0 +1,1196 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/cockroachdb/errors"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The check the fixture gives this feature its best workout on: three
+// remediations, six code blocks between them in three languages, one of them a
+// multi-command bash script.
+const copyFixtureCheck = "Ensure X Window System is not installed"
+
+// clipboardSpy replaces the real clipboard for the duration of a test.
+//
+// Calling the real one would overwrite whatever the developer running the test
+// had copied, and on a build box with no pbcopy, xclip or wl-copy it would fail
+// for a reason that has nothing to do with the viewer.
+func clipboardSpy(t *testing.T, err error) *string {
+	t.Helper()
+	var got string
+	was := clipboardWrite
+	clipboardWrite = func(s string) error {
+		got = s
+		return err
+	}
+	t.Cleanup(func() { clipboardWrite = was })
+	return &got
+}
+
+// run drives a command the way bubbletea would and returns the message.
+func run(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+// styled pins lipgloss's own color profile, which is what the chrome styles in
+// theme.go render through. lipgloss detects Ascii whenever stdout is not a
+// terminal -- every test run -- and with Ascii every style renders as the plain
+// string, so a test that wants to tell the armed button from the rest has to ask
+// for a profile that has an escape sequence to tell them apart with.
+func styled(t *testing.T) {
+	t.Helper()
+	was := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(was) })
+}
+
+// --- what a snippet is ------------------------------------------------------
+
+// The whole point of the feature: what lands on the clipboard is the source, not
+// the screen. The pane folded this block at the right edge, set it in two
+// columns from the left and coloured it; none of that may survive into the
+// clipboard, or the pasted command does not run.
+func TestCopiedTextIsTheSourceNotTheScreen(t *testing.T) {
+	colorful(t)
+	_, check := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	var ansible Snippet
+	for _, s := range checkSnippets(check) {
+		if s.From == "remediation [ansible]" {
+			ansible = s
+		}
+	}
+	require.NotEmpty(t, ansible.Text, "the ansible remediation has a fenced block")
+	require.Equal(t, "yaml", ansible.Lang)
+
+	// Not a fence in sight, and not an escape byte either.
+	require.NotContains(t, ansible.Text, "```")
+	require.NotContains(t, ansible.Text, "\x1b")
+	require.Equal(t, ansible.Text, ansi.Strip(ansible.Text))
+
+	// The block's own indentation is intact -- it is yaml, and yaml is
+	// indentation -- while the pane's two columns of section indent are not.
+	require.True(t, strings.HasPrefix(ansible.Text, "---\n- name:"),
+		"the block starts at column zero:\n%q", ansible.Text)
+	require.Contains(t, ansible.Text, "\n      ansible.builtin.yum:")
+
+	// And the lines are the author's, not the pane's. The pane folded this
+	// document at 60 cells; every line here is the length it was written at.
+	rendered := ansi.Strip(strings.Join(markdown.Lines(check.Detail().Remediation[1].Desc, 60), "\n"))
+	require.Contains(t, rendered, "- name: Remove X Window System packages on")
+	require.NotContains(t, rendered, `- name: Remove X Window System packages on RHEL/Fedora/Amazon Linux`,
+		"this line is too long for the pane, so the pane must have folded it")
+	require.Contains(t, ansible.Text, `- name: Remove X Window System packages on RHEL/Fedora/Amazon Linux`,
+		"and the copy must not have")
+}
+
+// A multi-command script comes out whole, in order, with its blank lines: it is
+// a program, and half of one is worse than none.
+func TestCopiedScriptIsIntact(t *testing.T) {
+	_, check := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	var script Snippet
+	for _, s := range checkSnippets(check) {
+		if s.From == "remediation [bash]" {
+			script = s
+		}
+	}
+	require.True(t, strings.HasPrefix(script.Text, "#!/bin/bash\nset -e\n"))
+	require.True(t, strings.HasSuffix(script.Text, "exit 1\nfi"),
+		"the block ends where the fence did, with no trailing blank line: %q",
+		script.Text[len(script.Text)-40:])
+	require.Contains(t, script.Text, "\nelif command -v apt-get >/dev/null 2>&1; then\n")
+	require.Equal(t, strings.Count(script.Text, "\n")+1, 19)
+}
+
+// The query is a snippet in its own right: pasting it into `cnspec shell` is how
+// you find out what the check saw.
+func TestQueryIsCopyable(t *testing.T) {
+	_, check := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+	snips := checkSnippets(check)
+	require.NotEmpty(t, snips)
+	require.Equal(t, "the query", snips[0].From, "the query comes before the remediation")
+	require.Equal(t, "mql", snips[0].Lang)
+	require.Equal(t, check.Detail().Mql, snips[0].Text)
+}
+
+// Every snippet is named by where it came from and what it is, because a check
+// with the same fix three times over cannot be reported as "copied".
+func TestSnippetsAreLabelledByOriginAndLanguage(t *testing.T) {
+	_, check := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	labels := make([]string, 0, 6)
+	for _, s := range checkSnippets(check) {
+		labels = append(labels, s.Label()+" "+s.Lang)
+	}
+	require.Equal(t, []string{
+		"the query mql",
+		// The cli fix is three commands, one per distro family, so they are
+		// numbered; the other two are one block each and are not.
+		"remediation [cli] #1 bash",
+		"remediation [cli] #2 bash",
+		"remediation [cli] #3 bash",
+		"remediation [ansible] yaml",
+		"remediation [bash] bash",
+	}, labels)
+
+	require.Equal(t, "remediation [cli] #2 (bash, 26 B)",
+		checkSnippets(check)[2].Describe())
+}
+
+// --- finding the blocks -----------------------------------------------------
+
+// The cases a scan for backticks gets wrong. Each is what CommonMark says, and
+// goldmark is what says it.
+func TestFencedBlockEdgeCases(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []mdCode
+	}{
+		{
+			name: "a fence may be tildes, and may then contain backticks",
+			src:  "before\n\n~~~sh\necho `date`\n~~~\n\nafter\n",
+			want: []mdCode{{Lang: "sh", Text: "echo `date`"}},
+		},
+		{
+			name: "a fence need not carry a language",
+			src:  "a\n\n```\necho hi\n```\n",
+			want: []mdCode{{Lang: "", Text: "echo hi"}},
+		},
+		{
+			name: "an unclosed fence runs to the end of the document",
+			src:  "before\n\n```bash\necho hi\nand more\n",
+			want: []mdCode{{Lang: "bash", Text: "echo hi\nand more"}},
+		},
+		{
+			name: "a longer fence is not closed by a shorter one inside it",
+			src:  "a\n\n````md\n```\nnested\n```\n````\n",
+			want: []mdCode{{Lang: "md", Text: "```\nnested\n```"}},
+		},
+		{
+			name: "an indented fence loses its indent, not the block's own",
+			src:  "a\n\n   ```bash\n   if x; then\n     echo hi\n   fi\n   ```\n",
+			want: []mdCode{{Lang: "bash", Text: "if x; then\n  echo hi\nfi"}},
+		},
+		{
+			name: "blank lines around the content are the author's spacing",
+			src:  "a\n\n```bash\n\necho hi\n\n```\n",
+			want: []mdCode{{Lang: "bash", Text: "echo hi"}},
+		},
+		{
+			name: "an empty fence has nothing to copy",
+			src:  "a\n\n```\n```\n\nb\n",
+			want: nil,
+		},
+		{
+			name: "an indented code block is not a fenced one",
+			src:  "a\n\n    echo indented\n\nb\n",
+			want: nil,
+		},
+		{
+			name: "a fence nested in a list is left alone",
+			src:  "1. do this:\n\n   ```bash\n   echo hi\n   ```\n\n2. done\n",
+			want: nil,
+		},
+		{
+			name: "several fences come back in document order",
+			src:  "a\n\n```bash\none\n```\n\nb\n\n```yaml\nk: v\n```\n",
+			want: []mdCode{{Lang: "bash", Text: "one"}, {Lang: "yaml", Text: "k: v"}},
+		},
+		{
+			name: "prose that merely mentions a backtick is not a block",
+			src:  "set the `PATH` and you are done\n",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := mdSource(tc.src)
+			got := fencedCodes(src)
+			require.Len(t, got, len(tc.want))
+			for i := range tc.want {
+				require.Equal(t, tc.want[i].Lang, got[i].Lang)
+				require.Equal(t, tc.want[i].Text, got[i].Text)
+				// The span brackets the whole block, fences included, so the
+				// renderer can cut the document at it without losing a byte.
+				block := src[got[i].Start:got[i].Stop]
+				require.True(t,
+					strings.HasPrefix(strings.TrimLeft(block, " "), "```") ||
+						strings.HasPrefix(strings.TrimLeft(block, " "), "~~~"),
+					"the span starts at the opening fence: %q", block)
+			}
+		})
+	}
+}
+
+// The spans must tile the document: everything outside them is prose, and
+// nothing may be counted twice or dropped.
+func TestFencedSpansTileTheDocument(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	sources := 0
+	for _, a := range report.Assets {
+		for _, c := range a.Checks {
+			d := c.Detail()
+			srcs := []string{d.Description, d.Audit}
+			for _, r := range d.Remediation {
+				srcs = append(srcs, r.Desc)
+			}
+			for _, raw := range srcs {
+				src := mdSource(raw)
+				codes := fencedCodes(src)
+				if len(codes) == 0 {
+					continue
+				}
+				sources++
+				var rebuilt strings.Builder
+				at := 0
+				for _, c := range codes {
+					require.GreaterOrEqual(t, c.Start, at, "spans overlap")
+					require.Greater(t, c.Stop, c.Start)
+					require.LessOrEqual(t, c.Stop, len(src))
+					rebuilt.WriteString(src[at:c.Start])
+					rebuilt.WriteString(src[c.Start:c.Stop])
+					at = c.Stop
+				}
+				rebuilt.WriteString(src[at:])
+				require.Equal(t, src, rebuilt.String())
+			}
+		}
+	}
+	require.Greater(t, sources, 20, "the fixture is supposed to be full of these")
+}
+
+// Splitting the document to find the blocks must not change how it reads. Every
+// markdown source in the fixture is rendered both ways and the rows compared.
+func TestSegmentedRenderMatchesWholeDocument(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	compared := 0
+	for _, a := range report.Assets {
+		for _, c := range a.Checks {
+			d := c.Detail()
+			srcs := []string{d.Description, d.Audit}
+			for _, r := range d.Remediation {
+				srcs = append(srcs, r.Desc)
+			}
+			for _, src := range srcs {
+				if strings.TrimSpace(src) == "" {
+					continue
+				}
+				compared++
+				var pieces []string
+				for i, b := range markdown.Blocks(src, 60, 60) {
+					if i > 0 {
+						pieces = append(pieces, "")
+					}
+					pieces = append(pieces, b.Lines...)
+				}
+				require.Equal(t, markdown.Lines(src, 60), pieces,
+					"rendering %q in pieces does not match rendering it whole", d.Title)
+			}
+		}
+	}
+	require.Greater(t, compared, 50)
+}
+
+// Splitting a document renders it at two widths -- prose at the pane's, code a
+// button's strip narrower. A renderer cache with one slot would rebuild
+// glamour's whole pipeline at every fence, so it has room for both, and the room
+// is bounded so a drag of the terminal's edge cannot fill it.
+func TestSegmentingDoesNotThrashTheRenderer(t *testing.T) {
+	colorful(t)
+	m := &markdownRenderer{}
+
+	src := "prose\n\n```bash\none\n```\n\nmore prose\n\n```yaml\nk: v\n```\n\nand more\n"
+	for i := 0; i < 50; i++ {
+		require.NotEmpty(t, m.Blocks(src, 60, 60-copyGutter))
+	}
+	require.Len(t, m.trs, 2, "one renderer for the prose width and one for the code width")
+
+	// Every width a resize sweeps through, and it still does not grow.
+	for w := 30; w < 120; w++ {
+		m.Blocks(src, w, w-copyGutter)
+	}
+	require.LessOrEqual(t, len(m.trs), markdownMaxTRs)
+}
+
+// --- the button -------------------------------------------------------------
+
+// A COPY sits at the top right of every code block, and the row it sits on is
+// still exactly one row of exactly the pane's width: the block is *rendered*
+// narrower to make space, so the button covers no part of the command.
+func TestCopyButtonSitsOnEveryCodeBlock(t *testing.T) {
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	p := &detailPane{}
+	rect := detailRect(64, 400)
+	r := p.Render(st, rect)
+
+	require.Len(t, p.buttons, 6, "six code blocks, six buttons")
+	require.Len(t, r.Zones, 6, "and one clickable zone each")
+
+	for i, btn := range p.buttons {
+		row := ansi.Strip(r.Lines[btn.Row])
+		require.True(t, strings.HasSuffix(row, copyLabel),
+			"button %d is not at the right edge of %q", i, row)
+		require.Equal(t, rect.W, tui.Width(r.Lines[btn.Row]),
+			"the button row is not exactly the pane's width")
+
+		// The first line of the block is still all there in front of it: the
+		// button took its strip out of the width the block was rendered at
+		// rather than being painted over the command.
+		snip := p.snips[btn.Idx]
+		first := strings.SplitN(snip.Text, "\n", 2)[0]
+		if tui.Width(first) <= rect.W-copyGutter-detailIndent {
+			require.Contains(t, row, first,
+				"button %d hid part of the block it copies", i)
+			require.NotContains(t, row, "…",
+				"button %d had to truncate the block's first line", i)
+		}
+	}
+
+	// The zones are where the buttons were drawn, in absolute cells.
+	for i, z := range r.Zones {
+		require.Equal(t, copyZoneTag, z.Tag)
+		require.Equal(t, rect.X+rect.W-copyLabelW, z.Rect.X)
+		require.Equal(t, copyLabelW, z.Rect.W)
+		require.Equal(t, 1, z.Rect.H)
+		require.Equal(t, rect.Y+p.buttons[i].Row, z.Rect.Y)
+		require.Equal(t, p.buttons[i].Idx, z.Idx)
+	}
+}
+
+// The armed button -- the one y takes -- is the topmost block *on screen*, and
+// it is the only one wearing the band. Scrolling is still an aim, so scrolling
+// still has to move it.
+//
+// The two ends of the page are the interesting part, and both changed when n and
+// p arrived: an arm is a thing the user can see now, so a page scrolled to a
+// place with no code on it arms nothing at all rather than reaching off screen
+// for the nearest block. See the arming rule at the top of copy.go.
+func TestArmedButtonFollowsTheScroll(t *testing.T) {
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	p := &detailPane{}
+	p.Render(st, detailRect(64, 20))
+	require.Greater(t, len(p.buttons), 2)
+
+	// This check opens on a long description: its first fence is well below the
+	// twenty rows on screen, so at the top of the page nothing is armed.
+	require.Greater(t, p.buttons[0].Row, 20)
+	require.Equal(t, -1, p.armed())
+	_, ok := p.CopyTarget(st)
+	require.False(t, ok, "y takes nothing it cannot show")
+
+	// Scroll so the first block's row is the top row: that one.
+	p.scroll.Off = p.buttons[0].Row
+	p.Render(st, detailRect(64, 20))
+	require.Equal(t, 0, p.armed())
+
+	// One row past it, and the next block takes over.
+	p.scroll.Off = p.buttons[0].Row + 1
+	p.Render(st, detailRect(64, 20))
+	require.Equal(t, 1, p.armed())
+
+	// Scrolled past every block -- a long check ends in POLICIES, which has no
+	// code in it -- nothing is armed rather than the last block being armed
+	// somewhere above the top of the screen.
+	p.scroll.Off = len(p.lines)
+	p.Render(st, detailRect(64, 20))
+	require.Equal(t, -1, p.armed())
+	_, ok = p.CopyTarget(st)
+	require.False(t, ok)
+}
+
+// Exactly one button on screen is banded, and it is the armed one. This is the
+// whole of what makes it obvious which block y would take.
+func TestArmedButtonIsTheOnlyAccentedOne(t *testing.T) {
+	colorful(t)
+	styled(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	p := &detailPane{}
+	p.Render(st, detailRect(64, 400))
+	require.Greater(t, len(p.buttons), 2)
+
+	// Both are bands, so both read as buttons; only the accent one says "y
+	// takes this". Drawing the unarmed ones as faint text made them look
+	// disabled, which they are not -- a click copies them just as well.
+	band := tui.BandSelected.Render(copyLabel)
+	quiet := tui.BandInactive.Render(copyLabel)
+	require.NotEqual(t, band, quiet, "armed and unarmed must not render the same")
+
+	// Three blocks in view at once, with the topmost of them armed. The viewport
+	// has to be shorter than the page or the scroll offset clamps back to zero.
+	p.scroll.Off = p.buttons[1].Row
+	r := p.Render(st, detailRect(64, 20))
+
+	var accented, quiets []int
+	for i, ln := range r.Lines {
+		switch {
+		case strings.Contains(ln, band):
+			accented = append(accented, i)
+		case strings.Contains(ln, quiet):
+			quiets = append(quiets, i)
+		}
+	}
+	require.Equal(t, []int{0}, accented, "one accented button, on the topmost visible block")
+	require.NotEmpty(t, quiets, "and the blocks below it still look like buttons")
+	require.Equal(t, 1, p.armed())
+}
+
+// A pane too narrow to set a button beside a block draws none: a COPY wider than
+// the command it copies is the bug, not the feature. The key still works.
+func TestNoButtonsInAVeryNarrowPane(t *testing.T) {
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+
+	p := &detailPane{}
+	r := p.Render(st, detailRect(12, 200))
+	require.False(t, p.room)
+	require.Empty(t, r.Zones)
+	for _, ln := range r.Lines {
+		require.NotContains(t, ansi.Strip(ln), "COPY")
+	}
+
+	// The blocks were still found, so y still has something to take.
+	require.NotEmpty(t, p.buttons)
+	snip, ok := p.CopyTarget(st)
+	require.True(t, ok)
+	require.Equal(t, "the query", snip.From)
+}
+
+// The frame's invariant, with the buttons on: every row is one row, no wider
+// than the terminal, at every size the geometry tests use.
+func TestButtonsKeepTheGeometry(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	asset := report.Assets[0]
+
+	for _, c := range asset.Checks {
+		st := NewState(report)
+		st.SelectCheck(asset, nil, c)
+		for _, s := range termSizes {
+			p := &detailPane{}
+			rect := detailRect(s.w, s.h)
+			r := p.Render(st, rect)
+			for i, ln := range r.Lines {
+				require.LessOrEqual(t, tui.Width(ln), rect.W,
+					"%dx%d row %d: %q", s.w, s.h, i, ansi.Strip(ln))
+				require.NotContains(t, ln, "\n")
+			}
+			for _, z := range r.Zones {
+				require.GreaterOrEqual(t, z.Rect.X, rect.X)
+				require.LessOrEqual(t, z.Rect.X+z.Rect.W, rect.X+rect.W)
+				require.GreaterOrEqual(t, z.Rect.Y, rect.Y)
+				require.Less(t, z.Rect.Y, rect.Y+rect.H)
+			}
+		}
+	}
+}
+
+// --- copying ----------------------------------------------------------------
+
+// The key takes the armed block, puts the source on the clipboard and says so.
+func TestCopyKeyCopiesTheArmedBlock(t *testing.T) {
+	colorful(t)
+	got := clipboardSpy(t, nil)
+
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 120, 40)
+	asset := report.Assets[0]
+	var check = asset.Checks[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			check = c
+		}
+	}
+	m.state.SelectCheck(asset, nil, check)
+	m.View() // one frame, so the detail pane knows where its blocks are
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	msg := run(cmd)
+	require.IsType(t, copyDoneMsg{}, msg)
+
+	nm, _ = nm.(Model).Update(msg)
+	m = nm.(Model)
+
+	require.Equal(t, check.Detail().Mql, *got, "the top block is the query")
+	require.Equal(t, "copied the query (mql, 85 B) to the clipboard", m.state.Notice)
+	require.Contains(t, m.View(), ansi.Strip("copied the query"))
+}
+
+// A click takes the block under the pointer, not the armed one: the button you
+// pressed is the answer to which block you meant.
+func TestClickOnACopyButtonTakesThatBlock(t *testing.T) {
+	colorful(t)
+	got := clipboardSpy(t, nil)
+
+	st, check := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+	p := &detailPane{}
+	rect := detailRect(64, 400)
+	r := p.Render(st, rect)
+	require.Len(t, r.Zones, 6)
+
+	// The ansible playbook, which is the fifth block and never the armed one at
+	// this scroll position.
+	z := r.Zones[4]
+	require.NotEqual(t, p.armed(), z.Idx)
+
+	cmd, handled := p.Update(st, ClickMsg{Zone: z, Mouse: tea.MouseMsg{X: z.Rect.X, Y: z.Rect.Y}})
+	require.True(t, handled)
+	msg := run(cmd)
+	require.IsType(t, copyDoneMsg{}, msg)
+	require.NoError(t, msg.(copyDoneMsg).Err)
+
+	require.Equal(t, "remediation [ansible]", msg.(copyDoneMsg).Snippet.From)
+	require.True(t, strings.HasPrefix(*got, "---\n- name: Remove X Window System packages"))
+	require.Contains(t, check.Detail().Remediation[1].Desc, *got,
+		"what was copied is a literal substring of the markdown it came from")
+}
+
+// The same click, through the whole frame: hit-tested against the zones of the
+// frame just rendered, so the button that responds is the button that was drawn.
+func TestClickThroughTheFrameCopies(t *testing.T) {
+	colorful(t)
+	got := clipboardSpy(t, nil)
+
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 140, 44)
+	asset := report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			m.state.SelectCheck(asset, nil, c)
+		}
+	}
+	m.View()
+
+	var target Zone
+	for _, z := range m.build().zones {
+		if z.Tag == copyZoneTag {
+			target = z
+			break
+		}
+	}
+	require.Equal(t, PaneDetail, target.Pane, "the zone belongs to the detail pane")
+
+	_, cmd := m.Update(tea.MouseMsg{
+		X: target.Rect.X, Y: target.Rect.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	msg := run(cmd)
+	require.IsType(t, copyDoneMsg{}, msg)
+	require.NotEmpty(t, *got)
+	require.Equal(t, msg.(copyDoneMsg).Snippet.Text, *got)
+}
+
+// A check with no code in it says so rather than opening something empty. This
+// package has a rule against empty pickers and the same rule applies to a key
+// that appears to do nothing.
+func TestNothingToCopySaysSo(t *testing.T) {
+	// report-k8s is fifteen assets that never scanned: no bundle, no checks, no
+	// code anywhere in it.
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 100, 30)
+	m.View()
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	require.Nil(t, cmd)
+	require.Equal(t, "nothing to copy: no check is selected", nm.(Model).state.Notice)
+
+	// And a check whose sections hold prose but no fenced block.
+	st := &State{Report: loadReport(t, fixtureUbuntu)}
+	asset := st.Report.Assets[0]
+	for _, c := range asset.Checks {
+		d := c.Detail()
+		if d.Mql == "" && len(checkSnippets(c)) == 0 {
+			st.SelectCheck(asset, nil, c)
+			p := &detailPane{}
+			p.Render(st, detailRect(80, 40))
+			_, ok := p.CopyTarget(st)
+			require.False(t, ok)
+			return
+		}
+	}
+}
+
+// A clipboard that refused says why, in the words of whatever refused it. There
+// is no hedging in either direction: clipboard.WriteAll returning nil means the
+// text is on the clipboard, and an error means it is not.
+func TestCopyFailureNamesTheReason(t *testing.T) {
+	clipboardSpy(t, errors.New(`exec: "xclip": executable file not found in $PATH`))
+
+	snip := Snippet{From: "remediation [cli]", Lang: "bash", Text: "yum remove xorg-x11*", Nth: 1, Of: 1}
+	msg := run(copyCmd(snip))
+	require.IsType(t, copyDoneMsg{}, msg)
+	done := msg.(copyDoneMsg)
+	require.Error(t, done.Err)
+
+	notice := copyNotice(done)
+	require.Equal(t,
+		`copy failed: the system clipboard refused it: exec: "xclip": executable file not found in $PATH`,
+		notice)
+	require.NotContains(t, notice, "copied ")
+}
+
+// A notice is one row of a fixed-height view, so it can never carry a newline:
+// a writer, an encoder or the operating system may put one in an error and the
+// frame has no way to see it.
+func TestCopyNoticeIsOneLine(t *testing.T) {
+	notice := copyNotice(copyDoneMsg{Err: errors.New("xclip died\nsignal: broken pipe\r\n")})
+	require.NotContains(t, notice, "\n")
+	require.NotContains(t, notice, "\r")
+	require.Equal(t, "copy failed: xclip died signal: broken pipe", notice)
+}
+
+// --- the key ----------------------------------------------------------------
+
+// y is free, and stays free while the header's search field is open: that field
+// consumes every rune before the frame is reached, so typing a y into a search
+// types a y.
+func TestCopyKeyDoesNotBreakSearch(t *testing.T) {
+	got := clipboardSpy(t, nil)
+
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range "yes" {
+		nm, _ = nm.(Model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m = nm.(Model)
+
+	require.Equal(t, "yes", m.state.Filter.Search)
+	require.Empty(t, *got, "the y went into the search field, not the clipboard")
+}
+
+// The keys are published, so they can be found without reading this file: y
+// fires the copy and n/p aim it, and neither is any use undiscovered.
+//
+// They are advertised in two different places for one reason, room. The compact
+// line is priority-ordered and the frame's keys sit at the end of it, so a sixth
+// frame hint pushes ? and q off a 120-column terminal; n/p therefore rides the
+// detail pane's hints, which is the pane that draws the band they move. The ?
+// list, which is the complete key map, carries them as the frame bindings they
+// are.
+func TestCopyKeysAreInTheHints(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	find := func(hints []Hint, key string) string {
+		for _, h := range hints {
+			if h.Key == key {
+				return h.Label
+			}
+		}
+		return ""
+	}
+
+	require.Equal(t, "copy", find(m.frameHints(), "y"))
+	require.Contains(t, ansi.Strip(m.View()), "y copy")
+	require.Contains(t, ansi.Strip(m.View()), "q quit",
+		"the compact line still reaches its last hint at this width")
+
+	// The pair, on the pane that shows what they move.
+	var d Pane = &detailPane{}
+	require.Equal(t, "block", find(d.Hints(m.state), "n/p"))
+	m.state.Focus = PaneDetail
+	require.Contains(t, ansi.Strip(m.View()), "n/p block")
+
+	// And ? spells both out, as the frame's own.
+	m.showHelp = true
+	require.Equal(t, "copy the highlighted code block", find(m.frameHints(), "y"))
+	require.Equal(t, "next / previous code block", find(m.frameHints(), "n/p"))
+	out := ansi.Strip(sized(m, 200, 40).View())
+	require.Contains(t, out, "n/p next / previous code block")
+	require.Contains(t, out, "y copy the highlighted code block")
+}
+
+// --- CopyTarget -------------------------------------------------------------
+
+// Below tui.MinTwoPaneWidth only the focused pane is drawn, so the detail pane
+// may not have been rendered for the current selection when y is pressed from
+// the tree. It answers from the check rather than refusing.
+func TestCopyWorksFromTheTreeInAOnePaneLayout(t *testing.T) {
+	colorful(t)
+	got := clipboardSpy(t, nil)
+
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 60, 24)
+	require.False(t, m.layout().TwoPane, "this width is one pane at a time")
+
+	asset := report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			m.state.SelectCheck(asset, nil, c)
+		}
+	}
+	m.state.Focus = PaneTree
+	m.View()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	msg := run(cmd)
+	require.IsType(t, copyDoneMsg{}, msg)
+	require.NoError(t, msg.(copyDoneMsg).Err)
+	require.Equal(t, "the query", msg.(copyDoneMsg).Snippet.From)
+	require.NotEmpty(t, *got)
+}
+
+// The detail pane is the one pane that offers a target, and it does so through
+// the optional interface rather than by the frame naming it.
+func TestDetailPaneIsACopySource(t *testing.T) {
+	var p Pane = &detailPane{}
+	_, ok := p.(CopySource)
+	require.True(t, ok)
+
+	var tp Pane = &treePane{}
+	_, ok = tp.(CopySource)
+	require.False(t, ok, "the tree has no code in it")
+}
+
+// A snippet with nothing in it never reaches the clipboard: writing an empty
+// string would clear whatever the user had copied and report success.
+func TestEmptySnippetIsRefused(t *testing.T) {
+	got := clipboardSpy(t, nil)
+	msg := run(copyCmd(Snippet{From: "remediation"}))
+	require.Error(t, msg.(copyDoneMsg).Err)
+	require.Empty(t, *got)
+}
+
+// The button strip is reserved out of the code's width rather than painted over
+// it, which is the whole reason no command loses a character to it.
+func TestButtonStripIsReservedNotOverwritten(t *testing.T) {
+	w, room := copyWidth(40)
+	require.True(t, room)
+	require.Equal(t, 40-copyGutter, w)
+
+	row := copyButtonRow(tui.StyleText.Render(strings.Repeat("x", 40-copyGutter)), 40, false)
+	require.Equal(t, 40, tui.Width(row))
+	require.Equal(t, strings.Repeat("x", 33)+"  COPY ", ansi.Strip(row))
+	require.NotContains(t, ansi.Strip(row), "…")
+
+	// Too narrow for a strip at all.
+	w, room = copyWidth(10)
+	require.False(t, room)
+	require.Equal(t, 10, w)
+}
+
+// The rect a zone claims is inside the pane it came from, which is what the
+// frame's hit-tester assumes.
+func TestCopyZonesStayInsideTheRect(t *testing.T) {
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+	p := &detailPane{}
+	rect := tui.Rect{X: 7, Y: 3, W: 50, H: 30}
+	r := p.Render(st, rect)
+	for _, z := range r.Zones {
+		require.True(t, z.Rect.Hit(z.Rect.X, z.Rect.Y))
+		require.GreaterOrEqual(t, z.Rect.X, rect.X)
+		require.LessOrEqual(t, z.Rect.X+z.Rect.W, rect.X+rect.W)
+		require.GreaterOrEqual(t, z.Rect.Y, rect.Y)
+		require.Less(t, z.Rect.Y, rect.Y+rect.H)
+	}
+}
+
+// --- aiming: n and p ---------------------------------------------------------
+
+// armedFixture is a pane rendered on the six-block check at a size where the
+// page is six times the height of the viewport, which is the shape the whole
+// feature exists for: several buttons on screen at once and no way to say which
+// one you meant.
+func armedFixture(t *testing.T) (*State, *detailPane) {
+	t.Helper()
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, copyFixtureCheck)
+	p := &detailPane{}
+	p.Render(st, detailRect(64, 20))
+	require.Len(t, p.buttons, 6)
+	return st, p
+}
+
+// The point of the whole change: the arm is a selection you drive, not a
+// consequence of where you happened to stop scrolling. n takes the next block, p
+// the one before, and every step is a block of this check in order.
+func TestArmKeysWalkTheBlocks(t *testing.T) {
+	st, p := armedFixture(t)
+
+	// Nothing is on screen to start with -- this check opens on its description
+	// -- so n means "the first block below the fold" rather than "one past
+	// nothing".
+	require.Equal(t, -1, p.armed())
+	require.True(t, p.ArmCopy(st, 1))
+	require.Equal(t, 0, p.armed())
+
+	for want := 1; want < len(p.buttons); want++ {
+		require.True(t, p.ArmCopy(st, 1))
+		require.Equal(t, want, p.armed())
+		p.Render(st, detailRect(64, 20))
+		require.Equal(t, want, p.armed(), "and the render agrees with the key")
+	}
+	for want := len(p.buttons) - 2; want >= 0; want-- {
+		require.True(t, p.ArmCopy(st, -1))
+		require.Equal(t, want, p.armed())
+	}
+
+	// Both ends hold rather than wrapping: a cursor that jumps from the last
+	// block of a check to the first also throws the pane from the bottom of the
+	// page to the top, which reads as a scroll accident, not a selection.
+	require.True(t, p.ArmCopy(st, -1))
+	require.Equal(t, 0, p.armed())
+	for range len(p.buttons) + 2 {
+		require.True(t, p.ArmCopy(st, 1))
+	}
+	require.Equal(t, len(p.buttons)-1, p.armed())
+}
+
+// An arm the user cannot see is worse than the arbitrary behaviour it replaces,
+// so moving it scrolls it into view -- with a few rows of the block under it
+// where the pane can spare them, because a band on the bottom row shows you the
+// button and not the command.
+func TestArmScrollsTheBlockIntoView(t *testing.T) {
+	st, p := armedFixture(t)
+
+	for i := range p.buttons {
+		require.True(t, p.ArmCopy(st, 1))
+		require.Equal(t, i, p.armed())
+
+		off, end := p.viewport()
+		row := p.buttons[i].Row
+		require.GreaterOrEqual(t, row, off, "block %d is above the viewport", i)
+		require.Less(t, row, end, "block %d is below the viewport", i)
+
+		// The rendered frame shows it too, not just the offsets.
+		r := p.Render(st, detailRect(64, 20))
+		require.Len(t, r.Lines, 20)
+		require.Contains(t, ansi.Strip(r.Lines[row-off]), "COPY")
+
+		if row+detailArmPeek < len(p.lines) {
+			require.Less(t, row+detailArmPeek, end,
+				"block %d got the band but none of the block", i)
+		}
+	}
+}
+
+// The explicit arm wins over the topmost block on screen. Without this the key
+// would be a scroll with extra steps: n scrolls the second block into view, the
+// first is still on screen above it, and "topmost" would hand the arm straight
+// back.
+func TestExplicitArmBeatsTheTopmostBlock(t *testing.T) {
+	st, p := armedFixture(t)
+
+	require.True(t, p.ArmCopy(st, 1))
+	require.True(t, p.ArmCopy(st, 1))
+	require.Equal(t, 1, p.armed())
+
+	off, end := p.viewport()
+	require.GreaterOrEqual(t, p.buttons[0].Row, off, "the first block is still on screen")
+	require.Less(t, p.buttons[0].Row, end)
+	require.Equal(t, 1, p.armed(), "and the arm stays where it was put")
+
+	// The band is on the armed one and only on it.
+	styled(t)
+	r := p.Render(st, detailRect(64, 20))
+	var banded []int
+	for i, ln := range r.Lines {
+		if strings.Contains(ln, tui.BandSelected.Render(copyLabel)) {
+			banded = append(banded, i+off)
+		}
+	}
+	require.Equal(t, []int{p.buttons[1].Row}, banded)
+}
+
+// The other half of the rule: a plain scroll that carries the armed block off
+// the screen gives the arm back to the topmost block still on it. Scrolling was
+// the only way to aim before this, and it is still an aim -- what it must not do
+// is leave the band somewhere nobody can see it.
+func TestScrollingAwayFromTheArmGivesItBack(t *testing.T) {
+	st, p := armedFixture(t)
+
+	require.True(t, p.ArmCopy(st, 1))
+	require.True(t, p.ArmCopy(st, 1))
+	require.True(t, p.armSet)
+	armed := p.armed()
+
+	// A scroll that keeps it on screen keeps it armed, even though a block above
+	// it is now the topmost one.
+	_, handled := p.Update(st, key("up"))
+	require.True(t, handled)
+	require.True(t, p.armSet)
+	require.Equal(t, armed, p.armed())
+
+	// A page down puts it above the top of the screen, and the arm reverts.
+	_, handled = p.Update(st, key("pgdown"))
+	require.True(t, handled)
+	require.False(t, p.armSet, "the explicit arm did not survive scrolling off screen")
+
+	off, end := p.viewport()
+	require.Less(t, p.buttons[armed].Row, off, "the old arm really is off screen")
+	if i := p.armed(); i >= 0 {
+		require.GreaterOrEqual(t, p.buttons[i].Row, off)
+		require.Less(t, p.buttons[i].Row, end)
+	}
+
+	// The wheel is a plain scroll too, and drops it the same way.
+	require.True(t, p.ArmCopy(st, -1))
+	require.True(t, p.armSet)
+	for range 20 {
+		p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress})
+	}
+	require.False(t, p.armSet)
+}
+
+// A new check is a new page, and the block you picked on the last one is not on
+// it. The arm goes back to the implicit rule, which at the top of a fresh page
+// is the first block on screen.
+func TestArmResetsWithTheSelection(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	st := NewState(report)
+	asset := report.Assets[0]
+
+	var first, second *reportmodel.Check
+	for _, c := range asset.Checks {
+		if len(checkSnippets(c)) < 2 {
+			continue
+		}
+		switch {
+		case first == nil:
+			first = c
+		case second == nil:
+			second = c
+		}
+	}
+	require.NotNil(t, second, "the fixture has two checks with code in them")
+
+	st.SelectCheck(asset, nil, first)
+	p := &detailPane{}
+	p.Render(st, detailRect(64, 20))
+	require.True(t, p.ArmCopy(st, 1))
+	require.True(t, p.ArmCopy(st, 1))
+	require.True(t, p.armSet)
+
+	st.SelectCheck(asset, nil, second)
+	p.Render(st, detailRect(64, 20))
+	require.False(t, p.armSet, "the arm did not follow the selection to a new check")
+	require.Equal(t, 0, p.scroll.Off, "and neither did the scroll")
+}
+
+// n and p are frame keys, like y and for the same reason: the tree is where the
+// cursor spends its time, and a pair that only aimed while the detail pane had
+// focus would work in fewer places than the key that fires.
+func TestArmKeysWorkFromTheTree(t *testing.T) {
+	colorful(t)
+	got := clipboardSpy(t, nil)
+
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 120, 40)
+	asset := report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			m.state.SelectCheck(asset, nil, c)
+		}
+	}
+	m.View()
+
+	require.Equal(t, PaneTree, m.state.Focus, "the tree has focus, as it does on open")
+	p := m.pane(PaneDetail).(*detailPane)
+	require.Equal(t, 0, p.armed(), "the query is on screen and armed")
+
+	m, cmd := press(m, "n")
+	require.Nil(t, cmd)
+	require.Equal(t, PaneTree, m.state.Focus, "and aiming did not steal focus")
+	require.Equal(t, 1, p.armed())
+	require.Empty(t, m.state.Notice)
+
+	// y takes what n aimed at.
+	m, cmd = press(m, "y")
+	msg := run(cmd)
+	require.IsType(t, copyDoneMsg{}, msg)
+	require.Equal(t, "remediation [cli]", msg.(copyDoneMsg).Snippet.From)
+	require.Equal(t, "yum remove xorg-x11*", *got)
+
+	// And p takes it back to the query.
+	m, _ = press(m, "p")
+	require.Equal(t, 0, p.armed())
+	_, cmd = press(m, "y")
+	msg = run(cmd)
+	require.Equal(t, "the query", msg.(copyDoneMsg).Snippet.From)
+}
+
+// A key that appears to do nothing is a key the user gives up on, so n and p say
+// what is missing rather than sitting there -- the same rule y already follows.
+func TestNothingToArmSaysSo(t *testing.T) {
+	// report-k8s is fifteen assets that never scanned: no bundle, no checks, no
+	// code anywhere in it.
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 100, 30)
+	m.View()
+	for _, k := range []string{"n", "p"} {
+		nm, cmd := press(m, k)
+		require.Nil(t, cmd)
+		require.Equal(t, "nothing to highlight: no check is selected", nm.state.Notice)
+	}
+
+	// And a check whose sections hold prose but not one fenced block. Every
+	// check of the ubuntu fixture has an MQL query, which is a block in its own
+	// right, so this one is built rather than found.
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	asset := report.Assets[0]
+	prose := &reportmodel.Check{
+		Title:  "a check with nothing to run",
+		Status: reportmodel.StatusFail,
+		Query: &policy.Mquery{
+			Title: "a check with nothing to run",
+			Docs: &policy.MqueryDocs{
+				Desc:  "Prose, and **bold** prose at that, but no fence anywhere in it.",
+				Audit: "Look at it and see.",
+			},
+		},
+	}
+	require.Empty(t, checkSnippets(prose))
+
+	m = sized(NewModel(report), 100, 30)
+	m.state.SelectCheck(asset, nil, prose)
+	m.View()
+	nm, cmd := press(m, "n")
+	require.Nil(t, cmd)
+	require.Equal(t, "nothing to highlight: this check has no code blocks", nm.state.Notice)
+
+	// y agrees, in its own words.
+	nm, cmd = press(nm, "y")
+	require.Nil(t, cmd)
+	require.Equal(t, "nothing to copy: this check has no code blocks", nm.state.Notice)
+}
+
+// Scrolled to a stretch of the page with no code on it, y says so and names the
+// key that gets to one, rather than reaching off screen for the nearest block.
+func TestNothingInViewSaysWhichKeyReachesOne(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	// Short enough that the tail of the check -- REFERENCES and POLICIES, which
+	// have no code in them -- fills the screen on its own.
+	m := sized(NewModel(report), 120, 24)
+	asset := report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			m.state.SelectCheck(asset, nil, c)
+		}
+	}
+	m.View()
+
+	p := m.pane(PaneDetail).(*detailPane)
+	_, handled := p.Update(m.state, key("end"))
+	require.True(t, handled)
+	m.View()
+	require.Equal(t, -1, p.armed(), "the end of this check has no code on it")
+
+	nm, cmd := press(m, "y")
+	require.Nil(t, cmd)
+	require.Equal(t,
+		"nothing to copy: no code block is in view (press n for the next one)",
+		nm.state.Notice)
+
+	// And n gets to one, from there.
+	nm, cmd = press(nm, "n")
+	require.Nil(t, cmd)
+	require.Empty(t, nm.state.Notice)
+	require.GreaterOrEqual(t, p.armed(), 0)
+	_, cmd = press(nm, "y")
+	require.IsType(t, copyDoneMsg{}, run(cmd))
+}
+
+// n and p are free, and stay free while the header's search field is open: that
+// field consumes every rune before the frame is reached, so typing an n into a
+// search types an n.
+func TestArmKeysDoNotBreakSearch(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 120, 40)
+	asset := report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == copyFixtureCheck {
+			m.state.SelectCheck(asset, nil, c)
+		}
+	}
+	m.View()
+	p := m.pane(PaneDetail).(*detailPane)
+	was := p.armed()
+
+	m, _ = press(m, "/")
+	for _, r := range "no ping" {
+		m, _ = press(m, string(r))
+	}
+	require.Equal(t, "no ping", m.state.Filter.Search)
+	require.False(t, p.armSet, "the runes went into the search field, not at the arm")
+	require.Equal(t, was, p.armed())
+}
+
+// The invariant, swept: whatever the pane has been through -- any size, any
+// scroll position, any number of n and p -- the block y would take is a block
+// whose button is on screen. This is what the accent band promises, and its
+// absence is what made the old behaviour a guess.
+func TestCopyNeverTakesABlockOffScreen(t *testing.T) {
+	colorful(t)
+	report := loadReport(t, fixtureUbuntu)
+	asset := report.Assets[0]
+
+	steps := []tea.Msg{
+		key("n"), key("n"), key("down"), key("n"), key("pgdown"),
+		key("p"), key("end"), key("n"), key("home"), key("p"),
+		tea.MouseMsg{Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress},
+		key("G"), key("n"), key("n"), key("up"),
+	}
+
+	for _, c := range asset.Checks {
+		st := NewState(report)
+		st.SelectCheck(asset, nil, c)
+
+		for _, s := range termSizes {
+			p := &detailPane{}
+			rect := detailRect(s.w, s.h)
+			p.Render(st, rect)
+
+			for _, msg := range steps {
+				switch k, isKey := msg.(tea.KeyMsg); {
+				case isKey && k.String() == "n":
+					require.Equal(t, len(p.buttons) > 0, p.ArmCopy(st, 1))
+				case isKey && k.String() == "p":
+					require.Equal(t, len(p.buttons) > 0, p.ArmCopy(st, -1))
+				default:
+					p.Update(st, msg)
+				}
+				p.Render(st, rect)
+
+				off, end := p.viewport()
+				i := p.armed()
+				snip, ok := p.CopyTarget(st)
+				if i < 0 {
+					require.False(t, ok, "%dx%d: y had a target with nothing on screen", s.w, s.h)
+					continue
+				}
+				require.True(t, ok)
+				row := p.buttons[i].Row
+				require.GreaterOrEqual(t, row, off,
+					"%dx%d: y would copy a block above the screen", s.w, s.h)
+				require.Less(t, row, end,
+					"%dx%d: y would copy a block below the screen", s.w, s.h)
+				require.Equal(t, p.snips[p.buttons[i].Idx].Text, snip.Text)
+			}
+		}
+	}
+}

--- a/cli/reportview/detail.go
+++ b/cli/reportview/detail.go
@@ -1,0 +1,950 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The detail pane: everything the report knows about whatever is selected.
+//
+// It draws two different things, because the tree selects two different things.
+// A check gets the section stack below. An asset -- selected when the cursor is
+// on an asset row, or when the asset has no checks to descend into -- gets its
+// platform, its tally and its findings, or, when it never scanned, the reason
+// why. Those are not the same page with fields missing: an asset that failed to
+// scan has no checks at all, and rendering it as an empty check list is the one
+// way this pane can lie.
+//
+// # Section order
+//
+// The stack follows cli/reporter/junit.go's detailedCheckBody, which is the
+// existing answer in this repo to "what does a reader want to know about a
+// finding, and in what order":
+//
+//	description -> query -> assessment -> failing locations -> remediation -> references
+//
+// with three additions it has no place for, each put where it answers the
+// question the section above it raises:
+//
+//   - AUDIT sits under QUERY. Both answer "how is this decided" -- one as the
+//     query that ran, one as the steps to check it by hand.
+//   - COMPLIANCE and POLICIES sit at the bottom. They are provenance: which
+//     framework control this satisfies and which policies pulled it in. Neither
+//     helps you fix anything, so neither belongs above the fix.
+//
+// The one deliberate departure is ERROR, which junit puts after the assessment
+// and this pane puts immediately under the status row. Detail.Error is populated
+// only for a ScoreType_Error score, so its presence *is* the errored case, and
+// for that case it is the headline: the check proved nothing, and the assessment
+// below it reads "[failed] ..." only because the query never completed. Burying
+// that eight sections down invites the reader to mistake an error for a failure.
+//
+// # Markdown
+//
+// Three of the sections are markdown *source*: the description, the audit steps
+// and every remediation body. They go through markdown.go, which renders them
+// rather than printing their markup. Nothing else does: MQL and the assessment
+// are code with a line structure of their own, and the error, the failing
+// locations, the references and the compliance tags are plain strings that never
+// carried markup to begin with.
+//
+// A reference URL is the one plain string that is still more than text: it is
+// drawn as an OSC 8 hyperlink and carries a click zone, so it can be opened
+// rather than retyped. See links.go, which also says why the URLs inside the
+// markdown sections are left to glamour.
+
+func init() {
+	RegisterDetail(func(*State) Pane { return &detailPane{} })
+}
+
+// detailPane renders the selection and scrolls it. Everything it remembers
+// between frames -- the offset, the geometry the offset was clamped against, the
+// cached lines -- is its own; the frame and the other panes see none of it.
+type detailPane struct {
+	scroll tui.Scroll
+
+	// rev and width are what the cache was built for. A new selection or a
+	// resize invalidates it, and a new selection also scrolls back to the top:
+	// opening a check halfway down the previous one is disorienting.
+	cached bool
+	rev    int
+	width  int
+	lines  []string
+
+	// snips is every copyable block of the selected check and buttons says which
+	// row each one's COPY sits on, both built in the same pass as lines so a
+	// button can never name a block that moved. room is false in a pane too
+	// narrow to give a button a strip of its own, in which case none is drawn.
+	snips   []Snippet
+	buttons []detailButton
+	room    bool
+
+	// urls is every clickable URL of the selected check and links says which
+	// cells each one occupies, built in the same pass as lines for the same
+	// reason the buttons are: a zone computed in a second pass is a zone that
+	// can drift off the row it names. See links.go.
+	urls  []string
+	links []detailLink
+
+	// armAt is the block n and p chose, and armSet says one was chosen. The zero
+	// value is no explicit choice, which is what a fresh pane and a newly
+	// selected check both want: see the arming rule in copy.go.
+	armAt  int
+	armSet bool
+
+	// visible is the height of the last render, which is what Update needs to
+	// page and to jump to the end. Update has no rect of its own.
+	visible int
+}
+
+// detailButton is one COPY affordance: the row it is drawn on, and the snippet
+// it copies.
+type detailButton struct {
+	Row int
+	Idx int
+}
+
+// detailLink is one clickable URL: the cells it occupies -- the row, the column
+// it starts at and how wide the visible text came out after truncation -- and
+// the URL it points at.
+//
+// W is the *rendered* width and not the length of the URL, because a link too
+// wide for the pane is drawn short: the zone has to cover the cells the reader
+// can see and no others.
+type detailLink struct {
+	Row int
+	Col int
+	W   int
+	Idx int
+}
+
+func (p *detailPane) ID() PaneID       { return PaneDetail }
+func (p *detailPane) Focusable() bool  { return true }
+func (p *detailPane) Claims() []string { return nil }
+
+// Hints. n and p are the frame's keys, not this pane's -- they aim the copy the
+// same way y fires it, and both work from the tree as well. The short form is
+// advertised here because this is the pane that draws the band they move, and
+// because the frame's own compact list has no room left for it; the ? list
+// carries them as the frame bindings they are. See Model.frameHints.
+func (p *detailPane) Hints(*State) []Hint {
+	return []Hint{
+		{Key: "↑/↓", Label: "scroll"},
+		{Key: "pgup/pgdn", Label: "page"},
+		{Key: "g/G", Label: "top/end"},
+		{Key: "n/p", Label: "block"},
+	}
+}
+
+func (p *detailPane) Render(st *State, rect tui.Rect) Render {
+	lines := p.body(st, rect.W)
+	p.visible = rect.H
+
+	off := p.scroll.Apply(len(lines), rect.H)
+	end := off + rect.H
+	if end > len(lines) {
+		end = len(lines)
+	}
+	// Copied rather than sliced: the buttons are drawn onto the visible rows,
+	// and writing them through into the cache would bake this frame's armed
+	// block into every later one.
+	rows := append([]string(nil), lines[off:end]...)
+
+	// The links go in first and the buttons after, so that a button wins a
+	// hit-test if the two ever overlapped (the frame lets a later zone win). No
+	// reference row carries a code block, so today they cannot.
+	zones := p.linkZones(rect, off, end)
+
+	return Render{
+		Title:  detailTitle(st),
+		Status: tui.Position(off, len(lines), rect.H),
+		Lines:  rows,
+		Zones:  append(zones, p.drawButtons(rows, rect, off, end)...),
+	}
+}
+
+// linkZones is a clickable region for every URL on screen.
+//
+// Nothing is drawn: the link was rendered into its row as an OSC 8 sequence when
+// the body was built, and this only says which cells it landed on. That is the
+// difference from drawButtons, which has to paint its affordance onto the rows
+// of this frame.
+func (p *detailPane) linkZones(rect tui.Rect, off, end int) []Zone {
+	if len(p.links) == 0 {
+		return nil
+	}
+	var zones []Zone
+	for _, l := range p.links {
+		if l.Row < off || l.Row >= end || l.W < 1 {
+			continue
+		}
+		w := min(l.W, rect.W-l.Col)
+		if w < 1 {
+			continue
+		}
+		zones = append(zones, Zone{
+			Rect: tui.Rect{X: rect.X + l.Col, Y: rect.Y + l.Row - off, W: w, H: 1},
+			Idx:  l.Idx,
+			Tag:  linkZoneTag,
+		})
+	}
+	return zones
+}
+
+// drawButtons puts a COPY on every code block whose first row is on screen, and
+// returns a clickable zone for each. The armed one -- the block the y key would
+// take -- wears the accent band; the rest wear the inactive one, because a click
+// copies those just as well.
+func (p *detailPane) drawButtons(rows []string, rect tui.Rect, off, end int) []Zone {
+	if !p.room || len(p.buttons) == 0 {
+		return nil
+	}
+	armed := p.armedIn(off, end)
+	var zones []Zone
+	for i, btn := range p.buttons {
+		if btn.Row < off || btn.Row >= end {
+			continue
+		}
+		row := btn.Row - off
+		rows[row] = copyButtonRow(rows[row], rect.W, i == armed)
+		zones = append(zones, Zone{
+			Rect: tui.Rect{X: rect.X + rect.W - copyLabelW, Y: rect.Y + row, W: copyLabelW, H: 1},
+			Idx:  btn.Idx,
+			Tag:  copyZoneTag,
+		})
+	}
+	return zones
+}
+
+// armedIn is the index into buttons of the block a copy key would take while
+// rows [off, end) are the ones on screen, or -1 when no block is on screen at
+// all. It is the whole of the arming rule stated in copy.go, in one place:
+//
+//   - the block n and p chose, if that block is on screen;
+//   - otherwise the topmost one that is;
+//   - otherwise nothing.
+//
+// The viewport bound is what makes the rule structural rather than a promise
+// kept by every caller: an explicit arm that a scroll, a resize or a reflow has
+// pushed off screen is not returned by this function, so y cannot take it.
+func (p *detailPane) armedIn(off, end int) int {
+	inView := func(i int) bool {
+		if i < 0 || i >= len(p.buttons) {
+			return false
+		}
+		row := p.buttons[i].Row
+		return row >= off && row < end
+	}
+	if p.armSet && inView(p.armAt) {
+		return p.armAt
+	}
+	for i := range p.buttons {
+		if inView(i) {
+			return i
+		}
+	}
+	return -1
+}
+
+// viewport is the rows on screen as [off, end), from the last render. Update has
+// no rect of its own, and the arming rule is about what is on screen right now.
+func (p *detailPane) viewport() (int, int) {
+	visible := p.visible
+	if visible < 1 {
+		visible = 1
+	}
+	return p.scroll.Off, p.scroll.Off + visible
+}
+
+// armed is armedIn over the current viewport.
+func (p *detailPane) armed() int {
+	return p.armedIn(p.viewport())
+}
+
+// CopyTarget implements CopySource: the block the y key takes.
+//
+// It answers from the check rather than refusing when the pane has not been
+// drawn for the current selection, which happens below tui.MinTwoPaneWidth --
+// there only the focused pane is rendered, and y must still work while the tree
+// has focus. With nothing rendered there is no viewport to aim with, and no pane
+// on screen to have aimed in, so it is the first block of the check.
+func (p *detailPane) CopyTarget(st *State) (Snippet, bool) {
+	if !p.cached || p.rev != st.SelectionRev {
+		snips := checkSnippets(st.Sel.Check)
+		if len(snips) == 0 {
+			return Snippet{}, false
+		}
+		return snips[0], true
+	}
+	i := p.armed()
+	if i < 0 || i >= len(p.buttons) {
+		return Snippet{}, false
+	}
+	idx := p.buttons[i].Idx
+	if idx < 0 || idx >= len(p.snips) {
+		return Snippet{}, false
+	}
+	return p.snips[idx], true
+}
+
+// ArmCopy implements CopySource: move the armed block delta places and scroll it
+// into view.
+//
+// An arm that is not on screen is an arm the user cannot see, so this is the one
+// place that sets one and it always follows with the scroll that reveals it.
+func (p *detailPane) ArmCopy(st *State, delta int) bool {
+	// Not drawn for this selection -- the same one-pane case CopyTarget covers.
+	// There is no viewport to move an arm through and no pane on screen to move
+	// it in, so all this can honestly answer is whether there is anything to aim
+	// at; the pane arms its first block when it is next drawn.
+	if !p.cached || p.rev != st.SelectionRev {
+		return len(checkSnippets(st.Sel.Check)) > 0
+	}
+	if len(p.buttons) == 0 {
+		return false
+	}
+	off, end := p.viewport()
+	next := p.nextArm(p.armedIn(off, end), delta, off, end)
+	p.armAt, p.armSet = next, true
+	p.reveal(p.buttons[next].Row, end-off)
+	return true
+}
+
+// nextArm is the block delta places from the armed one, clamped at both ends: a
+// list cursor that wraps from the last block to the first also jumps the pane
+// from the bottom of the check to the top, which reads as a scroll accident.
+//
+// With nothing on screen to count from, n takes the first block below the
+// viewport and p the last one above it, so the direction still means what it
+// says. With no block in that direction it takes the nearest one in the other,
+// which is the same clamp by another name.
+func (p *detailPane) nextArm(at, delta, off, end int) int {
+	last := len(p.buttons) - 1
+	if at >= 0 {
+		return min(max(at+delta, 0), last)
+	}
+	if delta > 0 {
+		for i, btn := range p.buttons {
+			if btn.Row >= end {
+				return i
+			}
+		}
+		return last
+	}
+	for i := last; i >= 0; i-- {
+		if p.buttons[i].Row < off {
+			return i
+		}
+	}
+	return 0
+}
+
+// detailArmPeek is how many rows of a block n and p try to bring on screen under
+// its COPY. A band on the bottom row, with the command it copies below the fold,
+// is a selection you cannot read before taking it.
+const detailArmPeek = 3
+
+// reveal scrolls the least that brings a block's first row on screen, and a few
+// rows of the block under it when the pane is tall enough to spare them. The
+// second call is what guarantees the row itself: the first may have pushed it
+// off the top of a viewport shorter than the peek.
+func (p *detailPane) reveal(row, visible int) {
+	total := len(p.lines)
+	p.scroll.EnsureVisible(min(row+detailArmPeek, total-1), total, visible)
+	p.scroll.EnsureVisible(row, total, visible)
+}
+
+// dropArm gives up an explicit arm that a plain scroll has moved out of view.
+//
+// This is the rule in copy.go doing its half of the work: armedIn would ignore
+// the arm anyway, but dropping it here means a scroll that leaves and returns
+// does not bring the old choice back with it. Once you have scrolled away from
+// the block you picked, the topmost one on screen is the one y takes.
+func (p *detailPane) dropArm() {
+	if p.armSet && p.armed() != p.armAt {
+		p.armSet = false
+	}
+}
+
+// body is the rendered detail, cached per selection and width. Detail() walks
+// the raw results to build an assessment and Render runs on every frame and
+// every mouse event, so recomputing it forty times a second is work nobody asked
+// for.
+func (p *detailPane) body(st *State, w int) []string {
+	if p.cached && p.rev == st.SelectionRev && p.width == w {
+		return p.lines
+	}
+	// Watch SelectionRev rather than the pointers in st.Sel: the tree bumps it
+	// on every change, and a check reselected after an edit to the filter is a
+	// new page even when it is the same *Check.
+	if !p.cached || p.rev != st.SelectionRev {
+		p.scroll.Off = 0
+		// A new check is a new page, and the block you picked on the last one is
+		// not on it. Back to the implicit arm, which at the top of a fresh page
+		// is the check's first block.
+		p.armSet = false
+	}
+	p.cached, p.rev, p.width = true, st.SelectionRev, w
+
+	b := detailContent(st, w)
+	p.lines, p.snips, p.buttons, p.room = b.out, b.snips, b.buttons, b.room
+	p.urls, p.links = b.urls, b.links
+	return p.lines
+}
+
+func detailTitle(st *State) string {
+	switch {
+	case st.Sel.Check != nil:
+		return "Check"
+	case st.Sel.Asset != nil:
+		return "Asset"
+	default:
+		return "Detail"
+	}
+}
+
+// detailBody is the rendered rows of the selection, and is what every test that
+// only cares about the text calls.
+func detailBody(st *State, w int) []string {
+	return detailContent(st, w).out
+}
+
+// detailContent is one full pass over the selection: the rows, the copyable
+// blocks and where their buttons go, all out of the same walk.
+func detailContent(st *State, w int) *detailBuf {
+	b := newDetailBuf(w)
+	switch {
+	case st.Sel.Check != nil:
+		checkLines(b, st.Sel.Check)
+	case st.Sel.Asset != nil:
+		assetLines(b, st, st.Sel.Asset)
+	default:
+		b.push(tui.StyleFaint.Render("nothing selected"))
+	}
+	return b
+}
+
+// --- the check page ---------------------------------------------------------
+
+func checkLines(b *detailBuf, c *reportmodel.Check) {
+	d := c.Detail()
+	// Every copyable block of this check, in the order the sections below draw
+	// them. The buffer claims them one at a time as it reaches each block, so
+	// the button on a row and the snippet the footer names are the same object
+	// rather than two walks that agree by luck.
+	b.snips = detailSnippets(d)
+
+	b.para(tui.StyleText, d.Title)
+	// A check with no title at all still gets its status row, so the pane never
+	// renders as blank.
+	b.blank()
+	b.push(statusRow(d))
+
+	// See the package comment: for an errored check this is the headline, not a
+	// footnote under a result that does not exist.
+	if d.Error != "" {
+		b.section("ERROR")
+		b.wrapped(StatusStyle(reportmodel.StatusError), d.Error)
+	}
+
+	if d.Description != "" {
+		b.section("DESCRIPTION")
+		b.markdown(d.Description)
+	}
+
+	if d.Mql != "" {
+		b.section("QUERY")
+		// MQL is code: one source line stays one row, cut at the right edge
+		// rather than folded, so an operator never moves to a line of its own.
+		// It gets a COPY of its own -- pasting the query into `cnspec shell` is
+		// how you find out what the check actually saw.
+		b.codeBlock(tui.StyleText, d.Mql)
+	}
+
+	if audit := strings.TrimSpace(d.Audit); audit != "" {
+		b.section("AUDIT")
+		b.markdown(audit)
+	}
+
+	if d.Assessment != "" {
+		b.section("RESULT")
+		// The assessment is laid out by the MQL printer in expected-vs-actual
+		// columns; wrapping it would scramble that.
+		b.code(tui.StyleDim, d.Assessment)
+	}
+
+	if len(d.FailingLocations) > 0 {
+		b.section("FAILING RESOURCES")
+		for _, loc := range d.FailingLocations {
+			b.body(tui.StyleDim.Render(tui.Clean(loc)))
+		}
+	}
+
+	if len(d.Remediation) > 0 {
+		b.section("REMEDIATION")
+		remediationLines(b, d.Remediation)
+	}
+
+	if len(d.References) > 0 {
+		b.section("REFERENCES")
+		for _, ref := range d.References {
+			if ref.Title != "" {
+				b.wrapped(tui.StyleText, ref.Title)
+			}
+			if ref.Url != "" {
+				b.reference(ref.Url)
+			}
+		}
+	}
+
+	if len(d.Compliance) > 0 {
+		b.section("COMPLIANCE")
+		for _, tag := range sortedComplianceTags(d.Compliance) {
+			b.wrapped(tui.StyleDim, tag+": "+d.Compliance[tag])
+		}
+	}
+
+	if len(d.Policies) > 0 {
+		b.section("POLICIES")
+		for _, ref := range d.Policies {
+			b.wrapped(tui.StyleDim, ref.Name)
+		}
+	}
+}
+
+// statusRow is the one line that says what happened. It is the tree's check row
+// said again with the words attached:
+//
+//	tree     ✗ ●●●● Ensure secure permissions on /etc/group- are set
+//	detail   ✗ FAIL      ●●●● CRIT   impact 100
+//
+// # The glyph and the word, not one or the other
+//
+// The tree spends one cell on an outcome and four on a severity because it is a
+// list of hundreds of rows being scanned for a shape. This is one row being
+// read, and it is also the first place a reader who has just met "✗" and "●●●●"
+// can find out what they said. So it draws both: the glyph and the dots are the
+// tree's vocabulary, unchanged and in the same order, and FAIL and CRIT are the
+// legend printed next to them. Neither alone would do that job -- words only
+// would make the reader re-learn the row they came from, glyphs only would leave
+// the vocabulary unexplained anywhere in the viewer.
+//
+// Every field is fixed-width (StatusMarkWidth, SeverityMarkWidth), so the impact
+// starts in the same column on every check and arrowing down the tree does not
+// make the row jitter.
+//
+// # What was dropped, and why it was the risk
+//
+// The row used to carry a fourth fact: the realized risk, drawn as a number and
+// its own four dots. Two four-dot groups on one line meaning different things is
+// exactly the confusion the tree was built to avoid, so one of them had to go --
+// and the risk is the one that says nothing the rest of the row does not.
+//
+// That is structural rather than a judgement about this fixture. RiskOf states a
+// number only for a ScoreType_Result score, and reporter.ScoreToSarifKind
+// defines PASS as such a score with value 100 and FAIL as one with value below
+// it. So on a check row "risk 0" is precisely PASS, "risk 100" is precisely
+// FAIL, and "-" is precisely every other outcome: the risk column was the status
+// column restated as arithmetic.
+//
+// The impact stays, because it is the one number that is not recoverable from
+// what is drawn beside it -- a check at 89 and one at 70 both say HIGH.
+//
+// The meter itself is not gone from the viewer. It still draws asset rows, in
+// the tree and on the asset page below, where a rolled-up risk really is a fact
+// of its own and there is no severity to collide with.
+func statusRow(d reportmodel.CheckDetail) string {
+	status := d.Status
+	if status == "" {
+		// reportmodel always resolves a status, but a zero-value Check does not,
+		// and a row of blank cells is not an outcome anybody can read.
+		status = reportmodel.StatusUnknown
+	}
+	row := StatusMark(status) + "  " + SeverityMark(detailSeverity(d), status.IsFinding())
+	if d.HasImpact {
+		row += "  " + tui.StyleFaint.Render("impact "+strconv.FormatInt(int64(d.Impact), 10))
+	}
+	return row
+}
+
+// detailSeverity is the severity band a check page states, and empty when the
+// check states none at all. It is checkSeverity over a composed CheckDetail,
+// and it exists for the same reason: reportmodel derives Severity from Impact,
+// an unset impact is 0, and RiskSeverityLabel reads 0 as NONE -- so without the
+// HasImpact gate the four errored ssh checks of the fixture would be badged
+// NONE, which is the page claiming somebody rated them harmless.
+func detailSeverity(d reportmodel.CheckDetail) string {
+	if !d.HasImpact {
+		return ""
+	}
+	return d.Severity
+}
+
+// remediationLines renders each fix. An item with a platform id ("bash",
+// "terraform") is announced by it, because a page of three unlabelled fixes does
+// not say which one applies to the machine in front of you.
+func remediationLines(b *detailBuf, items []reportmodel.RemediationItem) {
+	for i, item := range items {
+		if i > 0 {
+			b.blank()
+		}
+		if id := item.Id; id != "" && id != "default" {
+			b.body(tui.StyleLabel.Render("[" + id + "]"))
+		}
+		b.markdown(item.Desc)
+	}
+}
+
+// sortedComplianceTags orders the framework tags. A map iterates in a random
+// order, and a pane whose rows shuffle between frames is unreadable.
+func sortedComplianceTags(m map[string]string) []string {
+	res := make([]string, 0, len(m))
+	for k := range m {
+		res = append(res, k)
+	}
+	sort.Strings(res)
+	return res
+}
+
+// --- the asset page ---------------------------------------------------------
+
+func assetLines(b *detailBuf, st *State, a *reportmodel.Asset) {
+	b.para(tui.StyleText, a.Name)
+	if a.PlatformName != "" {
+		b.para(tui.StyleDim, a.PlatformName)
+	}
+
+	b.blank()
+	// The same shape as the check page's status row -- glyph, then word -- so the
+	// two pages of this pane say an outcome one way. What follows it differs
+	// because the tree differs: an asset row carries the meter and no severity,
+	// so there is no second dot group for it to collide with, and the meter is
+	// worth more here than anywhere else. This is the page that is open when the
+	// question is "how bad is this machine".
+	//
+	// An asset that never scanned reaches this row too, and answers "-": there is
+	// no report to take a risk from, which is exactly what the section below then
+	// spells out.
+	//
+	// The STATUS label that used to head this row is gone with it. It was naming
+	// a column that now announces itself -- the glyph is the tree's, the word is
+	// beside it -- and the cells go to the meter on a narrow pane.
+	b.push(StatusMark(a.Status) + "  " + riskField(a.Score))
+
+	if !a.Scanned() {
+		// The whole reason reportmodel keeps ScanError: say that the scan did
+		// not happen and why. An asset with no report has no checks, and drawing
+		// it as a check list with nothing in it reads as a clean bill of health.
+		b.section("THIS ASSET WAS NOT SCANNED")
+		msg := a.ScanError
+		if msg == "" {
+			msg = "the scan produced no report and no error for this asset"
+		}
+		b.wrapped(StatusStyle(reportmodel.StatusError), msg)
+		return
+	}
+
+	c := a.Counts
+	b.section("CHECKS")
+	b.wrapped(tui.StyleDim, fmt.Sprintf(
+		"%d total · %d passed · %d failed · %d errored · %d skipped · %d unscored",
+		c.Total, c.Passed, c.Failed, c.Errored, c.Skipped, c.Unscored))
+
+	b.section("FINDINGS")
+	findings := 0
+	for _, check := range st.FilteredChecks(a.Checks) {
+		if !check.Status.IsFinding() {
+			continue
+		}
+		findings++
+		// A list, so it takes the tree's trade rather than the status row's:
+		// glyph and dots, no words. These are the same rows the tree draws for
+		// the same checks, and spending twelve cells per row on PASS/FAIL/CRIT
+		// here would both re-say what the shape already says and push the title
+		// -- the thing a reader is looking for -- off a narrow pane.
+		b.body(StatusGlyph(check.Status) + " " +
+			SeverityDots(checkSeverity(check), check.Status.IsFinding()) + " " +
+			tui.StyleText.Render(tui.Clean(check.Title)))
+	}
+	if findings == 0 {
+		b.body(tui.StyleFaint.Render("none"))
+	}
+}
+
+// --- input ------------------------------------------------------------------
+
+func (p *detailPane) Update(_ *State, msg tea.Msg) (tea.Cmd, bool) {
+	total, visible := len(p.lines), p.visible
+	if visible < 1 {
+		visible = 1
+	}
+
+	switch msg := msg.(type) {
+	case ClickMsg:
+		// The two things in this pane that respond to a click. A click on a
+		// COPY takes that block, not the armed one: the button under the pointer
+		// is the answer to which one the user meant. A click on a reference URL
+		// opens it -- the terminal never sees that click, because the viewer
+		// runs with mouse tracking on. See links.go.
+		switch msg.Zone.Tag {
+		case copyZoneTag:
+			if msg.Zone.Idx < 0 || msg.Zone.Idx >= len(p.snips) {
+				return nil, false
+			}
+			return copyCmd(p.snips[msg.Zone.Idx]), true
+		case linkZoneTag:
+			if msg.Zone.Idx < 0 || msg.Zone.Idx >= len(p.urls) {
+				return nil, false
+			}
+			return openURLCmd(p.urls[msg.Zone.Idx]), true
+		}
+		return nil, false
+
+	case tea.MouseMsg:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			p.scroll.Move(-detailWheelStep, total, visible)
+		case tea.MouseButtonWheelDown:
+			p.scroll.Move(detailWheelStep, total, visible)
+		default:
+			return nil, false
+		}
+		// The wheel is a plain scroll like any other: it can carry the block the
+		// user armed off the screen, and when it does the arm goes with it.
+		p.dropArm()
+		return nil, true
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k", "ctrl+p":
+			p.scroll.Move(-1, total, visible)
+		case "down", "j", "ctrl+n":
+			p.scroll.Move(1, total, visible)
+		case "pgup", "ctrl+b":
+			p.scroll.Move(-visible, total, visible)
+		case "pgdown", "ctrl+f", " ":
+			p.scroll.Move(visible, total, visible)
+		case "home", "g":
+			p.scroll.Move(-total, total, visible)
+		case "end", "G":
+			p.scroll.Move(total, total, visible)
+		default:
+			return nil, false
+		}
+		// Every branch above is a plain scroll, and a plain scroll that moves the
+		// armed block off screen hands the arm back to the topmost block in view.
+		p.dropArm()
+		return nil, true
+	}
+	return nil, false
+}
+
+// detailWheelStep is how many rows one notch of the wheel moves. Three is what
+// the rest of the terminal does.
+const detailWheelStep = 3
+
+// --- line building ----------------------------------------------------------
+
+// detailBuf accumulates rendered rows and is the only thing in this file that
+// appends to the output, so the invariant -- one element is one terminal row, no
+// wider than the pane -- holds in one place instead of at twenty call sites.
+type detailBuf struct {
+	w   int
+	out []string
+
+	// snips is the check's copyable blocks, set by checkLines before any section
+	// is drawn; at is how many of them have been claimed so far. buttons is
+	// where the COPY for each claimed one goes.
+	snips   []Snippet
+	at      int
+	buttons []detailButton
+
+	// room says the pane is wide enough to set a button beside a code block
+	// rather than on top of it. codeW is the width a code block is rendered at,
+	// which is the body width less the button's strip when there is one.
+	room  bool
+	codeW int
+
+	// urls is the clickable URLs of the page and links is where each one landed,
+	// filled in by reference as the section is drawn.
+	urls  []string
+	links []detailLink
+}
+
+func newDetailBuf(w int) *detailBuf {
+	b := &detailBuf{w: w}
+	_, body := b.indent()
+	b.codeW, b.room = copyWidth(body)
+	return b
+}
+
+// claim takes the next snippet for a code block that is about to be drawn, and
+// records a button on the row that block starts on.
+//
+// It records one even in a pane with no room to draw it: the row is still where
+// that block begins, which is what the copy key aims with, and a terminal too
+// narrow for the affordance is not a terminal where the key should go dead.
+//
+// The text is compared rather than trusted. detailSnippets and the sections
+// below walk the same three markdown sources and the same query in the same
+// order, so they line up -- but if one of them ever stops lining up, a button
+// that copies the wrong block is far worse than no button, and a mismatch stops
+// the claiming for the rest of the page.
+func (b *detailBuf) claim(text string) {
+	if b.at >= len(b.snips) || b.snips[b.at].Text != text {
+		return
+	}
+	b.buttons = append(b.buttons, detailButton{Row: len(b.out), Idx: b.at})
+	b.at++
+}
+
+// detailIndent is how far a section body is set in from its label.
+const detailIndent = 2
+
+var detailPad = strings.Repeat(" ", detailIndent)
+
+// push adds one row, truncated to the pane. Every other method goes through it.
+func (b *detailBuf) push(s string) {
+	b.out = append(b.out, tui.Truncate(s, b.w))
+}
+
+func (b *detailBuf) blank() {
+	b.out = append(b.out, "")
+}
+
+// body adds one already-composed row at the body indent.
+func (b *detailBuf) body(s string) {
+	pad, w := b.indent()
+	b.push(pad + tui.Truncate(s, w))
+}
+
+// section starts a labelled block, blank-separated from whatever came before. It
+// leaves no leading blank line on the first section of a page.
+func (b *detailBuf) section(label string) {
+	if len(b.out) > 0 {
+		b.blank()
+	}
+	b.push(tui.StyleLabel.Render(label))
+}
+
+// para lays prose out at the left margin: the title block, which has no label
+// above it to be indented under.
+func (b *detailBuf) para(style lipgloss.Style, text string) {
+	for _, ln := range tui.Wrap(tui.Clean(text), b.w) {
+		b.push(style.Render(ln))
+	}
+}
+
+// wrapped lays prose out under a section label, folded at the body width. This
+// is what makes a 900-byte remediation readable in a 30-column pane.
+func (b *detailBuf) wrapped(style lipgloss.Style, text string) {
+	pad, w := b.indent()
+	for _, ln := range tui.Wrap(tui.Clean(text), w) {
+		b.push(pad + style.Render(ln))
+	}
+}
+
+// reference draws one URL of the REFERENCES section.
+//
+// A web address becomes a link: one row, an OSC 8 hyperlink for terminals that
+// understand one and a Zone for the mouse, cut at the right edge rather than
+// folded. Cut rather than folded because a link has to be one row -- half a URL
+// on the row below is neither clickable nor readable, and a zone spanning two
+// rows is not a zone. The sequence survives the cut (see links.go), so a URL too
+// wide for the pane comes out shortened and still valid.
+//
+// Anything that is not http or https is drawn as it always was: wrapped plain
+// text. The viewer will not open it, so it must not look like something that
+// opens.
+func (b *detailBuf) reference(raw string) {
+	text := tui.Clean(raw)
+	if !linkable(text) {
+		b.wrapped(tui.StyleDim, text)
+		return
+	}
+	pad, w := b.indent()
+	row := tui.Truncate(hyperlink(text, tui.StyleDim.Render(text)), w)
+	b.links = append(b.links, detailLink{
+		Row: len(b.out), Col: tui.Width(pad), W: tui.Width(row), Idx: len(b.urls),
+	})
+	b.urls = append(b.urls, text)
+	b.push(pad + row)
+}
+
+// markdown renders markdown source under a section label, folded at the body
+// width. The rows are pushed as glamour produced them: it brings its own colors,
+// and wrapping a row in a lipgloss style would reset those escapes halfway
+// through the line. A source that renders to nothing at all falls back to the
+// plain wrapped text, so a section that has source is never drawn empty.
+//
+// The document is rendered in pieces, one per fenced code block, so that each
+// block's first row is known and can carry a COPY. The pieces are separated by a
+// blank row, which is the gap glamour itself puts between a paragraph and the
+// code under it.
+func (b *detailBuf) markdown(text string) {
+	pad, w := b.indent()
+	blocks := markdown.Blocks(text, w, b.codeW)
+	if len(blocks) == 0 {
+		b.wrapped(tui.StyleText, text)
+		return
+	}
+	for i, blk := range blocks {
+		if i > 0 {
+			b.blank()
+		}
+		if blk.Code != nil {
+			b.claim(blk.Code.Text)
+		}
+		for _, ln := range blk.Lines {
+			b.push(pad + ln)
+		}
+	}
+}
+
+// code lays text out under a section label without folding it: one source line
+// is one row, cut at the right edge. MQL and the assessment printer both depend
+// on their own line structure, and a fold in the middle of a token turns either
+// into something that no longer reads as the thing it is.
+func (b *detailBuf) code(style lipgloss.Style, text string) {
+	b.codeAt(style, text, b.width())
+}
+
+// codeBlock is code that can be copied: the same layout, cut a button's strip
+// narrower so the COPY on its first row hides none of it.
+func (b *detailBuf) codeBlock(style lipgloss.Style, text string) {
+	b.claim(strings.TrimSpace(tui.Clean(text)))
+	b.codeAt(style, text, b.codeW)
+}
+
+func (b *detailBuf) codeAt(style lipgloss.Style, text string, w int) {
+	pad, _ := b.indent()
+	for _, ln := range tui.Lines(text) {
+		b.push(pad + tui.Truncate(style.Render(ln), w))
+	}
+}
+
+// width is the room a section body has after the indent.
+func (b *detailBuf) width() int {
+	_, w := b.indent()
+	return w
+}
+
+// indent is the body prefix and the width left for the body after it. A pane too
+// narrow to indent into gives the text the whole width rather than one column of
+// it.
+func (b *detailBuf) indent() (string, int) {
+	if b.w <= detailIndent+1 {
+		return "", max(b.w, 1)
+	}
+	return detailPad, b.w - detailIndent
+}

--- a/cli/reportview/detail_test.go
+++ b/cli/reportview/detail_test.go
@@ -1,0 +1,650 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// detailRect is the content area a test renders into: absolute cells, the way
+// the frame hands them over.
+func detailRect(w, h int) tui.Rect {
+	return tui.Rect{X: 1, Y: 2, W: w, H: h}
+}
+
+// renderDetail runs one frame of a fresh pane and returns the whole body, not
+// just the visible window, so a test can assert on sections that scrolled off.
+func renderDetail(st *State, w int) (*detailPane, []string) {
+	p := &detailPane{}
+	p.Render(st, detailRect(w, 1000))
+	return p, p.lines
+}
+
+// stateFor builds a state selecting the named check of the first asset.
+func stateFor(t *testing.T, fixture, title string) (*State, *reportmodel.Check) {
+	t.Helper()
+	st := NewState(loadReport(t, fixture))
+	require.NotEmpty(t, st.Report.Assets)
+	asset := st.Report.Assets[0]
+	for _, c := range asset.Checks {
+		if c.Title == title {
+			st.SelectCheck(asset, nil, c)
+			return st, c
+		}
+	}
+	t.Fatalf("no check titled %q on %s", title, asset.Name)
+	return nil, nil
+}
+
+// --- the invariant ----------------------------------------------------------
+
+// One element of Render.Lines is exactly one terminal row, and never wider than
+// the rect. This is the invariant the whole frame is built on: a line wider than
+// the pane wraps in the terminal and pushes every row below it down by one, and
+// a line containing a newline does the same thing without even being wide.
+//
+// It is asserted over every check of the fixture at every width that has ever
+// broken something, including widths narrower than the indent itself.
+func TestDetailLinesFitTheRect(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+	require.NotEmpty(t, asset.Checks)
+
+	widths := []int{1, 2, 3, 4, 8, 20, 37, 60, 80, 120, 200}
+
+	for _, check := range asset.Checks {
+		st.SelectCheck(asset, nil, check)
+		for _, w := range widths {
+			p := &detailPane{}
+			r := p.Render(st, detailRect(w, 24))
+			require.LessOrEqual(t, len(r.Lines), 24,
+				"%s at w=%d: rendered more rows than the rect is tall", check.Title, w)
+			for i, ln := range p.lines {
+				require.NotContains(t, ln, "\n",
+					"%s at w=%d: line %d holds a newline, so it is not one row", check.Title, w, i)
+				require.LessOrEqual(t, tui.Width(ln), w,
+					"%s at w=%d: line %d is %d cells wide (%q)", check.Title, w, i, tui.Width(ln), ansi.Strip(ln))
+			}
+		}
+	}
+}
+
+// The width evidence for the one section that is arbitrarily long: a 900-byte
+// remediation body full of shell, at a pane too narrow to hold one of its lines.
+// Wrapping is the frame's Wrap, so a token longer than the pane is broken rather
+// than allowed to overflow.
+func TestLongRemediationWrapsToNarrowPane(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+
+	d := check.Detail()
+	require.NotEmpty(t, d.Remediation, "this fixture check is the long-remediation case")
+	longest := 0
+	for _, item := range d.Remediation {
+		for _, ln := range strings.Split(item.Desc, "\n") {
+			longest = max(longest, len(ln))
+		}
+	}
+	require.Greater(t, longest, 60, "the remediation must be wider than the panes below")
+
+	for _, w := range []int{24, 30, 40} {
+		_, lines := renderDetail(st, w)
+		for i, ln := range lines {
+			require.LessOrEqual(t, tui.Width(ln), w, "w=%d line %d: %q", w, i, ansi.Strip(ln))
+		}
+		joined := ansi.Strip(strings.Join(lines, "\n"))
+		require.Contains(t, joined, "REMEDIATION")
+		// The body survived the fold: a word from deep inside the script is
+		// still there, so wrapping did not truncate the section away.
+		require.Contains(t, strings.ReplaceAll(joined, "\n", ""), "package manager")
+	}
+}
+
+// --- markdown ---------------------------------------------------------------
+
+// colorful pins the color profile the markdown renderer draws for. lipgloss
+// detects Ascii whenever stdout is not a terminal, which is every test run, and
+// a test that wants to see a bold sequence has to ask for a profile that has
+// one.
+func colorful(t *testing.T) {
+	t.Helper()
+	was := markdownProfile
+	markdownProfile = func() termenv.Profile { return termenv.ANSI256 }
+	t.Cleanup(func() { markdownProfile = was })
+}
+
+// The three markdown sections are rendered, not printed as their source. This is
+// the whole point of the file: the reader sees bold words, headings, list
+// markers and a code block, and none of the markup that produced them.
+func TestMarkdownIsRenderedNotPrinted(t *testing.T) {
+	colorful(t)
+	st, check := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+
+	d := check.Detail()
+	require.Contains(t, d.Description, "**", "the source is markdown, or this test proves nothing")
+	require.Contains(t, d.Remediation[0].Desc, "```bash")
+	require.Contains(t, d.Remediation[0].Desc, "### ")
+
+	_, lines := renderDetail(st, 80)
+	out := ansi.Strip(strings.Join(lines, "\n"))
+
+	// The markup is gone.
+	require.NotContains(t, out, "**")
+	require.NotContains(t, out, "```")
+	for _, ln := range lines {
+		// An ATX heading is hashes then a space. A shebang inside a code block
+		// is neither, and it stays exactly as it was written.
+		require.NotRegexp(t, `^#+ `, strings.TrimSpace(ansi.Strip(ln)),
+			"a heading is still wearing its hashes: %q", ansi.Strip(ln))
+	}
+	require.Contains(t, out, "#!/bin/bash", "a shebang is code, not a heading")
+
+	// The words it marked up are not.
+	require.Contains(t, out, "Why this matters")
+	require.Contains(t, out, "RHEL/Fedora/Amazon Linux and derivatives")
+	require.Contains(t, out, "yum remove xorg-x11*")
+	require.Contains(t, out, "•", "a bullet list is drawn with bullets")
+
+	// And the emphasis became an escape sequence rather than two asterisks.
+	require.Contains(t, strings.Join(lines, "\n"), "\x1b[1m", "nothing was rendered bold")
+}
+
+// The section that is code stays code. MQL goes nowhere near the renderer: a
+// markdown parser would eat its underscores and asterisks and fold its lines,
+// and the query the check ran is not a document.
+func TestMqlIsNotRenderedAsMarkdown(t *testing.T) {
+	colorful(t)
+	st, check := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+	d := check.Detail()
+	require.Contains(t, d.Mql, "*", "this query carries a character markdown would eat")
+
+	_, lines := renderDetail(st, 200)
+	start := indexOfLine(lines, "QUERY")
+	require.GreaterOrEqual(t, start, 0)
+
+	rows := make([]string, 0, len(d.Mql))
+	for i := start + 1; i < len(lines); i++ {
+		if strings.TrimSpace(ansi.Strip(lines[i])) == "" {
+			break
+		}
+		rows = append(rows, strings.TrimSpace(ansi.Strip(lines[i])))
+	}
+	require.Equal(t, tui.Lines(d.Mql), rows, "the query is not the source it ran")
+}
+
+// The invariant again, aimed at the row most likely to break it: a fenced code
+// block whose lines are far wider than the pane. glamour does not wrap fenced
+// code the way it wraps prose -- at a narrow enough width it stops wrapping
+// altogether -- so the renderer measures and folds every row itself.
+func TestMarkdownCodeBlockNeverOverflows(t *testing.T) {
+	colorful(t)
+	src := "Run it:\n\n```bash\n" +
+		"sudo launchctl list | grep com.apple.smbd && echo 'the SMB service is loaded, which it should not be' >&2\n" +
+		"nmcli connection modify eth0 ipv4.dns \"1.1.1.1 8.8.8.8\" ipv4.ignore-auto-dns yes\n" +
+		"```\n\nA passing result returns **no output**.\n"
+
+	for w := 1; w <= 60; w++ {
+		lines := markdown.Lines(src, w)
+		require.NotEmpty(t, lines, "w=%d: rendered nothing", w)
+		for i, ln := range lines {
+			require.NotContains(t, ln, "\n", "w=%d row %d holds a newline", w, i)
+			require.NotContains(t, ln, "\r", "w=%d row %d holds a carriage return", w, i)
+			require.LessOrEqual(t, tui.Width(ln), w,
+				"w=%d row %d is %d cells (%q)", w, i, tui.Width(ln), ansi.Strip(ln))
+		}
+		// Folding is not truncation: the command survives being cut up.
+		flat := strings.ReplaceAll(ansi.Strip(strings.Join(lines, "")), " ", "")
+		require.Contains(t, flat, "grepcom.apple.smbd", "w=%d: the command lost its middle", w)
+	}
+}
+
+// Carriage returns are what break lipgloss's width maths, and the source of
+// these fields comes from a reporter whose newline is "\r\n" on Windows. Nothing
+// the renderer emits may carry one.
+func TestMarkdownNormalizesWindowsNewlines(t *testing.T) {
+	colorful(t)
+	crlf := "**Bold**\r\n\r\n1. First step.\r\n2. Second step.\r\n\r\n```bash\r\nchmod 600 /etc/group-\r\n```\r\n"
+
+	lines := markdown.Lines(crlf, 40)
+	require.NotEmpty(t, lines)
+	for i, ln := range lines {
+		require.NotContains(t, ln, "\r", "row %d kept a carriage return", i)
+		require.LessOrEqual(t, tui.Width(ln), 40)
+	}
+	require.Contains(t, ansi.Strip(strings.Join(lines, "\n")), "chmod 600 /etc/group-")
+}
+
+// A source that renders to nothing at all -- an HTML comment, say -- falls back
+// to the plain wrapped source. A section the check actually filled in must never
+// draw as an empty label.
+func TestMarkdownFallsBackRatherThanRenderNothing(t *testing.T) {
+	colorful(t)
+	const hidden = "<!-- there is nothing to see here -->"
+	require.Empty(t, markdown.Lines(hidden, 40), "this source is the renders-to-nothing case")
+
+	b := &detailBuf{w: 40}
+	b.section("DESCRIPTION")
+	b.markdown(hidden)
+	require.Len(t, b.out, 2)
+	require.Contains(t, ansi.Strip(b.out[1]), "nothing to see here")
+}
+
+// Rendering markdown is not free, and Render runs on every frame and every
+// mouse event. It has to happen inside the body cache: once per selection and
+// width, not once per wheel notch.
+func TestMarkdownRunsInsideTheBodyCache(t *testing.T) {
+	colorful(t)
+	st, _ := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+
+	p := &detailPane{}
+	before := markdown.Renders()
+	p.Render(st, detailRect(80, 20))
+	first := markdown.Renders() - before
+	require.Greater(t, first, 1, "this check has a description and three remediations")
+
+	for i := 0; i < 20; i++ {
+		p.Render(st, detailRect(80, 20))
+		p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	}
+	require.Equal(t, first, markdown.Renders()-before, "the cache did not hold")
+
+	// A resize is a new body, and so is a new selection.
+	p.Render(st, detailRect(60, 20))
+	require.Equal(t, 2*first, markdown.Renders()-before)
+}
+
+// --- an asset that never scanned --------------------------------------------
+
+// The k8s fixture is fifteen assets, no reports, fifteen errors and no bundle.
+// Selecting one of them must say the scan did not happen and show the error. It
+// must not render an empty check page, which is indistinguishable from a clean
+// asset.
+func TestUnscannedAssetSaysWhy(t *testing.T) {
+	st := NewState(loadReport(t, fixtureK8s))
+	require.Len(t, st.Report.Assets, 15)
+
+	for _, asset := range st.Report.Assets {
+		require.False(t, asset.Scanned())
+		require.NotEmpty(t, asset.ScanError)
+		require.Empty(t, asset.Checks)
+
+		st.SelectAsset(asset)
+		_, lines := renderDetail(st, 80)
+		out := ansi.Strip(strings.Join(lines, "\n"))
+
+		require.Equal(t, "Asset", detailTitle(st))
+		require.Contains(t, out, "THIS ASSET WAS NOT SCANNED")
+		require.Contains(t, out, statusGlyph(reportmodel.StatusError)+" "+string(reportmodel.StatusError))
+		// The reason, wrapped, is the point of the page.
+		require.Contains(t, strings.ReplaceAll(out, "\n", " "),
+			strings.Fields(asset.ScanError)[0])
+		// None of the vocabulary of a scanned asset: no tally that reads as
+		// "we looked and found nothing", no findings list.
+		require.NotContains(t, out, "FINDINGS")
+		require.NotContains(t, out, "0 total")
+		require.NotContains(t, out, "CHECKS")
+	}
+}
+
+// An asset that scanned gets the other page entirely: its tally and its
+// findings, and nothing about a scan that did not happen.
+func TestScannedAssetPage(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+	require.True(t, asset.Scanned())
+	st.SelectAsset(asset)
+
+	_, lines := renderDetail(st, 100)
+	out := ansi.Strip(strings.Join(lines, "\n"))
+
+	require.Contains(t, out, "ubuntu:24.04")
+	require.Contains(t, out, "Ubuntu 24.04.2 LTS")
+	require.Contains(t, out, "CHECKS")
+	require.Contains(t, out, "24 total")
+	require.Contains(t, out, "FINDINGS")
+	require.NotContains(t, out, "THIS ASSET WAS NOT SCANNED")
+
+	// Every finding, and only the findings: two failed plus four errored, one
+	// row each, and nothing that passed.
+	require.Equal(t, 6, asset.Counts.Findings())
+	at := indexOfLine(lines, "FINDINGS")
+	require.GreaterOrEqual(t, at, 0)
+	rows := lines[at+1:]
+	require.Len(t, rows, 6)
+	for _, ln := range rows {
+		require.NotContains(t, ansi.Strip(ln), string(reportmodel.StatusPass))
+	}
+
+	// And they are drawn the way the tree draws the same checks: a glyph, the
+	// severity dots, then the title. This is a list being scanned, so it takes
+	// the tree's trade rather than the status row's -- spelling PASS/FAIL and
+	// CRIT out here would re-say the shape and cost the title twelve cells.
+	failed, errored := 0, 0
+	for _, ln := range rows {
+		s := ansi.Strip(ln)
+		require.NotContains(t, s, string(reportmodel.StatusFail))
+		require.NotContains(t, s, "CRIT")
+		switch {
+		case strings.Contains(s, "✗ ●●●● "):
+			failed++
+		// The four errored checks configure no impact, so their dot column is
+		// four spaces rather than four hollow dots -- the same distinction the
+		// tree makes, and for the same reason.
+		case strings.Contains(s, "! "+strings.Repeat(" ", SeverityDotsWidth)+" "):
+			errored++
+		}
+	}
+	require.Equal(t, 2, failed, "%q", rows)
+	require.Equal(t, 4, errored, "%q", rows)
+}
+
+// --- an errored check is not a failed check ---------------------------------
+
+// The four errored checks of the ubuntu fixture could not run at all. The page
+// has to say ERROR, carry the reason, and put it above the assessment, which for
+// an errored check reads "[failed] ..." only because the query never completed.
+func TestErroredCheckLeadsWithTheError(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Enable strict mode")
+	d := check.Detail()
+	require.Equal(t, reportmodel.StatusError, d.Status)
+	require.NotEmpty(t, d.Error)
+	require.NotEmpty(t, d.Assessment)
+
+	_, lines := renderDetail(st, 100)
+	out := ansi.Strip(strings.Join(lines, "\n"))
+
+	require.Contains(t, out, string(reportmodel.StatusError))
+	require.Contains(t, out, "sshd_config' not found")
+	// Not a single FAIL anywhere on the page. The assessment says "[failed]"
+	// in lower case because the query never completed, and that lower-case
+	// word is the whole reason the error is hoisted above it.
+	require.NotContains(t, out, string(reportmodel.StatusFail),
+		"an errored check must not be labelled as a failed one")
+	require.Contains(t, out, "[failed]")
+
+	errAt := indexOfLine(lines, "ERROR")
+	resultAt := indexOfLine(lines, "RESULT")
+	require.GreaterOrEqual(t, errAt, 0)
+	require.GreaterOrEqual(t, resultAt, 0)
+	require.Less(t, errAt, resultAt, "the reason a check could not run comes first")
+	// The reason is under its own label, not folded into the status row.
+	require.Contains(t, ansi.Strip(lines[errAt+1]), "1 error occurred")
+}
+
+// A check that failed carries no ERROR section at all, and its status row says
+// FAIL. The two outcomes stay two outcomes.
+func TestFailedCheckHasNoErrorSection(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Ensure secure permissions on /etc/group- are set")
+	d := check.Detail()
+	require.Equal(t, reportmodel.StatusFail, d.Status)
+	require.Empty(t, d.Error)
+
+	_, lines := renderDetail(st, 100)
+	require.Equal(t, -1, indexOfLine(lines, "ERROR"))
+
+	out := ansi.Strip(strings.Join(lines, "\n"))
+	require.Contains(t, out, string(reportmodel.StatusFail))
+	require.Contains(t, out, "CRIT", "severity is what the check is worth")
+	require.Contains(t, out, "impact 100")
+}
+
+// --- section order ----------------------------------------------------------
+
+// The stack follows junit's detailedCheckBody, with the error hoisted. A check
+// with every optional section present pins the order.
+func TestSectionOrder(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+	d := check.Detail()
+	require.NotEmpty(t, d.Description)
+	require.NotEmpty(t, d.Mql)
+	require.NotEmpty(t, d.Audit)
+	require.NotEmpty(t, d.Assessment)
+	require.NotEmpty(t, d.Error)
+	require.NotEmpty(t, d.Remediation)
+	require.NotEmpty(t, d.References)
+	require.NotEmpty(t, d.Policies)
+
+	_, lines := renderDetail(st, 100)
+
+	want := []string{
+		"ERROR", "DESCRIPTION", "QUERY", "AUDIT", "RESULT",
+		"REMEDIATION", "REFERENCES", "POLICIES",
+	}
+	at := -1
+	for _, label := range want {
+		i := indexOfLine(lines, label)
+		require.Greater(t, i, at, "%s is out of order", label)
+		at = i
+	}
+
+	out := ansi.Strip(strings.Join(lines, "\n"))
+	require.Contains(t, out, "Mondoo SSH Server Security")
+	require.Contains(t, out, "CIS RHEL 7")
+	require.Contains(t, out, "itsecure.hu")
+}
+
+// MQL is code: every source line stays one row. The frame's Wrap would fold a
+// long query onto a second line and move an operator onto a line of its own.
+func TestMqlKeepsItsLineStructure(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Ensure secure permissions on /etc/group- are set")
+	d := check.Detail()
+	sourceLines := strings.Count(d.Mql, "\n") + 1
+	require.Greater(t, len(d.Mql), 100, "this check's query is the multi-line case")
+
+	// Wide enough that nothing is cut, and narrow enough that Wrap certainly
+	// would have folded: the row count is the same either way. The block is
+	// measured label to label, so a blank line inside the query is still one of
+	// its rows.
+	for _, w := range []int{40, 400} {
+		_, lines := renderDetail(st, w)
+		start := indexOfLine(lines, "QUERY")
+		next := indexOfLine(lines, "REMEDIATION")
+		require.GreaterOrEqual(t, start, 0)
+		require.Greater(t, next, start)
+
+		// start+1 .. next-2, because section() puts a blank before each label.
+		rows := next - start - 2
+		require.Equal(t, sourceLines, rows, "w=%d: the query gained or lost rows", w)
+	}
+}
+
+// --- a check with nothing in it ---------------------------------------------
+
+// Every field of CheckDetail may be empty. The pane still has to render
+// something a person can read, rather than zero lines or a blank box.
+func TestEmptyCheckStillRenders(t *testing.T) {
+	st := NewState(reportmodel.New(nil))
+	st.Select(Selection{Check: &reportmodel.Check{}})
+
+	for _, w := range []int{1, 3, 40} {
+		_, lines := renderDetail(st, w)
+		require.NotEmpty(t, lines, "w=%d: an empty check rendered nothing at all", w)
+		for _, ln := range lines {
+			require.LessOrEqual(t, tui.Width(ln), w)
+			require.NotContains(t, ln, "\n")
+		}
+		require.Equal(t, "Check", detailTitle(st))
+	}
+
+	// The status row is the floor. A zero-value Check has no status either, and
+	// a row of blank cells is not an outcome, so it reports UNKNOWN rather than
+	// nothing -- and it is the only thing on the page.
+	full := ansi.Strip(strings.Join(detailBody(st, 60), "\n"))
+	require.Contains(t, full, string(reportmodel.StatusUnknown))
+	for _, label := range []string{"DESCRIPTION", "QUERY", "AUDIT", "RESULT", "ERROR",
+		"FAILING RESOURCES", "REMEDIATION", "REFERENCES", "COMPLIANCE", "POLICIES"} {
+		require.NotContains(t, full, label, "an empty check must not grow an empty %s section", label)
+	}
+}
+
+// Nothing selected at all is the third page, and it is one honest line rather
+// than an empty pane.
+func TestNothingSelected(t *testing.T) {
+	st := NewState(reportmodel.New(nil))
+	require.Nil(t, st.Sel.Asset)
+
+	_, lines := renderDetail(st, 40)
+	require.Len(t, lines, 1)
+	require.Equal(t, "nothing selected", ansi.Strip(lines[0]))
+	require.Equal(t, "Detail", detailTitle(st))
+}
+
+// --- scrolling --------------------------------------------------------------
+
+// The pane returns exactly the rows it wants visible, and scrolling moves the
+// window rather than the content.
+func TestScrollWindowsTheBody(t *testing.T) {
+	st, _ := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+
+	p := &detailPane{}
+	const h = 10
+	first := p.Render(st, detailRect(80, h))
+	require.Len(t, first.Lines, h)
+	require.Greater(t, len(p.lines), h, "this check is longer than the pane")
+
+	_, ok := p.Update(st, key("down"))
+	require.True(t, ok)
+	second := p.Render(st, detailRect(80, h))
+	require.Len(t, second.Lines, h)
+	require.Equal(t, first.Lines[1], second.Lines[0], "one row down is one row down")
+
+	// A page moves a pane's worth.
+	p.scroll.Off = 0
+	_, ok = p.Update(st, key("pgdown"))
+	require.True(t, ok)
+	require.Equal(t, h, p.scroll.Off)
+
+	// The end clamps to the last full page and never past it.
+	_, ok = p.Update(st, key("G"))
+	require.True(t, ok)
+	p.Render(st, detailRect(80, h))
+	require.Equal(t, len(p.lines)-h, p.scroll.Off)
+
+	_, ok = p.Update(st, key("g"))
+	require.True(t, ok)
+	require.Equal(t, 0, p.scroll.Off)
+
+	// A key the pane has no use for falls through to the frame.
+	_, ok = p.Update(st, key("x"))
+	require.False(t, ok)
+}
+
+// A short body does not scroll at all: there is nothing below the fold.
+func TestShortBodyDoesNotScroll(t *testing.T) {
+	st := NewState(reportmodel.New(nil))
+	p := &detailPane{}
+	p.Render(st, detailRect(40, 20))
+
+	_, ok := p.Update(st, key("down"))
+	require.True(t, ok, "the pane still consumes the key")
+	p.Render(st, detailRect(40, 20))
+	require.Equal(t, 0, p.scroll.Off)
+}
+
+// A new selection starts at the top. The pane watches SelectionRev, because the
+// tree is what bumps it and the pane has no other way to know.
+func TestSelectionResetsScroll(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+	require.Greater(t, len(asset.Checks), 1)
+
+	st.SelectCheck(asset, nil, asset.Checks[1])
+	p := &detailPane{}
+	p.Render(st, detailRect(80, 10))
+	p.Update(st, key("pgdown"))
+	p.Render(st, detailRect(80, 10))
+	require.Greater(t, p.scroll.Off, 0)
+
+	before := st.SelectionRev
+	st.SelectCheck(asset, nil, asset.Checks[2])
+	require.Greater(t, st.SelectionRev, before, "the selection actually changed")
+
+	p.Render(st, detailRect(80, 10))
+	require.Equal(t, 0, p.scroll.Off, "a new check opens at its top")
+}
+
+// A resize rebuilds the body at the new width but keeps the reader where they
+// were: re-wrapping is not a reason to jump back to the title.
+func TestResizeKeepsScroll(t *testing.T) {
+	st, _ := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+	p := &detailPane{}
+	p.Render(st, detailRect(80, 10))
+	p.Update(st, key("pgdown"))
+	p.Render(st, detailRect(80, 10))
+	off, wide := p.scroll.Off, len(p.lines)
+	require.Greater(t, off, 0)
+
+	p.Render(st, detailRect(40, 10))
+	require.Equal(t, 40, p.width)
+	require.Greater(t, len(p.lines), wide, "a narrower pane needs more rows")
+	require.Equal(t, off, p.scroll.Off)
+}
+
+// The wheel scrolls without moving focus, which is the frame's job; the pane
+// only has to answer it.
+func TestWheelScrolls(t *testing.T) {
+	st, _ := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+	p := &detailPane{}
+	p.Render(st, detailRect(80, 10))
+
+	_, ok := p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	require.True(t, ok)
+	require.Equal(t, detailWheelStep, p.scroll.Off)
+
+	_, ok = p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	require.True(t, ok)
+	require.Equal(t, 0, p.scroll.Off)
+
+	_, ok = p.Update(st, tea.MouseMsg{Button: tea.MouseButtonLeft})
+	require.False(t, ok, "a click is not this pane's business")
+}
+
+// --- the seam ---------------------------------------------------------------
+
+// The pane installs itself into the detail slot and answers the interface the
+// frame expects of it.
+func TestDetailPaneIsRegistered(t *testing.T) {
+	p := buildPane(PaneDetail, nil)
+	require.IsType(t, &detailPane{}, p)
+	require.Equal(t, PaneDetail, p.ID())
+	require.True(t, p.Focusable())
+	require.Nil(t, p.Claims())
+	require.NotEmpty(t, p.Hints(nil))
+}
+
+// Rendering through the whole frame keeps the view exactly the terminal size,
+// which is the frame's invariant and the pane's obligation to it.
+func TestDetailInsideTheFrame(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		report := loadReport(t, fixture)
+		for _, s := range termSizes {
+			m := sized(NewModel(report), s.w, s.h)
+			m.state.Focus = PaneDetail
+			lines := viewLines(m)
+			require.Len(t, lines, s.h, "%s %dx%d", fixture, s.w, s.h)
+			for i, ln := range lines {
+				require.LessOrEqual(t, ansi.StringWidth(ln), s.w,
+					"%s %dx%d: line %d", fixture, s.w, s.h, i)
+			}
+		}
+	}
+}
+
+// indexOfLine is the row a section label is on, or -1. The label is the whole
+// line, so "ERROR" does not match the status row of an errored check.
+func indexOfLine(lines []string, label string) int {
+	for i, ln := range lines {
+		if strings.TrimSpace(ansi.Strip(ln)) == label {
+			return i
+		}
+	}
+	return -1
+}

--- a/cli/reportview/export.go
+++ b/cli/reportview/export.go
@@ -1,0 +1,580 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/cli/reporter"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Exporting is cheap here because the viewer never reduced anything: it was
+// built from a whole *policy.ReportCollection and still holds it (see
+// reportmodel.Report.Collection), and cli/reporter already knows how to write
+// every output format cnspec has. So "export" is a format picker, a file name
+// and a tea.Cmd -- no second rendering path, and nothing the CLI can produce
+// that the viewer cannot.
+//
+// # Which formats are offered
+//
+// Four, out of the nineteen names in reporter.Formats. The picker is a question
+// asked mid-read -- "give me this report as a file" -- and the answer is one of
+// json, yaml, junit and sarif. The rest made the reader choose between artifacts
+// they would have to know cnspec's history to tell apart.
+//
+// What is left out, and why:
+//
+//   - the older shapes. json-v1, yaml-v1 and json-v2 are earlier reductions of
+//     the same report, still reachable from `cnspec scan --output` for anything
+//     already parsing them. A viewer opened to read one scan is not where a
+//     reader picks a schema version, so each family offers its current one: json
+//     is the full collection, yaml is yaml-v2.
+//
+//   - the four terminal renderings. compact, summary, full and report are the
+//     report drawn for a screen -- which is what the CLI already prints, and
+//     what this viewer is a richer replacement for. Writing one to a file was
+//     also the only reason this package ever had to strip ANSI on the way out:
+//     those writers take their color from colors.DefaultColorTheme, built from
+//     termenv.EnvColorProfile() at init, so under a real terminal they emit SGR
+//     escapes wherever their output is pointed. With none of them offered, the
+//     strip has nothing to strip, and it is gone with them. Anything added back
+//     here that renders for a screen has to bring it back.
+//
+//   - the OCSF formats, which are an ingestion target rather than something a
+//     reader opens. ocsf-json and ocsf-parquet exist for a security data lake and
+//     stay reachable from `cnspec scan --output`; ocsf-parquet cannot be written
+//     to a single file at all, since it emits one file per event class.
+//
+//   - csv, which cannot be written at all. reporter.FormatCSV has no case in
+//     (*Reporter).WriteReport: it falls through to the default branch and comes
+//     back "unknown reporter type, don't recognize this format". The switch has
+//     the CSV arm commented out, so this is a format that exists in the name
+//     table and nowhere else. TestCSVIsExcludedBecauseItCannotBeWritten holds
+//     that to it rather than trusting this paragraph.
+//
+// # Shown as, written as
+//
+// The name on a row is not always the reporter's name for it, because the
+// reporter's names carry the history this list is dropping. `json` writes
+// json-full and `yaml` writes yaml-v2; both are simply "the json one" and "the
+// yaml one" to a reader who has never met a v1. Format is what reaches
+// reporter.ParseConfig, Name is what the modal and the footer say, and the
+// suffixes follow the shown name -- with one json on offer there is no reason
+// for a .full.json.
+//
+// That makes `json` the row that round-trips: json-full is the whole
+// *policy.ReportCollection rather than a reduction of it, so the file it writes
+// is the file `cnspec report view` reopens. TestTheJSONRowRoundTrips proves it
+// by reading one back through reporter.LoadCollectionFile.
+//
+// # Bundles
+//
+// junit and sarif are offered only when the collection carries a policy bundle.
+// Both writers refuse a collection without one ("no policy bundle found",
+// junit.go and sarif.go), which is exactly the shape of a scan where every asset
+// failed before a policy could run. Rather than offer a row that is guaranteed
+// to fail, exportable drops them, and such a report gets two rows instead of
+// four.
+//
+// TestEveryOfferedFormatWrites proves the list rather than trusting any of this:
+// it writes every offered format for both fixtures and reads the files back.
+
+// exportFormat is one row of the export modal: what it is called, the reporter
+// format behind it, the file it writes and the sentence that says what it is
+// for.
+type exportFormat struct {
+	// Name is what the row is called on screen and in the footer notice.
+	Name string
+	// Format is the reporter format it writes, spelled the way
+	// `cnspec scan --output` spells it. It is often the same string as Name and
+	// deliberately not always -- see "Shown as, written as" above.
+	Format string
+	// Suffix is what is appended to the base name. Every offered format has a
+	// distinct one, so exporting two formats of the same report never lands
+	// them on the same path.
+	Suffix string
+	// Desc is the one-line explanation shown beside the name.
+	Desc string
+	// needsBundle marks a format whose writer refuses a collection with no
+	// policy bundle.
+	needsBundle bool
+}
+
+// exportFormats is every format the picker offers, machine-readable first: the
+// reason to leave the viewer with a file is usually to feed it to something
+// else, and json is what most things eat.
+var exportFormats = []exportFormat{
+	{Name: "json", Format: "json-full", Suffix: ".json", Desc: "everything, reopens in this viewer"},
+	{Name: "yaml", Format: "yaml-v2", Suffix: ".yaml", Desc: "scores, data and errors, as yaml"},
+	{Name: "junit", Format: "junit", Suffix: ".junit.xml", Desc: "one test case per check", needsBundle: true},
+	{Name: "sarif", Format: "sarif", Suffix: ".sarif", Desc: "code scanning findings", needsBundle: true},
+}
+
+// exportable is the subset of exportFormats that can be written for this
+// collection. A nil collection yields none: the viewer can be opened on an
+// empty model (reportmodel.New(nil)), and writing four empty files is not a
+// service to anybody.
+func exportable(c *policy.ReportCollection) []exportFormat {
+	if c == nil {
+		return nil
+	}
+	res := make([]exportFormat, 0, len(exportFormats))
+	for _, f := range exportFormats {
+		if f.needsBundle && c.Bundle == nil {
+			continue
+		}
+		res = append(res, f)
+	}
+	return res
+}
+
+// --- where the file goes ----------------------------------------------------
+
+// exportFallbackName is the base name for a report that is not one asset.
+const exportFallbackName = "cnspec-report"
+
+// exportNameMax caps the base name. Asset names can be an ARN or a container
+// digest, and a 200-character file name is not a name anybody can type.
+const exportNameMax = 48
+
+// exportBaseName is the file name the export is built from, without a suffix.
+//
+// A single-asset report is named after its asset, because that is what the user
+// would call the file themselves. Anything else is named cnspec-report: the
+// export is the whole collection, and naming a fifteen-asset file after the row
+// the cursor happens to be on would be a lie about its contents.
+func exportBaseName(r *reportmodel.Report) string {
+	if r != nil && len(r.Assets) == 1 {
+		if s := exportSlug(r.Assets[0].Name); s != "" {
+			return s
+		}
+	}
+	return exportFallbackName
+}
+
+// exportSlug reduces a name to lowercase letters, digits and dashes. The
+// charset is the point: an asset name can hold a slash, a colon or a space, and
+// the result of this is pasted straight into a path.
+func exportSlug(s string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			dash = false
+		case b.Len() > 0 && !dash:
+			b.WriteByte('-')
+			dash = true
+		}
+	}
+	out := strings.TrimRight(b.String(), "-")
+	if len(out) > exportNameMax {
+		out = strings.TrimRight(out[:exportNameMax], "-")
+	}
+	return out
+}
+
+// --- writing ----------------------------------------------------------------
+
+// writeExport renders the collection in one format and writes it to
+// dir/base+suffix, returning the path and how many bytes landed there.
+//
+// The file is created with O_EXCL, so an export never replaces one that is
+// already there. The alternative -- overwriting, or silently picking
+// name-1.json -- trades a predictable path for a surprise, and the whole reason
+// the name is derived from the report rather than typed is that the user should
+// be able to say where the file will be before pressing the key. A collision is
+// reported and the existing file is left exactly as it was.
+func writeExport(ctx context.Context, c *policy.ReportCollection, f exportFormat, dir, base string) (string, int64, error) {
+	path := filepath.Join(dir, base+f.Suffix)
+
+	conf, err := reporter.ParseConfig(f.Format)
+	if err != nil {
+		return path, 0, errors.Wrapf(err, "cannot configure the %s reporter", f.Format)
+	}
+
+	// Rendered whole before the file is opened: a failure halfway through a
+	// writer must not leave a truncated artifact behind under a name that says
+	// it is complete.
+	var buf bytes.Buffer
+	if err := reporter.NewReporter(conf, false).WithOutput(&buf).WriteReport(ctx, c); err != nil {
+		return path, 0, errors.Wrapf(err, "cannot render %s", f.Name)
+	}
+
+	// The bytes go to the file exactly as the writer produced them. Every format
+	// offered here is a machine format, and an escape byte inside one came from
+	// scanned data -- a command's captured output, say -- so stripping it would
+	// corrupt the artifact rather than tidy it. See the package comment for the
+	// terminal formats this used to have to strip, and no longer offers.
+	out := buf.Bytes()
+
+	fh, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return path, 0, errors.Newf("%s already exists, remove it first", filepath.Base(path))
+		}
+		return path, 0, errors.Wrapf(err, "cannot create %s", filepath.Base(path))
+	}
+	if _, err := fh.Write(out); err != nil {
+		_ = fh.Close()
+		_ = os.Remove(path)
+		return path, 0, errors.Wrapf(err, "cannot write %s", filepath.Base(path))
+	}
+	if err := fh.Close(); err != nil {
+		_ = os.Remove(path)
+		return path, 0, errors.Wrapf(err, "cannot write %s", filepath.Base(path))
+	}
+	return path, int64(len(out)), nil
+}
+
+// ExportDoneMsg is the outcome of a write, on its way back to the frame.
+//
+// It is exported because a program embedding this viewer -- the launcher does
+// -- can outlive the view: close the report while a large json-full is still
+// being written and the result arrives with nobody left to show it. Such a
+// program routes this to its own footer via ExportNotice.
+type ExportDoneMsg struct {
+	Format string
+	Path   string
+	Size   int64
+	Err    error
+}
+
+// exportCmd is the write, as a command. Rendering a large collection is not
+// instant -- json-full of a real scan is megabytes and sarif walks every
+// finding -- and doing it inline would freeze the viewer mid-keystroke, so it
+// happens off the event loop like any other slow thing in bubbletea.
+//
+// The collection is read, never modified, by every writer it is handed to,
+// which is what lets the user keep browsing while the file is being written.
+// TestExportDoesNotRaceTheView holds that to it.
+func exportCmd(c *policy.ReportCollection, f exportFormat, base string) tea.Cmd {
+	return func() tea.Msg {
+		dir, err := os.Getwd()
+		if err != nil {
+			return ExportDoneMsg{Format: f.Name, Err: errors.Wrap(err, "cannot find the working directory")}
+		}
+		path, n, err := writeExport(context.Background(), c, f, dir, base)
+		return ExportDoneMsg{Format: f.Name, Path: path, Size: n, Err: err}
+	}
+}
+
+// ExportNotice is the one line to show when the modal is not there to say it: what was written and how big it is, or why nothing was.
+func ExportNotice(msg ExportDoneMsg) string {
+	if msg.Err != nil {
+		return "export failed: " + tui.OneLine(msg.Err.Error())
+	}
+	return "wrote ./" + filepath.Base(msg.Path) + " (" + humanSize(msg.Size) + ")"
+}
+
+// humanSize renders a byte count the way a person reads one.
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}
+
+// --- the modal --------------------------------------------------------------
+
+// exportModal is the format picker. It is a value on Model rather than a pane:
+// a pane occupies a slot in the layout and competes for focus, and a modal is
+// the opposite of both -- it takes the body, and it takes every key until it is
+// closed.
+type exportModal struct {
+	open   bool
+	busy   bool
+	cursor int
+	// formats is fixed when the modal opens, because what can be written
+	// depends on the collection (see exportable) and the collection does not
+	// change while the viewer is up.
+	formats []exportFormat
+	// err is the last failed write, shown in the box. A failure leaves the
+	// modal open on purpose: the footer notice is cleared by the next key, and
+	// "your export did not happen" is not a message to show for one keystroke.
+	err error
+}
+
+// exportHeadLines is the prompt and the blank line under it; exportTailLines is
+// the status row, which is pinned to the bottom of the box.
+const (
+	exportHeadLines = 2
+	exportTailLines = 1
+)
+
+// exportTitle names the box, and is also what the tests look for.
+const exportTitle = "Export"
+
+// The prompt above the list. The long form says the one thing the rest of the
+// box does not -- that the path is relative to the working directory -- and the
+// short one is what a box too narrow for that says instead of showing the same
+// sentence with its end cut off.
+const (
+	exportPrompt      = "write this report to the working directory"
+	exportPromptShort = "write to ./"
+)
+
+// exportCursorW is the "▸ " column in front of every row, which the unselected
+// rows spend on spaces so the two kinds of row line up.
+const exportCursorW = 2
+
+// render draws the picker into rect, which is the whole body. The result is
+// exactly rect.H lines of at most rect.W cells.
+//
+// The box is sized to its contents (exportBoxSize) and centered in the body
+// rather than filling it. Four rows in a box the height of the terminal is
+// mostly air with a question somewhere in it, and a modal that is visibly
+// smaller than what it covers also reads as what it is -- something in front of
+// the report, not a new page. The rest of the rect is left blank: the panes
+// underneath are not drawn while the picker is up, because compositing a box
+// over them would mean slicing styled lines in half.
+func (x exportModal) render(base string, rect tui.Rect) []string {
+	box := x.box(rect)
+	inner := tui.InnerWidth(box.W)
+	innerH := tui.InnerHeight(box.H)
+
+	body := make([]string, 0, innerH)
+	prompt := exportPrompt
+	if tui.Width(prompt) > inner {
+		prompt = exportPromptShort
+	}
+	body = append(body, tui.StyleFaint.Render(prompt), "")
+
+	start, end := x.window(innerH)
+	for i := start; i < end; i++ {
+		row := exportRow(x.formats[i], inner-exportCursorW)
+		if i == x.cursor {
+			body = append(body, tui.Bar("▸ "+row, inner, tui.BandSelected))
+			continue
+		}
+		body = append(body, strings.Repeat(" ", exportCursorW)+tui.StyleText.Render(row))
+	}
+	if more := tui.MoreRow(len(x.formats) - (end - start)); more != "" {
+		body = append(body, more)
+	}
+
+	// The status sits on the last row inside the border rather than following
+	// the list, so it does not move up and down the box as the list scrolls.
+	for len(body) < innerH-exportTailLines {
+		body = append(body, "")
+	}
+	body = append(body, x.status(base))
+
+	panel := strings.Split(tui.Panel(
+		tui.StyleAccent.Render(exportTitle), "", body, box.W, box.H, tui.BorderColor(true)), "\n")
+
+	// Placed into the body rect by hand, because tui.Panel draws a box and knows
+	// nothing about where it sits. Exactly rect.H lines go back, whatever the
+	// box came out as: the frame's Fit would cut an overrun anyway, and a pane
+	// that returns its own size is one less thing depending on it.
+	pad := strings.Repeat(" ", max(box.X-rect.X, 0))
+	out := make([]string, 0, rect.H)
+	for i := box.Y - rect.Y; i > 0; i-- {
+		out = append(out, "")
+	}
+	for _, ln := range panel {
+		out = append(out, pad+ln)
+	}
+	for len(out) < rect.H {
+		out = append(out, "")
+	}
+	return out[:rect.H]
+}
+
+// box is where the picker is drawn inside the body: as big as its contents want,
+// never bigger than the body, and centered in whatever is left over.
+func (x exportModal) box(rect tui.Rect) tui.Rect {
+	w, h := exportBoxSize(x.formats)
+	w = min(w, rect.W)
+	h = min(h, rect.H)
+	return tui.Rect{
+		X: rect.X + (rect.W-w)/2,
+		Y: rect.Y + (rect.H-h)/2,
+		W: w,
+		H: h,
+	}
+}
+
+// exportBoxSize is the size the box wants: wide enough for the widest row it can
+// draw and for the prompt above them, tall enough for one line per format plus
+// the prompt, the blank under it and the status row.
+//
+// It is measured off the rows rather than written down, so a format with a
+// longer description widens the box instead of being truncated by it.
+func exportBoxSize(formats []exportFormat) (int, int) {
+	inner := tui.Width(exportPrompt)
+	for _, f := range formats {
+		// A width nothing can exceed, so exportRow returns every column.
+		if w := exportCursorW + tui.Width(exportRow(f, exportRowFullW)); w > inner {
+			inner = w
+		}
+	}
+	return inner + tui.BorderCols,
+		len(formats) + exportHeadLines + exportTailLines + tui.BorderLines
+}
+
+// exportRowFullW is a width wide enough that exportRow keeps all three columns,
+// which is how exportBoxSize asks for a row's full width.
+const exportRowFullW = 1 << 10
+
+// window is the slice of the list that is drawn, given the room inside the box.
+// The centring is tui.Window's; what belongs here is the row budget.
+//
+// The "n more" marker costs a row of its own: leaving it out of this
+// arithmetic is what pushes the status line off the bottom of a short box.
+func (x exportModal) window(innerH int) (int, int) {
+	rows := innerH - exportHeadLines - exportTailLines
+	if rows < len(x.formats) && rows > 1 {
+		rows--
+	}
+	if rows < 1 {
+		rows = 1
+	}
+	return tui.Window(x.cursor, len(x.formats), rows)
+}
+
+// status is the bottom line of the box: what the write is doing, why it failed,
+// or -- the ordinary case -- the exact path the highlighted row would write, so
+// the answer to "where does it go" is on screen before the key is pressed.
+func (x exportModal) status(base string) string {
+	switch {
+	case x.err != nil:
+		return StatusStyle(reportmodel.StatusError).Render("! " + tui.OneLine(x.err.Error()))
+	case x.busy:
+		return tui.StyleDim.Render("writing " + x.current().Name + "…")
+	default:
+		return tui.StyleDim.Render("→ ./" + base + x.current().Suffix)
+	}
+}
+
+// current is the highlighted format. It is never called on an empty modal --
+// Model.openExport refuses to open one -- but a cursor left of range by a
+// resize or a rebuild would panic in View, which takes the terminal with it.
+func (x exportModal) current() exportFormat {
+	if x.cursor < 0 || x.cursor >= len(x.formats) {
+		return exportFormat{}
+	}
+	return x.formats[x.cursor]
+}
+
+// exportRow is one line of the list: the format, the file it writes and what it
+// is for, in columns. The two tail columns drop off as the terminal narrows,
+// rather than all three being cut to a stub by the panel's truncation.
+func exportRow(f exportFormat, w int) string {
+	row := tui.PadRight(f.Name, exportNameW)
+	if w >= exportNameW+exportSuffixW+2 {
+		row += " " + tui.PadRight(f.Suffix, exportSuffixW)
+	}
+	if w >= exportNameW+exportSuffixW+exportDescW+2 {
+		row += " " + f.Desc
+	}
+	return row
+}
+
+// Column widths: the longest name, the longest suffix, and enough of a
+// description to be a sentence rather than a hint.
+// TestTheColumnsFitTheFormats keeps the first two matched to the list above.
+const (
+	exportNameW   = 5  // junit, sarif
+	exportSuffixW = 10 // .junit.xml
+	exportDescW   = 20
+)
+
+// exportHints are the footer bindings while the picker is open. They replace
+// the focused pane's, because none of that pane's keys reach it right now.
+func exportHints() []Hint {
+	return []Hint{
+		{Key: "↑/↓", Label: "format"},
+		{Key: "enter", Label: "write"},
+		{Key: "esc", Label: "cancel"},
+	}
+}
+
+// --- frame integration ------------------------------------------------------
+
+// openExport opens the picker, or explains in the footer why there is nothing
+// to open it on.
+func (m Model) openExport() (tea.Model, tea.Cmd) {
+	formats := exportable(m.state.Report.Collection())
+	if len(formats) == 0 {
+		m.state.Notice = "nothing to export: this view was not opened on a report"
+		return m, nil
+	}
+	m.export = exportModal{open: true, formats: formats}
+	return m, nil
+}
+
+// exportKey drives the open picker. Nothing here reaches a pane, and nothing
+// here quits: a modal that lets q end the program underneath it is a modal that
+// loses the user's place in the report.
+func (m Model) exportKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	last := len(m.export.formats) - 1
+
+	switch msg.String() {
+	case "esc", "e", "q":
+		m.export = exportModal{}
+	case "up", "k", "ctrl+p":
+		if m.export.cursor > 0 {
+			m.export.cursor--
+		}
+	case "down", "j", "ctrl+n":
+		if m.export.cursor < last {
+			m.export.cursor++
+		}
+	case "home", "g":
+		m.export.cursor = 0
+	case "end", "G":
+		m.export.cursor = last
+	case "enter":
+		if m.export.busy {
+			return m, nil
+		}
+		f := m.export.current()
+		if f.Name == "" {
+			return m, nil
+		}
+		m.export.busy, m.export.err = true, nil
+		return m, exportCmd(m.state.Report.Collection(), f, exportBaseName(m.state.Report))
+	}
+	return m, nil
+}
+
+// exportDone takes the result of a write.
+//
+// A failure that arrives while the box is still open is shown in it, in the
+// error color, and the box stays up so the user can pick another format or read
+// the reason twice. A failure that arrives after the box was closed has nowhere
+// to go but the footer -- which is also where a success goes, because the file
+// is written and the report is what the user wants to be looking at.
+func (m Model) exportDone(msg ExportDoneMsg) (tea.Model, tea.Cmd) {
+	if !m.export.open {
+		m.state.Notice = ExportNotice(msg)
+		return m, nil
+	}
+	m.export.busy = false
+	if msg.Err != nil {
+		m.export.err = msg.Err
+		return m, nil
+	}
+	m.export = exportModal{}
+	m.state.Notice = ExportNotice(msg)
+	return m, nil
+}

--- a/cli/reportview/export_test.go
+++ b/cli/reportview/export_test.go
@@ -1,0 +1,708 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reporter"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func loadCollection(t *testing.T, fixture string) *policy.ReportCollection {
+	t.Helper()
+	if fixture == fixtureUbuntu {
+		collection, err := reportfixture.UbuntuScan()
+		require.NoError(t, err)
+		return collection
+	}
+
+	raw, err := os.ReadFile("../reporter/testdata/" + fixture + ".json")
+	require.NoError(t, err)
+
+	collection := &policy.ReportCollection{}
+	require.NoError(t, json.Unmarshal(raw, collection))
+	return collection
+}
+
+// --- what is offered --------------------------------------------------------
+
+// The list is only worth anything if every row on it writes. This is the test
+// that keeps exportFormats honest: it does not read the switch in
+// cli_reporter.go and reason about it, it writes every offered format for both
+// fixtures and reads the files back.
+func TestEveryOfferedFormatWrites(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		collection := loadCollection(t, fixture)
+		formats := exportable(collection)
+		require.NotEmpty(t, formats)
+
+		dir := t.TempDir()
+		for _, f := range formats {
+			t.Run(filepath.Base(fixture)+"/"+f.Name, func(t *testing.T) {
+				path, n, err := writeExport(context.Background(), collection, f, dir, "report")
+				require.NoError(t, err)
+				require.Equal(t, filepath.Join(dir, "report"+f.Suffix), path)
+				require.Positive(t, n, "an export with no bytes in it is not an export")
+
+				raw, err := os.ReadFile(path)
+				require.NoError(t, err)
+				require.Len(t, raw, int(n), "the reported size must be the size on disk")
+
+				if strings.HasSuffix(f.Suffix, ".json") || f.Name == "sarif" {
+					require.True(t, json.Valid(raw), "%s must be valid json", f.Name)
+				}
+				if f.Name == "junit" {
+					require.True(t, bytes.HasPrefix(bytes.TrimSpace(raw), []byte("<")), "junit must be xml")
+				}
+			})
+		}
+	}
+}
+
+// The list is exactly four rows, and they are the four a reader would name. It
+// is pinned rather than inferred: dropping the older shapes and the terminal
+// renderings is the whole point of the list being this length, and a row
+// creeping back in should have to say so here.
+func TestFourFormatsAreOffered(t *testing.T) {
+	shown := make([]string, 0, len(exportFormats))
+	writes := make([]string, 0, len(exportFormats))
+	for _, f := range exportFormats {
+		shown = append(shown, f.Name)
+		writes = append(writes, f.Format)
+	}
+	require.Equal(t, []string{"json", "yaml", "junit", "sarif"}, shown)
+	// The names on the rows are not the reporter's names for two of them: json
+	// is the full collection and yaml is the current yaml, and neither carries
+	// the version in what the reader sees.
+	require.Equal(t, []string{"json-full", "yaml-v2", "junit", "sarif"}, writes)
+
+	// None of the shapes this list dropped, under either name.
+	for _, gone := range []string{"json-v1", "json-v2", "yaml-v1", "compact", "summary", "full", "report", "csv"} {
+		for _, f := range exportFormats {
+			require.NotEqual(t, gone, f.Name, "%s is offered again", gone)
+			require.NotEqual(t, gone, f.Format, "%s is written again", gone)
+		}
+	}
+}
+
+// Every format has its own file name. Two formats sharing one would turn a
+// second export into a collision with the first, for no reason the user could
+// see. Every name is also one the reporter actually knows.
+func TestOfferedFormatsHaveDistinctNames(t *testing.T) {
+	seen := map[string]string{}
+	names := map[string]bool{}
+	for _, f := range exportFormats {
+		require.NotContains(t, seen, f.Suffix, "%s and %s both write %s", seen[f.Suffix], f.Name, f.Suffix)
+		seen[f.Suffix] = f.Name
+
+		require.False(t, names[f.Name], "%s is offered twice", f.Name)
+		names[f.Name] = true
+
+		// The suffix follows the shown name, not the reporter's: with one json
+		// on offer there is no reason for a .full.json.
+		require.True(t, strings.Contains(f.Suffix, f.Name),
+			"%s writes %s, which does not name it", f.Name, f.Suffix)
+
+		_, ok := reporter.Formats[f.Format]
+		require.True(t, ok, "%s is not a format cli/reporter knows", f.Format)
+	}
+}
+
+// The columns are as wide as the widest thing that goes in them, and no wider:
+// a name column short of the longest name truncates a row, and one longer pads
+// every row with air the box then has to be wide enough for.
+func TestTheColumnsFitTheFormats(t *testing.T) {
+	name, suffix := 0, 0
+	for _, f := range exportFormats {
+		name = max(name, tui.Width(f.Name))
+		suffix = max(suffix, tui.Width(f.Suffix))
+	}
+	require.Equal(t, name, exportNameW)
+	require.Equal(t, suffix, exportSuffixW)
+}
+
+// csv is in reporter.Formats and cannot be written: FormatCSV has no arm in
+// WriteReport's switch, so it lands in the default branch. The exclusion is not
+// a matter of taste, and this is the assertion that says so out loud -- if the
+// CSV arm is ever implemented, this fails and the format should be offered.
+func TestCSVIsExcludedBecauseItCannotBeWritten(t *testing.T) {
+	for _, f := range exportFormats {
+		require.NotEqual(t, "csv", f.Name)
+		require.NotEqual(t, "csv", f.Format)
+	}
+
+	conf, err := reporter.ParseConfig("csv")
+	require.NoError(t, err)
+	err = reporter.NewReporter(conf, false).
+		WithOutput(&bytes.Buffer{}).
+		WriteReport(context.Background(), loadCollection(t, fixtureUbuntu))
+	require.ErrorContains(t, err, "unknown reporter type")
+}
+
+// junit and sarif need a policy bundle, and the k8s fixture -- fifteen assets
+// that never scanned -- has none. Offering them for such a report would be
+// offering a row that is guaranteed to fail, so both are dropped; and to be
+// sure that is a real limitation rather than a superstition, the test also
+// writes them and watches them refuse.
+func TestBundlelessReportDropsTheBundleFormats(t *testing.T) {
+	collection := loadCollection(t, fixtureK8s)
+	require.Nil(t, collection.Bundle, "the k8s fixture is the no-bundle case")
+
+	offered := []string{}
+	for _, f := range exportable(collection) {
+		offered = append(offered, f.Name)
+	}
+	// Two rows, not four, and they are the two that do not need a bundle.
+	require.Equal(t, []string{"json", "yaml"}, offered)
+
+	dir := t.TempDir()
+	for _, f := range exportFormats {
+		if !f.needsBundle {
+			continue
+		}
+		_, _, err := writeExport(context.Background(), collection, f, dir, "report")
+		require.ErrorContains(t, err, "no policy bundle found", "%s", f.Name)
+		require.NoFileExists(t, filepath.Join(dir, "report"+f.Suffix), "a failed render must not leave a file")
+	}
+
+	// The report that does have a bundle gets all four.
+	require.Len(t, exportable(loadCollection(t, fixtureUbuntu)), len(exportFormats))
+}
+
+// A viewer opened on nothing has nothing to export, and says so rather than
+// writing four empty files.
+func TestNothingToExport(t *testing.T) {
+	require.Nil(t, exportable(nil))
+
+	m := sized(NewModel(reportmodel.New(nil)), 100, 30)
+	m, _ = press(m, "e")
+	require.False(t, m.export.open)
+	require.Contains(t, ansi.Strip(m.View()), "nothing to export")
+}
+
+// --- the bytes --------------------------------------------------------------
+
+// Every offered format is a machine format, and the bytes reach the file exactly
+// as the writer produced them. An escape byte inside a collection came from
+// scanned data -- a command's captured output -- and an exporter that tidied it
+// away would be corrupting the artifact, not cleaning it.
+//
+// This is also what pins the removal of the ANSI strip that used to run here: it
+// existed for compact, summary, full and report, which color their output from a
+// profile decided at init from the terminal, and none of them is offered any
+// more.
+func TestExportedBytesAreWhatTheScanSaw(t *testing.T) {
+	collection := loadCollection(t, fixtureUbuntu)
+	for _, a := range collection.Assets {
+		a.Name = "\x1b[31mubuntu\x1b[0m"
+	}
+
+	dir := t.TempDir()
+	for _, f := range exportable(collection) {
+		_, _, err := writeExport(context.Background(), collection, f, dir, "report")
+		require.NoError(t, err, f.Name)
+	}
+
+	// json-encoded, but still there: the byte the scan saw survived rather than
+	// being tidied away by an exporter that decided it knew better.
+	raw, err := os.ReadFile(filepath.Join(dir, "report"+formatNamed(t, "json").Suffix))
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "\\u001b[31mubuntu", "json keeps what the scan saw")
+
+	// And nothing on the list renders for a screen, which is what makes that
+	// safe for all four of them rather than for some.
+	for _, f := range exportFormats {
+		require.NotContains(t, f.Suffix, ".txt", "%s renders for a terminal", f.Name)
+	}
+}
+
+// json is the row that round-trips, which is what makes "export it, reopen it" a
+// thing a user can do. It is `json` on screen and json-full on the wire: the
+// whole *policy.ReportCollection rather than a reduction of it, and a reduction
+// is not something reporter.LoadCollectionFile can read back.
+func TestTheJSONRowRoundTrips(t *testing.T) {
+	f := formatNamed(t, "json")
+	require.Equal(t, "json-full", f.Format, "the reduced json would not reopen")
+	require.Equal(t, ".json", f.Suffix)
+
+	dir := t.TempDir()
+	path, _, err := writeExport(context.Background(), loadCollection(t, fixtureUbuntu), f, dir, "report")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "report.json"), path)
+
+	reloaded, err := reporter.LoadCollectionFile(path)
+	require.NoError(t, err)
+
+	again := reportmodel.New(reloaded)
+	require.Len(t, again.Assets, 1)
+	require.Equal(t, 24, again.Assets[0].Counts.Total)
+	require.Equal(t, 2, again.Assets[0].Counts.Failed)
+	require.Equal(t, 4, again.Assets[0].Counts.Errored)
+	require.NotNil(t, reloaded.Bundle, "the bundle survives, so the reopened report still offers all four")
+}
+
+// And the reduced json is not what that row writes. Under a name that suggests
+// it is the same artifact it is a different one, so the mistake this renaming
+// could have made is worth an assertion of its own: reporter refuses a reduced
+// report by name when asked to load it back.
+func TestTheReducedJSONWouldNotReopen(t *testing.T) {
+	dir := t.TempDir()
+	reduced := exportFormat{Name: "json-v2", Format: "json-v2", Suffix: ".v2.json"}
+	path, _, err := writeExport(context.Background(), loadCollection(t, fixtureUbuntu), reduced, dir, "report")
+	require.NoError(t, err)
+
+	_, err = reporter.LoadCollectionFile(path)
+	require.ErrorContains(t, err, "this is a reduced report")
+}
+
+// --- where the file goes ----------------------------------------------------
+
+func TestExportBaseName(t *testing.T) {
+	// One asset: the file is named after it, in a charset that is safe to
+	// paste into a path.
+	require.Equal(t, "ubuntu-24-04", exportBaseName(loadReport(t, fixtureUbuntu)))
+	// Fifteen: the export is the whole collection, so naming it after one of
+	// them would be a lie about what is in the file.
+	require.Equal(t, exportFallbackName, exportBaseName(loadReport(t, fixtureK8s)))
+	require.Equal(t, exportFallbackName, exportBaseName(reportmodel.New(nil)))
+
+	for _, tc := range []struct{ in, want string }{
+		{"ubuntu:24.04", "ubuntu-24-04"},
+		{"  ", ""},
+		{"../../etc/passwd", "etc-passwd"},
+		{"arn:aws:ec2:us-east-1:123:instance/i-0abc", "arn-aws-ec2-us-east-1-123-instance-i-0abc"},
+		{strings.Repeat("x", 200), strings.Repeat("x", exportNameMax)},
+		{"K8s Cluster (prod)", "k8s-cluster-prod"},
+	} {
+		got := exportSlug(tc.in)
+		require.Equal(t, tc.want, got, "slug(%q)", tc.in)
+		require.NotContains(t, got, string(filepath.Separator))
+		require.LessOrEqual(t, len(got), exportNameMax)
+	}
+}
+
+// An export never replaces a file that is already there. The path is derived
+// rather than typed, so the user did not get a chance to say "yes, that one",
+// and quietly overwriting the artifact they exported a minute ago is not a
+// recoverable mistake.
+func TestExportRefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	f := formatNamed(t, "json")
+	existing := filepath.Join(dir, "report"+f.Suffix)
+	require.NoError(t, os.WriteFile(existing, []byte("mine"), 0o600))
+
+	_, _, err := writeExport(context.Background(), loadCollection(t, fixtureUbuntu), f, dir, "report")
+	require.ErrorContains(t, err, "already exists")
+
+	raw, err := os.ReadFile(existing)
+	require.NoError(t, err)
+	require.Equal(t, "mine", string(raw), "the file that was there must be untouched")
+}
+
+// --- the modal --------------------------------------------------------------
+
+// e opens the picker, esc closes it, and while it is open no key reaches a pane
+// or the frame: the tree does not move, the help does not toggle, and q does
+// not quit the program out from under it.
+func TestExportModalTakesEveryKey(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	before := m.state.Sel.Asset
+
+	m, _ = press(m, "e")
+	require.True(t, m.export.open)
+	require.Len(t, m.export.formats, len(exportFormats)-2, "no bundle, so junit and sarif are gone")
+
+	m, _ = press(m, "down")
+	require.Equal(t, 1, m.export.cursor)
+	require.Equal(t, before, m.state.Sel.Asset, "the tree must not have moved behind the modal")
+
+	m, _ = press(m, "?")
+	require.False(t, m.showHelp, "the frame's own bindings do not fire either")
+
+	m, cmd := press(m, "q")
+	require.Nil(t, cmd, "q closes the modal rather than quitting")
+	require.False(t, m.export.open)
+
+	// And the cursor survives nothing: reopening starts fresh.
+	m, _ = press(m, "e")
+	require.Zero(t, m.export.cursor)
+	m, _ = press(m, "esc")
+	require.False(t, m.export.open)
+}
+
+// G and g reach the ends of the list, and neither runs off it.
+func TestExportModalCursorBounds(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "e")
+
+	m, _ = press(m, "up")
+	require.Zero(t, m.export.cursor, "up at the top stays at the top")
+
+	m, _ = press(m, "G")
+	require.Equal(t, len(m.export.formats)-1, m.export.cursor)
+	m, _ = press(m, "down")
+	require.Equal(t, len(m.export.formats)-1, m.export.cursor, "down at the end stays at the end")
+
+	m, _ = press(m, "g")
+	require.Zero(t, m.export.cursor)
+}
+
+// The mouse does nothing while the picker is up. The panes underneath still
+// render and still publish their zones, so without the guard a click would
+// select a row nobody can see.
+func TestExportModalSwallowsTheMouse(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	f := m.build()
+	require.NotEmpty(t, f.zones)
+	target := f.zones[len(f.zones)-1]
+
+	m, _ = press(m, "e")
+	rev := m.state.SelectionRev
+	nm, _ := m.Update(tea.MouseMsg{
+		X: target.Rect.X, Y: target.Rect.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	require.Equal(t, rev, nm.(Model).state.SelectionRev)
+}
+
+// The whole point of the modal is that the answer to "where does it go" is on
+// screen before the key is pressed.
+func TestExportModalShowsTheTarget(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "e")
+	out := ansi.Strip(m.View())
+
+	require.Contains(t, out, exportTitle)
+	require.Contains(t, out, "json")
+	require.Contains(t, out, "→ ./ubuntu-24-04.json")
+	// The footer stops advertising keys that cannot fire.
+	require.Contains(t, out, "cancel")
+	require.NotContains(t, out, "next pane")
+}
+
+// The binding is only useful if it is discoverable, and the frame's hint line
+// is where the viewer publishes its own keys.
+func TestExportIsAdvertised(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 200, 40)
+	require.Contains(t, ansi.Strip(m.View()), "e export")
+
+	m, _ = press(m, "?")
+	require.Contains(t, ansi.Strip(m.View()), "e export report")
+}
+
+// e is free: no pane switches on it. The one place it means something else is
+// the header's search field, which consumes every rune before the frame is
+// reached -- typing "e" into a search must type an e, not open a modal.
+func TestExportKeyDoesNotFightTheSearch(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	m, _ = press(m, "/")
+	require.Equal(t, PaneHeader, m.state.Focus)
+	m, _ = press(m, "e")
+	require.False(t, m.export.open, "the search field ate it")
+	require.Contains(t, ansi.Strip(m.View()), "e")
+
+	// Out of the search, it opens.
+	m, _ = press(m, "esc")
+	m, _ = press(m, "e")
+	require.True(t, m.export.open)
+}
+
+// The geometry tests in layout_test.go assert the view is exactly the terminal
+// size at ten sizes. The modal is drawn into the same body those tests measure,
+// so it has to hold the same invariant -- including at 20x3, where the box is
+// taller than the room it has.
+func TestExportModalKeepsTheViewExact(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		report := loadReport(t, fixture)
+		for _, s := range termSizes {
+			for _, state := range []struct {
+				name string
+				mut  func(Model) Model
+			}{
+				{"open", func(m Model) Model { return m }},
+				{"busy", func(m Model) Model { m.export.busy = true; return m }},
+				{"failed", func(m Model) Model {
+					m.export.err = errorForTest("report.json already exists, remove it first")
+					return m
+				}},
+				// An error is the one string in the box nobody in this package
+				// wrote, and a newline in it would be a row the geometry cannot
+				// see.
+				{"failed-multiline", func(m Model) Model {
+					m.export.err = errorForTest("cannot render yaml:\r\n  line 3:\n\ttab here")
+					return m
+				}},
+				{"end", func(m Model) Model { m.export.cursor = len(m.export.formats) - 1; return m }},
+			} {
+				m := sized(NewModel(report), s.w, s.h)
+				m, _ = press(m, "e")
+				m = state.mut(m)
+
+				lines := viewLines(m)
+				if len(lines) != s.h {
+					t.Errorf("%s %s %dx%d: rendered %d lines, want exactly %d",
+						fixture, state.name, s.w, s.h, len(lines), s.h)
+				}
+				for i, ln := range lines {
+					if w := ansi.StringWidth(ln); w > s.w {
+						t.Errorf("%s %s %dx%d: line %d is %d cells wide, want <= %d",
+							fixture, state.name, s.w, s.h, i, w, s.w)
+					}
+					if strings.Contains(ln, "\n") {
+						t.Errorf("%s %s %dx%d: line %d holds a newline", fixture, state.name, s.w, s.h, i)
+					}
+				}
+			}
+		}
+	}
+}
+
+// The box is the size of what is in it, not the size of what it covers. Four
+// rows in a box the height of the terminal is mostly air with a question
+// somewhere in it.
+func TestTheModalFitsItsContents(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "e")
+	require.Len(t, m.export.formats, 4)
+
+	body := tui.Rect{X: 0, Y: m.layout().BodyTop, W: 120, H: m.layout().BodyH}
+	box := m.export.box(body)
+
+	// One line per format, plus the prompt, the blank under it, the status row
+	// and the border: nine, not the thirty-eight the body offers.
+	require.Equal(t, 4+exportHeadLines+exportTailLines+tui.BorderLines, box.H)
+	require.Less(t, box.H, body.H)
+	require.Less(t, box.W, body.W)
+
+	// Wide enough for the longest row without truncating it, and no wider.
+	widest := 0
+	for _, f := range m.export.formats {
+		widest = max(widest, exportCursorW+tui.Width(exportRow(f, exportRowFullW)))
+	}
+	require.Equal(t, widest+tui.BorderCols, box.W)
+
+	// Centered, so it does not read as a pane that lost its border.
+	require.Equal(t, (body.W-box.W)/2, box.X)
+	require.Equal(t, body.Y+(body.H-box.H)/2, box.Y)
+
+	// And it shrinks again for a report that offers only two rows.
+	k8s := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	k8s, _ = press(k8s, "e")
+	require.Len(t, k8s.export.formats, 2)
+	require.Equal(t, box.H-2, k8s.export.box(body).H)
+}
+
+// Whatever the box comes out as, render hands back exactly the body it was given
+// and no line of it is wider. This is the same invariant the two real panes hold,
+// asserted at the modal's own seam rather than only through the frame.
+func TestTheModalFillsTheBodyExactly(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		m := sized(NewModel(loadReport(t, fixture)), 120, 40)
+		m, _ = press(m, "e")
+
+		for _, s := range termSizes {
+			rect := tui.Rect{X: 0, Y: 1, W: s.w, H: max(s.h-2, 1)}
+			lines := m.export.render("cnspec-report", rect)
+			require.Len(t, lines, rect.H, "%s %dx%d", fixture, s.w, s.h)
+			for i, ln := range lines {
+				require.LessOrEqual(t, tui.Width(ln), rect.W, "%s %dx%d line %d", fixture, s.w, s.h, i)
+				require.NotContains(t, ln, "\n", "%s %dx%d line %d", fixture, s.w, s.h, i)
+			}
+			box := m.export.box(rect)
+			require.LessOrEqual(t, box.W, rect.W)
+			require.LessOrEqual(t, box.H, rect.H)
+		}
+	}
+}
+
+// A box too narrow for the long prompt says the short one rather than showing
+// the long one with its end cut off. The destination is still on screen: the
+// status row under the list carries the whole path.
+func TestTheNarrowModalKeepsItsPrompt(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 40, 10)
+	m, _ = press(m, "e")
+	out := ansi.Strip(m.View())
+
+	require.Contains(t, out, exportPromptShort)
+	require.NotContains(t, out, exportPrompt)
+	require.Contains(t, out, "→ ./ubuntu-24-04.json")
+	// And the list is still a list: the rows that do not fit are counted rather
+	// than dropped silently.
+	require.Contains(t, out, "json")
+	require.Contains(t, out, "more")
+}
+
+// A narrow terminal drops the columns it cannot fit rather than showing three
+// of them cut to stubs.
+func TestExportRowNarrows(t *testing.T) {
+	f := formatNamed(t, "json")
+	require.Contains(t, exportRow(f, 80), f.Desc)
+	require.Contains(t, exportRow(f, 30), f.Suffix)
+	require.NotContains(t, exportRow(f, 30), f.Desc)
+	require.NotContains(t, exportRow(f, 12), f.Suffix)
+	require.Contains(t, exportRow(f, 12), f.Name, "the name is the last thing to go")
+}
+
+// --- the round trip through the event loop ----------------------------------
+
+// enter writes the file, and the footer says what landed where.
+func TestExportEndToEnd(t *testing.T) {
+	// The fixture path is relative to the package, so it is read before the
+	// working directory moves to the one the export writes into.
+	report := loadReport(t, fixtureUbuntu)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	m := sized(NewModel(report), 120, 40)
+	m, _ = press(m, "e")
+	m, _ = press(m, "down") // json -> yaml
+	require.Equal(t, "yaml", m.export.current().Name)
+
+	m, cmd := press(m, "enter")
+	require.True(t, m.export.busy)
+	require.NotNil(t, cmd, "the write is a command, not something the event loop does inline")
+	// The row's own name, not the reporter's yaml-v2: the modal and the footer
+	// speak the same four words.
+	require.Contains(t, ansi.Strip(m.View()), "writing yaml…")
+
+	msg := cmd()
+	nm, _ := m.Update(msg)
+	m = nm.(Model)
+
+	require.False(t, m.export.open, "a success closes the picker")
+	out := ansi.Strip(m.View())
+	require.Contains(t, out, "wrote ./ubuntu-24-04.yaml")
+	require.FileExists(t, filepath.Join(dir, "ubuntu-24-04.yaml"))
+
+	// The next key dismisses the notice, which is what a one-shot notice is.
+	m, _ = press(m, "down")
+	require.NotContains(t, ansi.Strip(m.View()), "wrote ./")
+}
+
+// A write that fails has to say so on the screen. It says it in the box, which
+// stays open: the footer notice is cleared by the very next key, and "your
+// export did not happen" is not a message to show for one keystroke.
+func TestFailedExportIsVisible(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ubuntu-24-04.json"), []byte("mine"), 0o600))
+
+	m := sized(NewModel(report), 120, 40)
+	m, _ = press(m, "e")
+	m, cmd := press(m, "enter")
+
+	nm, _ := m.Update(cmd())
+	m = nm.(Model)
+
+	require.True(t, m.export.open, "a failure keeps the box up")
+	require.False(t, m.export.busy)
+	require.Error(t, m.export.err)
+	require.Contains(t, ansi.Strip(m.View()), "! ubuntu-24-04.json already exists")
+
+	// Picking another format after the refusal works, and clears the message.
+	m, _ = press(m, "down")
+	m, cmd = press(m, "enter")
+	require.NoError(t, cmd().(ExportDoneMsg).Err)
+}
+
+// A result that arrives after the box was closed still has to be heard, so it
+// goes to the footer.
+func TestExportResultAfterClosingLandsInTheFooter(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	nm, _ := m.Update(ExportDoneMsg{Format: "sarif", Err: errorForTest("disk full")})
+	require.Contains(t, ansi.Strip(nm.(Model).View()), "export failed: disk full")
+
+	// A multi-line error is flattened rather than allowed to add a row the
+	// geometry cannot see.
+	nm, _ = m.Update(ExportDoneMsg{Format: "yaml", Err: errorForTest("cannot render:\n  line 3")})
+	lines := viewLines(nm.(Model))
+	require.Len(t, lines, 40)
+	require.Contains(t, ansi.Strip(lines[39]), "export failed: cannot render: line 3")
+
+	nm, _ = m.Update(ExportDoneMsg{Format: "sarif", Path: "/tmp/x.sarif", Size: 2048})
+	require.Contains(t, ansi.Strip(nm.(Model).View()), "wrote ./x.sarif (2.0 KB)")
+}
+
+// The write runs off the event loop while the viewer keeps drawing the same
+// collection. Every writer only reads it -- this is the test that holds them to
+// that, and it is the reason the export does not have to clone megabytes first.
+func TestExportDoesNotRaceTheView(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	names := []string{"json", "yaml", "junit", "sarif"}
+	cmds := make([]tea.Cmd, len(names))
+	for i, name := range names {
+		cmds[i] = exportCmd(report.Collection(), formatNamed(t, name), name)
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	m := sized(NewModel(report), 120, 40)
+
+	var wg sync.WaitGroup
+	results := make([]tea.Msg, len(cmds))
+	for i, cmd := range cmds {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = cmd()
+		}()
+	}
+	for i := 0; i < 200; i++ {
+		_ = m.View()
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		msg, ok := res.(ExportDoneMsg)
+		require.True(t, ok)
+		require.NoError(t, msg.Err, "%s", names[i])
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	for _, tc := range []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"}, {999, "999 B"}, {1024, "1.0 KB"}, {2560, "2.5 KB"},
+		{1024 * 1024, "1.0 MB"}, {2464164, "2.4 MB"}, {3 * 1024 * 1024 * 1024, "3.0 GB"},
+	} {
+		require.Equal(t, tc.want, humanSize(tc.n))
+	}
+}
+
+// formatNamed is the offered format with this name, so a test can name the one
+// it means rather than index into the list.
+func formatNamed(t *testing.T, name string) exportFormat {
+	t.Helper()
+	for _, f := range exportFormats {
+		if f.Name == name {
+			return f
+		}
+	}
+	t.Fatalf("no offered format named %q", name)
+	return exportFormat{}
+}
+
+// errorForTest is a plain error; the export path only ever renders err.Error().
+type errorForTest string
+
+func (e errorForTest) Error() string { return string(e) }

--- a/cli/reportview/filter.go
+++ b/cli/reportview/filter.go
@@ -1,0 +1,249 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"sort"
+	"strings"
+
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Filter narrows what the viewer shows. It lives in the frame rather than in the
+// header pane because two panes have to agree about it: the pane that edits it
+// and the pane that obeys it. Both call the Match methods here, so "what the
+// filter means" is decided once.
+//
+// A zero Filter matches everything. An empty Statuses or Severities set means
+// "no restriction on this axis", not "match nothing".
+type Filter struct {
+	// Search is matched case-insensitively as a substring of a check title or
+	// an asset name.
+	Search string
+	// Statuses restricts to these outcomes. All six of reportmodel's statuses
+	// are distinct here: a check that errored is not a check that failed and
+	// must never be folded into one bucket.
+	Statuses map[reportmodel.Status]bool
+	// Severities restricts to these severity labels, which are the
+	// policy.ScoreRatingText* values that reportmodel.Check.Severity carries.
+	Severities map[string]bool
+}
+
+// AllStatuses is every status a filter can select, in the order a UI should
+// offer them: the ones that need action first.
+var AllStatuses = []reportmodel.Status{
+	reportmodel.StatusFail,
+	reportmodel.StatusError,
+	reportmodel.StatusPass,
+	reportmodel.StatusSkipped,
+	reportmodel.StatusUnscored,
+	reportmodel.StatusUnknown,
+}
+
+// AllSeverities is every severity label a filter can select, worst first.
+var AllSeverities = []string{
+	policy.ScoreRatingTextCritical,
+	policy.ScoreRatingTextHigh,
+	policy.ScoreRatingTextMedium,
+	policy.ScoreRatingTextLow,
+	policy.ScoreRatingTextNone,
+}
+
+// Active reports whether the filter restricts anything at all.
+func (f Filter) Active() bool {
+	return f.Search != "" || len(f.Statuses) > 0 || len(f.Severities) > 0
+}
+
+// Equal compares two filters by value, ignoring the difference between a nil
+// set and an empty one.
+func (f Filter) Equal(o Filter) bool {
+	if f.Search != o.Search || len(f.Statuses) != len(o.Statuses) || len(f.Severities) != len(o.Severities) {
+		return false
+	}
+	for k, v := range f.Statuses {
+		if o.Statuses[k] != v {
+			return false
+		}
+	}
+	for k, v := range f.Severities {
+		if o.Severities[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Clone returns a deep copy, so a pane can edit a filter and only publish it
+// through State.SetFilter once it is complete.
+func (f Filter) Clone() Filter {
+	res := Filter{Search: f.Search}
+	if len(f.Statuses) > 0 {
+		res.Statuses = make(map[reportmodel.Status]bool, len(f.Statuses))
+		for k, v := range f.Statuses {
+			res.Statuses[k] = v
+		}
+	}
+	if len(f.Severities) > 0 {
+		res.Severities = make(map[string]bool, len(f.Severities))
+		for k, v := range f.Severities {
+			res.Severities[k] = v
+		}
+	}
+	return res
+}
+
+// ToggleStatus flips one status on or off, returning the new filter. The
+// receiver is not modified.
+func (f Filter) ToggleStatus(s reportmodel.Status) Filter {
+	res := f.Clone()
+	if res.Statuses[s] {
+		delete(res.Statuses, s)
+		return res
+	}
+	if res.Statuses == nil {
+		res.Statuses = map[reportmodel.Status]bool{}
+	}
+	res.Statuses[s] = true
+	return res
+}
+
+// ToggleSeverity flips one severity on or off, returning the new filter.
+func (f Filter) ToggleSeverity(sev string) Filter {
+	res := f.Clone()
+	if res.Severities[sev] {
+		delete(res.Severities, sev)
+		return res
+	}
+	if res.Severities == nil {
+		res.Severities = map[string]bool{}
+	}
+	res.Severities[sev] = true
+	return res
+}
+
+// MatchText reports whether s matches the search term.
+func (f Filter) MatchText(s string) bool {
+	if f.Search == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(s), strings.ToLower(f.Search))
+}
+
+// MatchStatus reports whether a status is selected.
+func (f Filter) MatchStatus(s reportmodel.Status) bool {
+	if len(f.Statuses) == 0 {
+		return true
+	}
+	return f.Statuses[s]
+}
+
+// MatchSeverity reports whether a severity label is selected.
+func (f Filter) MatchSeverity(sev string) bool {
+	if len(f.Severities) == 0 {
+		return true
+	}
+	return f.Severities[sev]
+}
+
+// MatchCheck reports whether a check survives the filter.
+func (f Filter) MatchCheck(c *reportmodel.Check) bool {
+	if c == nil {
+		return false
+	}
+	return f.MatchStatus(c.Status) && f.MatchSeverity(c.Severity) && f.MatchText(c.Title)
+}
+
+// MatchPolicy reports whether a policy survives, which it does when any of its
+// checks does or when the policy's own name matches the search and its status is
+// selected. A policy with no checks left is still worth showing when the user
+// searched for it by name.
+func (f Filter) MatchPolicy(p *reportmodel.Policy) bool {
+	if p == nil {
+		return false
+	}
+	for _, c := range p.Checks {
+		if f.MatchCheck(c) {
+			return true
+		}
+	}
+	return len(p.Checks) == 0 && f.MatchText(p.Name) && f.MatchStatus(p.Status)
+}
+
+// MatchAsset reports whether an asset survives the filter.
+//
+// An asset matches when any of its checks does -- or when the asset itself does.
+// That second clause is the one that matters: an asset that failed to scan has
+// no checks at all, so judging assets purely by their checks would hide exactly
+// the assets that need attention behind an apparently empty screen. Filtering by
+// ERROR must show them; filtering by severity, which is a property a check has
+// and an unscanned asset cannot, must not remove them.
+func (f Filter) MatchAsset(a *reportmodel.Asset) bool {
+	if a == nil {
+		return false
+	}
+	if f.matchesAssetItself(a) {
+		return true
+	}
+	for _, c := range a.Checks {
+		if f.MatchCheck(c) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f Filter) matchesAssetItself(a *reportmodel.Asset) bool {
+	if !f.MatchText(a.Name) || !f.MatchStatus(a.Status) {
+		return false
+	}
+	// A severity filter is about checks. A scanned asset is represented by its
+	// checks, which MatchAsset tries next; an asset that never produced one has
+	// nothing to be judged by and stays.
+	return len(f.Severities) == 0 || !a.Scanned()
+}
+
+// Describe renders the active restrictions as a short human-readable string,
+// e.g. `"ssh" · FAIL, ERROR · critical`. It is empty when the filter is not
+// active.
+func (f Filter) Describe() string {
+	var parts []string
+	if f.Search != "" {
+		parts = append(parts, `"`+f.Search+`"`)
+	}
+	if len(f.Statuses) > 0 {
+		var st []string
+		for _, s := range AllStatuses {
+			if f.Statuses[s] {
+				st = append(st, string(s))
+			}
+		}
+		parts = append(parts, strings.Join(st, ", "))
+	}
+	if len(f.Severities) > 0 {
+		var sev []string
+		for _, s := range AllSeverities {
+			if f.Severities[s] {
+				sev = append(sev, s)
+			}
+		}
+		// A severity outside the known set is still worth naming.
+		if len(sev) != len(f.Severities) {
+			sev = sortedSet(f.Severities)
+		}
+		parts = append(parts, strings.Join(sev, ", "))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func sortedSet(m map[string]bool) []string {
+	res := make([]string, 0, len(m))
+	for k, v := range m {
+		if v {
+			res = append(res, k)
+		}
+	}
+	sort.Strings(res)
+	return res
+}

--- a/cli/reportview/filter_test.go
+++ b/cli/reportview/filter_test.go
@@ -1,0 +1,187 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func TestZeroFilterMatchesEverything(t *testing.T) {
+	var f Filter
+	require.False(t, f.Active())
+	require.Empty(t, f.Describe())
+
+	st := NewState(loadReport(t, fixtureUbuntu))
+	require.Len(t, st.FilteredAssets(), 1)
+	require.Len(t, st.FilteredChecks(st.Report.Assets[0].Checks), 24)
+}
+
+// The six statuses stay six. A filter on FAIL must not sweep up ERROR, and a
+// filter on ERROR must not sweep up FAIL: a check that could not run and a check
+// that ran and failed are different findings with different fixes.
+func TestStatusFilterKeepsOutcomesApart(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	checks := st.Report.Assets[0].Checks
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusFail: true}})
+	failed := st.FilteredChecks(checks)
+	require.Len(t, failed, 2)
+	for _, c := range failed {
+		require.Equal(t, reportmodel.StatusFail, c.Status)
+	}
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusError: true}})
+	errored := st.FilteredChecks(checks)
+	require.Len(t, errored, 4)
+	for _, c := range errored {
+		require.Equal(t, reportmodel.StatusError, c.Status)
+	}
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{
+		reportmodel.StatusFail: true, reportmodel.StatusError: true,
+	}})
+	require.Len(t, st.FilteredChecks(checks), 6)
+}
+
+func TestSearchIsCaseInsensitiveSubstring(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	checks := st.Report.Assets[0].Checks
+
+	st.SetFilter(Filter{Search: "PERMISSIONS"})
+	upper := st.FilteredChecks(checks)
+	require.Len(t, upper, 8)
+
+	st.SetFilter(Filter{Search: "permissions"})
+	require.Equal(t, upper, st.FilteredChecks(checks), "the search is case-insensitive")
+
+	st.SetFilter(Filter{Search: "no such check anywhere"})
+	require.Empty(t, st.FilteredChecks(checks))
+}
+
+// Severity is what a check is worth, and is independent of how it did. The
+// ubuntu fixture is 10 critical, 10 high and 4 with none.
+func TestSeverityFilter(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	checks := st.Report.Assets[0].Checks
+
+	st.SetFilter(Filter{Severities: map[string]bool{policy.ScoreRatingTextCritical: true}})
+	require.Len(t, st.FilteredChecks(checks), 10)
+
+	st.SetFilter(Filter{Severities: map[string]bool{
+		policy.ScoreRatingTextCritical: true, policy.ScoreRatingTextHigh: true,
+	}})
+	require.Len(t, st.FilteredChecks(checks), 20)
+
+	// Severity and status are combined with AND: the critical checks that failed, not the
+	// critical checks plus the failed ones.
+	st.SetFilter(Filter{
+		Severities: map[string]bool{policy.ScoreRatingTextCritical: true},
+		Statuses:   map[reportmodel.Status]bool{reportmodel.StatusFail: true},
+	})
+	require.Len(t, st.FilteredChecks(checks), 2)
+}
+
+// The case the viewer exists to get right: an asset that failed to scan has no
+// checks at all, so a filter that judges assets only by their checks hides
+// exactly the assets that need attention. Filtering by ERROR must show them, and
+// a severity filter -- severity being a property of a check -- must not remove
+// them.
+func TestFilterKeepsUnscannedAssets(t *testing.T) {
+	st := NewState(loadReport(t, fixtureK8s))
+	require.Len(t, st.Report.Assets, 15)
+	for _, a := range st.Report.Assets {
+		require.False(t, a.Scanned())
+		require.Empty(t, a.Checks)
+	}
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusError: true}})
+	require.Len(t, st.FilteredAssets(), 15, "filtering for errors must show the errored assets")
+
+	st.SetFilter(Filter{Severities: map[string]bool{policy.ScoreRatingTextCritical: true}})
+	require.Len(t, st.FilteredAssets(), 15, "an unscanned asset has no severity to be judged by")
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusPass: true}})
+	require.Empty(t, st.FilteredAssets(), "none of them passed")
+
+	st.SetFilter(Filter{Search: "kube-proxy"})
+	assets := st.FilteredAssets()
+	require.NotEmpty(t, assets)
+	require.Less(t, len(assets), 15)
+}
+
+// A scanned asset survives on the strength of its checks, and disappears when
+// none of them matches.
+func TestFilterOnScannedAsset(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusFail: true}})
+	require.Len(t, st.FilteredAssets(), 1)
+
+	st.SetFilter(Filter{Search: "no check has this in its title"})
+	require.Empty(t, st.FilteredAssets())
+}
+
+func TestFilterCountsMatchWhatIsShown(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	require.Equal(t, 24, st.Counts().Total)
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusError: true}})
+	c := st.Counts()
+	require.Equal(t, 4, c.Total)
+	require.Equal(t, 4, c.Errored)
+	require.Equal(t, 0, c.Passed)
+}
+
+func TestToggleAndClone(t *testing.T) {
+	base := Filter{Search: "tls"}
+
+	one := base.ToggleStatus(reportmodel.StatusFail)
+	require.True(t, one.Statuses[reportmodel.StatusFail])
+	require.Empty(t, base.Statuses, "toggling must not touch the receiver")
+
+	two := one.ToggleSeverity(policy.ScoreRatingTextHigh)
+	require.True(t, two.Severities[policy.ScoreRatingTextHigh])
+	require.Empty(t, one.Severities)
+
+	require.False(t, two.ToggleStatus(reportmodel.StatusFail).Statuses[reportmodel.StatusFail])
+	require.Equal(t, `"tls" · FAIL · HIGH`, two.Describe())
+
+	clone := two.Clone()
+	require.True(t, two.Equal(clone))
+	clone.Statuses[reportmodel.StatusPass] = true
+	require.False(t, two.Equal(clone), "a clone must not share its maps")
+}
+
+func TestFilterEqualIgnoresNilVersusEmpty(t *testing.T) {
+	require.True(t, Filter{}.Equal(Filter{Statuses: map[reportmodel.Status]bool{}}))
+	require.False(t, Filter{Search: "a"}.Equal(Filter{}))
+}
+
+// SetFilter bumps the revision only when something actually changed, so a pane
+// that rebuilds its rows on FilterRev does not rebuild them on every keystroke
+// that changed nothing.
+func TestFilterRevision(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	require.Equal(t, 0, st.FilterRev)
+
+	st.SetFilter(Filter{Search: "ssh"})
+	require.Equal(t, 1, st.FilterRev)
+	st.SetFilter(Filter{Search: "ssh"})
+	require.Equal(t, 1, st.FilterRev)
+	st.SetFilter(Filter{})
+	require.Equal(t, 2, st.FilterRev)
+}
+
+// MatchAsset and MatchCheck are nil-safe: a pane walking a partially built tree
+// must not panic.
+func TestMatchNil(t *testing.T) {
+	var f Filter
+	require.False(t, f.MatchAsset(nil))
+	require.False(t, f.MatchCheck(nil))
+	require.False(t, f.MatchPolicy(nil))
+}

--- a/cli/reportview/header.go
+++ b/cli/reportview/header.go
@@ -1,0 +1,670 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The header band: what the scan found, and the controls that narrow it.
+//
+// # What it says
+//
+// The top row is the scan's shape at a glance: how many assets there were, how
+// many of them never scanned, and the tally of check outcomes. The five outcomes
+// stay five. A check that errored is not a check that failed and neither is a
+// check nobody scored, so they are five separate numbers and never a single
+// "problems" figure.
+//
+// The number that matters most is the one that is easiest to lose. An asset that
+// failed to scan is not an asset with no findings: report-k8s.json is fifteen
+// assets, zero reports and no bundle at all, and a header that answers "0 failed"
+// for it has told the user the opposite of the truth. So the asset row leads with
+// "15 not scanned", and when the report produced no checks at all the tally says
+// "no checks ran" rather than printing five zeroes that read like a clean bill of
+// health.
+//
+// # What it does
+//
+// Filtering is not implemented here. filter.go owns what a filter means -- so
+// that the pane that edits one and the panes that obey it cannot disagree about
+// it -- and this pane only builds a Filter and publishes it through
+// State.SetFilter. Every count it prints comes back out of State, which is the
+// same path the tree reads, so "showing 3 of 15" and the rows below it are the
+// same computation.
+//
+// The one place the two vocabularies have to meet is the severity axis, and it
+// is the trap this feature exists to avoid: severity is a property a *check*
+// has. An asset that never ran a check has none, so a severity filter must not
+// take it off the screen. Filter.MatchAsset already gets this right; the header's
+// job is to say so out loud, which is the NOTE row.
+//
+// # How tall it is
+//
+// It grows and shrinks. Idle it is a single line; opening the search adds one,
+// opening the chips adds two, an active filter adds the line that says what is
+// left. HeightFor answers with exactly the number of lines Render will emit at
+// that width -- both come out of compose -- so the frame's arithmetic and the
+// band's contents cannot drift apart. The frame still clamps at MaxHeaderLines,
+// and asking honestly is what keeps the clamp from ever being needed.
+
+func init() {
+	RegisterHeader(func(st *State) Pane {
+		p := &headerPane{returnTo: PaneTree}
+		if st != nil {
+			p.search = st.Filter.Search
+		}
+		return p
+	})
+}
+
+// headerLabelW is the width of the label column: STATUS, SEVERITY, FILTER,
+// SEARCH, NOTE and the "✦ cnspec" wordmark all fit in it, so every row's content
+// begins in the same column.
+const headerLabelW = 8
+
+// headerContentX is the column a row's content starts at: one marker cell, the
+// label column, one space.
+const headerContentX = headerLabelW + 2
+
+// filterRow names a row of chips. The cursor is on exactly one of them.
+type filterRow int
+
+const (
+	rowStatus filterRow = iota
+	rowSeverity
+)
+
+// headerPane is the summary band, the search field and the filter chips.
+//
+// Everything on it is this pane's own business and lives here rather than on
+// State: which row the chip cursor is on, whether the chips are showing, what
+// has been typed into the search so far. The only thing that crosses the seam is
+// the Filter, and it crosses through State.SetFilter.
+type headerPane struct {
+	// search is the text in the search field. It is published to the filter on
+	// every keystroke, so the tree narrows as you type rather than on enter.
+	search string
+	// searching is whether the search field is open and taking keys.
+	searching bool
+	// open is whether the status and severity chip rows are showing.
+	open bool
+	// active mirrors Filter.Active(). Focusable takes no State, so the one bit
+	// of the filter the pane needs before it has been handed one is kept here
+	// and refreshed on every pass through setFilter and sync.
+	active bool
+
+	// row and cursor are the chip under the cursor.
+	row    filterRow
+	cursor int
+
+	// returnTo is the pane focus goes back to when the header closes. It is
+	// remembered rather than assumed, because the header can be reached from
+	// either body pane.
+	returnTo PaneID
+
+	// severities caches the per-severity tally of every check in the report,
+	// which is a walk over every check and does not change while the report
+	// does not. severitiesFor is the report it was computed for.
+	severities    map[string]int
+	severitiesFor *reportmodel.Report
+}
+
+func (p *headerPane) ID() PaneID { return PaneHeader }
+
+// Focusable is state-dependent on purpose. An idle header has nothing to drive,
+// so it stays out of the tab cycle and "esc" keeps its ordinary meaning of quit.
+// A header that is showing a search, a set of chips or an active filter does
+// have something to drive, takes focus, and gets "esc" routed to it -- which is
+// what makes the ladder work: esc closes the chips, esc clears the filter, esc
+// quits.
+func (p *headerPane) Focusable() bool { return p.searching || p.open || p.active }
+
+// Claims are the two keys the header owns from anywhere. "/" opens the search
+// while the tree still has focus, which is the only way a search field is worth
+// having, and "f" reaches the chips the same way.
+func (p *headerPane) Claims() []string { return []string{"/", "f"} }
+
+func (p *headerPane) Hints(*State) []Hint {
+	if p.searching {
+		return []Hint{
+			{Key: "type", Label: "narrow"},
+			{Key: "enter", Label: "done"},
+			{Key: "esc", Label: "clear search"},
+		}
+	}
+	return []Hint{
+		{Key: "←/→", Label: "chip"},
+		{Key: "↑/↓", Label: "row"},
+		{Key: "space", Label: "toggle"},
+		{Key: "/", Label: "search"},
+		{Key: "c", Label: "clear"},
+		{Key: "esc", Label: "close"},
+	}
+}
+
+// HeightFor is the honest answer: exactly the lines Render will emit at this
+// width. Both call compose, so a row that appears cannot fail to be counted.
+func (p *headerPane) HeightFor(st *State, width int) int {
+	if st == nil {
+		return 1
+	}
+	return len(p.compose(st, width))
+}
+
+func (p *headerPane) Render(st *State, rect tui.Rect) Render {
+	rows := p.compose(st, rect.W)
+
+	res := Render{Lines: make([]string, 0, len(rows))}
+	for i, row := range rows {
+		res.Lines = append(res.Lines, row.text)
+		for _, z := range row.zones {
+			// compose works in band-relative columns; the frame hit-tests in
+			// absolute cells.
+			z.Rect.X += rect.X
+			z.Rect.Y = rect.Y + i
+			res.Zones = append(res.Zones, z)
+		}
+	}
+	return res
+}
+
+// headerRow is one rendered line and the chips on it that answer a click. The
+// zone rects are relative to the band's left edge and Render moves them.
+type headerRow struct {
+	text  string
+	zones []Zone
+}
+
+// compose builds the band. It is the single description of what the header shows
+// at a given width, which is what lets HeightFor promise a number Render keeps.
+func (p *headerPane) compose(st *State, w int) []headerRow {
+	p.sync(st)
+	if w < 1 {
+		w = 1
+	}
+
+	rows := []headerRow{{text: p.summaryLine(st, w)}}
+	if note, ok := p.noteLine(st, w); ok {
+		rows = append(rows, headerRow{text: note})
+	}
+	if st.Filter.Active() {
+		rows = append(rows, headerRow{text: p.filterLine(st, w)})
+	}
+	if p.searching {
+		rows = append(rows, headerRow{text: p.searchLine(st, w)})
+	}
+	if p.open {
+		rows = append(rows, p.chipRow(st, rowStatus, w), p.chipRow(st, rowSeverity, w))
+	}
+	return rows
+}
+
+// sync reconciles the pane with a focus the frame may have moved underneath it.
+// A search field the user tabbed away from is closed rather than left silently
+// eating keys, and the pane remembers where focus came from so it can hand it
+// back when it closes.
+func (p *headerPane) sync(st *State) {
+	p.active = st.Filter.Active()
+	if st.Focus != PaneHeader {
+		p.searching = false
+		if st.Focus != PaneNone {
+			p.returnTo = st.Focus
+		}
+	}
+	if p.returnTo == PaneNone || p.returnTo == PaneHeader {
+		p.returnTo = PaneTree
+	}
+	p.clampCursor(st)
+}
+
+// --- the rows ---------------------------------------------------------------
+
+// summaryLine is the scan's shape: assets on the left, check outcomes on the
+// right.
+func (p *headerPane) summaryLine(st *State, w int) string {
+	assets := st.Report.AssetCounts
+
+	left := " " + tui.StyleAccent.Render(tui.PadRight("✦ cnspec", headerLabelW)) + " " +
+		tui.StyleDim.Render(plural(assets.Total, "asset"))
+	// The one number that must never hide inside a total. An asset that failed
+	// to scan produced no checks, so every tally to the right of here is silent
+	// about it, and this is the only place it gets said.
+	if assets.Errored > 0 {
+		left += tui.StyleDim.Render(" · ") +
+			StatusStyle(reportmodel.StatusError).Render(fmt.Sprintf("%d not scanned", assets.Errored))
+	}
+
+	right := p.tally(st, w-tui.Width(left)-1)
+	if right != "" {
+		right += " "
+	}
+
+	// The two keys that reach everything else on this band. They are shown only
+	// while it is idle -- which is the only state in which the user has not
+	// already found them -- and only on a terminal wide enough that they cost
+	// nothing.
+	mid := ""
+	if !p.open && !p.searching && !st.Filter.Active() {
+		mid = tui.Kbd("/", "search") + "   " + tui.Kbd("f", "filter")
+	}
+	return tui.Band3(left, mid, right, w)
+}
+
+// tally is the check outcomes, five of them, never summed.
+//
+// When the report produced no checks at all there is nothing to tally, and
+// saying so is the honest answer -- five zeroes here would read as "everything
+// passed" for a scan where nothing ran.
+func (p *headerPane) tally(st *State, budget int) string {
+	if budget < 1 {
+		return ""
+	}
+	if st.Report.CheckCounts.Total == 0 {
+		out := tui.StyleFaint.Render("no checks ran")
+		if tui.Width(out) > budget {
+			return ""
+		}
+		return out
+	}
+
+	counts := st.Counts()
+	shown := p.tallyStatuses(st)
+	for {
+		out := renderTally(counts, shown)
+		if tui.Width(out) <= budget || len(shown) <= 1 {
+			return out
+		}
+		// Too wide. Drop an outcome that has nothing in it rather than merge two
+		// that do: an outcome that is absent from the band is zero, and one that
+		// is present is exact. When every remaining outcome is non-zero there is
+		// nothing left to drop and the band gets truncated instead.
+		next := dropLastEmpty(counts, shown)
+		if next == nil {
+			return out
+		}
+		shown = next
+	}
+}
+
+func renderTally(counts reportmodel.Counts, shown []reportmodel.Status) string {
+	parts := make([]string, 0, len(shown))
+	for _, s := range shown {
+		parts = append(parts, StatusStyle(s).Render(fmt.Sprintf("%d %s", countOf(counts, s), s)))
+	}
+	return strings.Join(parts, tui.StyleDim.Render("  "))
+}
+
+func dropLastEmpty(counts reportmodel.Counts, shown []reportmodel.Status) []reportmodel.Status {
+	for i := len(shown) - 1; i >= 0; i-- {
+		if countOf(counts, shown[i]) == 0 {
+			res := make([]reportmodel.Status, 0, len(shown)-1)
+			res = append(res, shown[:i]...)
+			return append(res, shown[i+1:]...)
+		}
+	}
+	return nil
+}
+
+// noteLine is the sentence the severity filter needs to be honest.
+//
+// Severity describes a check. An asset that never produced one has no severity
+// to be judged by, so Filter.MatchAsset keeps it whatever severities are
+// selected -- which is correct, and looks like a bug unless the header says why
+// those rows are still there.
+func (p *headerPane) noteLine(st *State, w int) (string, bool) {
+	if len(st.Filter.Severities) == 0 {
+		return "", false
+	}
+	kept := 0
+	for _, a := range st.FilteredAssets() {
+		if !a.Scanned() {
+			kept++
+		}
+	}
+	if kept == 0 {
+		return "", false
+	}
+	body := fmt.Sprintf("%s kept: severity describes a check, and these ran none",
+		plural(kept, "unscanned asset"))
+	return tui.Truncate(" "+tui.StyleLabel.Render(tui.PadRight("NOTE", headerLabelW))+" "+tui.StyleFaint.Render(body), w), true
+}
+
+// filterLine says what is being filtered on, and what survives it.
+func (p *headerPane) filterLine(st *State, w int) string {
+	left := " " + tui.StyleLabel.Render(tui.PadRight("FILTER", headerLabelW)) + " " +
+		tui.StyleText.Render(tui.Clean(st.Filter.Describe()))
+
+	parts := []string{fmt.Sprintf("%d of %d assets", len(st.FilteredAssets()), len(st.Report.Assets))}
+	// Only claim a check count when the scan produced checks to count. "0 of 0
+	// checks" is noise on a report that never ran one.
+	if total := st.Report.CheckCounts.Total; total > 0 {
+		parts = append(parts, fmt.Sprintf("%d of %d checks", st.Counts().Total, total))
+	}
+	right := tui.StyleDim.Render("showing "+strings.Join(parts, " · ")) + " "
+
+	return tui.Band(left, right, w)
+}
+
+// searchLine is the search field. The term is already published to the filter by
+// the time it is drawn, so the counts on the FILTER row above move as you type.
+func (p *headerPane) searchLine(st *State, w int) string {
+	body := tui.StyleText.Render(tui.Clean(p.search)) + tui.StyleAccent.Render("▌")
+	if p.search == "" {
+		body += " " + tui.StyleFaint.Render("title or asset name")
+	}
+	left := " " + tui.StyleLabel.Render(tui.PadRight("SEARCH", headerLabelW)) + " " + body
+	right := tui.StyleFaint.Render("enter done · esc clear") + " "
+	return tui.Band(left, right, w)
+}
+
+// chipRow is one axis of the filter: the outcomes, or the severities. The counts
+// on the chips are the whole report's, not the filtered view's, because "how
+// many checks errored" is a fact about the scan and should not move when you
+// toggle something else on.
+func (p *headerPane) chipRow(st *State, row filterRow, w int) headerRow {
+	label, tag := "STATUS", "status"
+	if row == rowSeverity {
+		label, tag = "SEVERITY", "severity"
+	}
+
+	marker := " "
+	if st.Focus == PaneHeader && p.row == row {
+		marker = tui.StyleAccent.Render("›")
+	}
+	line := marker + tui.StyleLabel.Render(tui.PadRight(label, headerLabelW)) + " "
+
+	var zones []Zone
+	col := headerContentX
+	for i, c := range p.chips(st, row) {
+		onCursor := st.Focus == PaneHeader && p.row == row && p.cursor == i
+		text := chip(c.style, c.label, c.selected, onCursor)
+		cw := tui.Width(text)
+		if col+cw <= w {
+			zones = append(zones, Zone{
+				Rect: tui.Rect{X: col, W: cw, H: 1},
+				Idx:  i,
+				Tag:  tag,
+			})
+		}
+		line += text
+		col += cw
+	}
+	return headerRow{text: tui.Truncate(line, w), zones: zones}
+}
+
+// chipSpec is one toggleable value on a chip row.
+type chipSpec struct {
+	label    string
+	style    lipgloss.Style
+	selected bool
+}
+
+func (p *headerPane) chips(st *State, row filterRow) []chipSpec {
+	if row == rowSeverity {
+		counts := p.severityCounts(st)
+		res := make([]chipSpec, 0, len(AllSeverities))
+		for _, sev := range AllSeverities {
+			res = append(res, chipSpec{
+				label:    fmt.Sprintf("%s %d", sev, counts[sev]),
+				style:    SeverityStyle(sev),
+				selected: st.Filter.Severities[sev],
+			})
+		}
+		return res
+	}
+
+	statuses := p.tallyStatuses(st)
+	res := make([]chipSpec, 0, len(statuses))
+	for _, s := range statuses {
+		res = append(res, chipSpec{
+			label:    fmt.Sprintf("%s %d", s, countOf(st.Report.CheckCounts, s)),
+			style:    StatusStyle(s),
+			selected: st.Filter.Statuses[s],
+		})
+	}
+	return res
+}
+
+// chip renders one toggleable value. Selected and unselected are the same width,
+// so a row does not shift under the cursor when something is toggled, and the
+// colour is the frame's -- a chip must never pick its own.
+func chip(style lipgloss.Style, label string, selected, cursor bool) string {
+	if cursor {
+		style = style.Underline(true).Bold(true)
+	}
+	if selected {
+		// Reverse, rather than a hand-picked background: whatever colour the
+		// rating palette gave this value becomes the band behind the label.
+		return style.Reverse(true).Render(" " + label + " ")
+	}
+	return " " + style.Render(label) + " "
+}
+
+// --- keys -------------------------------------------------------------------
+
+func (p *headerPane) Update(st *State, msg tea.Msg) (tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case ClickMsg:
+		switch msg.Zone.Tag {
+		case "status":
+			p.row, p.cursor = rowStatus, msg.Zone.Idx
+		case "severity":
+			p.row, p.cursor = rowSeverity, msg.Zone.Idx
+		default:
+			return nil, false
+		}
+		p.toggle(st)
+		return nil, true
+
+	case tea.KeyMsg:
+		if p.searching {
+			return p.typing(st, msg)
+		}
+		return p.command(st, msg)
+	}
+	return nil, false
+}
+
+// typing is the search field. Only the keys that edit text are consumed, so tab
+// still cycles panes and the arrows still belong to whatever else wants them.
+func (p *headerPane) typing(st *State, msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.Type {
+	case tea.KeyRunes, tea.KeySpace:
+		if msg.Alt {
+			return nil, false
+		}
+		p.search += string(msg.Runes)
+	case tea.KeyBackspace:
+		if r := []rune(p.search); len(r) > 0 {
+			p.search = string(r[:len(r)-1])
+		}
+	case tea.KeyCtrlU:
+		p.search = ""
+	case tea.KeyEnter:
+		p.searching = false
+		p.restoreFocus(st)
+		return nil, true
+	case tea.KeyEsc:
+		// esc backs out of the narrowing rather than quitting. The frame only
+		// routes it here because this pane has focus, and it only has focus
+		// because the search is open.
+		p.searching = false
+		p.search = ""
+		p.publishSearch(st)
+		p.restoreFocus(st)
+		return nil, true
+	default:
+		return nil, false
+	}
+	p.publishSearch(st)
+	return nil, true
+}
+
+func (p *headerPane) command(st *State, msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.String() {
+	case "/":
+		p.searching = true
+		st.Focus = PaneHeader
+		return nil, true
+
+	case "f":
+		switch {
+		case !p.open:
+			p.open = true
+			st.Focus = PaneHeader
+		case st.Focus != PaneHeader:
+			// Reached from a body pane while the chips were already showing:
+			// go to them rather than close them.
+			st.Focus = PaneHeader
+		default:
+			p.open = false
+			p.restoreFocus(st)
+		}
+		return nil, true
+
+	case "left", "h":
+		p.cursor--
+	case "right", "l":
+		p.cursor++
+	case "up", "k":
+		p.row = rowStatus
+	case "down", "j":
+		p.row = rowSeverity
+	case "home":
+		p.cursor = 0
+	case "end":
+		p.cursor = len(p.chips(st, p.row)) - 1
+
+	case " ", "enter":
+		p.toggle(st)
+		return nil, true
+
+	case "c":
+		p.search = ""
+		p.setFilter(st, Filter{})
+		return nil, true
+
+	case "esc":
+		// The ladder: close what is open, then clear what is set, and only then
+		// let the frame have it and quit.
+		switch {
+		case p.open:
+			p.open = false
+		case p.active:
+			p.search = ""
+			p.setFilter(st, Filter{})
+		default:
+			return nil, false
+		}
+		p.restoreFocus(st)
+		return nil, true
+
+	default:
+		return nil, false
+	}
+
+	p.clampCursor(st)
+	return nil, true
+}
+
+func (p *headerPane) toggle(st *State) {
+	chips := p.chips(st, p.row)
+	if p.cursor < 0 || p.cursor >= len(chips) {
+		return
+	}
+	if p.row == rowSeverity {
+		p.setFilter(st, st.Filter.ToggleSeverity(AllSeverities[p.cursor]))
+		return
+	}
+	p.setFilter(st, st.Filter.ToggleStatus(p.tallyStatuses(st)[p.cursor]))
+}
+
+// setFilter is the only way this pane publishes a filter. It exists so that
+// Focusable's view of "is anything filtered" cannot fall behind the filter
+// itself between a keypress and the next frame.
+func (p *headerPane) setFilter(st *State, f Filter) {
+	st.SetFilter(f)
+	p.active = st.Filter.Active()
+}
+
+// publishSearch is the only way the search term reaches the rest of the viewer.
+// The rest of the filter is preserved: typing must not silently drop the chips.
+func (p *headerPane) publishSearch(st *State) {
+	f := st.Filter.Clone()
+	f.Search = p.search
+	p.setFilter(st, f)
+}
+
+func (p *headerPane) restoreFocus(st *State) {
+	if p.Focusable() {
+		return
+	}
+	st.Focus = p.returnTo
+}
+
+func (p *headerPane) clampCursor(st *State) {
+	p.cursor = tui.ClampIndex(p.cursor, len(p.chips(st, p.row)))
+}
+
+// --- counting ---------------------------------------------------------------
+
+// tallyStatuses is the outcomes worth a column. The five that always mean
+// something always get one; UNKNOWN is a bucket for a score cnspec did not
+// recognise and only earns its space when something landed in it.
+func (p *headerPane) tallyStatuses(st *State) []reportmodel.Status {
+	if st.Report.CheckCounts.Unknown > 0 {
+		return AllStatuses
+	}
+	return AllStatuses[:len(AllStatuses)-1]
+}
+
+// severityCounts tallies every check in the report by severity. The result is
+// cached against the report it was computed from: the walk is over every check
+// of every asset and the answer cannot change while the report does not.
+func (p *headerPane) severityCounts(st *State) map[string]int {
+	if p.severitiesFor == st.Report && p.severities != nil {
+		return p.severities
+	}
+	res := map[string]int{}
+	for _, a := range st.Report.Assets {
+		for _, c := range a.Checks {
+			res[c.Severity]++
+		}
+	}
+	p.severities, p.severitiesFor = res, st.Report
+	return res
+}
+
+func countOf(c reportmodel.Counts, s reportmodel.Status) int {
+	switch s {
+	case reportmodel.StatusPass:
+		return c.Passed
+	case reportmodel.StatusFail:
+		return c.Failed
+	case reportmodel.StatusError:
+		return c.Errored
+	case reportmodel.StatusSkipped:
+		return c.Skipped
+	case reportmodel.StatusUnscored:
+		return c.Unscored
+	default:
+		return c.Unknown
+	}
+}
+
+// --- text -------------------------------------------------------------------
+
+func plural(n int, unit string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, unit)
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
+}

--- a/cli/reportview/header_test.go
+++ b/cli/reportview/header_test.go
@@ -1,0 +1,572 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The header is asserted on as lines and widths rather than as a screenshot: a
+// golden picture of a terminal breaks on every colour change and proves nothing
+// about the two things that matter, which are that the numbers are true and that
+// the band is exactly as tall as it said it would be.
+
+// headerFor builds the registered header for a fixture, which is also a check
+// that init() put the real pane in the slot rather than the placeholder.
+func headerFor(t *testing.T, fixture string) (*headerPane, *State) {
+	t.Helper()
+	st := NewState(loadReport(t, fixture))
+	p, ok := buildPane(PaneHeader, st).(*headerPane)
+	require.True(t, ok, "the header slot must hold the registered header pane")
+	return p, st
+}
+
+// headerRows renders the band at a width and strips the styling, so an assertion
+// is about the words and the columns rather than about the escape sequences.
+func headerRows(p *headerPane, st *State, w int) []string {
+	lines := p.Render(st, tui.Rect{W: w, H: MaxHeaderLines}).Lines
+	res := make([]string, len(lines))
+	for i, ln := range lines {
+		res[i] = ansi.Strip(ln)
+	}
+	return res
+}
+
+// headerWidths are the terminal widths the band has to survive, from a wide
+// window down to one narrower than a single row of chips.
+var headerWidths = []int{200, 160, 120, 100, 80, 76, 60, 40, 20, 8, 1}
+
+// --- the summary ------------------------------------------------------------
+
+// Five outcomes stay five. Pass, fail, error, skipped and unscored are different
+// things with different fixes, and the band reports each of them as its own
+// number rather than adding any two of them together.
+func TestSummaryKeepsFiveOutcomesApart(t *testing.T) {
+	p, st := headerFor(t, fixtureUbuntu)
+	line := headerRows(p, st, 160)[0]
+
+	require.Contains(t, line, "1 asset")
+	for _, want := range []string{"2 FAIL", "4 ERROR", "18 PASS", "0 SKIPPED", "0 UNSCORED"} {
+		require.Contains(t, line, want, "each outcome gets its own number")
+	}
+	// 2 failed plus 4 errored is six findings, and the band must never say so:
+	// a check that could not run is not a check that ran and failed.
+	require.NotContains(t, line, "6 ")
+	require.NotContains(t, line, "24 ", "the total is not an outcome")
+
+	// UNKNOWN is a bucket for a score cnspec did not recognise. Nothing landed
+	// in it here, so it does not take a column.
+	require.Equal(t, 0, st.Report.CheckCounts.Unknown)
+	require.NotContains(t, line, "UNKNOWN")
+}
+
+// The trap this feature must not fall into. report-k8s.json is fifteen assets,
+// zero reports, fifteen errors and no bundle: "0 failed" would be a lie, and
+// five zeroes would read as a clean bill of health for a scan where nothing ran.
+func TestSummaryTellsTheUnscannedStory(t *testing.T) {
+	p, st := headerFor(t, fixtureK8s)
+	require.Equal(t, 15, len(st.Report.Assets))
+	require.Equal(t, 15, st.Report.AssetCounts.Errored)
+	require.Equal(t, 0, st.Report.CheckCounts.Total)
+
+	line := headerRows(p, st, 160)[0]
+	require.Contains(t, line, "15 assets")
+	require.Contains(t, line, "15 not scanned")
+	require.Contains(t, line, "no checks ran")
+
+	for _, lie := range []string{"0 FAIL", "0 PASS", "0 ERROR", "0 failed", "0 total"} {
+		require.NotContains(t, line, lie, "a scan that ran nothing has no outcome tally")
+	}
+}
+
+// A narrow band drops an outcome that has nothing in it rather than merging two
+// that do. What is shown is exact; what is missing is zero.
+func TestNarrowSummaryDropsOnlyEmptyOutcomes(t *testing.T) {
+	p, st := headerFor(t, fixtureUbuntu)
+
+	full := headerRows(p, st, 160)[0]
+	require.Contains(t, full, "0 UNSCORED")
+
+	narrow := headerRows(p, st, 46)[0]
+	// The three that happened are never dropped, however little room there is.
+	require.Contains(t, narrow, "2 FAIL")
+	require.Contains(t, narrow, "4 ERROR")
+	require.NotContains(t, narrow, "0 UNSCORED")
+	require.NotContains(t, narrow, "0 SKIPPED")
+}
+
+// --- height -----------------------------------------------------------------
+
+// HeightFor is a promise, and this is the test that keeps it. A band that asks
+// for four lines and draws five is a band whose last row lands on the panel
+// below it.
+func TestHeightForMatchesTheLinesItEmits(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		for _, w := range headerWidths {
+			for name, setup := range headerStates() {
+				p, st := headerFor(t, fixture)
+				setup(p, st)
+
+				want := p.HeightFor(st, w)
+				lines := p.Render(st, tui.Rect{W: w, H: MaxHeaderLines}).Lines
+
+				assert.Len(t, lines, want, "%s %s w=%d", fixture, name, w)
+				assert.LessOrEqual(t, want, MaxHeaderLines, "%s %s w=%d", fixture, name, w)
+				for i, ln := range lines {
+					assert.NotContains(t, ln, "\n", "%s %s w=%d line %d", fixture, name, w, i)
+					assert.LessOrEqual(t, tui.Width(ln), w, "%s %s w=%d line %d", fixture, name, w, i)
+				}
+			}
+		}
+	}
+}
+
+// headerStates are the shapes the band takes, keyed by name so a failure says
+// which one broke.
+func headerStates() map[string]func(*headerPane, *State) {
+	sev := func(st *State) {
+		st.SetFilter(st.Filter.ToggleSeverity(policy.ScoreRatingTextCritical))
+	}
+	return map[string]func(*headerPane, *State){
+		"idle": func(*headerPane, *State) {},
+		"searching": func(p *headerPane, st *State) {
+			st.Focus, p.searching = PaneHeader, true
+		},
+		"searching with a term": func(p *headerPane, st *State) {
+			st.Focus, p.searching, p.search = PaneHeader, true, "ssh"
+			p.publishSearch(st)
+		},
+		"chips open": func(p *headerPane, st *State) {
+			st.Focus, p.open = PaneHeader, true
+		},
+		"filtered, closed": func(_ *headerPane, st *State) { sev(st) },
+		"everything at once": func(p *headerPane, st *State) {
+			st.Focus, p.open, p.searching, p.search = PaneHeader, true, true, "ssh"
+			p.publishSearch(st)
+			sev(st)
+		},
+	}
+}
+
+// The band grows when there is something to say and shrinks back when there is
+// not. Idle it is one line, which is what leaves the body the room it needs.
+func TestBandGrowsAndShrinks(t *testing.T) {
+	p, st := headerFor(t, fixtureUbuntu)
+	require.Equal(t, 1, p.HeightFor(st, 120), "idle: the summary and nothing else")
+
+	st.Focus = PaneHeader
+	p.searching = true
+	require.Equal(t, 2, p.HeightFor(st, 120), "the search field")
+
+	p.search = "permissions"
+	p.publishSearch(st)
+	require.Equal(t, 3, p.HeightFor(st, 120), "and the line that says what survives it")
+
+	p.open = true
+	require.Equal(t, 5, p.HeightFor(st, 120), "plus a row of chips per axis")
+
+	p.searching, p.search = false, ""
+	p.publishSearch(st)
+	require.Equal(t, 3, p.HeightFor(st, 120), "the search field and its count both go")
+
+	p.open = false
+	require.Equal(t, 1, p.HeightFor(st, 120), "back to the summary")
+}
+
+// The tallest the band ever gets is every row at once, and it still fits inside
+// what the frame allows. The sixth row is the severity note, which only a report
+// with unscanned assets can produce.
+func TestTallestBandFitsTheFrame(t *testing.T) {
+	p, st := headerFor(t, fixtureK8s)
+	st.Focus, p.open, p.searching, p.search = PaneHeader, true, true, "kube"
+	p.publishSearch(st)
+	st.SetFilter(st.Filter.ToggleSeverity(policy.ScoreRatingTextHigh))
+
+	require.Equal(t, MaxHeaderLines, p.HeightFor(st, 160))
+	rows := headerRows(p, st, 160)
+	require.Len(t, rows, MaxHeaderLines)
+	require.Contains(t, rows[1], "NOTE")
+	require.Contains(t, rows[2], "FILTER")
+	require.Contains(t, rows[3], "SEARCH")
+	require.Contains(t, rows[4], "STATUS")
+	require.Contains(t, rows[5], "SEVERITY")
+}
+
+// --- filtering never hides an unscanned asset -------------------------------
+
+// The rule the whole feature turns on. Severity is a property a check has; an
+// asset that never ran one has none to be judged by, so no severity filter may
+// take it off the screen -- and the band has to say why those rows are still
+// there, or the behaviour reads as a bug.
+func TestSeverityFilterKeepsUnscannedAssetsAndSaysSo(t *testing.T) {
+	p, st := headerFor(t, fixtureK8s)
+	st.Focus, p.open, p.row = PaneHeader, true, rowSeverity
+
+	for i := range AllSeverities {
+		p.cursor = i
+		p.toggle(st)
+	}
+	require.Len(t, st.Filter.Severities, len(AllSeverities))
+	require.Len(t, st.FilteredAssets(), 15, "not one of them may be filtered away")
+
+	rows := headerRows(p, st, 160)
+	require.Contains(t, rows[0], "15 not scanned", "the summary never stops saying it")
+	require.Contains(t, rows[0], "no checks ran")
+	require.Contains(t, rows[1], "15 unscanned assets kept")
+	require.Contains(t, rows[1], "severity describes a check")
+	require.Contains(t, rows[2], "showing 15 of 15 assets")
+	require.NotContains(t, rows[2], "checks", "a scan with no checks does not count them")
+}
+
+// The note is about unscanned assets, so a report where everything scanned does
+// not carry it: it would be an explanation of something that did not happen.
+func TestNoNoteWhenEverythingScanned(t *testing.T) {
+	p, st := headerFor(t, fixtureUbuntu)
+	st.SetFilter(st.Filter.ToggleSeverity(policy.ScoreRatingTextCritical))
+
+	rows := headerRows(p, st, 160)
+	require.Len(t, rows, 2)
+	require.Contains(t, rows[1], "FILTER")
+	require.NotContains(t, strings.Join(rows, "\n"), "unscanned")
+}
+
+// A status filter narrows the k8s report the way the model says it should, and
+// the band's own count is the one the tree will draw from.
+func TestFilterLineCountsWhatTheTreeShows(t *testing.T) {
+	p, st := headerFor(t, fixtureUbuntu)
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusError: true}})
+
+	rows := headerRows(p, st, 160)
+	require.Contains(t, rows[1], "showing 1 of 1 assets")
+	require.Contains(t, rows[1], fmt.Sprintf("%d of 24 checks", st.Counts().Total))
+	require.Equal(t, 4, st.Counts().Total)
+	// The summary tally follows the filter, so the two halves of the band agree.
+	require.Contains(t, rows[0], "4 ERROR")
+	require.Contains(t, rows[0], "0 PASS")
+}
+
+// --- search -----------------------------------------------------------------
+
+// "/" belongs to the header from anywhere, and what is typed into it narrows
+// what the tree is looking at on every keystroke rather than on enter.
+func TestSearchNarrowsFilteredAssets(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	require.Equal(t, PaneTree, m.state.Focus)
+	require.Len(t, m.state.FilteredAssets(), 15)
+
+	m, _ = press(m, "/")
+	require.Equal(t, PaneHeader, m.state.Focus, "the header claims / whatever has focus")
+
+	m = typeInto(m, "kube-proxy")
+	require.Equal(t, "kube-proxy", m.state.Filter.Search)
+
+	narrowed := m.state.FilteredAssets()
+	require.NotEmpty(t, narrowed)
+	require.Less(t, len(narrowed), 15)
+	for _, a := range narrowed {
+		require.Contains(t, strings.ToLower(a.Name), "kube-proxy")
+	}
+	require.Contains(t, ansi.Strip(m.View()),
+		fmt.Sprintf("showing %d of 15 assets", len(narrowed)))
+
+	// Backspacing widens it again, one character at a time.
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = nm.(Model)
+	require.Equal(t, "kube-prox", m.state.Filter.Search)
+	require.GreaterOrEqual(t, len(m.state.FilteredAssets()), len(narrowed))
+}
+
+// A search must not fight the frame for the alphabet: every printable key is a
+// character while the field is open, including the ones that otherwise quit,
+// open the search or open the chips.
+func TestFrameKeysAreTextWhileSearching(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "/")
+
+	m, cmd := press(m, "q")
+	require.Nil(t, cmd, "q is a character here, not a quit")
+	m = typeInto(m, "f/ x")
+
+	require.Equal(t, "qf/ x", m.state.Filter.Search)
+	require.True(t, m.header.(*headerPane).searching, "and the field is still open")
+}
+
+// esc clears the search and hands focus back, rather than quitting. It only gets
+// the chance because the header is focusable while the field is open.
+func TestEscClearsTheSearchRatherThanQuitting(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	m, _ = press(m, "/")
+	m = typeInto(m, "kube-proxy")
+	require.Less(t, len(m.state.FilteredAssets()), 15)
+
+	m, cmd := press(m, "esc")
+	require.Nil(t, cmd, "esc must not quit while a search is open")
+	require.Empty(t, m.state.Filter.Search)
+	require.Len(t, m.state.FilteredAssets(), 15)
+	require.Equal(t, PaneTree, m.state.Focus, "focus goes back where it came from")
+	require.Equal(t, 1, m.headerHeight(), "and the band shrinks back to one line")
+
+	// Nothing is open and nothing is filtered, so esc is the frame's again.
+	_, cmd = press(m, "esc")
+	require.NotNil(t, cmd, "esc quits once there is nothing left to back out of")
+}
+
+// enter closes the field and keeps the term: the search is committed as it is
+// typed, so there is nothing left for enter to apply.
+func TestEnterClosesTheSearchAndKeepsIt(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	m, _ = press(m, "/")
+	m = typeInto(m, "kube")
+	m, _ = press(m, "enter")
+
+	require.Equal(t, "kube", m.state.Filter.Search)
+	require.False(t, m.header.(*headerPane).searching)
+	require.Equal(t, PaneHeader, m.state.Focus,
+		"a filter is still set, so the band keeps focus and esc can clear it")
+	require.Equal(t, 2, m.headerHeight(), "the summary and what survives the filter")
+}
+
+// --- chips ------------------------------------------------------------------
+
+// "f" reaches the chips from the body, and space toggles the one under the
+// cursor through the frame's own vocabulary rather than a second idea of what a
+// filter means.
+func TestChipKeysToggleTheFilter(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	m, _ = press(m, "f")
+	require.Equal(t, PaneHeader, m.state.Focus)
+	require.Equal(t, 3, m.headerHeight(), "the summary plus a row per axis")
+
+	// The cursor opens on the first status, which is FAIL.
+	m, _ = press(m, " ")
+	require.True(t, m.state.Filter.Statuses[reportmodel.StatusFail])
+	require.Equal(t, 2, m.state.Counts().Total, "24 checks, 2 of which failed")
+
+	// Right moves along the row; down moves to the severity axis.
+	m, _ = press(m, "right")
+	m, _ = press(m, " ")
+	require.True(t, m.state.Filter.Statuses[reportmodel.StatusError])
+	require.Equal(t, 6, m.state.Counts().Total, "fail and error, kept apart and added up by nobody")
+
+	// Down moves to the severity axis and keeps the column, the way a grid does.
+	m, _ = press(m, "down")
+	require.Equal(t, 1, m.header.(*headerPane).cursor)
+	m, _ = press(m, "home")
+	m, _ = press(m, " ")
+	require.True(t, m.state.Filter.Severities[policy.ScoreRatingTextCritical])
+
+	// The two axes are combined with AND, and the outcomes within the status axis are not
+	// merged: what is left is the critical checks that failed or errored.
+	left := m.state.FilteredChecks(m.state.Report.Assets[0].Checks)
+	require.NotEmpty(t, left)
+	require.Equal(t, len(left), m.state.Counts().Total)
+	for _, c := range left {
+		require.Equal(t, policy.ScoreRatingTextCritical, c.Severity)
+		require.True(t, c.Status.IsFinding())
+	}
+
+	// Toggling the same chip again takes it off.
+	m, _ = press(m, " ")
+	require.Empty(t, m.state.Filter.Severities)
+}
+
+// A chip's zone has to name the cells the chip was drawn in, or a click lands on
+// the neighbour. Both come out of one Render, and this is what pins them
+// together.
+func TestChipZonesLandOnTheChipTheyName(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 160, 40)
+	m, _ = press(m, "f")
+
+	f := m.build()
+	rendered := f.rendered[PaneHeader]
+	require.NotEmpty(t, rendered.Zones)
+
+	band := f.layout.Header
+	seen := map[string]int{}
+	for _, z := range rendered.Zones {
+		require.Equal(t, PaneHeader, z.Pane)
+		require.True(t, z.Rect.Hit(z.Rect.X, z.Rect.Y), "a zone covers its own corner")
+		require.GreaterOrEqual(t, z.Rect.Y, band.Y)
+		require.Less(t, z.Rect.Y, band.Y+band.H)
+		require.LessOrEqual(t, z.Rect.X+z.Rect.W, band.X+band.W, "a zone stays inside the band")
+		seen[z.Tag]++
+
+		// The cells the zone claims are the cells the chip occupies.
+		row := []rune(ansi.Strip(rendered.Lines[z.Rect.Y-band.Y]))
+		require.LessOrEqual(t, z.Rect.X+z.Rect.W, len(row))
+		text := strings.TrimSpace(string(row[z.Rect.X : z.Rect.X+z.Rect.W]))
+		if z.Tag == "severity" {
+			require.Equal(t, fmt.Sprintf("%s ", AllSeverities[z.Idx]), text[:len(AllSeverities[z.Idx])+1])
+		}
+	}
+	require.Equal(t, len(AllSeverities), seen["severity"])
+	require.Positive(t, seen["status"])
+}
+
+// Clicking a chip toggles it and moves the cursor onto it, so the keyboard picks
+// up where the mouse left off.
+func TestClickingAChipTogglesIt(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 160, 40)
+	m, _ = press(m, "f")
+
+	var target Zone
+	for _, z := range m.build().rendered[PaneHeader].Zones {
+		if z.Tag == "severity" && z.Idx == 1 {
+			target = z
+		}
+	}
+	require.Equal(t, "severity", target.Tag)
+
+	nm, _ := m.Update(tea.MouseMsg{
+		X: target.Rect.X, Y: target.Rect.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = nm.(Model)
+
+	require.True(t, m.state.Filter.Severities[AllSeverities[1]])
+	require.Equal(t, PaneHeader, m.state.Focus)
+
+	p := m.header.(*headerPane)
+	require.Equal(t, rowSeverity, p.row)
+	require.Equal(t, 1, p.cursor)
+}
+
+// A closed band answers no clicks at all, which is what keeps a click on the top
+// row of an idle viewer from doing something invisible.
+func TestClosedBandHasNoZones(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		m := sized(NewModel(loadReport(t, fixture)), 120, 40)
+		for _, z := range m.build().zones {
+			require.NotEqual(t, PaneHeader, z.Pane, "%s: an idle band is not clickable", fixture)
+		}
+	}
+}
+
+// --- focus and the esc ladder -----------------------------------------------
+
+// The band stays out of the tab cycle until it has something to drive, and
+// rejoins it the moment it does.
+func TestBandJoinsTheTabCycleOnlyWhenItHasSomethingToDo(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	require.False(t, m.header.Focusable())
+
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneDetail, m.state.Focus)
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneTree, m.state.Focus, "an idle band is skipped")
+
+	m, _ = press(m, "f")
+	require.True(t, m.header.Focusable())
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneTree, m.state.Focus)
+	m, _ = press(m, "tab")
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneHeader, m.state.Focus, "an open band is in the cycle")
+}
+
+// esc backs out one step at a time and only quits once there is nothing left to
+// back out of: close the chips, clear the filter, then quit.
+func TestEscLadder(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	m, _ = press(m, "f")
+	m, _ = press(m, " ")
+	require.True(t, m.state.Filter.Active())
+
+	m, cmd := press(m, "esc")
+	require.Nil(t, cmd, "the first esc closes the chips")
+	require.False(t, m.header.(*headerPane).open)
+	require.True(t, m.state.Filter.Active(), "and leaves the filter alone")
+	require.Equal(t, PaneHeader, m.state.Focus, "the band still holds a filter, so it keeps focus")
+
+	m, cmd = press(m, "esc")
+	require.Nil(t, cmd, "the second esc clears the filter")
+	require.False(t, m.state.Filter.Active())
+	require.Equal(t, PaneTree, m.state.Focus)
+
+	_, cmd = press(m, "esc")
+	require.NotNil(t, cmd, "the third esc quits")
+}
+
+// "c" clears every axis at once without closing anything, which is the escape
+// hatch from a filter that has been narrowed into an empty screen.
+func TestClearKeyEmptiesEveryAxis(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "/")
+	m = typeInto(m, "zzz")
+	m, _ = press(m, "enter")
+	m, _ = press(m, "f")
+	m, _ = press(m, " ")
+	require.True(t, m.state.Filter.Active())
+	require.Empty(t, m.state.FilteredAssets())
+
+	m, _ = press(m, "c")
+	require.False(t, m.state.Filter.Active())
+	require.Empty(t, m.state.Filter.Search)
+	require.Len(t, m.state.FilteredAssets(), 1)
+	require.True(t, m.header.(*headerPane).open, "clearing is not closing")
+}
+
+// Tabbing away from an open search closes the field rather than leaving it
+// silently swallowing keys it will never see.
+func TestTabbingAwayClosesTheSearchField(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	m, _ = press(m, "/")
+	m = typeInto(m, "ssh")
+	require.True(t, m.header.(*headerPane).searching)
+
+	m, _ = press(m, "tab")
+	_ = m.View() // the band reconciles with the frame's focus as it draws
+	require.False(t, m.header.(*headerPane).searching)
+	require.Equal(t, "ssh", m.state.Filter.Search, "the term it committed survives")
+}
+
+// --- wiring -----------------------------------------------------------------
+
+// The header is built once per model and may be handed a state that already
+// carries a filter, e.g. from a caller that preselected one.
+func TestHeaderAdoptsAPresetFilter(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	st.SetFilter(Filter{Search: "ssh"})
+
+	p, ok := buildPane(PaneHeader, st).(*headerPane)
+	require.True(t, ok)
+	require.Equal(t, "ssh", p.search, "the field opens on the term already in force")
+
+	rows := headerRows(p, st, 160)
+	require.Len(t, rows, 2)
+	require.Contains(t, rows[1], `"ssh"`)
+	require.True(t, p.Focusable(), "a filter is set, so esc has somewhere to go")
+}
+
+// The band survives a report with no assets at all rather than dividing by the
+// number of them.
+func TestEmptyReportBand(t *testing.T) {
+	st := NewState(reportmodel.New(nil))
+	p := &headerPane{returnTo: PaneTree}
+
+	require.Equal(t, 1, p.HeightFor(st, 80))
+	require.Contains(t, headerRows(p, st, 80)[0], "0 assets")
+	require.Contains(t, headerRows(p, st, 80)[0], "no checks ran")
+}
+
+// typeInto sends each character of s as its own keypress, which is what the
+// terminal does.
+func typeInto(m Model, s string) Model {
+	for _, r := range s {
+		m, _ = press(m, string(r))
+	}
+	return m
+}

--- a/cli/reportview/layout.go
+++ b/cli/reportview/layout.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import "go.mondoo.com/cnspec/cli/tui"
+
+// The viewer's geometry is computed in exactly one place: computeLayout. It
+// renders nothing and mutates nothing, and both View (to draw) and Update (to
+// hit-test a mouse click) derive from it, so a drawn element and the region that
+// responds to it cannot drift apart.
+//
+// The pane arithmetic itself is tui.Dims, shared with the launcher: the same
+// 38% split, the same minimum width below which two panes stop being readable
+// and only the focused one is shown. What is added here is a header band that
+// can be more than one line tall, because the viewer's header carries a search
+// field and filter chips rather than just a title.
+//
+// The invariant underneath all of it: every row a pane returns is exactly one
+// terminal line. No style may carry a margin -- a margin adds a line this
+// arithmetic cannot see, which is how a pane that "obviously" fits ends up
+// scrolling the screen.
+
+const (
+	// MaxHeaderLines caps what the header pane may ask for. A header that eats
+	// the body is a worse bug than a header that gets truncated.
+	MaxHeaderLines = 6
+	// MinBodyLines is what the body keeps even on a very short terminal.
+	MinBodyLines = 1
+)
+
+// Layout is the viewer's geometry: the header band, the two body panels and the
+// footer, plus the content rect inside each panel.
+//
+// Panel rects include the border; Content rects are the region a pane renders
+// into and are what Pane.Render receives.
+type Layout struct {
+	tui.Layout
+
+	// HeaderH is the height of the header band, at least 1.
+	HeaderH int
+	// Header is the header band: full width, no border.
+	Header tui.Rect
+	// Footer is the single hint line at the bottom.
+	Footer tui.Rect
+
+	// TreePanel and DetailPanel are the bordered boxes, in absolute cells.
+	TreePanel   tui.Rect
+	DetailPanel tui.Rect
+	// TreeContent and DetailContent are the regions inside those borders.
+	TreeContent   tui.Rect
+	DetailContent tui.Rect
+
+	// ShowTree and ShowDetail say which body panes are drawn. Below
+	// tui.MinTwoPaneWidth only the focused one is.
+	ShowTree, ShowDetail bool
+}
+
+// Content is the region inside a panel's border: one line down from the top,
+// tui.InnerX in from the left, and tui.InnerWidth by tui.InnerHeight in size.
+func Content(panel tui.Rect) tui.Rect {
+	return tui.Rect{
+		X: panel.X + tui.InnerX,
+		Y: panel.Y + 1,
+		W: tui.InnerWidth(panel.W),
+		H: tui.InnerHeight(panel.H),
+	}
+}
+
+// computeLayout derives every rect from the terminal size, the focus and the
+// height the header asks for.
+func computeLayout(width, height int, headerH int, focus PaneID) Layout {
+	l := Layout{Layout: tui.Dims(width, height)}
+
+	// The header takes what it asks for, within reason: at least one line, never
+	// more than MaxHeaderLines, and never so much that the body is squeezed out.
+	if headerH < 1 {
+		headerH = 1
+	}
+	if headerH > MaxHeaderLines {
+		headerH = MaxHeaderLines
+	}
+	if room := height - tui.FooterLines - MinBodyLines; headerH > room {
+		headerH = room
+	}
+	if headerH < 1 {
+		headerH = 1
+	}
+	l.HeaderH = headerH
+
+	l.BodyTop = headerH
+	l.BodyH = height - headerH - tui.FooterLines
+	if l.BodyH < MinBodyLines {
+		l.BodyH = MinBodyLines
+	}
+
+	l.Header = tui.Rect{X: 0, Y: 0, W: width, H: headerH}
+	l.Footer = tui.Rect{X: 0, Y: height - tui.FooterLines, W: width, H: tui.FooterLines}
+
+	l.ShowTree = l.TwoPane || focus != PaneDetail
+	l.ShowDetail = l.TwoPane || focus == PaneDetail
+
+	l.TreePanel = tui.Rect{X: 0, Y: l.BodyTop, W: l.LeftW, H: l.BodyH}
+	l.DetailPanel = tui.Rect{X: l.RightX, Y: l.BodyTop, W: l.RightW, H: l.BodyH}
+	if !l.TwoPane {
+		// One pane at a time gets the whole width.
+		l.TreePanel.W = width
+		l.DetailPanel = tui.Rect{X: 0, Y: l.BodyTop, W: width, H: l.BodyH}
+	}
+
+	l.TreeContent = Content(l.TreePanel)
+	l.DetailContent = Content(l.DetailPanel)
+
+	// tui.Dims computed these for the launcher's list, which starts below a
+	// search field inside the panel. The viewer's list starts at the top of its
+	// panel, so restate them rather than leave the launcher's numbers here for
+	// someone to trust.
+	l.ListTop = l.TreeContent.Y
+	l.ListH = l.TreeContent.H
+
+	return l
+}
+
+// ContentFor returns the rect a pane renders into, and whether it is drawn at
+// all.
+func (l Layout) ContentFor(id PaneID) (tui.Rect, bool) {
+	switch id {
+	case PaneHeader:
+		return l.Header, l.Header.H > 0
+	case PaneTree:
+		return l.TreeContent, l.ShowTree
+	case PaneDetail:
+		return l.DetailContent, l.ShowDetail
+	default:
+		return tui.Rect{}, false
+	}
+}
+
+// PanelFor returns the bordered box a pane is drawn in. The header has no panel.
+func (l Layout) PanelFor(id PaneID) (tui.Rect, bool) {
+	switch id {
+	case PaneTree:
+		return l.TreePanel, l.ShowTree
+	case PaneDetail:
+		return l.DetailPanel, l.ShowDetail
+	default:
+		return tui.Rect{}, false
+	}
+}
+
+// PaneAt returns the pane whose region contains (x, y), which is what a scroll
+// wheel needs: the wheel scrolls what the pointer is over, not what has focus.
+func (l Layout) PaneAt(x, y int) PaneID {
+	if l.Header.Hit(x, y) {
+		return PaneHeader
+	}
+	if l.ShowDetail && l.DetailPanel.Hit(x, y) {
+		return PaneDetail
+	}
+	if l.ShowTree && l.TreePanel.Hit(x, y) {
+		return PaneTree
+	}
+	return PaneNone
+}

--- a/cli/reportview/layout_test.go
+++ b/cli/reportview/layout_test.go
@@ -1,0 +1,263 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The fixtures are named rather than pathed, because the two no longer come from
+// the same place. report-ubuntu is one asset that scanned, and it is shared with
+// every reporter through internal/reportfixture; report-k8s is fifteen that did
+// not, with no bundle at all, and it still lives with the reporter tests. Both
+// are raw collections rather than json-full artifacts.
+const (
+	fixtureUbuntu = "report-ubuntu"
+	fixtureK8s    = "report-k8s"
+)
+
+func loadReport(t *testing.T, fixture string) *reportmodel.Report {
+	t.Helper()
+	return reportmodel.New(loadCollection(t, fixture))
+}
+
+// termSizes covers the sizes that actually break things: the 80x24 default, a
+// narrow window that has to drop to one pane, and a window so short that the
+// header, the body and the footer cannot all have the room they want.
+var termSizes = []struct{ w, h int }{
+	{80, 24}, {100, 30}, {120, 40}, {200, 60}, {76, 24}, {70, 24}, {60, 15}, {40, 10}, {30, 6}, {20, 3},
+}
+
+func sized(m Model, w, h int) Model {
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	return nm.(Model)
+}
+
+func viewLines(m Model) []string {
+	return strings.Split(m.View(), "\n")
+}
+
+// TestViewIsExactlyTerminalSize is the test that keeps the viewer inside the
+// terminal. A view taller than the screen scrolls the alt-screen buffer, which
+// pushes the header off and leaves the cursor pointing at rows nobody can see; a
+// line wider than the screen wraps and does the same thing one row at a time.
+func TestViewIsExactlyTerminalSize(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		report := loadReport(t, fixture)
+		for _, focus := range []PaneID{PaneTree, PaneDetail} {
+			for _, s := range termSizes {
+				m := sized(NewModel(report), s.w, s.h)
+				m.state.Focus = focus
+				lines := viewLines(m)
+				if len(lines) != s.h {
+					t.Errorf("%s focus=%s %dx%d: rendered %d lines, want exactly %d",
+						fixture, focus, s.w, s.h, len(lines), s.h)
+				}
+				for i, ln := range lines {
+					if w := ansi.StringWidth(ln); w > s.w {
+						t.Errorf("%s focus=%s %dx%d: line %d is %d cells wide, want <= %d",
+							fixture, focus, s.w, s.h, i, w, s.w)
+					}
+				}
+			}
+		}
+	}
+}
+
+// The same at the end of a long list: the last page is where an off-by-one in
+// the scroll clamp shows up.
+func TestViewIsExactlyTerminalSizeAtEndOfList(t *testing.T) {
+	report := loadReport(t, fixtureK8s)
+	for _, s := range termSizes {
+		m := sized(NewModel(report), s.w, s.h)
+		nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+		m = nm.(Model)
+		if lines := viewLines(m); len(lines) != s.h {
+			t.Errorf("%dx%d at end of list: rendered %d lines, want exactly %d", s.w, s.h, len(lines), s.h)
+		}
+	}
+}
+
+// A growing terminal must not leave a pane scrolled past the end of its rows.
+func TestScrollClampsOnResize(t *testing.T) {
+	report := loadReport(t, fixtureK8s)
+	// The placeholder is passed in explicitly: this is a frame test about the
+	// scroll contract, so it names the pane it drives rather than taking
+	// whichever one happens to be registered.
+	m := sized(NewModel(report, &assetListPane{}), 120, 12)
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	m = nm.(Model)
+	_ = m.View() // Render is what scrolls: it is the only place that knows how many rows fit
+
+	tree := m.tree.(*assetListPane)
+	require.Positive(t, tree.scroll.Off, "the k8s fixture should be long enough to scroll at height 12")
+
+	m = sized(m, 120, 200)
+	_ = m.View() // Render is what clamps
+	require.Equal(t, 0, tree.scroll.Off, "everything fits now, so the list must be back at the top")
+	require.Len(t, viewLines(m), 200)
+}
+
+// TestLayoutAccountsForEveryLine checks the arithmetic directly rather than
+// through the renderer: header plus body plus footer is the terminal, exactly.
+func TestLayoutAccountsForEveryLine(t *testing.T) {
+	for _, s := range termSizes {
+		for _, want := range []int{1, 2, 3, MaxHeaderLines, MaxHeaderLines + 10} {
+			l := computeLayout(s.w, s.h, want, PaneTree)
+
+			require.GreaterOrEqual(t, l.HeaderH, 1, "%dx%d header=%d", s.w, s.h, want)
+			require.LessOrEqual(t, l.HeaderH, MaxHeaderLines, "%dx%d header=%d", s.w, s.h, want)
+			require.Equal(t, l.HeaderH, l.Header.H)
+
+			// The body is what is left, unless the terminal is too short to
+			// leave anything, in which case the body claims its minimum and the
+			// renderer clips.
+			leftover := s.h - l.HeaderH - tui.FooterLines
+			if leftover >= MinBodyLines {
+				require.Equal(t, leftover, l.BodyH, "%dx%d header=%d", s.w, s.h, want)
+				require.Equal(t, s.h, l.HeaderH+l.BodyH+tui.FooterLines)
+			} else {
+				require.Equal(t, MinBodyLines, l.BodyH, "%dx%d header=%d", s.w, s.h, want)
+			}
+
+			require.Equal(t, l.BodyTop, l.HeaderH, "the body starts where the header ends")
+			require.Equal(t, s.h-1, l.Footer.Y, "the footer is the last line")
+		}
+	}
+}
+
+// The two panels must tile the width exactly: left, one column of gutter, right.
+func TestPanelsTileTheWidth(t *testing.T) {
+	for _, s := range termSizes {
+		l := computeLayout(s.w, s.h, 1, PaneTree)
+		if !l.TwoPane {
+			require.Equal(t, s.w, l.TreePanel.W, "%dx%d: a single pane takes the whole width", s.w, s.h)
+			require.Equal(t, s.w, l.DetailPanel.W)
+			continue
+		}
+		require.Equal(t, s.w, l.TreePanel.W+1+l.DetailPanel.W, "%dx%d", s.w, s.h)
+		require.Equal(t, l.TreePanel.W+1, l.DetailPanel.X, "%dx%d", s.w, s.h)
+	}
+}
+
+// The content rect a pane renders into is the inside of its border, and the
+// panel it lives in is drawn at exactly the size the layout gave it.
+func TestContentRectIsInsideTheBorder(t *testing.T) {
+	l := computeLayout(120, 40, 2, PaneTree)
+
+	require.Equal(t, tui.InnerX, l.TreeContent.X)
+	require.Equal(t, l.TreePanel.Y+1, l.TreeContent.Y)
+	require.Equal(t, tui.InnerWidth(l.TreePanel.W), l.TreeContent.W)
+	require.Equal(t, tui.InnerHeight(l.TreePanel.H), l.TreeContent.H)
+
+	require.Equal(t, l.DetailPanel.X+tui.InnerX, l.DetailContent.X)
+	require.Equal(t, tui.InnerWidth(l.DetailPanel.W), l.DetailContent.W)
+
+	// The accessors a pane reaches the geometry through agree with the fields.
+	for _, id := range []PaneID{PaneHeader, PaneTree, PaneDetail} {
+		rect, visible := l.ContentFor(id)
+		require.True(t, visible, "%s should be drawn at 120x40", id)
+		require.Positive(t, rect.W)
+		require.Positive(t, rect.H)
+	}
+	tree, ok := l.PanelFor(PaneTree)
+	require.True(t, ok)
+	require.Equal(t, l.TreePanel, tree)
+	require.Equal(t, Content(tree), l.TreeContent)
+
+	_, ok = l.PanelFor(PaneHeader)
+	require.False(t, ok, "the header band has no bordered panel")
+	_, ok = l.ContentFor(PaneNone)
+	require.False(t, ok)
+}
+
+// PaneAt is what routes a scroll wheel: it answers with the pane the pointer is
+// over, and with nothing when the pointer is on the footer.
+func TestPaneAt(t *testing.T) {
+	l := computeLayout(120, 40, 1, PaneTree)
+
+	require.Equal(t, PaneHeader, l.PaneAt(0, 0))
+	require.Equal(t, PaneTree, l.PaneAt(l.TreeContent.X, l.TreeContent.Y))
+	require.Equal(t, PaneDetail, l.PaneAt(l.DetailContent.X, l.DetailContent.Y))
+	require.Equal(t, PaneNone, l.PaneAt(0, l.Footer.Y))
+
+	// In one-pane mode only the pane on screen answers.
+	narrow := computeLayout(60, 20, 1, PaneTree)
+	require.Equal(t, PaneTree, narrow.PaneAt(2, narrow.BodyTop+1))
+	narrow = computeLayout(60, 20, 1, PaneDetail)
+	require.Equal(t, PaneDetail, narrow.PaneAt(2, narrow.BodyTop+1))
+}
+
+// Below tui.MinTwoPaneWidth the viewer shows one pane, following focus, rather
+// than squeezing two unreadable columns into the window.
+func TestNarrowTerminalUsesOnePane(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 60, 20)
+
+	l := m.layout()
+	require.False(t, l.TwoPane)
+	require.True(t, l.ShowTree)
+	require.False(t, l.ShowDetail)
+	require.Contains(t, ansi.Strip(m.View()), "ubuntu:24.04")
+
+	m.state.Focus = PaneDetail
+	l = m.layout()
+	require.False(t, l.ShowTree)
+	require.True(t, l.ShowDetail)
+	// The asset page's status row, which is the one thing every detail page has.
+	require.Contains(t, ansi.Strip(m.View()), "risk ")
+}
+
+// At exactly tui.MinTwoPaneWidth both panes appear; one column narrower they do
+// not. The boundary is worth pinning because both sides of it are drawn by
+// different code paths.
+func TestTwoPaneBoundary(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+
+	wide := sized(NewModel(report), tui.MinTwoPaneWidth, 24)
+	require.True(t, wide.layout().TwoPane)
+	require.Len(t, viewLines(wide), 24)
+
+	narrow := sized(NewModel(report), tui.MinTwoPaneWidth-1, 24)
+	require.False(t, narrow.layout().TwoPane)
+	require.Len(t, viewLines(narrow), 24)
+}
+
+// A header that asks for more than it can have gets clamped, and the view still
+// occupies exactly the terminal.
+func TestGreedyHeaderIsClamped(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	for _, s := range termSizes {
+		m := sized(NewModel(report, &greedyHeader{want: 99}), s.w, s.h)
+		l := m.layout()
+		require.LessOrEqual(t, l.HeaderH, MaxHeaderLines, "%dx%d", s.w, s.h)
+		require.GreaterOrEqual(t, l.BodyH, MinBodyLines, "%dx%d", s.w, s.h)
+		require.Len(t, viewLines(m), s.h, "%dx%d", s.w, s.h)
+	}
+}
+
+// greedyHeader is a header pane that always asks for more lines than it should
+// get, and fills every one of them.
+type greedyHeader struct{ want int }
+
+func (p *greedyHeader) ID() PaneID                             { return PaneHeader }
+func (p *greedyHeader) Focusable() bool                        { return false }
+func (p *greedyHeader) Claims() []string                       { return nil }
+func (p *greedyHeader) Hints(*State) []Hint                    { return nil }
+func (p *greedyHeader) Update(*State, tea.Msg) (tea.Cmd, bool) { return nil, false }
+func (p *greedyHeader) HeightFor(*State, int) int              { return p.want }
+func (p *greedyHeader) Render(_ *State, rect tui.Rect) Render {
+	lines := make([]string, p.want)
+	for i := range lines {
+		lines[i] = strings.Repeat("H", rect.W+20) // deliberately too wide
+	}
+	return Render{Lines: lines}
+}

--- a/cli/reportview/links.go
+++ b/cli/reportview/links.go
@@ -1,0 +1,210 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"bytes"
+	"net/url"
+	"os/exec"
+	"runtime"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Clickable URLs, for the REFERENCES section of a check.
+//
+// A reference is a link and nothing else -- a CIS benchmark PDF, a CVE, a
+// vendor advisory -- and printing it as eighty characters of plain text asks
+// the reader to retype it, or to leave the viewer, find the report again and
+// select it with the mouse. Both of the affordances below exist because either
+// one alone leaves somebody stuck.
+//
+// # OSC 8, for the terminal
+//
+// termenv.Hyperlink wraps the text in an OSC 8 sequence, which is how iTerm2,
+// WezTerm, Kitty, foot, GNOME Terminal, Windows Terminal and modern VTE
+// terminals turn text into something you can click or ctrl-click. Two
+// properties make it safe inside a pane that is measured in exact cells:
+//
+//   - it is zero width. ansi.StringWidth returns the same number for the bare
+//     URL and the wrapped one, so a row that fits before wrapping still fits.
+//   - ansi.Truncate cuts the *visible* text and keeps the sequences either side
+//     of it, so a URL wider than the pane comes out as a shortened, still-valid
+//     link rather than as an escape sequence leaking into the row below.
+//
+// TestHyperlinkIsZeroWidth and TestATruncatedLinkIsStillALink hold both to it,
+// with the raw bytes in the failure message.
+//
+// A terminal that does not understand OSC 8 -- Terminal.app, older xterm, the
+// Linux console -- skips the sequence and draws the text, so nothing degrades
+// except the clicking. Nothing is printed twice and no marker is left behind.
+//
+// # A click zone, for this program
+//
+// OSC 8 is not enough on its own here, and the reason is specific to a TUI: the
+// viewer runs with mouse tracking on, so the terminal hands the click to the
+// application instead of acting on it. The link is live to a ctrl-click or a
+// right-click-and-open, and dead to a plain one -- which is the click a reader
+// will try first.
+//
+// So a link is also a Zone, exactly the way a COPY button is: a rect on the row
+// it was drawn on, tagged, carrying the index of the URL it names. The detail
+// pane turns a ClickMsg on one into a command, and the command hands the URL to
+// the platform opener.
+//
+// # Where links are, and are not
+//
+// The REFERENCES section only. It is the one place the viewer prints a bare URL
+// as a thing to go and read.
+//
+// Descriptions, audit steps and remediation prose are markdown, and they go
+// through glamour, which already gives a link its own color and underline
+// (styles.DarkStyleConfig.Link). Adding OSC 8 there would mean finding the URLs
+// again inside a wall of styled rows that glamour has already word-wrapped,
+// matching them back to the source by eye, and hoping the mapping holds -- the
+// same guessing game markdown.Blocks exists to avoid for code fences. The row
+// provenance simply is not there for prose, and a link zone on the wrong cells
+// is worse than no link at all.
+//
+// # Opening it
+//
+// The platform opener: `open` on macOS, `rundll32 url.dll,FileProtocolHandler`
+// on Windows, `xdg-open` elsewhere. No new module -- github.com/pkg/browser is
+// in the graph but only as an indirect dependency, and promoting it would edit
+// go.mod for four lines of exec.
+//
+// Three things it does that a naive exec does not:
+//
+//   - it refuses anything that is not http or https. A reference URL comes out
+//     of a policy bundle, which is content, and `open` will cheerfully hand
+//     file://, a custom scheme or an app URL to whatever claims it. The same
+//     check gates whether the row is drawn as a link at all, so the viewer never
+//     offers a link it would then refuse.
+//   - it keeps the child off the terminal. The viewer owns an alt-screen, and a
+//     helper writing "gio: no handler" onto it corrupts the frame. stdout and
+//     stderr go to a buffer, which is also where the reason for a failure comes
+//     from.
+//   - it waits, and reports. A click that appears to do nothing is the complaint
+//     this package keeps getting, so the outcome comes back as a message and the
+//     footer says either what was opened or why it was not. Waiting is what makes
+//     the failing cases visible at all: a missing xdg-open fails at start, but an
+//     xdg-open with no handler only fails on exit. It costs nothing the user is
+//     waiting on -- this runs as a tea.Cmd, off the event loop, so the viewer
+//     keeps repainting whatever the opener does.
+
+// linkZoneTag marks a Zone as a URL. The zone's Idx is the index of the URL in
+// the pane's list.
+const linkZoneTag = "link"
+
+// linkable reports whether a string is a web address this viewer will present as
+// a link and hand to the platform opener.
+//
+// It is deliberately narrow. Everything else -- a relative path, a mailto:, a
+// scheme nobody recognizes, a bundle field that was never a URL -- is drawn as
+// the plain text it is, which is what the section did before any of this.
+func linkable(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// hyperlink wraps text in an OSC 8 sequence pointing at url. The result is the
+// same number of cells wide as text.
+func hyperlink(url, text string) string {
+	return termenv.Hyperlink(url, text)
+}
+
+// openDoneMsg is the outcome of opening a URL, on its way back to the frame.
+//
+// Unexported, like copyDoneMsg and unlike ExportDoneMsg: handing a URL to a
+// helper is a subprocess that returns, not a render that can outlive the view,
+// so there is no case where the viewer is gone and the result still matters.
+type openDoneMsg struct {
+	URL string
+	Err error
+}
+
+// openURLCmd opens a URL, as a command.
+func openURLCmd(raw string) tea.Cmd {
+	return func() tea.Msg {
+		return openDoneMsg{URL: raw, Err: openURL(raw)}
+	}
+}
+
+// openURL hands a URL to the platform opener, having first checked that it is
+// one worth handing over.
+func openURL(raw string) error {
+	if !linkable(raw) {
+		return errors.Newf("%q is not an http or https address", raw)
+	}
+	return urlOpener(raw)
+}
+
+// urlOpener is what actually launches the browser.
+//
+// It is a variable for the same reason clipboardWrite is: a test that called the
+// real one would open a browser window on the developer's machine and would fail
+// on a build box that has no xdg-open, for a reason that has nothing to do with
+// this viewer.
+var urlOpener = runOpener
+
+// runOpener runs the platform's opener and waits for it.
+func runOpener(raw string) error {
+	name, args := openerFor(runtime.GOOS, raw)
+	cmd := exec.Command(name, args...)
+	// The viewer owns an alt-screen buffer; a helper printing a diagnostic onto
+	// it would corrupt the frame. The buffer catches that diagnostic instead,
+	// which is the most useful half of the failure message.
+	var out bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &out
+	if err := cmd.Run(); err != nil {
+		if msg := tui.OneLine(out.String()); msg != "" {
+			return errors.Wrap(err, msg)
+		}
+		return errors.Wrapf(err, "%s failed", name)
+	}
+	return nil
+}
+
+// openerFor is the command that opens a URL on an operating system, split out
+// from running it so a test can check the three of them anywhere.
+//
+// The Windows form is rundll32 rather than `cmd /c start`, because start is a
+// shell builtin and would put the URL through cmd's parser -- where & and ^ mean
+// something -- for no gain.
+func openerFor(goos, raw string) (string, []string) {
+	switch goos {
+	case "darwin":
+		return "open", []string{raw}
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", raw}
+	default:
+		return "xdg-open", []string{raw}
+	}
+}
+
+// openNotice is the one line the footer shows afterwards. A success says what
+// was opened, because "opened" alone on a page of six references does not say
+// which one; a failure says why, in the words of whatever refused.
+func openNotice(msg openDoneMsg) string {
+	if msg.Err != nil {
+		return "could not open " + msg.URL + ": " + tui.OneLine(msg.Err.Error())
+	}
+	return "opened " + msg.URL
+}
+
+// openDone puts the outcome in the footer. Like a copy, this needs no box: the
+// click was one action and the reason it failed fits on the line.
+func (m Model) openDone(msg openDoneMsg) (tea.Model, tea.Cmd) {
+	m.state.Notice = openNotice(msg)
+	return m, nil
+}

--- a/cli/reportview/links_test.go
+++ b/cli/reportview/links_test.go
@@ -1,0 +1,348 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// refURL is the URL both reference-carrying checks of the ubuntu fixture cite.
+// It is 88 cells wide, which is wider than either pane on an 80-column terminal
+// -- i.e. exactly the case truncation has to survive.
+const refURL = "http://www.itsecure.hu/library/image/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v2.1.1.pdf"
+
+// osc8 is the two halves of the sequence termenv.Hyperlink emits.
+const (
+	osc8Open  = "\x1b]8;;"
+	osc8Close = "\x1b]8;;\x1b\\"
+)
+
+// withOpener swaps the platform opener for one that records what it was asked to
+// open. The real one would launch a browser on the machine running the tests and
+// would fail on a build box with no xdg-open, for a reason that has nothing to
+// do with this viewer.
+func withOpener(t *testing.T, err error) *[]string {
+	t.Helper()
+	var got []string
+	was := urlOpener
+	urlOpener = func(raw string) error {
+		got = append(got, raw)
+		return err
+	}
+	t.Cleanup(func() { urlOpener = was })
+	return &got
+}
+
+// --- the sequence -----------------------------------------------------------
+
+// A hyperlink is zero width. This is the property that lets a link go into a
+// pane measured in exact cells at all: the wrapped URL takes the same number of
+// columns as the bare one, so a row that fitted before still fits.
+func TestHyperlinkIsZeroWidth(t *testing.T) {
+	link := hyperlink(refURL, refURL)
+
+	require.Equal(t, 88, ansi.StringWidth(refURL))
+	require.Equal(t, ansi.StringWidth(refURL), ansi.StringWidth(link),
+		"the sequence took cells: %q", link)
+	require.Equal(t, osc8Open+refURL+"\x1b\\"+refURL+osc8Close, link)
+}
+
+// And a truncated hyperlink is still a hyperlink. ansi.Truncate cuts the visible
+// text and keeps the sequences either side of it, so a URL wider than the pane
+// comes out shortened and clickable rather than as an escape sequence leaking
+// into the row below.
+func TestATruncatedLinkIsStillALink(t *testing.T) {
+	link := hyperlink(refURL, refURL)
+
+	for _, w := range []int{1, 5, 20, 30, 60, 87} {
+		cut := ansi.Truncate(link, w, "…")
+		require.Equal(t, w, ansi.StringWidth(cut), "w=%d: %q", w, cut)
+		require.True(t, strings.HasPrefix(cut, osc8Open+refURL+"\x1b\\"),
+			"w=%d lost the target, so it is no longer a link: %q", w, cut)
+		require.True(t, strings.HasSuffix(cut, osc8Close),
+			"w=%d lost the terminator, so the escape leaks: %q", w, cut)
+		// The target is intact even though the text is not: what is clicked is
+		// the whole URL, not the visible stub.
+		require.Contains(t, cut, refURL)
+		require.True(t, strings.HasSuffix(ansi.Strip(cut), "…"),
+			"w=%d did not actually cut: %q", w, ansi.Strip(cut))
+		require.True(t, strings.HasPrefix(refURL, strings.TrimSuffix(ansi.Strip(cut), "…")),
+			"w=%d shows something other than the head of the URL: %q", w, ansi.Strip(cut))
+	}
+}
+
+// --- what gets a link -------------------------------------------------------
+
+func TestOnlyWebAddressesAreLinked(t *testing.T) {
+	for _, ok := range []string{
+		"http://example.com",
+		"https://mondoo.com/docs/cnspec",
+		"https://example.com/a?b=c#d",
+	} {
+		require.True(t, linkable(ok), ok)
+	}
+	for _, no := range []string{
+		"",
+		"CIS RHEL 7",
+		"example.com",
+		"/etc/ssh/sshd_config",
+		"mailto:security@example.com",
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+		"http://",
+		"https://",
+		"-nasty",
+	} {
+		require.False(t, linkable(no), no)
+	}
+}
+
+// The viewer never offers a link it would then refuse: the same predicate gates
+// the drawing and the opening.
+func TestARefusedSchemeIsNeverDrawnAsALink(t *testing.T) {
+	b := newDetailBuf(80)
+	b.reference("file:///etc/passwd")
+
+	require.Empty(t, b.links, "nothing to click")
+	require.Empty(t, b.urls)
+	require.Len(t, b.out, 1)
+	require.Contains(t, b.out[0], "file:///etc/passwd", "it is still shown, as text")
+	require.NotContains(t, b.out[0], osc8Open)
+
+	got := withOpener(t, nil)
+	require.Error(t, openURL("file:///etc/passwd"))
+	require.Empty(t, *got, "the opener was never reached")
+}
+
+// --- in the pane ------------------------------------------------------------
+
+// The REFERENCES section of a real check: the URL is one row, it is wrapped in
+// OSC 8, and the pane publishes a zone over exactly the cells it drew.
+func TestAReferenceIsDrawnAsALinkWithAZone(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+	require.Len(t, check.Detail().References, 1)
+
+	p, lines := renderDetail(st, 100)
+	require.Len(t, p.urls, 1)
+	require.Equal(t, refURL, p.urls[0])
+	require.Len(t, p.links, 1)
+
+	link := p.links[0]
+	row := lines[link.Row]
+	require.Contains(t, row, osc8Open+refURL+"\x1b\\", "the row is not a link")
+	require.True(t, strings.HasSuffix(row, osc8Close))
+	require.Equal(t, refURL, ansi.Strip(row)[link.Col:], "the zone does not cover the URL")
+	require.Equal(t, detailIndent, link.Col)
+	require.Equal(t, tui.Width(refURL), link.W)
+
+	// It sits under the section label, where the plain text used to.
+	require.Equal(t, "REFERENCES", ansi.Strip(lines[link.Row-2]))
+}
+
+// A pane too narrow for the URL draws a shortened link, and the zone shrinks
+// with it: a click has to land on cells the reader can see.
+func TestANarrowPaneKeepsTheLinkWhole(t *testing.T) {
+	st, _ := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+
+	for _, w := range []int{20, 37, 40, 60, 80, 100, 200} {
+		p, lines := renderDetail(st, w)
+		require.Len(t, p.links, 1, "w=%d", w)
+		link := p.links[0]
+		row := lines[link.Row]
+
+		require.LessOrEqual(t, tui.Width(row), w, "w=%d: %q", w, ansi.Strip(row))
+		require.NotContains(t, ansi.Strip(row), "\x1b", "w=%d leaked an escape", w)
+		require.Contains(t, row, refURL, "w=%d lost the target", w)
+		require.True(t, strings.HasSuffix(row, osc8Close), "w=%d lost the terminator", w)
+		require.Equal(t, link.W, tui.Width(ansi.Strip(row))-link.Col, "w=%d: the zone and the text disagree", w)
+	}
+}
+
+// The whole pane invariant, restated over the section that now emits escape
+// sequences of its own: one element of Lines is one terminal row, never wider
+// than the rect, at every width and for every check of the fixture.
+func TestLinkedRowsStillFitTheRect(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+
+	for _, check := range asset.Checks {
+		st.SelectCheck(asset, nil, check)
+		for _, w := range []int{1, 2, 3, 4, 8, 20, 37, 60, 80, 120, 200} {
+			p := &detailPane{}
+			p.Render(st, detailRect(w, 24))
+			for i, ln := range p.lines {
+				require.NotContains(t, ln, "\n", "%s w=%d line %d", check.Title, w, i)
+				require.LessOrEqual(t, tui.Width(ln), w,
+					"%s w=%d line %d: %q", check.Title, w, i, ansi.Strip(ln))
+			}
+		}
+	}
+}
+
+// A link zone is only published while its row is on screen, exactly like a COPY
+// button's. A zone for a row that scrolled away is a click that lands on
+// whatever is there now.
+func TestLinkZonesFollowTheViewport(t *testing.T) {
+	st, _ := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+
+	p := &detailPane{}
+	rect := detailRect(100, 8)
+	p.Render(st, rect)
+	require.Len(t, p.links, 1)
+	row := p.links[0].Row
+
+	require.Empty(t, linkZonesOf(p.Render(st, rect)), "the references are far below the fold")
+
+	// Scrolling to the end brings the references on screen; the offset the pane
+	// settles on is what the zone's row is measured against.
+	p.scroll.Off = len(p.lines)
+	zones := linkZonesOf(p.Render(st, rect))
+	require.Len(t, zones, 1)
+	require.Equal(t, rect.Y+row-p.scroll.Off, zones[0].Rect.Y, "the zone is not on the row it drew")
+	require.Equal(t, rect.X+detailIndent, zones[0].Rect.X)
+	require.Equal(t, tui.Width(refURL), zones[0].Rect.W)
+}
+
+// --- clicking ---------------------------------------------------------------
+
+// The click the terminal never sees. Mouse tracking is on, so a plain click on
+// an OSC 8 link is delivered to the application; the pane turns it into the
+// command that opens the URL.
+func TestClickingALinkOpensIt(t *testing.T) {
+	got := withOpener(t, nil)
+	st, _ := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+
+	p := &detailPane{}
+	rect := detailRect(100, 8)
+	p.Render(st, rect)
+	// Scroll to the end, which is where the references are.
+	p.scroll.Off = len(p.lines)
+	zones := linkZonesOf(p.Render(st, rect))
+	require.Len(t, zones, 1)
+	zone := zones[0]
+
+	cmd, handled := p.Update(st, ClickMsg{
+		Zone:  zone,
+		Mouse: tea.MouseMsg{X: zone.Rect.X, Y: zone.Rect.Y, Action: tea.MouseActionPress},
+	})
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+
+	msg, ok := cmd().(openDoneMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.Err)
+	require.Equal(t, []string{refURL}, *got, "the whole URL is opened, not the visible stub")
+	require.Equal(t, "opened "+refURL, openNotice(msg))
+}
+
+// Even when the pane drew a stub. What is opened is the URL, not what fitted.
+func TestClickingATruncatedLinkOpensTheWholeURL(t *testing.T) {
+	got := withOpener(t, nil)
+	st, _ := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+
+	p := &detailPane{}
+	rect := tui.Rect{X: 1, Y: 2, W: 30, H: 8}
+	p.Render(st, rect)
+	p.scroll.Off = len(p.lines)
+	zones := linkZonesOf(p.Render(st, rect))
+	require.Len(t, zones, 1)
+	zone := zones[0]
+	require.Less(t, zone.Rect.W, tui.Width(refURL), "this pane is too narrow for the URL, or the test proves nothing")
+
+	cmd, handled := p.Update(st, ClickMsg{Zone: zone})
+	require.True(t, handled)
+	cmd()
+	require.Equal(t, []string{refURL}, *got)
+}
+
+// A click that appears to do nothing is the complaint this package keeps
+// getting, so a failure is a sentence in the footer and not a swallowed error.
+func TestAFailedOpenIsSaidOutLoud(t *testing.T) {
+	withOpener(t, errors.New("exec: \"xdg-open\": executable file not found in $PATH"))
+
+	msg, ok := openURLCmd(refURL)().(openDoneMsg)
+	require.True(t, ok)
+	require.Error(t, msg.Err)
+
+	notice := openNotice(msg)
+	require.Contains(t, notice, "could not open")
+	require.Contains(t, notice, refURL)
+	require.Contains(t, notice, "xdg-open")
+	require.NotContains(t, notice, "\n", "a notice is one footer row")
+
+	// And it reaches the footer.
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	next, _ := m.Update(msg)
+	require.Equal(t, notice, next.(Model).state.Notice)
+}
+
+// The reason is the opener's own words, so a missing helper and a helper that
+// declined are told apart by the person who can fix either.
+func TestTheOpenerNamesWhatRefused(t *testing.T) {
+	require.Equal(t, "open", first(openerFor("darwin", refURL)))
+	require.Equal(t, []string{refURL}, second(openerFor("darwin", refURL)))
+
+	require.Equal(t, "rundll32", first(openerFor("windows", refURL)))
+	require.Equal(t, []string{"url.dll,FileProtocolHandler", refURL}, second(openerFor("windows", refURL)))
+
+	require.Equal(t, "xdg-open", first(openerFor("linux", refURL)))
+	require.Equal(t, []string{refURL}, second(openerFor("freebsd", refURL)))
+}
+
+// A click on a zone this pane does not own, or one carrying an index that is not
+// a URL, is not a click it handles. Neither can happen through the frame; both
+// would be a crash if the bounds were trusted.
+func TestABadLinkZoneIsIgnored(t *testing.T) {
+	got := withOpener(t, nil)
+	st, _ := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+	p, _ := renderDetail(st, 100)
+
+	for _, zone := range []Zone{
+		{Tag: linkZoneTag, Idx: -1},
+		{Tag: linkZoneTag, Idx: len(p.urls)},
+		{Tag: "twisty", Idx: 0},
+	} {
+		cmd, handled := p.Update(st, ClickMsg{Zone: zone})
+		require.False(t, handled, "%+v", zone)
+		require.Nil(t, cmd)
+	}
+	require.Empty(t, *got)
+}
+
+// A check with no references publishes no link zones, and its COPY buttons are
+// untouched by any of this.
+func TestACheckWithoutReferencesHasNoLinks(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+	require.Empty(t, check.Detail().References)
+
+	p := &detailPane{}
+	res := p.Render(st, detailRect(100, 40))
+	require.Empty(t, p.links)
+	require.Empty(t, p.urls)
+	require.Empty(t, linkZonesOf(res))
+	require.NotEmpty(t, p.buttons, "the code blocks are still there")
+	for _, z := range res.Zones {
+		require.Equal(t, copyZoneTag, z.Tag)
+	}
+}
+
+func linkZonesOf(r Render) []Zone {
+	var res []Zone
+	for _, z := range r.Zones {
+		if z.Tag == linkZoneTag {
+			res = append(res, z)
+		}
+	}
+	return res
+}
+
+func first(name string, _ []string) string    { return name }
+func second(_ string, args []string) []string { return args }

--- a/cli/reportview/markdown.go
+++ b/cli/reportview/markdown.go
@@ -1,0 +1,315 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Markdown for the detail pane.
+//
+// A check's description, its audit steps and every remediation body are markdown
+// *source*. Printed raw they read as markup -- asterisks around the words that
+// should be bold, hashes in front of the headings, three backticks around the
+// command you are meant to run -- so this renders them with glamour, which is
+// the terminal markdown renderer from the same family as the TUI stack this
+// viewer is already built on (bubbletea, lipgloss, x/ansi).
+//
+// # The stylesheet
+//
+// The base is glamour's *dark* style, for one concrete reason: it is written in
+// the same ANSI-256 index vocabulary as this viewer's chrome. Its body color is
+// literally 252, which is theme.go's colText, and its horizontal rule is 240,
+// which is colFaint. The alternatives ship as hex themes (dracula, tokyo-night,
+// pink) that would put a second, unrelated accent next to the pane's violet and
+// cyan.
+//
+// Five changes to it, each because this is a pane and not a page:
+//
+//   - The document margin goes to zero. detailBuf already indents a section
+//     body under its label, and glamour's own margin would indent it a second
+//     time and eat two columns of an already narrow pane. The code block keeps
+//     its margin, though: that indent is the only thing that still says "this is
+//     a command, not a sentence" on a terminal with no colors.
+//   - The document block prefix and suffix -- a blank line above and below the
+//     whole document -- go away. The pane spaces its own sections.
+//   - The heading prefixes ("## ", "### ", ...) go away. Keeping them is what
+//     the raw source already did; a heading here is bold and colored instead.
+//     H1 loses its filled background band as well, because in this viewer a
+//     colored band means "selected" and nothing else.
+//   - An inline code span loses the two padding cells glamour puts around it.
+//     They cost real width in a 30-column pane, and with colors off -- NO_COLOR,
+//     or any terminal lipgloss reports as Ascii -- they read as a stray double
+//     space around every path and setting name. The color and the background
+//     already set the span apart where there are colors to set it apart with.
+//   - The document foreground color is dropped so body prose inherits the
+//     terminal's own. That is the light-terminal answer: 252 is near-white and
+//     would be invisible on a white background, and every color left in the
+//     sheet (39 headings, 203/236 inline code, 244 code blocks, chroma's own
+//     mid-tones) is legible on either. It also means this pane never queries the
+//     terminal for its background color, which is what glamour's own auto style
+//     does -- an OSC round trip in the middle of a running TUI, that also
+//     degrades to the ASCII stylesheet whenever stdout is not a terminal, which
+//     would put the literal asterisks straight back.
+//
+// # Width
+//
+// glamour word-wraps prose to the width it is given, and mostly gets fenced code
+// too, but not reliably: it gives up on a token it cannot fit, at a very narrow
+// width it stops wrapping altogether, and a code row it does wrap comes out
+// without the indent the row above it has. So its output overflows exactly where
+// a remediation is most likely to be wide. Every row it produces is therefore
+// measured in cells and folded if it is over, which is the one thing the frame
+// cannot forgive: a row wider than the pane wraps in the terminal and pushes the
+// whole layout down by one.
+
+// markdownProfile is the color profile the renderer emits for. It matches the
+// rest of the viewer, which draws through lipgloss's detected profile, so a
+// 16-color terminal is not sent 24-bit escapes. It is a variable because
+// lipgloss detects Ascii whenever stdout is not a terminal -- which is every
+// test run -- and a test that wants to see the colors has to say so.
+var markdownProfile = sync.OnceValue(lipgloss.ColorProfile)
+
+// markdown is the pane's renderer. One is enough: the detail pane renders on one
+// goroutine, and the mutex is there so that a test rendering in parallel cannot
+// interleave two documents through glamour's block stack.
+var markdown markdownRenderer
+
+// markdownRenderer renders markdown source to terminal rows, holding on to the
+// glamour renderers it built. Building one compiles a goldmark pipeline and the
+// word wrap is baked into it, so they are kept and reused; the set is thrown
+// away only when the color profile changes, which happens once, in a test.
+//
+// There is one per width because Blocks renders a document at two of them --
+// prose at the pane's width, a code block a button's strip narrower -- and a
+// single-slot cache would rebuild the pipeline at every fence. markdownMaxTRs
+// bounds the set so that dragging a terminal's edge cannot accumulate one
+// renderer per column crossed.
+type markdownRenderer struct {
+	mu      sync.Mutex
+	trs     map[int]*glamour.TermRenderer
+	profile termenv.Profile
+
+	// renders counts the documents that went through glamour. The detail pane
+	// caches its body per selection and width, and this is how a test proves
+	// that the markdown is rendered inside that cache rather than on every
+	// frame and every mouse wheel notch.
+	renders int
+}
+
+// markdownMaxTRs is how many widths are kept. Two is the working set of one
+// pane; the rest of the room is for the other pane and for a resize in flight.
+const markdownMaxTRs = 6
+
+// Lines renders markdown source into rows no wider than w cells. It returns nil
+// when there is nothing to draw or when glamour fails, so a caller can fall back
+// to printing the source: a section that has source must never render empty.
+func (m *markdownRenderer) Lines(src string, w int) []string {
+	src = strings.TrimSpace(tui.Clean(src))
+	if src == "" || w < 1 {
+		return nil
+	}
+
+	out, err := m.render(src, w)
+	if err != nil {
+		return nil
+	}
+
+	var res []string
+	for _, ln := range tui.Lines(out) {
+		// glamour pads every row out to the wrap width. Where the padding is
+		// plain it is dropped; where it is inside a styled run -- the band
+		// behind a code block -- it is not, because that band is the thing that
+		// sets the code off from the prose.
+		ln = strings.TrimRight(ln, " ")
+		if tui.Width(ln) <= w {
+			res = append(res, ln)
+			continue
+		}
+		// Over-wide rows are code and unbreakable tokens. They are cut at the
+		// edge and continued on the next row rather than truncated: a command
+		// you are meant to paste is worth more whole than tidy.
+		res = append(res, strings.Split(ansi.Hardwrap(ln, w, false), "\n")...)
+	}
+	return trimBlankRows(res)
+}
+
+// mdBlock is one piece of a rendered document: the rows it drew, and, when the
+// piece is a fenced code block, what was between the fences.
+//
+// The pane needs the split because the COPY button sits on a block's first row:
+// a document rendered whole comes back as rows with no idea which of them is
+// code, and matching them back up afterwards means guessing from the escape
+// sequences glamour happened to use.
+type mdBlock struct {
+	// Lines are the rendered rows, one terminal row each, already folded to the
+	// width they were rendered at.
+	Lines []string
+	// Code is the block's source when this piece is a fenced code block, and nil
+	// when it is prose.
+	Code *mdCode
+}
+
+// Blocks renders markdown source, split at every top-level fenced code block.
+//
+// Prose is rendered at w cells and code at codeW, which is how the button gets a
+// strip of its own at the right of a block without any of the command
+// disappearing under it. Pass codeW == w for no strip.
+//
+// Each piece goes through glamour separately. That costs a render per piece and
+// gains the one thing this needs: the row a block starts on is known exactly,
+// rather than being looked for in a wall of styled output. Prose either side of
+// a fence is a paragraph either way -- what does *not* survive being split is a
+// fence nested in a list or a blockquote, which is why fencedCodes only reports
+// the ones at the top level.
+func (m *markdownRenderer) Blocks(src string, w, codeW int) []mdBlock {
+	src = mdSource(src)
+	if src == "" || w < 1 {
+		return nil
+	}
+	if codeW < 1 || codeW > w {
+		codeW = w
+	}
+
+	codes := fencedCodes(src)
+	if len(codes) == 0 {
+		if lines := m.Lines(src, w); len(lines) > 0 {
+			return []mdBlock{{Lines: lines}}
+		}
+		return nil
+	}
+
+	res := make([]mdBlock, 0, 2*len(codes)+1)
+	prose := func(s string) {
+		if lines := m.Lines(s, w); len(lines) > 0 {
+			res = append(res, mdBlock{Lines: lines})
+		}
+	}
+
+	at := 0
+	for i := range codes {
+		code := codes[i]
+		prose(src[at:code.Start])
+
+		// The block is re-rendered from its own source text rather than from a
+		// fence rebuilt around code.Text, so what glamour is handed is byte for
+		// byte what it would have been handed had the document gone through in
+		// one piece.
+		lines := m.Lines(src[code.Start:code.Stop], codeW)
+		if len(lines) == 0 {
+			// glamour declined it. The source is still worth showing, and it is
+			// still worth copying, so it is drawn as plain rows.
+			lines = codeRows(code.Text, codeW)
+		}
+		res = append(res, mdBlock{Lines: lines, Code: &code})
+		at = code.Stop
+	}
+	prose(src[at:])
+
+	return res
+}
+
+// codeRows is the fallback for a block glamour would not render: the source, cut
+// at the right edge rather than folded, in the style the pane gives its other
+// code.
+func codeRows(text string, w int) []string {
+	lines := tui.Lines(text)
+	res := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		res = append(res, tui.Truncate(tui.StyleText.Render(ln), w))
+	}
+	return res
+}
+
+// Renders is how many documents this renderer has put through glamour.
+func (m *markdownRenderer) Renders() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.renders
+}
+
+func (m *markdownRenderer) render(src string, w int) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profile := markdownProfile()
+	if m.trs == nil || m.profile != profile {
+		m.trs, m.profile = map[int]*glamour.TermRenderer{}, profile
+	}
+
+	tr := m.trs[w]
+	if tr == nil {
+		var err error
+		tr, err = glamour.NewTermRenderer(
+			markdownStyle(),
+			glamour.WithWordWrap(w),
+			glamour.WithColorProfile(profile),
+		)
+		if err != nil {
+			return "", err
+		}
+		if len(m.trs) >= markdownMaxTRs {
+			// A resize walks through every intermediate width. Dropping the lot
+			// costs one rebuild of the two widths in use and keeps this from
+			// growing with the number of columns the user dragged through.
+			clear(m.trs)
+		}
+		m.trs[w] = tr
+	}
+
+	m.renders++
+	return tr.Render(src)
+}
+
+// markdownStyle is glamour's dark stylesheet with the five changes the package
+// comment explains.
+//
+// styles.DarkStyleConfig is a package-level value in glamour and a copy of it
+// shares glamour's own pointers, so every field below is *replaced* and none is
+// written through: this pane must not edit the stylesheet every other glamour
+// caller in the process is using.
+func markdownStyle() glamour.TermRendererOption {
+	cfg := styles.DarkStyleConfig
+	none := uint(0)
+
+	cfg.Document.Margin = &none
+	cfg.Document.BlockPrefix = ""
+	cfg.Document.BlockSuffix = ""
+	cfg.Document.Color = nil
+
+	cfg.H1.Prefix = ""
+	cfg.H1.Suffix = ""
+	cfg.H1.BackgroundColor = nil
+	cfg.H2.Prefix = ""
+	cfg.H3.Prefix = ""
+	cfg.H4.Prefix = ""
+	cfg.H5.Prefix = ""
+	cfg.H6.Prefix = ""
+
+	cfg.Code.Prefix = ""
+	cfg.Code.Suffix = ""
+
+	return glamour.WithStyles(cfg)
+}
+
+// trimBlankRows drops the blank rows at both ends of a rendered block. glamour
+// ends a document with one, and the pane puts its own blank line between
+// sections; two of them reads as a gap nobody asked for.
+func trimBlankRows(lines []string) []string {
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}

--- a/cli/reportview/mdcode.go
+++ b/cli/reportview/mdcode.go
@@ -1,0 +1,204 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Finding the fenced code blocks in a markdown source, and splitting the source
+// at them so the pane can draw a button on each.
+//
+// # Why a parser and not a scan for backticks
+//
+// Because CommonMark says something specific about every one of these and a
+// scanner would have to reimplement all of it:
+//
+//	~~~sh          a fence may be tildes, and a tilde fence may contain backticks
+//	```            a fence may carry no info string at all
+//	  ```bash      a fence may be indented up to three spaces, and the same
+//	               indent is then stripped from every line inside it
+//	````           a longer fence closes only on one at least as long, so a
+//	 ```           three-backtick line inside it is content, not the end
+//	```bash        an unclosed fence runs to the end of the document rather
+//	echo hi        than swallowing it as if the fence were never opened
+//
+// goldmark implements all of that, and it is already in the module graph
+// underneath glamour -- the same parser glamour itself renders this markdown
+// with, so what this finds and what the pane draws cannot disagree about where a
+// block is.
+//
+// # Only the blocks at the top level of the document
+//
+// A fence inside a list item or a blockquote is skipped. The reason is the
+// splitting, not the parsing: the pane renders the document in pieces, one per
+// code block, and cutting a list in half to pull a block out of it would restart
+// its numbering and drop its markers. Every fenced block in cnspec's own content
+// is written at the top level, which is what the markdown a policy author writes
+// looks like.
+
+// mdParser is the parser every source goes through. Building one assembles the
+// whole block and inline pipeline, and a Parser is reusable -- it takes no state
+// from a parse, keeping what it needs in a per-call context -- so one is built
+// and kept rather than one per markdown section of every check.
+//
+// Stock CommonMark, with no extension registered: a fenced code block is core
+// syntax, and nothing an extension adds changes where a fence begins or ends.
+var mdParser = sync.OnceValue(func() parser.Parser {
+	return goldmark.New().Parser()
+})
+
+// mdCode is one fenced code block of a markdown source.
+type mdCode struct {
+	// Lang is the fence's info word: "bash" for ```bash, empty for a bare ```.
+	Lang string
+	// Text is the literal source between the fences, with the container indent
+	// already stripped and the blank lines at either end removed. This is what
+	// goes on the clipboard.
+	Text string
+	// Start and Stop bracket the whole block in the source it was found in,
+	// fences included, so a caller can split the document at it. Source[Start:Stop]
+	// is the block exactly as it was written.
+	Start, Stop int
+}
+
+// mdSource normalizes a markdown source the way the renderer does, so an offset
+// found here indexes the same string the renderer parses.
+func mdSource(s string) string {
+	return strings.TrimSpace(tui.Clean(s))
+}
+
+// fencedCodes is the top-level fenced code blocks of a normalized markdown
+// source, in document order. Pass it mdSource(s).
+//
+// A block with no content between its fences is left out: there is nothing to
+// copy, and a button on it would be a button that does nothing.
+func fencedCodes(src string) []mdCode {
+	if !strings.ContainsAny(src, "`~") {
+		// The overwhelmingly common case for a description: no fence, no parse.
+		return nil
+	}
+
+	b := []byte(src)
+	doc := mdParser().Parse(text.NewReader(b))
+
+	var res []mdCode
+	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
+		fence, ok := n.(*ast.FencedCodeBlock)
+		if !ok {
+			continue
+		}
+		code, ok := fenceSpan(src, b, fence)
+		if !ok {
+			continue
+		}
+		// Defensive: the spans must march forward and stay inside the source.
+		// They do, for siblings of a document -- but every consumer of this
+		// slices src with them, and a slice with a bad bound panics in a View.
+		if code.Start < 0 || code.Stop > len(src) || code.Start >= code.Stop {
+			continue
+		}
+		if len(res) > 0 && code.Start < res[len(res)-1].Stop {
+			continue
+		}
+		res = append(res, code)
+	}
+	return res
+}
+
+// fenceSpan works out where a block starts and ends and what is inside it.
+//
+// goldmark hands back the *content* lines, not the fences: the block runs from
+// the line before the first content line (the opening fence) to the end of the
+// line after the last one (the closing fence), when there is a closing fence at
+// all.
+func fenceSpan(src string, b []byte, fence *ast.FencedCodeBlock) (mdCode, bool) {
+	lines := fence.Lines()
+	if lines.Len() == 0 {
+		return mdCode{}, false
+	}
+
+	var body strings.Builder
+	for i := 0; i < lines.Len(); i++ {
+		seg := lines.At(i)
+		body.Write(seg.Value(b))
+	}
+	// Blank lines at either end of a block are the author's spacing, not part of
+	// the command. A leading newline in front of a pasted `yum remove` is noise.
+	code := mdCode{
+		Lang: string(fence.Language(b)),
+		Text: strings.Trim(body.String(), "\n"),
+	}
+	if code.Text == "" {
+		return mdCode{}, false
+	}
+
+	// The opening fence is the line before the content.
+	contentAt := lineStart(src, lines.At(0).Start)
+	if contentAt == 0 {
+		return mdCode{}, false
+	}
+	code.Start = lineStart(src, contentAt-1)
+
+	// The closing fence is the line after it, if the block was closed at all.
+	code.Stop = lines.At(lines.Len() - 1).Stop
+	if code.Stop < len(src) {
+		if end := lineStop(src, code.Stop); isFenceLine(src[code.Stop:end]) {
+			code.Stop = end
+		}
+	}
+	if code.Stop > len(src) {
+		code.Stop = len(src)
+	}
+	return code, true
+}
+
+// lineStart is the offset of the first byte of the line containing off.
+func lineStart(s string, off int) int {
+	if off > len(s) {
+		off = len(s)
+	}
+	if off < 0 {
+		off = 0
+	}
+	if i := strings.LastIndexByte(s[:off], '\n'); i >= 0 {
+		return i + 1
+	}
+	return 0
+}
+
+// lineStop is the offset just past the line beginning at off, newline included.
+func lineStop(s string, off int) int {
+	if i := strings.IndexByte(s[off:], '\n'); i >= 0 {
+		return off + i + 1
+	}
+	return len(s)
+}
+
+// isFenceLine reports whether a line is nothing but a closing fence: at least
+// three of one fence character, indented no more than the three spaces
+// CommonMark allows.
+func isFenceLine(line string) bool {
+	s := strings.TrimRight(strings.TrimRight(line, "\n"), " \t")
+	indent := len(s) - len(strings.TrimLeft(s, " "))
+	if indent > 3 {
+		return false
+	}
+	s = s[indent:]
+	if len(s) < 3 {
+		return false
+	}
+	c := s[0]
+	if c != '`' && c != '~' {
+		return false
+	}
+	return strings.Trim(s, string(c)) == ""
+}

--- a/cli/reportview/model.go
+++ b/cli/reportview/model.go
@@ -1,0 +1,508 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// Model is the viewer's bubbletea model: the frame around the panes.
+//
+// It owns the terminal size, the focus, the routing and the chrome. It does not
+// own a single row of content -- every line inside the header band and the two
+// panels comes from a Pane.
+//
+// The panes are pointers held by the frame, so Model stays copyable the way
+// bubbletea expects while a pane's own state (its cursor, its scroll offset)
+// survives the copy. State is shared for the same reason.
+type Model struct {
+	width, height int
+
+	// leaveLabel is what the footer calls q -- "quit" standalone, "back" when
+	// embedded in another program. See Embedded.
+	leaveLabel string
+
+	state  *State
+	header Pane
+	tree   Pane
+	detail Pane
+
+	// showHelp expands the footer into the full key map.
+	showHelp bool
+
+	// export is the format picker, when it is open. It is not a pane: it takes
+	// the whole body and every key until it closes. See export.go.
+	export exportModal
+}
+
+// NewModel builds a viewer for a report. Panes come from the registry (see
+// RegisterTree and friends); passing a pane here overrides the registered one
+// for its slot, which is what tests and embedders use.
+func NewModel(report *reportmodel.Report, panes ...Pane) Model {
+	st := NewState(report)
+	m := Model{
+		state:      st,
+		leaveLabel: "quit",
+		header:     buildPane(PaneHeader, st),
+		tree:       buildPane(PaneTree, st),
+		detail:     buildPane(PaneDetail, st),
+	}
+	for _, p := range panes {
+		if p == nil {
+			continue
+		}
+		switch p.ID() {
+		case PaneHeader:
+			m.header = p
+		case PaneTree:
+			m.tree = p
+		case PaneDetail:
+			m.detail = p
+		}
+	}
+	m.state.Focus = m.firstFocusable()
+	return m
+}
+
+// State exposes the shared state, so a caller that built the model can inspect
+// or preselect through it.
+func (m Model) State() *State { return m.state }
+
+// Init implements tea.Model.
+func (m Model) Init() tea.Cmd { return nil }
+
+// panes returns the three panes in focus-cycle order: the body first, because
+// that is where the user starts, then the header.
+func (m Model) panes() []Pane {
+	return []Pane{m.tree, m.detail, m.header}
+}
+
+func (m Model) pane(id PaneID) Pane {
+	for _, p := range m.panes() {
+		if p != nil && p.ID() == id {
+			return p
+		}
+	}
+	return nil
+}
+
+func (m Model) firstFocusable() PaneID {
+	for _, p := range m.panes() {
+		if p != nil && p.Focusable() {
+			return p.ID()
+		}
+	}
+	return PaneNone
+}
+
+// headerHeight asks the header pane how tall it wants to be. computeLayout
+// clamps the answer.
+func (m Model) headerHeight() int {
+	if sp, ok := m.header.(SizedPane); ok {
+		return sp.HeightFor(m.state, m.width)
+	}
+	return tui.HeaderLines
+}
+
+// layout is the frame's geometry for the current size and focus.
+func (m Model) layout() Layout {
+	return computeLayout(m.width, m.height, m.headerHeight(), m.state.Focus)
+}
+
+// frame is one complete pass: the geometry plus what each visible pane drew into
+// it. Render is called exactly once per pane per frame, and both the renderer
+// and the hit-tester read the result, which is what keeps a click on a row
+// landing on the thing that row drew.
+type frame struct {
+	layout   Layout
+	rendered map[PaneID]Render
+	zones    []Zone
+}
+
+func (m Model) build() frame {
+	f := frame{layout: m.layout(), rendered: map[PaneID]Render{}}
+	for _, p := range m.panes() {
+		if p == nil {
+			continue
+		}
+		rect, visible := f.layout.ContentFor(p.ID())
+		if !visible || rect.W < 1 || rect.H < 1 {
+			continue
+		}
+		r := p.Render(m.state, rect)
+		for i := range r.Zones {
+			r.Zones[i].Pane = p.ID()
+		}
+		f.rendered[p.ID()] = r
+		f.zones = append(f.zones, r.Zones...)
+	}
+	return f
+}
+
+// hit returns the topmost zone containing (x, y). Zones are appended in render
+// order, so walk in reverse and let a later one win.
+func (f frame) hit(x, y int) (Zone, bool) {
+	for i := len(f.zones) - 1; i >= 0; i-- {
+		if f.zones[i].Rect.Hit(x, y) {
+			return f.zones[i], true
+		}
+	}
+	return Zone{}, false
+}
+
+// Update implements tea.Model.
+//
+// Routing, in order:
+//
+//  1. ctrl+c always quits.
+//  2. An open export modal takes every remaining key, and no pane sees any of
+//     them. It is the one thing in the viewer that is modal in the literal
+//     sense.
+//  3. A resize, and any message that is neither a key nor a mouse event, is
+//     broadcast to every pane.
+//  4. A key claimed by a pane (Pane.Claims) moves focus to that pane and is
+//     delivered there.
+//  5. Otherwise the focused pane sees the key first.
+//  6. A key no pane consumed falls through to the frame's own bindings, which is
+//     how "esc" can clear a search in the pane that has one and quit everywhere
+//     else.
+//
+// A mouse click is hit-tested against the zones of the frame just rendered: the
+// owning pane takes focus and receives a ClickMsg. A scroll wheel goes to the
+// pane under the pointer without moving focus, because scrolling something you
+// are only looking at should not steal the keyboard.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, m.broadcast(msg)
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
+
+	case ExportDoneMsg:
+		return m.exportDone(msg)
+
+	case copyDoneMsg:
+		return m.copyDone(msg)
+
+	case openDoneMsg:
+		return m.openDone(msg)
+	}
+
+	return m, m.broadcast(msg)
+}
+
+// broadcast hands a message to every pane and batches whatever they return.
+func (m Model) broadcast(msg tea.Msg) tea.Cmd {
+	var cmds []tea.Cmd
+	for _, p := range m.panes() {
+		if p == nil {
+			continue
+		}
+		if cmd, _ := p.Update(m.state, msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	if key == "ctrl+c" {
+		return m, tea.Quit
+	}
+	// Any key dismisses whatever notice is showing.
+	m.state.Notice = ""
+
+	// The export picker is modal: while it is up it is the only thing keys can
+	// mean, so no pane and none of the frame's own bindings see them.
+	if m.export.open {
+		return m.exportKey(msg)
+	}
+
+	// A pane that claims the key gets focus and the key, unless it already has
+	// focus, in which case the ordinary path below delivers it once.
+	if p := m.claimant(key); p != nil && p.ID() != m.state.Focus {
+		m.state.Focus = p.ID()
+		if cmd, handled := p.Update(m.state, msg); handled {
+			return m, cmd
+		}
+	}
+
+	if p := m.pane(m.state.Focus); p != nil {
+		if cmd, handled := p.Update(m.state, msg); handled {
+			return m, cmd
+		}
+	}
+
+	switch key {
+	case "tab":
+		m.focusNext(1)
+	case "shift+tab":
+		m.focusNext(-1)
+	case "e":
+		// Free everywhere else: no pane switches on it, the header claims only
+		// "/" and "f", and while the header's search field is open it consumes
+		// every rune before the frame is reached, so typing an e into a search
+		// still types an e.
+		return m.openExport()
+	case "y":
+		// The yank key, and free: no pane switches on it -- the tree owns the
+		// arrows, hjkl, g/G, enter, space and s, the detail pane the scroll set,
+		// the header / f and c, and export e. It is handled here rather than
+		// claimed by the detail pane so that it also copies while the tree has
+		// focus, and, like e, it never reaches the frame while the header's
+		// search field is open, because that field consumes every rune.
+		return m.copySnippet()
+	case "n":
+		// Aiming y, and free for the same reasons it is: no pane switches on the
+		// bare runes -- the scroll sets take ctrl+n and ctrl+p, and the modal is
+		// modal. [ and ] would have been the other obvious pair, and are not
+		// usable: both need AltGr on a German keyboard.
+		return m.armCopy(1)
+	case "p":
+		return m.armCopy(-1)
+	case "?":
+		m.showHelp = !m.showHelp
+	case "esc", "q":
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// claimant is the pane that claims a key regardless of focus.
+func (m Model) claimant(key string) Pane {
+	for _, p := range m.panes() {
+		if p == nil {
+			continue
+		}
+		for _, c := range p.Claims() {
+			if c == key {
+				return p
+			}
+		}
+	}
+	return nil
+}
+
+// focusNext moves focus by n places through the focusable panes.
+func (m *Model) focusNext(n int) {
+	var ids []PaneID
+	for _, p := range m.panes() {
+		if p != nil && p.Focusable() {
+			ids = append(ids, p.ID())
+		}
+	}
+	if len(ids) == 0 {
+		m.state.Focus = PaneNone
+		return
+	}
+	at := 0
+	for i, id := range ids {
+		if id == m.state.Focus {
+			at = i
+		}
+	}
+	next := ((at+n)%len(ids) + len(ids)) % len(ids)
+	m.state.Focus = ids[next]
+}
+
+func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// The modal covers the body, but the panes underneath it still render and
+	// still publish their zones -- so without this, a click would select a row
+	// the user cannot see. The picker is keyboard-driven; while it is up the
+	// mouse does nothing.
+	if m.export.open {
+		return m, nil
+	}
+
+	f := m.build()
+
+	switch msg.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		// The wheel scrolls what the pointer is over and leaves focus alone.
+		if p := m.pane(f.layout.PaneAt(msg.X, msg.Y)); p != nil {
+			cmd, _ := p.Update(m.state, msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	if msg.Action != tea.MouseActionPress {
+		return m, nil
+	}
+	z, ok := f.hit(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+	p := m.pane(z.Pane)
+	if p == nil {
+		return m, nil
+	}
+	if p.Focusable() {
+		m.state.Focus = z.Pane
+	}
+	m.state.Notice = ""
+	cmd, _ := p.Update(m.state, ClickMsg{Zone: z, Mouse: msg})
+	return m, cmd
+}
+
+// View implements tea.Model. The result is always exactly m.height lines of at
+// most m.width cells: the panes are sized in exact lines, and the final Fit is
+// the belt to that pair of braces.
+func (m Model) View() string {
+	if m.width < 1 || m.height < 1 {
+		return ""
+	}
+	f := m.build()
+	l := f.layout
+
+	lines := make([]string, 0, m.height)
+	lines = append(lines, tui.Fit(m.rendered(f, PaneHeader), l.HeaderH)...)
+	lines = append(lines, tui.Fit(m.body(f), l.BodyH)...)
+	lines = append(lines, m.footer(l))
+
+	lines = tui.Fit(lines, m.height)
+	for i, ln := range lines {
+		lines[i] = tui.Truncate(ln, m.width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) rendered(f frame, id PaneID) []string {
+	r, ok := f.rendered[id]
+	if !ok {
+		return nil
+	}
+	return r.Lines
+}
+
+// body draws the panels. tui.Panel is exactly the size it is given, so the two
+// columns are the same height by construction and JoinHorizontal cannot grow
+// the body.
+func (m Model) body(f frame) []string {
+	l := f.layout
+
+	// The export picker takes the body whole, across both columns: it is a
+	// question about the report, not about either pane, and a box floated over
+	// the panels would have to slice styled lines in half to do it.
+	if m.export.open {
+		return m.export.render(exportBaseName(m.state.Report),
+			tui.Rect{X: 0, Y: l.BodyTop, W: l.Width, H: l.BodyH})
+	}
+
+	panelOf := func(id PaneID, rect tui.Rect) string {
+		r := f.rendered[id]
+		title, status := r.Title, r.Status
+		focused := m.state.Focus == id
+		if focused {
+			title = tui.StyleAccent.Render(title)
+		} else {
+			title = tui.StyleDim.Render(title)
+		}
+		if status != "" {
+			status = tui.StyleFaint.Render(status)
+		}
+		return tui.Panel(title, status, r.Lines, rect.W, rect.H, tui.BorderColor(focused))
+	}
+
+	switch {
+	case l.TwoPane:
+		return strings.Split(lipgloss.JoinHorizontal(lipgloss.Top,
+			panelOf(PaneTree, l.TreePanel), " ", panelOf(PaneDetail, l.DetailPanel)), "\n")
+	case l.ShowDetail:
+		return strings.Split(panelOf(PaneDetail, l.DetailPanel), "\n")
+	default:
+		return strings.Split(panelOf(PaneTree, l.TreePanel), "\n")
+	}
+}
+
+// footer is the hint line: a notice if there is one, otherwise the focused
+// pane's key hints plus the frame's own.
+func (m Model) footer(l Layout) string {
+	if m.state.Notice != "" {
+		return tui.StyleDim.Render(tui.Truncate(" "+tui.Clean(m.state.Notice), l.Width))
+	}
+
+	// While the picker is up it owns every key, so the pane's hints and the
+	// frame's would both be advertising keys that do nothing.
+	if m.export.open {
+		return m.hintLine(exportHints(), l.Width)
+	}
+
+	hints := []Hint{}
+	if p := m.pane(m.state.Focus); p != nil {
+		hints = append(hints, p.Hints(m.state)...)
+	}
+	hints = append(hints, m.frameHints()...)
+	return m.hintLine(hints, l.Width)
+}
+
+// hintLine renders a set of bindings as the single footer row.
+func (m Model) hintLine(hints []Hint, width int) string {
+	parts := make([]string, 0, len(hints))
+	for _, h := range hints {
+		parts = append(parts, tui.Kbd(h.Key, h.Label))
+	}
+	return tui.Truncate(" "+strings.Join(parts, tui.HintSep), width)
+}
+
+// frameHints are the bindings the frame itself owns, and are shown after
+// whatever the focused pane contributes.
+//
+// n and p are the frame's, and the ? list says so. The compact list leaves them
+// to the detail pane's own hints instead, for room: the line is priority-ordered
+// left to right and the frame's keys are last, so a sixth entry here pushes ?
+// and q off an 80- or 120-column terminal -- and those are the two keys a reader
+// who is lost needs most. The pane that draws the band is also the pane where
+// aiming means anything, so that is where the short form belongs.
+//
+// ? is labelled "help" rather than "keys" because every other label on this line
+// names what the key gets you rather than how it works, and a reader who is
+// stuck is looking for help, not for a list of keys -- "keys" is the answer to a
+// question they have not thought to ask yet. Its expanded form stays "less": the
+// ? list is the one that already truncates at 120 columns, so it names the
+// direction of the toggle rather than spending five more cells repeating the
+// noun in front of ? and q.
+func (m Model) frameHints() []Hint {
+	if m.showHelp {
+		return []Hint{
+			{Key: "tab", Label: "next pane"},
+			{Key: "shift+tab", Label: "previous pane"},
+			{Key: "n/p", Label: "next / previous code block"},
+			{Key: "y", Label: "copy the highlighted code block"},
+			{Key: "e", Label: "export report"},
+			{Key: "?", Label: "less"},
+			{Key: "q", Label: m.leaveLabel},
+		}
+	}
+	return []Hint{
+		{Key: "tab", Label: "pane"},
+		{Key: "y", Label: "copy"},
+		{Key: "e", Label: "export"},
+		{Key: "?", Label: "help"},
+		{Key: "q", Label: m.leaveLabel},
+	}
+}
+
+// Embedded says the viewer is running inside another program, which changes
+// only what leaving is called: q still ends the view, but it hands control back
+// rather than ending the process, and a footer that says "quit" would be
+// telling the user something that does not happen.
+func (m Model) Embedded() Model {
+	m.leaveLabel = "back"
+	return m
+}

--- a/cli/reportview/model_test.go
+++ b/cli/reportview/model_test.go
@@ -1,0 +1,421 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "shift+tab":
+		return tea.KeyMsg{Type: tea.KeyShiftTab}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func press(m Model, s string) (Model, tea.Cmd) {
+	nm, cmd := m.Update(key(s))
+	return nm.(Model), cmd
+}
+
+// TestZonesMatchRender is the test that proves the click map and the picture
+// agree. Both come out of one Render call per pane, and this is what keeps them
+// from drifting: the row a zone names must be the row the renderer drew there.
+func TestZonesMatchRender(t *testing.T) {
+	report := loadReport(t, fixtureK8s)
+	// The placeholder goes in explicitly: this is the frame's contract, so the
+	// test names the pane whose row format it asserts against rather than
+	// taking whichever one happens to be registered. The registered tree proves
+	// the same property over its own rows in tree_test.go.
+	m := sized(NewModel(report, &assetListPane{}), 120, 40)
+
+	f := m.build()
+	lines := viewLines(m)
+	require.NotEmpty(t, f.zones)
+
+	assets := m.state.FilteredAssets()
+	// A row is " " + the status label + " " + the name, truncated to the pane. A
+	// long name is cut, so the assertion is against as much of it as fits.
+	fits := f.layout.TreeContent.W - statusLabelWidth - 2
+
+	for _, z := range f.zones {
+		require.Equal(t, PaneTree, z.Pane)
+		require.Equal(t, "asset", z.Tag)
+		require.GreaterOrEqual(t, z.Rect.Y, f.layout.TreeContent.Y, "a zone must lie inside the pane")
+		require.Less(t, z.Rect.Y, f.layout.TreeContent.Y+f.layout.TreeContent.H)
+		require.Equal(t, f.layout.TreeContent.X, z.Rect.X)
+
+		got := ansi.Strip(lines[z.Rect.Y])
+		want := []rune(assets[z.Idx].Name)
+		if len(want) > fits {
+			want = want[:fits-1] // one cell goes to the ellipsis
+		}
+		require.Contains(t, got, string(want), "zone at y=%d claims asset %d (%q)",
+			z.Rect.Y, z.Idx, assets[z.Idx].Name)
+	}
+}
+
+// A click selects what it landed on, and gives the pane that owns the zone the
+// keyboard.
+func TestClickSelectsAsset(t *testing.T) {
+	report := loadReport(t, fixtureK8s)
+	m := sized(NewModel(report), 120, 40)
+	m.state.Focus = PaneDetail
+
+	f := m.build()
+	var target Zone
+	for _, z := range f.zones {
+		if z.Idx == 3 {
+			target = z
+		}
+	}
+	require.Equal(t, 3, target.Idx, "expected a zone for the fourth asset")
+
+	nm, _ := m.Update(tea.MouseMsg{
+		X: target.Rect.X, Y: target.Rect.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = nm.(Model)
+
+	require.Equal(t, PaneTree, m.state.Focus, "the click moves focus to the pane it landed in")
+	require.Equal(t, m.state.FilteredAssets()[3], m.state.Sel.Asset)
+}
+
+// A click outside every zone changes nothing.
+func TestClickOutsideAnyZone(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	m := sized(NewModel(report), 120, 40)
+	before := m.state.SelectionRev
+
+	nm, _ := m.Update(tea.MouseMsg{
+		X: 0, Y: 0, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	require.Equal(t, before, nm.(Model).state.SelectionRev)
+}
+
+// --- errored assets ---------------------------------------------------------
+
+// An asset that failed to scan is not an asset with no findings. The k8s fixture
+// is fifteen assets, no reports and no bundle at all: the viewer has to show
+// fifteen rows and say why each of them is empty, not draw an empty screen.
+func TestErroredAssetsAreVisible(t *testing.T) {
+	report := loadReport(t, fixtureK8s)
+	require.Len(t, report.Assets, 15)
+	require.Equal(t, 15, report.AssetCounts.Errored)
+
+	m := sized(NewModel(report), 120, 40)
+	f := m.build()
+	out := ansi.Strip(m.View())
+
+	// Every asset is drawn and every one of them is clickable: fifteen rows,
+	// fifteen zones, one per asset, none of them skipped.
+	require.Len(t, f.rendered[PaneTree].Lines, 15)
+	require.Len(t, f.zones, 15)
+	seen := map[int]bool{}
+	for _, z := range f.zones {
+		seen[z.Idx] = true
+	}
+	require.Len(t, seen, 15)
+
+	// Every row says ERROR rather than looking like a clean asset -- as the
+	// glyph the tree draws an outcome with, which is a shape and not a color, so
+	// this holds on a terminal with none.
+	for _, ln := range f.rendered[PaneTree].Lines {
+		require.Contains(t, ansi.Strip(ln), statusGlyph(reportmodel.StatusError))
+	}
+
+	// The header says how many never scanned.
+	require.Contains(t, out, "15 not scanned")
+	// And the detail pane says why, rather than showing a clean bill of health.
+	require.Contains(t, out, "THIS ASSET WAS NOT SCANNED")
+	require.Contains(t, out, "asset doesn't support any")
+	require.NotContains(t, out, "0 total")
+	require.NotContains(t, out, "no assets match")
+}
+
+// The single-asset happy path still shows its findings.
+func TestScannedAssetShowsFindings(t *testing.T) {
+	report := loadReport(t, fixtureUbuntu)
+	require.Len(t, report.Assets, 1)
+	require.True(t, report.Assets[0].Scanned())
+
+	m := sized(NewModel(report), 160, 50)
+	out := ansi.Strip(m.View())
+
+	require.Contains(t, out, "ubuntu:24.04")
+	require.Contains(t, out, "FINDINGS")
+	require.NotContains(t, out, "THIS ASSET WAS NOT SCANNED")
+
+	// The four outcomes of this fixture stay four outcomes.
+	c := report.Assets[0].Counts
+	require.Equal(t, 24, c.Total)
+	require.Equal(t, 18, c.Passed)
+	require.Equal(t, 2, c.Failed)
+	require.Equal(t, 4, c.Errored)
+}
+
+// --- routing and focus ------------------------------------------------------
+
+// Tab cycles the focusable panes and skips the ones that only display.
+func TestTabCyclesFocusablePanes(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+	require.Equal(t, PaneTree, m.state.Focus, "the tree has focus on open")
+
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneDetail, m.state.Focus)
+	m, _ = press(m, "tab")
+	require.Equal(t, PaneTree, m.state.Focus, "the summary header is not focusable, so it is skipped")
+	m, _ = press(m, "shift+tab")
+	require.Equal(t, PaneDetail, m.state.Focus)
+}
+
+// A key the focused pane consumes never reaches the frame, and a key it does not
+// consume always does.
+func TestKeyFallsThroughToTheFrame(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 120, 40)
+
+	// "down" belongs to the tree; the frame must not also act on it.
+	m, cmd := press(m, "down")
+	require.Nil(t, cmd)
+	require.Equal(t, PaneTree, m.state.Focus)
+
+	// "?" belongs to nobody, so the frame takes it.
+	require.False(t, m.showHelp)
+	m, _ = press(m, "?")
+	require.True(t, m.showHelp)
+	require.Contains(t, ansi.Strip(m.View()), "previous pane")
+
+	// "q" belongs to nobody either, and the frame quits.
+	_, cmd = press(m, "q")
+	require.NotNil(t, cmd, "q must quit")
+}
+
+// The ? hint is labelled for what it gets you. Every other label on the compact
+// line -- pane, copy, export, quit -- names an outcome, and "keys" named the
+// mechanism instead: a reader who is stuck wants help, and would not think to
+// look for a list of keys. The expanded form stays "less", which names the
+// direction of the toggle on the one line that is already truncating.
+func TestTheHelpHintOffersHelp(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu)), 200, 40)
+
+	label := func(m Model, key string) string {
+		for _, h := range m.frameHints() {
+			if h.Key == key {
+				return h.Label
+			}
+		}
+		return ""
+	}
+
+	require.Equal(t, "help", label(m, "?"))
+	require.Contains(t, ansi.Strip(m.View()), "? help")
+	require.NotContains(t, ansi.Strip(m.View()), "? keys")
+
+	m, _ = press(m, "?")
+	require.True(t, m.showHelp)
+	require.Equal(t, "less", label(m, "?"))
+	// Asserted on the hint rather than on the frame: the expanded line is long
+	// enough that even 200 columns truncate it before ?, which is the whole
+	// reason its label is not lengthened to repeat the noun.
+	require.NotContains(t, ansi.Strip(m.View()), "? keys")
+}
+
+// A pane that claims a key gets focus and the key, even when the focus was
+// somewhere else. This is how a filter pane owns "/" without the frame knowing
+// what a filter is.
+func TestClaimedKeyMovesFocusAndIsDelivered(t *testing.T) {
+	claimer := &claimingPane{}
+	m := sized(NewModel(loadReport(t, fixtureUbuntu), claimer), 120, 40)
+	require.Equal(t, PaneTree, m.state.Focus)
+
+	m, _ = press(m, "/")
+	require.Equal(t, PaneDetail, m.state.Focus, "the claiming pane takes focus")
+	require.Equal(t, 1, claimer.claimed, "and receives the key exactly once")
+
+	// Once it has focus the ordinary path delivers it, still exactly once.
+	m, _ = press(m, "/")
+	require.Equal(t, 2, claimer.claimed)
+}
+
+// A pane that refuses a key it claims lets the frame have it.
+func TestUnhandledClaimStillFallsThrough(t *testing.T) {
+	claimer := &claimingPane{refuse: true}
+	m := sized(NewModel(loadReport(t, fixtureUbuntu), claimer), 120, 40)
+
+	_, cmd := press(m, "q")
+	require.NotNil(t, cmd, "the pane refused q, so the frame quits")
+}
+
+// ctrl+c always quits, whatever a pane thinks.
+func TestCtrlCAlwaysQuits(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureUbuntu), &claimingPane{}), 120, 40)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
+}
+
+// The wheel scrolls whatever the pointer is over and leaves focus alone: taking
+// the keyboard because someone looked at a pane would be a surprise.
+func TestWheelDoesNotStealFocus(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	l := m.layout()
+
+	nm, _ := m.Update(tea.MouseMsg{
+		X: l.DetailContent.X, Y: l.DetailContent.Y,
+		Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown,
+	})
+	m = nm.(Model)
+	require.Equal(t, PaneTree, m.state.Focus)
+	require.Equal(t, PaneDetail, l.PaneAt(l.DetailContent.X, l.DetailContent.Y))
+}
+
+// A message that is neither a key nor a mouse event reaches every pane, which is
+// how a pane can react to something the frame knows nothing about.
+func TestBroadcast(t *testing.T) {
+	spy := &claimingPane{}
+	m := sized(NewModel(loadReport(t, fixtureUbuntu), spy), 120, 40)
+	require.Equal(t, 1, spy.broadcasts, "the resize itself is a broadcast")
+
+	m.Update(struct{ custom string }{"hello"})
+	require.Equal(t, 2, spy.broadcasts)
+}
+
+// --- selection --------------------------------------------------------------
+
+// The selection revision is what a detail pane watches to know it should scroll
+// back to the top; re-selecting the same thing must not bump it.
+func TestSelectionRevision(t *testing.T) {
+	st := NewState(loadReport(t, fixtureK8s))
+	require.Equal(t, 1, st.SelectionRev, "opening on the first asset is a selection")
+
+	first := st.Sel.Asset
+	st.SelectAsset(first)
+	require.Equal(t, 1, st.SelectionRev, "re-selecting the same asset changes nothing")
+
+	st.SelectAsset(st.Report.Assets[1])
+	require.Equal(t, 2, st.SelectionRev)
+}
+
+// Moving the cursor in the tree is what the detail pane draws.
+func TestTreeSelectionDrivesDetail(t *testing.T) {
+	m := sized(NewModel(loadReport(t, fixtureK8s)), 120, 40)
+	assets := m.state.FilteredAssets()
+
+	m, _ = press(m, "down")
+	require.Equal(t, assets[1], m.state.Sel.Asset)
+	require.Contains(t, ansi.Strip(m.View()), assets[1].Name)
+
+	// Enter hands focus over to the detail pane, which is where the reading is.
+	m, _ = press(m, "enter")
+	require.Equal(t, PaneDetail, m.state.Focus)
+}
+
+// An empty report renders rather than panicking, and says so.
+func TestEmptyReport(t *testing.T) {
+	m := sized(NewModel(reportmodel.New(nil)), 100, 30)
+	out := ansi.Strip(m.View())
+	require.Len(t, viewLines(m), 30)
+	require.Contains(t, out, "no assets match")
+	require.Contains(t, out, "nothing selected")
+	require.Nil(t, m.state.Sel.Asset)
+}
+
+// A zero-size terminal draws nothing at all rather than one stray line.
+func TestZeroSizeRendersNothing(t *testing.T) {
+	require.Empty(t, NewModel(loadReport(t, fixtureUbuntu)).View())
+}
+
+// Passing a pane replaces whatever that slot would otherwise hold and leaves
+// the other two alone. The other two are whatever the registry says, which is a
+// real pane once one has registered itself and the placeholder until then.
+func TestPaneOverrideReplacesOneSlot(t *testing.T) {
+	m := NewModel(loadReport(t, fixtureUbuntu), &claimingPane{})
+	require.IsType(t, &claimingPane{}, m.detail)
+	require.IsType(t, buildPane(PaneTree, m.state), m.tree)
+	require.IsType(t, buildPane(PaneHeader, m.state), m.header)
+}
+
+// A slot takes one pane. Two panes fighting over one is a wiring mistake, and it
+// has to fail at init rather than resolve itself by init order -- otherwise
+// which pane you get depends on the order the files happen to be compiled in.
+//
+// The test uses a slot of its own so it cannot disturb the real three.
+func TestRegisterRejectsDuplicates(t *testing.T) {
+	const slot = PaneID(99)
+	t.Cleanup(func() { delete(registry, slot) })
+
+	want := &claimingPane{}
+	register(slot, func(*State) Pane { return want })
+	require.Same(t, want, buildPane(slot, nil))
+
+	require.Panics(t, func() { register(slot, func(*State) Pane { return nil }) })
+	require.Panics(t, func() { register(PaneID(98), nil) })
+}
+
+// An unregistered slot falls back to its placeholder, which is what makes the
+// frame runnable before any pane exists.
+func TestUnregisteredSlotFallsBackToPlaceholder(t *testing.T) {
+	// The fallback is what is under test, not which panes happen to be
+	// compiled in, so the registry is emptied for the duration.
+	saved := registry
+	registry = map[PaneID]PaneFactory{}
+	t.Cleanup(func() { registry = saved })
+
+	require.IsType(t, &summaryPane{}, buildPane(PaneHeader, nil))
+	require.IsType(t, &assetListPane{}, buildPane(PaneTree, nil))
+	require.IsType(t, &plainDetailPane{}, buildPane(PaneDetail, nil))
+	require.Nil(t, buildPane(PaneNone, nil))
+}
+
+// claimingPane is a detail-slot pane that claims "/" and counts what it is sent.
+type claimingPane struct {
+	refuse     bool
+	claimed    int
+	broadcasts int
+}
+
+func (p *claimingPane) ID() PaneID       { return PaneDetail }
+func (p *claimingPane) Focusable() bool  { return true }
+func (p *claimingPane) Claims() []string { return []string{"/", "q"} }
+func (p *claimingPane) Hints(*State) []Hint {
+	return []Hint{{Key: "/", Label: "search"}}
+}
+
+func (p *claimingPane) Render(_ *State, rect tui.Rect) Render {
+	return Render{Title: "Claim", Lines: []string{strings.Repeat("x", rect.W)}}
+}
+
+func (p *claimingPane) Update(_ *State, msg tea.Msg) (tea.Cmd, bool) {
+	k, ok := msg.(tea.KeyMsg)
+	if !ok {
+		p.broadcasts++
+		return nil, false
+	}
+	if p.refuse {
+		return nil, false
+	}
+	if k.String() == "/" {
+		p.claimed++
+		return nil, true
+	}
+	return nil, false
+}

--- a/cli/reportview/pane.go
+++ b/cli/reportview/pane.go
@@ -1,0 +1,232 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package reportview is the terminal browser for a scan report: a two-pane view
+// over the reportmodel tree, driven by `cnspec report view` and, later, by the
+// interactive launcher once a scan it started has finished.
+//
+// # The seam
+//
+// This package is a frame, not a set of panes. The frame owns the terminal: the
+// geometry, the focus, the key and mouse routing, the header band and the footer
+// hint line. Everything inside a pane -- what a row looks like, how a detail is
+// laid out, what a filter does -- belongs to a Pane, and each Pane lives in its
+// own file so that panes can be written independently of one another.
+//
+// A pane plugs in through three things and nothing else:
+//
+//   - It reads and writes *State, the small amount of state that genuinely
+//     crosses pane boundaries: the report, the selection and the filter. Per-pane
+//     state (a scroll offset, a cursor, a set of collapsed nodes) belongs to the
+//     pane's own struct, never here, so that adding a pane never edits a struct
+//     another pane also has to edit.
+//
+//   - It answers Render(st, rect) with the lines to draw *and* the clickable
+//     zones in one call. Both come out of the same pass over the same rect, which
+//     is what keeps a click on row seven landing on the thing row seven drew. The
+//     frame calls Render exactly once per frame and uses the result for drawing
+//     and for hit-testing alike.
+//
+//   - It answers Update(st, msg) with whether it handled the message. Keys go to
+//     the focused pane first; anything it does not claim falls through to the
+//     frame's own bindings. See Model.Update for the full order.
+//
+// A pane installs itself by calling RegisterTree, RegisterDetail or
+// RegisterHeader from an init function in its own file. There is no table of
+// panes to append to.
+//
+// # Invariants
+//
+// One rendered line is exactly one terminal line. No style may carry a margin: a
+// margin adds a line the geometry cannot see, and the panels are sized in exact
+// lines. Render may return fewer lines than the rect is tall (the frame pads) or
+// more (the frame drops the excess), but a single element of the slice is always
+// one row.
+//
+// Color for a status or a severity comes from SeverityStyle / StatusStyle in
+// theme.go, which resolve through components.DefaultScoreRatingColors. Do not
+// hand-pick a color for a finding: the CLI already has one and the viewer must
+// agree with it.
+//
+// Text that came from the reporter must be passed through Wrap or Clean before
+// it reaches a rendered line. NewLineCharacter is "\r\n" on Windows and a stray
+// carriage return corrupts every width calculation downstream.
+package reportview
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// PaneID names a pane. There is at most one pane per id, and the id is also its
+// slot in the layout: the header is the band across the top, the tree is the
+// left panel and the detail is the right one.
+type PaneID int
+
+const (
+	// PaneNone is the zero value: no pane.
+	PaneNone PaneID = iota
+	// PaneHeader is the band above the body. It holds the summary, the search
+	// field and the filter chips.
+	PaneHeader
+	// PaneTree is the left panel: asset -> policy -> check.
+	PaneTree
+	// PaneDetail is the right panel: everything about the selected check.
+	PaneDetail
+)
+
+// String names the pane, for hints and tests.
+func (id PaneID) String() string {
+	switch id {
+	case PaneHeader:
+		return "header"
+	case PaneTree:
+		return "tree"
+	case PaneDetail:
+		return "detail"
+	default:
+		return "none"
+	}
+}
+
+// Zone is a clickable region and the pane that owns it. Idx and Tag are the
+// pane's own business: the frame only finds the zone, focuses its pane and hands
+// the zone back in a ClickMsg.
+//
+// It deliberately does not reuse tui.ZoneKind, whose values name the launcher's
+// widgets. tui.Rect, the part that is geometry rather than vocabulary, is shared.
+type Zone struct {
+	// Rect is the region in absolute terminal cells.
+	Rect tui.Rect
+	// Pane owns the zone. The frame fills this in from the pane that returned
+	// it, so a pane may leave it zero.
+	Pane PaneID
+	// Idx identifies what was clicked within the pane, e.g. a row index.
+	Idx int
+	// Tag distinguishes kinds of target within one pane, e.g. "row" from
+	// "twisty". It is free-form and only the owning pane reads it.
+	Tag string
+}
+
+// ClickMsg is delivered to a pane when a click lands in one of its zones. The
+// frame has already moved focus to that pane by the time it arrives.
+type ClickMsg struct {
+	Zone  Zone
+	Mouse tea.MouseMsg
+}
+
+// Hint is one key binding shown in the footer.
+type Hint struct {
+	Key   string
+	Label string
+}
+
+// Render is everything a pane produces for one frame.
+//
+// Title and Status are inlaid into the top edge of the pane's border (the header
+// band has no border and ignores both). Lines are the content rows, one per
+// terminal line. Zones are the regions of those rows that respond to a click, in
+// absolute coordinates.
+//
+// Lines and Zones come out of the same call because they have to agree: a zone
+// computed in a second pass is a zone that can drift off the row it names.
+type Render struct {
+	Title  string
+	Status string
+	Lines  []string
+	Zones  []Zone
+}
+
+// Pane is one region of the viewer. Implementations live in their own file and
+// keep their own state; the only state they share is *State.
+//
+// Every method may be called several times per frame and must not block: the
+// frame calls Render on each visible pane once per View and once per mouse
+// event.
+type Pane interface {
+	// ID is the pane's slot. It must be constant.
+	ID() PaneID
+
+	// Focusable reports whether the pane takes keyboard focus. A pane that only
+	// displays -- a static summary band, say -- returns false and is skipped by
+	// the focus cycle; it can still own clickable zones.
+	Focusable() bool
+
+	// Render draws the pane into rect, which is the pane's *content* area in
+	// absolute terminal cells: for a bordered panel that is the region inside
+	// the border, so rect.W is tui.InnerWidth of the panel and rect.H is its
+	// tui.InnerHeight.
+	//
+	// Returning fewer than rect.H lines is fine (the frame pads with blanks) and
+	// so is returning more (the frame drops them), but a pane that scrolls
+	// should return exactly the rows it wants visible. Every element must be one
+	// terminal row: no line may contain "\n".
+	//
+	// Zones must lie inside rect.
+	Render(st *State, rect tui.Rect) Render
+
+	// Update handles a message routed to this pane and reports whether it
+	// consumed it. An unconsumed key falls through to the frame's own bindings,
+	// which is how "esc" can clear a search in the pane that has one and quit
+	// everywhere else.
+	//
+	// The pane mutates itself and st in place. The returned command is passed
+	// back to bubbletea.
+	Update(st *State, msg tea.Msg) (tea.Cmd, bool)
+
+	// Hints are the key bindings the footer shows while this pane has focus.
+	Hints(st *State) []Hint
+
+	// Claims are keys the pane handles even when it does not have focus, e.g.
+	// "/" to open a search. The frame moves focus to the pane and then delivers
+	// the key. Return nil for none.
+	Claims() []string
+}
+
+// SizedPane is the optional interface for a pane that decides its own height.
+// Only the header slot honors it: the tree and detail panes are sized by the
+// frame, which splits whatever the header leaves. The frame clamps the result so
+// the body always keeps at least one line.
+type SizedPane interface {
+	Pane
+	HeightFor(st *State, width int) int
+}
+
+// PaneFactory builds a pane for one viewer. It is called once per Model, so a
+// pane may hold mutable state.
+type PaneFactory func(st *State) Pane
+
+// registry holds at most one factory per slot. A pane registers itself from its
+// own file, so no two panes ever edit the same declaration.
+var registry = map[PaneID]PaneFactory{}
+
+// RegisterHeader installs the header pane: the summary band, search and filters.
+func RegisterHeader(f PaneFactory) { register(PaneHeader, f) }
+
+// RegisterTree installs the left pane: the asset -> policy -> check tree.
+func RegisterTree(f PaneFactory) { register(PaneTree, f) }
+
+// RegisterDetail installs the right pane: the detail of the selected check.
+func RegisterDetail(f PaneFactory) { register(PaneDetail, f) }
+
+// register panics on a second registration for the same slot, at init time,
+// because two panes fighting over one slot is a wiring mistake that must not
+// resolve itself by init order.
+func register(id PaneID, f PaneFactory) {
+	if f == nil {
+		panic("reportview: nil pane factory for the " + id.String() + " slot")
+	}
+	if _, exists := registry[id]; exists {
+		panic("reportview: a pane is already registered for the " + id.String() + " slot")
+	}
+	registry[id] = f
+}
+
+// buildPane returns the registered pane for a slot, or the placeholder that
+// stands in until one is registered.
+func buildPane(id PaneID, st *State) Pane {
+	if f, ok := registry[id]; ok {
+		return f(st)
+	}
+	return newPlaceholder(id, st)
+}

--- a/cli/reportview/placeholder.go
+++ b/cli/reportview/placeholder.go
@@ -1,0 +1,366 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+)
+
+// The placeholder panes. Each slot falls back to one of these until a real pane
+// registers itself, which is what makes the frame runnable on its own: the
+// command works end to end today and each pane is swapped in without touching
+// anything else.
+//
+// They are deliberately thin -- an asset list, a summary line, a plain dump of
+// the selection -- but they are not fake. They select, they scroll, they answer
+// clicks and they show an errored asset as an error, so the seam is exercised by
+// something real rather than by a box that says "tree pane goes here".
+
+func newPlaceholder(id PaneID, _ *State) Pane {
+	switch id {
+	case PaneHeader:
+		return &summaryPane{}
+	case PaneTree:
+		return &assetListPane{}
+	case PaneDetail:
+		return &plainDetailPane{}
+	default:
+		return nil
+	}
+}
+
+// --- header -----------------------------------------------------------------
+
+// summaryPane is one line: how many assets, how many of them never scanned, and
+// the tally of checks. It stands in for the real header (summary, search and
+// filter chips) and is not focusable, because there is nothing on it to drive.
+type summaryPane struct{}
+
+func (p *summaryPane) ID() PaneID      { return PaneHeader }
+func (p *summaryPane) Focusable() bool { return false }
+func (p *summaryPane) Claims() []string {
+	return nil
+}
+func (p *summaryPane) Hints(*State) []Hint { return nil }
+
+func (p *summaryPane) Update(*State, tea.Msg) (tea.Cmd, bool) { return nil, false }
+
+func (p *summaryPane) HeightFor(*State, int) int { return 1 }
+
+func (p *summaryPane) Render(st *State, rect tui.Rect) Render {
+	assets := st.Report.AssetCounts
+	checks := st.Counts()
+
+	left := " " + tui.StyleAccent.Render("✦ cnspec") + "  " +
+		tui.StyleDim.Render(fmt.Sprintf("%d assets", assets.Total))
+	// An asset that could not be scanned is the one number that must not hide
+	// inside a total.
+	if assets.Errored > 0 {
+		left += tui.StyleDim.Render(" · ") +
+			StatusStyle(reportmodel.StatusError).Render(fmt.Sprintf("%d not scanned", assets.Errored))
+	}
+
+	right := strings.Join([]string{
+		StatusStyle(reportmodel.StatusFail).Render(fmt.Sprintf("%d failed", checks.Failed)),
+		StatusStyle(reportmodel.StatusError).Render(fmt.Sprintf("%d errored", checks.Errored)),
+		StatusStyle(reportmodel.StatusPass).Render(fmt.Sprintf("%d passed", checks.Passed)),
+	}, tui.StyleDim.Render(" · ")) + " "
+
+	if st.Filter.Active() {
+		left += tui.StyleDim.Render(" · ") + tui.StyleFaint.Render(st.Filter.Describe())
+	}
+
+	return Render{Lines: []string{tui.Band(left, right, rect.W)}}
+}
+
+// --- tree -------------------------------------------------------------------
+
+// assetListPane is a flat list of assets: enough to navigate a multi-asset scan
+// and to prove the selection seam, but not the collapsible asset -> policy ->
+// check tree that replaces it.
+type assetListPane struct {
+	cursor int
+	scroll tui.Scroll
+}
+
+func (p *assetListPane) ID() PaneID       { return PaneTree }
+func (p *assetListPane) Focusable() bool  { return true }
+func (p *assetListPane) Claims() []string { return nil }
+func (p *assetListPane) Hints(*State) []Hint {
+	return []Hint{{Key: "↑/↓", Label: "asset"}, {Key: "enter", Label: "detail"}}
+}
+
+func (p *assetListPane) Render(st *State, rect tui.Rect) Render {
+	assets := st.FilteredAssets()
+	p.cursor = tui.ClampIndex(p.cursor, len(assets))
+	// The cursor is followed here rather than where it moves, because this is
+	// the only place that knows how many rows fit.
+	p.scroll.EnsureVisible(p.cursor, len(assets), rect.H)
+	off := p.scroll.Apply(len(assets), rect.H)
+
+	res := Render{
+		Title:  "Assets",
+		Status: tui.Position(p.cursor, len(assets), rect.H),
+	}
+	if len(assets) == 0 {
+		res.Lines = []string{tui.StyleFaint.Render("no assets match")}
+		return res
+	}
+
+	for i := off; i < len(assets) && i < off+rect.H; i++ {
+		a := assets[i]
+		row := i - off
+		res.Lines = append(res.Lines, p.row(st, a, i == p.cursor, rect.W))
+		res.Zones = append(res.Zones, Zone{
+			Rect: tui.Rect{X: rect.X, Y: rect.Y + row, W: rect.W, H: 1},
+			Idx:  i,
+			Tag:  "asset",
+		})
+	}
+	return res
+}
+
+func (p *assetListPane) row(st *State, a *reportmodel.Asset, selected bool, w int) string {
+	// A selected row is a full-width band, which is what makes the viewer read
+	// as an application rather than as printed lines. The band's own colors have
+	// to win, so its text goes in unstyled.
+	if selected {
+		style := tui.BandInactive
+		if st.Focus == PaneTree {
+			style = tui.BandSelected
+		}
+		return tui.Bar(" "+string(a.Status)+"  "+tui.Clean(a.Name), w, style)
+	}
+
+	label := StatusStyle(a.Status).Render(tui.PadRight(string(a.Status), statusLabelWidth))
+	name := tui.StyleText.Render(tui.Clean(a.Name))
+	if !a.Scanned() {
+		// An asset that failed to scan is not an asset with no findings, and the
+		// list is where that has to be visible.
+		name = StatusStyle(reportmodel.StatusError).Render(tui.Clean(a.Name))
+	}
+	return tui.Truncate(" "+label+" "+name, w)
+}
+
+func (p *assetListPane) Update(st *State, msg tea.Msg) (tea.Cmd, bool) {
+	assets := st.FilteredAssets()
+
+	switch msg := msg.(type) {
+	case ClickMsg:
+		if msg.Zone.Tag != "asset" {
+			return nil, false
+		}
+		p.cursor = msg.Zone.Idx
+		p.sync(st, assets)
+		return nil, true
+
+	case tea.MouseMsg:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			p.scroll.Move(-1, len(assets), 1)
+			return nil, true
+		case tea.MouseButtonWheelDown:
+			p.scroll.Move(1, len(assets), 1)
+			return nil, true
+		}
+		return nil, false
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k", "ctrl+p":
+			p.cursor--
+		case "down", "j", "ctrl+n":
+			p.cursor++
+		case "home", "g":
+			p.cursor = 0
+		case "end", "G":
+			p.cursor = len(assets) - 1
+		case "enter", "right", "l":
+			p.sync(st, assets)
+			st.Focus = PaneDetail
+			return nil, true
+		default:
+			return nil, false
+		}
+		p.cursor = tui.ClampIndex(p.cursor, len(assets))
+		p.sync(st, assets)
+		return nil, true
+	}
+	return nil, false
+}
+
+func (p *assetListPane) sync(st *State, assets []*reportmodel.Asset) {
+	p.cursor = tui.ClampIndex(p.cursor, len(assets))
+	if p.cursor < len(assets) {
+		st.SelectAsset(assets[p.cursor])
+	}
+}
+
+// --- detail -----------------------------------------------------------------
+
+// plainDetailPane dumps what is selected as wrapped text. The real detail pane
+// lays the same information out in sections; this one exists so the seam has
+// something on the other end of it.
+type plainDetailPane struct {
+	scroll tui.Scroll
+	// rev is the selection the scroll offset belongs to. A new selection starts
+	// at the top rather than halfway down the previous one.
+	rev int
+}
+
+func (p *plainDetailPane) ID() PaneID       { return PaneDetail }
+func (p *plainDetailPane) Focusable() bool  { return true }
+func (p *plainDetailPane) Claims() []string { return nil }
+func (p *plainDetailPane) Hints(*State) []Hint {
+	return []Hint{{Key: "↑/↓", Label: "scroll"}}
+}
+
+func (p *plainDetailPane) Render(st *State, rect tui.Rect) Render {
+	if p.rev != st.SelectionRev {
+		p.rev = st.SelectionRev
+		p.scroll.Off = 0
+	}
+
+	lines := p.lines(st, rect.W)
+	off := p.scroll.Apply(len(lines), rect.H)
+
+	end := off + rect.H
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return Render{
+		Title:  p.title(st),
+		Status: tui.Position(off, len(lines), rect.H),
+		Lines:  lines[off:end],
+	}
+}
+
+func (p *plainDetailPane) title(st *State) string {
+	if st.Sel.Check != nil {
+		return "Check"
+	}
+	if st.Sel.Asset != nil {
+		return "Asset"
+	}
+	return "Detail"
+}
+
+func (p *plainDetailPane) lines(st *State, w int) []string {
+	if st.Sel.Check != nil {
+		return p.checkLines(st.Sel.Check, w)
+	}
+	if st.Sel.Asset != nil {
+		return p.assetLines(st, st.Sel.Asset, w)
+	}
+	return []string{tui.StyleFaint.Render("nothing selected")}
+}
+
+func (p *plainDetailPane) assetLines(st *State, a *reportmodel.Asset, w int) []string {
+	var res []string
+	res = append(res, tui.Wrap(tui.StyleText.Render(tui.Clean(a.Name)), w)...)
+	if a.PlatformName != "" {
+		res = append(res, tui.Wrap(tui.StyleDim.Render(tui.Clean(a.PlatformName)), w)...)
+	}
+	res = append(res, "")
+	res = append(res, tui.StyleLabel.Render("STATUS")+" "+StatusStyle(a.Status).Render(string(a.Status)))
+
+	if !a.Scanned() {
+		// The whole point of the model's ScanError: say why there is nothing
+		// here, rather than showing an empty pane that looks like a clean bill
+		// of health.
+		res = append(res, "")
+		res = append(res, tui.StyleLabel.Render("THIS ASSET WAS NOT SCANNED"))
+		msg := a.ScanError
+		if msg == "" {
+			msg = "the scan produced no report and no error for this asset"
+		}
+		for _, ln := range tui.Wrap(tui.Clean(msg), w) {
+			res = append(res, StatusStyle(reportmodel.StatusError).Render(ln))
+		}
+		return res
+	}
+
+	c := a.Counts
+	res = append(res, "")
+	res = append(res, tui.StyleLabel.Render("CHECKS")+" "+tui.StyleDim.Render(fmt.Sprintf(
+		"%d total · %d passed · %d failed · %d errored · %d skipped · %d unscored",
+		c.Total, c.Passed, c.Failed, c.Errored, c.Skipped, c.Unscored)))
+
+	findings := 0
+	res = append(res, "")
+	res = append(res, tui.StyleLabel.Render("FINDINGS"))
+	for _, check := range st.FilteredChecks(a.Checks) {
+		if !check.Status.IsFinding() {
+			continue
+		}
+		findings++
+		res = append(res, tui.Truncate(" "+StatusLabel(check.Status)+" "+
+			SeverityBadge(check.Severity)+" "+tui.StyleText.Render(tui.Clean(check.Title)), w))
+	}
+	if findings == 0 {
+		res = append(res, tui.StyleFaint.Render(" none"))
+	}
+	return res
+}
+
+func (p *plainDetailPane) checkLines(c *reportmodel.Check, w int) []string {
+	d := c.Detail()
+	var res []string
+	res = append(res, tui.Wrap(tui.StyleText.Render(tui.Clean(d.Title)), w)...)
+	res = append(res, "")
+	res = append(res, StatusLabel(d.Status)+" "+SeverityBadge(d.Severity))
+	for _, section := range []struct{ label, body string }{
+		{"DESCRIPTION", d.Description},
+		{"MQL", d.Mql},
+		{"ASSESSMENT", d.Assessment},
+		{"ERROR", d.Error},
+	} {
+		if section.body == "" {
+			continue
+		}
+		res = append(res, "", tui.StyleLabel.Render(section.label))
+		res = append(res, tui.Wrap(section.body, w)...)
+	}
+	return res
+}
+
+func (p *plainDetailPane) Update(_ *State, msg tea.Msg) (tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			p.scroll.Off--
+			return nil, true
+		case tea.MouseButtonWheelDown:
+			p.scroll.Off++
+			return nil, true
+		}
+		return nil, false
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			p.scroll.Off--
+		case "down", "j":
+			p.scroll.Off++
+		case "pgup":
+			p.scroll.Off -= 10
+		case "pgdown":
+			p.scroll.Off += 10
+		case "home", "g":
+			p.scroll.Off = 0
+		default:
+			return nil, false
+		}
+		if p.scroll.Off < 0 {
+			p.scroll.Off = 0
+		}
+		return nil, true
+	}
+	return nil, false
+}

--- a/cli/reportview/risk.go
+++ b/cli/reportview/risk.go
@@ -1,0 +1,253 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/cnspec/reports/reportdoc"
+)
+
+// The risk meter: a number and four dots, the way Mondoo's web UI draws risk.
+//
+//	100 ●●●●   critical
+//	 78 ●●●○   high
+//	 51 ●●○○   medium
+//	 22 ●○○○   low
+//	  0 ○○○○   none -- scored, and nothing came of it
+//	  -        no score at all
+//
+// # The bands are cnspec's, not this file's
+//
+// reportdoc.RiskSeverityLabel already decides where one band ends and the next
+// begins (>= 90 critical, >= 70 high, >= 40 medium, >= 1 low, else none), and
+// sarif, the CLI and reportmodel.Check.Severity all read it. A second ladder
+// here would be a viewer that disagrees with the report it is viewing about
+// whether a thing is high or critical, so the band is asked for rather than
+// recomputed and the only decision left in this file is how many dots each band
+// is worth.
+//
+// The color is the same story one layer down: SeverityStyle resolves the band
+// through components.DefaultScoreRatingColors, which is the palette the CLI
+// draws its scorecard with. See the note at the top of theme.go.
+//
+// # Why the dots carry the band too
+//
+// The count is not decoration on top of the color -- it is the same fact said a
+// second way, so that the meter still reads on a monochrome terminal, under
+// NO_COLOR, in a piped `script` capture, and to a reader who cannot tell the
+// red from the amber. Four dots is critical whatever color they came out. That
+// is also why the number is drawn: three signals, one fact.
+//
+// # No score is not zero risk
+//
+// A score with no value is drawn as "-", never as four hollow dots. The two are
+// different facts and this package keeps its outcomes apart: a check that
+// errored, one that was skipped and one nobody scored have no risk to state,
+// while a check that ran and came back clean has a risk and it is zero. Reading
+// them as the same thing is how a scan that did not happen gets mistaken for a
+// clean bill of health.
+//
+// The trap is in the data rather than in the drawing. policy.Score.Value is 0
+// for every score type that carries no value, so the arithmetic behind
+// reportdoc.ScoreRisk -- 100 minus the value -- turns an errored check into risk
+// 100, which is a confident CRITICAL for a check that proved nothing.
+// reportmodel says as much where it stores Check.Risk ("read Risk together with
+// Status rather than on its own"); RiskOf is that reading, in one place.
+
+const (
+	// riskDotCount is how many dots a meter has. Four is what the web UI uses,
+	// and four bands above NONE is exactly what RiskSeverityLabel defines, so
+	// each band adds one dot.
+	riskDotCount = 4
+	// riskFilled and riskHollow are both one cell wide in every terminal that
+	// draws them (they are ambiguous-width, which x/ansi resolves as narrow --
+	// TestRiskMeterIsOneRowAndFixedWidth pins it).
+	riskFilled = "●"
+	riskHollow = "○"
+	// riskNoScore is what a thing with no score to state says instead of a
+	// number.
+	riskNoScore = "-"
+	// riskNumWidth is the room the number gets: "100" is the widest risk there
+	// is.
+	riskNumWidth = 3
+	// RiskMeterWidth is the rendered width of every meter, whatever it says. A
+	// column of them lines up, and the geometry can budget for one.
+	RiskMeterWidth = riskNumWidth + 1 + riskDotCount
+)
+
+// RiskOf is the realized risk of a score -- 0 for a check that came back clean,
+// 100 for one that failed outright -- and whether the score states one at all.
+//
+// It is false for every score that carries no value: a nil score, an error, a
+// skip, an unscored or unknown type, and a result whose completion is zero (the
+// same case policy.Score.Rating treats as unrated). See the package comment
+// above for why that gate is not optional.
+func RiskOf(score *policy.Score) (int32, bool) {
+	if score == nil || score.Type != policy.ScoreType_Result || score.Completion() == 0 {
+		return 0, false
+	}
+	risk := reportdoc.ScoreRisk(score)
+	// A score value above 100 is not a thing cnspec produces, but it is a thing
+	// a hand-edited json-full can hold, and a negative risk would render as a
+	// four-cell number in a three-cell column.
+	return min(max(risk, 0), 100), true
+}
+
+// RiskMeter draws a score as the number and the dots, RiskMeterWidth cells wide.
+// A score with no risk to state comes out as "-".
+func RiskMeter(score *policy.Score) string {
+	risk, ok := RiskOf(score)
+	return riskMeter(risk, ok)
+}
+
+// riskMeter is RiskMeter over an already-resolved risk, which is what the tests
+// walk the bands with.
+func riskMeter(risk int32, ok bool) string {
+	if !ok {
+		// The dash sits in the number's column so that it lines up with the
+		// numbers above and below it, and the dot column is left empty rather
+		// than filled with hollows -- that is the whole point of the case.
+		return tui.StyleFaint.Render(padLeftTo(riskNoScore, riskNumWidth)) +
+			strings.Repeat(" ", RiskMeterWidth-riskNumWidth)
+	}
+	style := riskStyle(risk)
+	filled := riskBandDots(riskBand(risk))
+	return style.Render(padLeftTo(strconv.Itoa(int(risk)), riskNumWidth)) + " " +
+		style.Render(strings.Repeat(riskFilled, filled)+
+			strings.Repeat(riskHollow, riskDotCount-filled))
+}
+
+// riskBand is the severity band a risk falls in. It is reporter's decision, and
+// asking for it is the whole of this package's agreement with the CLI about
+// where high stops and critical starts.
+func riskBand(risk int32) string {
+	return reportdoc.RiskSeverityLabel(risk)
+}
+
+// riskStyle is the color a risk is drawn in: its band, resolved through the
+// shared rating palette by SeverityStyle. Nothing here picks a color.
+func riskStyle(risk int32) lipgloss.Style {
+	return SeverityStyle(riskBand(risk))
+}
+
+// riskBandDots is how many of the four dots a band fills. One per band above
+// NONE, and none for NONE itself: a scored thing with no risk shows four hollow
+// dots, which is a statement, while a thing with no score shows no dots at all.
+func riskBandDots(band string) int {
+	switch band {
+	case policy.ScoreRatingTextCritical:
+		return 4
+	case policy.ScoreRatingTextHigh:
+		return 3
+	case policy.ScoreRatingTextMedium:
+		return 2
+	case policy.ScoreRatingTextLow:
+		return 1
+	default: // NONE, and anything the reporter grows later
+		return 0
+	}
+}
+
+// --- severity, drawn with the same dots -------------------------------------
+//
+// A severity is what a check is *worth* -- how bad it would be if it failed --
+// and that is a property of the check and not of how it did. So the dots say
+// two things at once and they are deliberately different things:
+//
+//	severity   outcome     drawn
+//	CRITICAL   FAIL        ●●●● in the critical color
+//	CRITICAL   PASS        ●●●● in grey
+//	HIGH       ERROR       ●●●○ in the error color's band
+//	LOW        PASS        ●○○○ in grey
+//	NONE       PASS        ○○○○ in grey
+//	(none set) ERROR       blank
+//
+// # The count is the band, always
+//
+// A passing critical check is still a critical check, so it keeps its four
+// dots. Counting the band down because the check happened to pass would be
+// drawing risk, which the meter above already draws and which is 0 for a pass.
+// The count comes from riskBandDots, the same ladder the meter uses, so the two
+// cannot drift apart about where high stops and critical starts.
+//
+// # The color is whether that severity was realized
+//
+// reportmodel.Status.IsFinding already draws the line the reader cares about --
+// fail and error on one side, pass, skipped and unscored on the other -- so it
+// is asked rather than re-derived. A finding gets its band's color; everything
+// else goes grey. What that buys is the only reason to do any of this: a pane of
+// grey with a few colored clusters in it, sized by how much they matter, is read
+// in one glance, and a pane of colored badges is read one row at a time.
+//
+// The grey is tui.StyleFaint and not a rating color on purpose. Every color that
+// *states a severity* comes from the shared palette (see theme.go), but this one
+// states the opposite -- that the severity did not happen -- and the palette has
+// no entry for that, so borrowing one would be claiming a rating the check does
+// not have. Grey is chrome, and it comes from the chrome palette.
+//
+// # Filled and hollow, so the band survives without color
+//
+// The dots are filled up to the band and hollow after it, exactly as the meter
+// draws them. Grey against red is invisible on a monochrome terminal and to a
+// good number of readers on a color one, but filled against hollow is a shape,
+// and three filled dots is HIGH whatever came out of the terminal. The status
+// glyph beside them carries the outcome the same way. Between them the row reads
+// with the color stripped entirely, which is what
+// TestACheckRowReadsWithNoColorAtAll holds.
+//
+// # No severity is not zero severity
+//
+// A check with no impact configured is drawn blank, and a check configured at
+// impact 0 is drawn ○○○○. They are different claims: one is "nobody said what
+// this is worth", the other is "somebody said it is worth nothing", and four
+// hollow dots is the second. This is the same distinction the meter makes above
+// between "-" and ○○○○, for the same reason, and the trap is in the same place:
+// reportmodel derives Check.Severity from Check.Impact, which is 0 when no
+// impact was set, so Severity reads NONE for both. Check.HasImpact is what tells
+// them apart, and checkSeverity below is that reading.
+
+// SeverityDotsWidth is the rendered width of a severity, whatever it says --
+// the same four cells as the meter's dots, so the two line up in a pane that
+// draws both.
+const SeverityDotsWidth = riskDotCount
+
+// SeverityDots draws a severity band as riskDotCount dots: filled up to the
+// band, hollow after it, colored when the severity was realized and grey when it
+// was not. An empty severity -- a check that states none at all -- is blank.
+//
+// severity is one of the policy.ScoreRatingText* labels, which is what
+// reportmodel.Check.Severity carries; realized is Status.IsFinding.
+func SeverityDots(severity string, realized bool) string {
+	if severity == "" {
+		return strings.Repeat(" ", SeverityDotsWidth)
+	}
+	style := tui.StyleFaint
+	if realized {
+		style = SeverityStyle(severity)
+	}
+	filled := riskBandDots(severity)
+	return style.Render(strings.Repeat(riskFilled, filled) +
+		strings.Repeat(riskHollow, riskDotCount-filled))
+}
+
+// riskField is the meter with the word in front of it, which is what a row of
+// mixed facts needs: on a line that already says "impact 100", a bare number is
+// a second number nobody can name.
+func riskField(score *policy.Score) string {
+	return tui.StyleFaint.Render("risk") + " " + RiskMeter(score)
+}
+
+// padLeftTo right-aligns a string in w cells, which is what a column of numbers
+// wants and padTo (which pads on the right) is not.
+func padLeftTo(s string, w int) string {
+	if d := w - tui.Width(s); d > 0 {
+		return strings.Repeat(" ", d) + s
+	}
+	return s
+}

--- a/cli/reportview/risk_test.go
+++ b/cli/reportview/risk_test.go
@@ -1,0 +1,682 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/cnspec/reports/reportdoc"
+)
+
+// meter is what a meter looks like with the colors taken off, which is also what
+// it looks like on a terminal that has none.
+func meter(score *policy.Score) string {
+	return ansi.Strip(RiskMeter(score))
+}
+
+// result builds a scored result. Completion matters: a result with none is a
+// score policy.Score.Rating itself calls unrated, and RiskOf agrees.
+func result(value uint32) *policy.Score {
+	return &policy.Score{
+		Type: policy.ScoreType_Result, Value: value,
+		DataCompletion: 100, ScoreCompletion: 100,
+	}
+}
+
+// --- the bands --------------------------------------------------------------
+
+// The bands are reportdoc.RiskSeverityLabel's, and the dots are one per band. The
+// table is written out in full rather than computed, so that a change to either
+// ladder has to be made here as well as there.
+func TestRiskMeterDrawsTheBand(t *testing.T) {
+	for _, tc := range []struct {
+		risk int32
+		want string
+	}{
+		{100, "100 ●●●●"},
+		{92, " 92 ●●●●"},
+		{90, " 90 ●●●●"},
+		{89, " 89 ●●●○"},
+		{78, " 78 ●●●○"},
+		{70, " 70 ●●●○"},
+		{69, " 69 ●●○○"},
+		{51, " 51 ●●○○"},
+		{40, " 40 ●●○○"},
+		{39, " 39 ●○○○"},
+		{22, " 22 ●○○○"},
+		{5, "  5 ●○○○"},
+		{1, "  1 ●○○○"},
+		{0, "  0 ○○○○"},
+	} {
+		require.Equal(t, tc.want, ansi.Strip(riskMeter(tc.risk, true)), "risk %d", tc.risk)
+	}
+
+	require.Equal(t, "  -     ", ansi.Strip(riskMeter(0, false)),
+		"a thing with no score says so, in the number's column")
+}
+
+// The dot count is not decoration on top of the color: it is the band, said
+// again, so the meter survives a monochrome terminal, NO_COLOR, a piped capture
+// and a reader who cannot tell the red from the amber. Every risk value from 0
+// to 100 is checked against the band reporter puts it in.
+func TestDotCountEncodesTheBandWithoutColor(t *testing.T) {
+	dots := map[string]int{
+		policy.ScoreRatingTextCritical: 4,
+		policy.ScoreRatingTextHigh:     3,
+		policy.ScoreRatingTextMedium:   2,
+		policy.ScoreRatingTextLow:      1,
+		policy.ScoreRatingTextNone:     0,
+	}
+	for risk := int32(0); risk <= 100; risk++ {
+		band := reportdoc.RiskSeverityLabel(risk)
+		want, ok := dots[band]
+		require.True(t, ok, "risk %d fell in band %q, which has no dot count", risk, band)
+
+		// Stripped, i.e. exactly what a terminal with no colors shows.
+		plain := ansi.Strip(riskMeter(risk, true))
+		require.Equal(t, want, strings.Count(plain, riskFilled),
+			"risk %d is %s and must fill %d dots: %q", risk, band, want, plain)
+		require.Equal(t, riskDotCount-want, strings.Count(plain, riskHollow), "risk %d", risk)
+	}
+}
+
+// The color is the band's, out of components.DefaultScoreRatingColors -- the
+// same palette the CLI's scorecard draws with. A fourth hand-picked severity
+// palette in this repo would be one too many; see the note at the top of
+// theme.go.
+func TestRiskColorComesFromTheRatingPalette(t *testing.T) {
+	for risk := int32(0); risk <= 100; risk++ {
+		require.Equal(t,
+			components.DefaultScoreRatingColors.LipglossColor(reportdoc.RiskSeverityLabel(risk)),
+			riskStyle(risk).GetForeground(), "risk %d", risk)
+	}
+}
+
+// --- unscored is not zero ---------------------------------------------------
+
+// The distinction the whole file exists for. "Nobody scored this" and "this
+// scored clean" are different facts and are drawn differently: a dash against
+// four hollow dots. This package keeps pass, fail, error, skipped and unscored
+// as five things, and a risk meter is not the place to quietly merge two of
+// them.
+func TestUnscoredAndZeroRiskAreDifferent(t *testing.T) {
+	require.Equal(t, "  0 ○○○○", meter(result(100)), "a check that ran and came back clean")
+	require.Equal(t, "  -     ", meter(nil), "a check nobody scored")
+	require.NotEqual(t, meter(result(100)), meter(nil))
+}
+
+// Every score type that carries no value is refused, because policy.Score.Value
+// is 0 for all of them and 100-minus-the-value would call each one a confident
+// CRITICAL. This is the trap reportmodel warns about where it stores Check.Risk.
+func TestRiskOfRefusesAScoreWithNoValue(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		score *policy.Score
+	}{
+		{"nil", nil},
+		{"unknown", &policy.Score{Type: policy.ScoreType_Unknown}},
+		{"error", &policy.Score{Type: policy.ScoreType_Error, DataCompletion: 100, ScoreCompletion: 100}},
+		{"skip", &policy.Score{Type: policy.ScoreType_Skip, DataCompletion: 100, ScoreCompletion: 100}},
+		{"unscored", &policy.Score{Type: policy.ScoreType_Unscored, DataCompletion: 100, ScoreCompletion: 100}},
+		{"out of scope", &policy.Score{Type: policy.ScoreType_OutOfScope}},
+		{"disabled", &policy.Score{Type: policy.ScoreType_Disabled}},
+		{"a result nothing completed", &policy.Score{Type: policy.ScoreType_Result}},
+	} {
+		risk, ok := RiskOf(tc.score)
+		require.False(t, ok, "%s carries no risk to state", tc.name)
+		require.Zero(t, risk)
+		require.Equal(t, "  -     ", meter(tc.score), "%s", tc.name)
+	}
+
+	risk, ok := RiskOf(result(31))
+	require.True(t, ok)
+	require.EqualValues(t, 69, risk, "risk is the inverse of the score value")
+}
+
+// A score value outside 0..100 is not something cnspec writes, but it is
+// something a hand-edited json-full holds, and a negative risk would render as a
+// four-cell number in a three-cell column.
+func TestRiskIsClampedToTheScale(t *testing.T) {
+	risk, ok := RiskOf(result(255))
+	require.True(t, ok)
+	require.Zero(t, risk)
+	require.Equal(t, RiskMeterWidth, tui.Width(meter(result(255))))
+}
+
+// --- geometry ---------------------------------------------------------------
+
+// Every meter is the same width and exactly one row, whatever it says. That is
+// what lets a column of them line up and what lets rowLine budget for one.
+func TestRiskMeterIsOneRowAndFixedWidth(t *testing.T) {
+	cases := []string{meter(nil)}
+	for risk := int32(0); risk <= 100; risk++ {
+		cases = append(cases, ansi.Strip(riskMeter(risk, true)))
+	}
+	for _, m := range cases {
+		require.Equal(t, RiskMeterWidth, tui.Width(m), "%q", m)
+		require.NotContains(t, m, "\n", "%q", m)
+	}
+	// Both glyphs are ambiguous-width runes. x/ansi resolves them as one cell,
+	// which is the assumption every width above rests on.
+	require.Equal(t, 1, tui.Width(riskFilled))
+	require.Equal(t, 1, tui.Width(riskHollow))
+}
+
+// --- where they land --------------------------------------------------------
+
+// The check page's status row is the tree's row with the words attached: the
+// same glyph in the same first cell, the same four dots for the severity, and
+// FAIL and CRIT beside them as the legend for both. The fixture supplies each of
+// the three cases: a check that failed, one that passed and one that errored
+// before it could score anything.
+func TestCheckStatusRowSpeaksTheTreesVocabulary(t *testing.T) {
+	for _, tc := range []struct {
+		title  string
+		status reportmodel.Status
+		want   string
+	}{
+		{"Ensure secure permissions on /etc/group- are set", reportmodel.StatusFail, "✗ FAIL      ●●●● CRIT"},
+		{"Ensure X Window System is not installed", reportmodel.StatusPass, "✓ PASS      ●●●● CRIT"},
+		// No impact configured, so no dots and no badge -- see
+		// TestAnErroredCheckIsNotBadgedNone below.
+		{"Only use strong Ciphers", reportmodel.StatusError, "! ERROR"},
+	} {
+		st, check := stateFor(t, fixtureUbuntu, tc.title)
+		require.Equal(t, tc.status, check.Status, tc.title)
+
+		_, lines := renderDetail(st, 100)
+		row := ansi.Strip(lines[statusRowAt(t, lines)])
+		require.True(t, strings.HasPrefix(row, tc.want),
+			"%s: row is %q, want it to open with %q", tc.title, row, tc.want)
+	}
+}
+
+// A passing critical check still shows four dots, exactly as it does in the
+// tree: the count is what the check is *worth*, and that does not move when the
+// check does well. What moves is the color -- the band's when the severity was
+// realized, grey when it was not.
+func TestTheStatusRowsDotsAreSeverityNotOutcome(t *testing.T) {
+	styled(t)
+	crit := policy.ScoreRatingTextCritical
+
+	for _, tc := range []struct {
+		title string
+		want  string
+	}{
+		{"Ensure secure permissions on /etc/group- are set", SeverityStyle(crit).Render("●●●●")},
+		{"Ensure X Window System is not installed", tui.StyleFaint.Render("●●●●")},
+	} {
+		st, _ := stateFor(t, fixtureUbuntu, tc.title)
+		_, lines := renderDetail(st, 100)
+		require.Contains(t, lines[statusRowAt(t, lines)], tc.want, tc.title)
+	}
+}
+
+// The check row carries no meter, and that is the change this row was made for:
+// its four dots are the severity, the way the tree's are, and a second four-dot
+// group next to them meaning the realized risk is the confusion the tree exists
+// to avoid.
+//
+// Nothing is lost by dropping it. RiskOf states a number only for a
+// ScoreType_Result score, and reporter defines PASS as such a score with value
+// 100 and FAIL as one below it -- so "risk 0" was precisely PASS, "risk 100" was
+// precisely FAIL, and "-" was precisely every other outcome. The glyph and the
+// word say all three, and say them without a number to decode.
+func TestTheCheckPageCarriesNoMeter(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+	require.NotEmpty(t, asset.Checks)
+
+	for _, check := range asset.Checks {
+		st.SelectCheck(asset, nil, check)
+		_, lines := renderDetail(st, 100)
+		row := ansi.Strip(lines[statusRowAt(t, lines)])
+		require.NotContains(t, row, "risk", check.Title)
+		// One dot group, not two: at most riskDotCount dots on the row.
+		dots := strings.Count(row, riskFilled) + strings.Count(row, riskHollow)
+		require.LessOrEqual(t, dots, riskDotCount, "%s: %q", check.Title, row)
+	}
+}
+
+// An errored check must not read as a rated one. reportmodel derives Severity
+// from Impact and an unset impact is 0, which RiskSeverityLabel reads as NONE --
+// so without the HasImpact gate this page would badge four checks that nobody
+// rated as rated harmless, and draw four hollow dots saying so.
+//
+// The row also cannot reach the older trap it used to have to dodge: the raw
+// Risk reportmodel stores for these checks is 100, a confident CRITICAL for a
+// check that proved nothing, and the page no longer states a risk at all.
+func TestAnErroredCheckIsNotBadgedNone(t *testing.T) {
+	st, check := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+	require.Equal(t, reportmodel.StatusError, check.Status)
+	require.False(t, check.HasImpact, "the fixture's ssh checks configure no impact")
+	require.NotNil(t, check.Score)
+	require.EqualValues(t, policy.ScoreType_Error, check.Score.Type)
+	require.EqualValues(t, 100, check.Risk, "100 minus a value that is not there")
+
+	_, lines := renderDetail(st, 100)
+	row := ansi.Strip(lines[statusRowAt(t, lines)])
+	require.Equal(t,
+		"! "+tui.PadRight(string(reportmodel.StatusError), statusLabelWidth)+
+			"  "+strings.Repeat(" ", SeverityMarkWidth), row,
+		"the severity half of the row is spent and blank, so the impact column does not move")
+	require.NotContains(t, row, riskFilled)
+	require.NotContains(t, row, riskHollow)
+	require.NotContains(t, row, policy.ScoreRatingTextNone)
+}
+
+// The alignment the row was asked for, stated as an equality rather than as a
+// pair of literals that happen to match: for every check of the fixture, the
+// glyph and the dot group the tree drew are the glyph and the dot group the
+// detail page draws. One vocabulary, two panes, and neither can be changed
+// without the other.
+func TestTheDetailRowRepeatsTheTreeRow(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 100, H: 200})
+	rows := p.build(st)
+	require.Equal(t, len(rows), len(res.Lines))
+
+	checks := 0
+	for i, r := range rows {
+		if r.kind != nodeCheck {
+			continue
+		}
+		checks++
+
+		treeRow := ansi.Strip(res.Lines[i])
+		st.SelectCheck(r.asset, r.policy, r.check)
+		_, lines := renderDetail(st, 100)
+		detailRow := ansi.Strip(lines[statusRowAt(t, lines)])
+
+		require.Equal(t, firstRune(treeRow), firstRune(detailRow),
+			"%s: the tree's glyph and the page's must be the same cell", r.check.Title)
+		require.Equal(t, dotRuns(treeRow), dotRuns(detailRow),
+			"%s: the tree's dots and the page's must be the same dots", r.check.Title)
+	}
+	require.Equal(t, 24, checks, "every check of the fixture")
+}
+
+// The row is a grid: every field is fixed-width, so the impact lands in the same
+// column on every check and arrowing down the tree does not make the row shuffle
+// under the cursor. That is what "line up in a column" buys.
+func TestTheStatusRowIsAColumn(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+
+	col := -1
+	rated := 0
+	for _, check := range asset.Checks {
+		st.SelectCheck(asset, nil, check)
+		_, lines := renderDetail(st, 100)
+		row := ansi.Strip(lines[statusRowAt(t, lines)])
+
+		// The two fixed groups, whatever they say.
+		require.GreaterOrEqual(t, tui.Width(row), StatusMarkWidth+2+SeverityMarkWidth, check.Title)
+
+		byteAt := strings.Index(row, "impact ")
+		if !check.HasImpact {
+			require.Equal(t, -1, byteAt, "%s states no impact", check.Title)
+			continue
+		}
+		rated++
+		// In cells, not bytes: the dots are three bytes each.
+		at := tui.Width(row[:byteAt])
+		if col < 0 {
+			col = at
+		}
+		require.Equal(t, col, at, "%s: the impact moved column", check.Title)
+	}
+	require.Equal(t, 20, rated, "the fixture's twenty rated checks")
+	require.Equal(t, StatusMarkWidth+2+SeverityMarkWidth+2, col,
+		"the impact starts right after the two fixed groups and their separators")
+}
+
+// firstRune is the first non-space cell of a row, which on both a tree row and a
+// status row is the status glyph.
+func firstRune(s string) string {
+	for _, r := range strings.TrimLeft(s, " ") {
+		return string(r)
+	}
+	return ""
+}
+
+// dotRuns is every maximal run of meter or severity dots in a row, so two rows
+// can be compared on what their dots say without caring where they sit.
+func dotRuns(s string) []string {
+	var res []string
+	var cur strings.Builder
+	for _, r := range s {
+		if string(r) == riskFilled || string(r) == riskHollow {
+			cur.WriteRune(r)
+			continue
+		}
+		if cur.Len() > 0 {
+			res = append(res, cur.String())
+			cur.Reset()
+		}
+	}
+	if cur.Len() > 0 {
+		res = append(res, cur.String())
+	}
+	return res
+}
+
+// An asset's page states its risk, which is the number a reader wants when the
+// question is how bad this one machine is. The meter stays here -- and only here
+// -- because an asset row has no severity for it to collide with, and because a
+// rolled-up risk really is a fact of its own rather than the status restated.
+// The tree makes the same split; see TestOnlyAssetRowsCarryAMeter.
+func TestAssetPageCarriesTheRisk(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	asset := st.Report.Assets[0]
+	st.SelectAsset(asset)
+
+	out := ansi.Strip(strings.Join(detailBody(st, 100), "\n"))
+	require.Contains(t, out, "✗ FAIL      risk 100 ●●●●")
+}
+
+// And an asset that never scanned has no risk to state. Fifteen of them here,
+// every one a "-": there is no report to take a number from, which is what the
+// section below the row goes on to say in words.
+func TestAnUnscannedAssetStatesNoRisk(t *testing.T) {
+	st := NewState(loadReport(t, fixtureK8s))
+	require.Len(t, st.Report.Assets, 15)
+
+	for _, asset := range st.Report.Assets {
+		require.False(t, asset.Scanned())
+		st.SelectAsset(asset)
+		out := ansi.Strip(strings.Join(detailBody(st, 100), "\n"))
+		require.Contains(t, out, "! ERROR     risk   -", asset.Name)
+		require.Contains(t, out, "THIS ASSET WAS NOT SCANNED", asset.Name)
+	}
+}
+
+// The tree puts the *meter* on asset rows and nowhere else. A policy row spends
+// its right-hand slot on the findings tally, and a check row draws its severity
+// on the left -- see treePane.parts for both.
+//
+// The check row now draws dots too, and this is where the pane has to keep the
+// two apart. They are different facts: the meter is the realized risk of a
+// scored thing and is 0 for a pass, the check's dots are what the check is worth
+// and do not move when it passes. What tells them apart on screen is the number:
+// a meter is "100 ●●●●" and a severity is bare dots, and they sit at opposite
+// ends of the row. This pins that a check row never grows a number in front of
+// its dots and that a policy row has neither.
+func TestOnlyAssetRowsCarryAMeter(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	rows := p.build(st)
+	lines := treeText(t, p, st)
+	require.Len(t, lines, len(rows))
+
+	assets, checks := 0, 0
+	for i, r := range rows {
+		switch r.kind {
+		case nodeAsset:
+			assets++
+			require.Contains(t, lines[i], "100 ●●●●", "asset row %d", i)
+		case nodeCheck:
+			checks++
+			// A severity is dots and nothing else. Every risk the meter can
+			// state is a number followed by a space and then the dots, so a row
+			// with no digit before its dots cannot be carrying a meter.
+			require.NotRegexp(t, `[0-9-] [`+riskFilled+riskHollow+`]`, lines[i],
+				"check row %d must not read as a risk meter", i)
+		default:
+			require.NotContains(t, lines[i], riskFilled, "row %d is a %s row", i, r.kind.tag())
+			require.NotContains(t, lines[i], riskHollow, "row %d is a %s row", i, r.kind.tag())
+		}
+	}
+	require.Equal(t, 1, assets)
+	require.Equal(t, 24, checks)
+}
+
+// --- severity, drawn with the same dots -------------------------------------
+
+// The count is the band and nothing but the band: four for critical, down to
+// none for a check somebody rated as harmless. Whether the check passed or
+// failed does not enter into it -- a passing critical check is still a critical
+// check -- so every band is checked in both states and both give the same dots.
+func TestSeverityDotsCountTheBand(t *testing.T) {
+	for _, tc := range []struct{ severity, want string }{
+		{policy.ScoreRatingTextCritical, "●●●●"},
+		{policy.ScoreRatingTextHigh, "●●●○"},
+		{policy.ScoreRatingTextMedium, "●●○○"},
+		{policy.ScoreRatingTextLow, "●○○○"},
+		{policy.ScoreRatingTextNone, "○○○○"},
+	} {
+		require.Equal(t, tc.want, ansi.Strip(SeverityDots(tc.severity, true)),
+			"%s, realized", tc.severity)
+		require.Equal(t, tc.want, ansi.Strip(SeverityDots(tc.severity, false)),
+			"%s, not realized -- the band does not shrink because the check passed",
+			tc.severity)
+	}
+
+	// And the count agrees with the ladder the risk meter uses, rather than
+	// being a second one written out by hand above.
+	for _, sev := range AllSeverities {
+		require.Equal(t, riskBandDots(sev),
+			strings.Count(ansi.Strip(SeverityDots(sev, true)), riskFilled), sev)
+	}
+}
+
+// A check that states no severity at all is blank, and a check rated NONE is
+// four hollow dots. The two are different claims -- "nobody said what this is
+// worth" against "somebody said it is worth nothing" -- and this is the same
+// distinction the meter makes between "-" and ○○○○, for the same reason.
+func TestNoSeverityAndZeroSeverityAreDifferent(t *testing.T) {
+	require.Equal(t, "○○○○", ansi.Strip(SeverityDots(policy.ScoreRatingTextNone, false)))
+	require.Equal(t, "    ", ansi.Strip(SeverityDots("", false)))
+	require.NotEqual(t, SeverityDots(policy.ScoreRatingTextNone, false), SeverityDots("", false))
+
+	// reportmodel is where the trap is: an unset impact is 0, and 0 reads as
+	// NONE, so Severity alone cannot tell the two apart. HasImpact can, and
+	// checkSeverity is the reading of the pair.
+	_, none := stateFor(t, fixtureUbuntu, "Only use strong Ciphers")
+	require.False(t, none.HasImpact, "the fixture's ssh checks configure no impact")
+	require.Equal(t, policy.ScoreRatingTextNone, none.Severity, "which still reads as NONE")
+	require.Equal(t, "", checkSeverity(none), "and must not be drawn as a rating")
+
+	_, rated := stateFor(t, fixtureUbuntu, "Ensure X Window System is not installed")
+	require.True(t, rated.HasImpact)
+	require.Equal(t, policy.ScoreRatingTextCritical, checkSeverity(rated))
+}
+
+// The color is the only thing the outcome moves, and it moves exactly where
+// Status.IsFinding draws the line: a fail and an error get the band's color out
+// of the shared rating palette, a pass, a skip and an unscored check go grey.
+// That is what makes a screen of passes read as a wall of grey with the findings
+// as the only color on it.
+//
+// The grey is tui.StyleFaint rather than a rating color on purpose: the palette has
+// no entry for "this severity did not happen", and borrowing one would be
+// claiming a rating the check does not have.
+func TestSeverityColorIsTheBandOnlyWhenItWasRealized(t *testing.T) {
+	styled(t)
+
+	for _, sev := range AllSeverities {
+		require.Equal(t,
+			SeverityStyle(sev).Render(ansi.Strip(SeverityDots(sev, true))),
+			SeverityDots(sev, true),
+			"a realized %s is drawn in the palette's color for %s", sev, sev)
+		require.Equal(t,
+			tui.StyleFaint.Render(ansi.Strip(SeverityDots(sev, false))),
+			SeverityDots(sev, false),
+			"an unrealized %s is grey", sev)
+	}
+
+	// Which is a real difference on a terminal that has colors, and no
+	// difference at all in what the dots say.
+	crit := policy.ScoreRatingTextCritical
+	require.NotEqual(t, SeverityDots(crit, true), SeverityDots(crit, false))
+	require.Equal(t, ansi.Strip(SeverityDots(crit, true)), ansi.Strip(SeverityDots(crit, false)))
+
+	// IsFinding is asked rather than re-derived, so the split is fail and error
+	// against everything else, in one place, for the whole viewer.
+	require.True(t, reportmodel.StatusFail.IsFinding())
+	require.True(t, reportmodel.StatusError.IsFinding())
+	for _, s := range []reportmodel.Status{
+		reportmodel.StatusPass, reportmodel.StatusSkipped,
+		reportmodel.StatusUnscored, reportmodel.StatusUnknown,
+	} {
+		require.False(t, s.IsFinding(), "%s is not a finding, so its severity is grey", s)
+	}
+}
+
+// Every severity is the same four cells, whatever it says, so the column lines
+// up and the title starts in the same place on every row.
+func TestSeverityDotsAreOneRowAndFixedWidth(t *testing.T) {
+	styled(t)
+	for _, sev := range append(append([]string{}, AllSeverities...), "", "NOT A BAND") {
+		for _, realized := range []bool{true, false} {
+			d := SeverityDots(sev, realized)
+			require.Equal(t, SeverityDotsWidth, tui.Width(d), "%q realized=%v", sev, realized)
+			require.NotContains(t, ansi.Strip(d), "\n", "%q", sev)
+		}
+	}
+	require.Equal(t, riskDotCount, SeverityDotsWidth,
+		"a severity and a meter's dots line up, which is why they are the same count")
+}
+
+// The whole claim, end to end and in the pane: the ubuntu fixture's failing and
+// passing critical checks draw the same four dots, and differ only in color.
+// Counting the band down for a pass would be drawing risk, which is a different
+// fact and lives in the detail pane.
+func TestAPassingCriticalCheckKeepsItsFourDots(t *testing.T) {
+	styled(t)
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 74, H: 40})
+	rows := p.build(st)
+
+	var failed, passed string
+	for i, r := range rows {
+		if r.kind != nodeCheck || checkSeverity(r.check) != policy.ScoreRatingTextCritical {
+			continue
+		}
+		switch r.check.Status {
+		case reportmodel.StatusFail:
+			failed = res.Lines[i]
+		case reportmodel.StatusPass:
+			passed = res.Lines[i]
+		}
+	}
+	require.NotEmpty(t, failed)
+	require.NotEmpty(t, passed)
+
+	require.Contains(t, ansi.Strip(failed), "✗ ●●●●")
+	require.Contains(t, ansi.Strip(passed), "✓ ●●●●",
+		"a passing critical check is still a critical check")
+	require.Contains(t, failed, SeverityStyle(policy.ScoreRatingTextCritical).Render("●●●●"))
+	require.Contains(t, passed, tui.StyleFaint.Render("●●●●"), "and its dots are grey")
+}
+
+// The errored ssh checks of the fixture configure no impact at all, so their
+// severity column is four spaces -- not four hollow dots, which would be the
+// pane claiming somebody rated them harmless.
+func TestACheckWithNoSeverityDrawsNoDots(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 74, H: 40})
+	rows := p.build(st)
+
+	unrated := 0
+	for i, r := range rows {
+		if r.kind != nodeCheck || r.check.HasImpact {
+			continue
+		}
+		unrated++
+		line := ansi.Strip(res.Lines[i])
+		require.NotContains(t, line, riskFilled, "row %d", i)
+		require.NotContains(t, line, riskHollow, "row %d", i)
+		// The cells are still spent, so the title still starts where every
+		// other title does.
+		require.Contains(t, line, "! "+strings.Repeat(" ", SeverityDotsWidth)+" ", "row %d", i)
+	}
+	require.Equal(t, 4, unrated, "the fixture's four errored ssh checks")
+}
+
+// A check row has to be readable with the color taken off entirely -- a
+// monochrome terminal, NO_COLOR, a piped `script` capture, a reader who cannot
+// tell the red from the amber. Stripped, the glyph still names the outcome and
+// the filled dots still count the band, for every check in the fixture.
+func TestACheckRowReadsWithNoColorAtAll(t *testing.T) {
+	styled(t) // colors on, so that stripping them is a real strip
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 74, H: 40})
+	rows := p.build(st)
+
+	seen := map[reportmodel.Status]int{}
+	for i, r := range rows {
+		if r.kind != nodeCheck {
+			continue
+		}
+		plain := ansi.Strip(res.Lines[i])
+		require.NotContains(t, plain, "\x1b", "row %d still carries an escape", i)
+		seen[r.check.Status]++
+
+		// The outcome, from the glyph alone.
+		require.Equal(t, statusGlyph(r.check.Status), strings.Fields(plain)[0],
+			"row %d: %q", i, plain)
+		// The band, from the filled dots alone.
+		require.Equal(t, riskBandDots(checkSeverity(r.check)),
+			strings.Count(plain, riskFilled), "row %d: %q", i, plain)
+		// And the rest of the row is the title, in full: what the two columns
+		// gave up in width went here.
+		require.True(t, strings.HasSuffix(plain, r.check.Title), "row %d: %q", i, plain)
+	}
+	require.Equal(t, map[reportmodel.Status]int{
+		reportmodel.StatusPass: 18, reportmodel.StatusFail: 2, reportmodel.StatusError: 4,
+	}, seen, "the fixture's spread of outcomes")
+}
+
+// The meter is a right-aligned tag like any other, so a pane too narrow for one
+// drops it rather than letting it eat the asset name. rowLine already had that
+// rule; this pins that the meter obeys it.
+func TestANarrowTreeDropsTheMeterBeforeTheName(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+
+	for _, w := range []int{1, 2, 8, 12, 19, 20, 21, 40, 74} {
+		res := p.Render(st, tui.Rect{X: 0, Y: 0, W: w, H: 20})
+		for i, ln := range res.Lines {
+			require.LessOrEqual(t, tui.Width(ln), w, "w=%d row %d: %q", w, i, ansi.Strip(ln))
+		}
+		if w <= 20 {
+			require.NotContains(t, ansi.Strip(res.Lines[0]), riskFilled,
+				"w=%d has no room for a meter", w)
+		}
+	}
+	require.Contains(t, ansi.Strip(p.Render(st, tui.Rect{X: 0, Y: 0, W: 74, H: 20}).Lines[0]), "100 ●●●●")
+}
+
+// statusRowAt is the index of a detail page's status row: the first row that
+// opens with a status glyph and the word for it, which is the row directly under
+// the title block on both the check page and the asset page.
+func statusRowAt(t *testing.T, lines []string) int {
+	t.Helper()
+	for i, ln := range lines {
+		s := ansi.Strip(ln)
+		for _, st := range AllStatuses {
+			if strings.HasPrefix(s, statusGlyph(st)+" "+string(st)) {
+				return i
+			}
+		}
+	}
+	t.Fatalf("no status row in %q", lines)
+	return -1
+}

--- a/cli/reportview/run.go
+++ b/cli/reportview/run.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Run opens the viewer on a report and blocks until the user quits.
+//
+// The alt-screen is deliberate: the viewer takes the terminal, and the scrollback
+// the user had before it is theirs again afterwards. Mouse cell motion is on so
+// panes can report clicks through their zones.
+func Run(report *reportmodel.Report) error {
+	m := NewModel(report)
+	_, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
+	if err != nil {
+		return errors.Wrap(err, "report viewer failed")
+	}
+	return nil
+}
+
+// RunCollection builds the model from a report collection and opens the viewer
+// on it. It is the whole of what a caller with a loaded scan has to do.
+func RunCollection(collection *policy.ReportCollection) error {
+	return Run(reportmodel.New(collection))
+}

--- a/cli/reportview/state.go
+++ b/cli/reportview/state.go
@@ -1,0 +1,151 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"go.mondoo.com/cnspec/cli/reportmodel"
+)
+
+// State is what the panes share, and nothing more.
+//
+// The rule for whether something belongs here: does another pane have to see it?
+// The selected check does -- the tree sets it and the detail draws it. The
+// filter does -- the header sets it and the tree obeys it. A scroll offset, a
+// cursor, a set of collapsed nodes and an open twisty do not: they are the
+// pane's own business and live on the pane's own struct, which is what lets
+// three panes be written at once without editing one file between them.
+//
+// A pane mutates State in place through the methods below. The methods exist so
+// that a change carries its consequences with it: Select bumps SelectionRev so a
+// detail pane knows to scroll back to the top, and SetFilter bumps FilterRev so
+// a tree knows to rebuild its rows.
+type State struct {
+	// Report is the model being browsed. It is never nil, but it may be empty.
+	Report *reportmodel.Report
+
+	// Sel is what the panes agree is selected right now.
+	Sel Selection
+	// SelectionRev increments on every change to Sel. A pane that caches
+	// anything derived from the selection compares this against the revision it
+	// cached at, rather than comparing pointers.
+	SelectionRev int
+
+	// Filter narrows what the tree shows. It is owned by the header pane and
+	// read by everyone else; use Filtered* rather than reimplementing it.
+	Filter Filter
+	// FilterRev increments on every change to Filter.
+	FilterRev int
+
+	// Focus is the pane that keys go to. The frame maintains it; a pane may set
+	// it to hand focus on (the tree does this when enter opens a check).
+	Focus PaneID
+
+	// Notice is a single line of feedback shown in the footer instead of the key
+	// hints. The frame clears it on the next keypress, so it is for "copied",
+	// "no more matches" and the like, not for permanent status.
+	Notice string
+}
+
+// Selection is the asset, policy and check the panes agree on.
+//
+// The three fields are not independent: Check belongs to Policy, which ran on
+// Asset. A selection may stop early -- an asset with no policies selects only an
+// asset, and an asset that failed to scan can never select more than itself.
+type Selection struct {
+	Asset  *reportmodel.Asset
+	Policy *reportmodel.Policy
+	Check  *reportmodel.Check
+}
+
+// NewState builds the shared state for a report. A nil report is replaced by an
+// empty one so no pane has to nil-check it.
+func NewState(report *reportmodel.Report) *State {
+	if report == nil {
+		report = reportmodel.New(nil)
+	}
+	st := &State{Report: report, Focus: PaneTree}
+	// Select something immediately: a viewer that opens on an empty detail pane
+	// looks broken, and the first asset is the only defensible default.
+	if len(report.Assets) > 0 {
+		st.Select(Selection{Asset: report.Assets[0]})
+	}
+	return st
+}
+
+// Select replaces the selection and bumps SelectionRev. It is a no-op when
+// nothing actually changes, so a tree may call it on every cursor move without
+// resetting the detail pane's scroll.
+func (s *State) Select(sel Selection) {
+	if s.Sel == sel {
+		return
+	}
+	s.Sel = sel
+	s.SelectionRev++
+}
+
+// SelectAsset selects an asset and clears the policy and check beneath it.
+func (s *State) SelectAsset(a *reportmodel.Asset) {
+	s.Select(Selection{Asset: a})
+}
+
+// SelectCheck selects a check within an asset, optionally within a policy.
+func (s *State) SelectCheck(a *reportmodel.Asset, p *reportmodel.Policy, c *reportmodel.Check) {
+	s.Select(Selection{Asset: a, Policy: p, Check: c})
+}
+
+// SetFilter replaces the filter and bumps FilterRev. Like Select it is a no-op
+// when nothing changes.
+func (s *State) SetFilter(f Filter) {
+	if s.Filter.Equal(f) {
+		return
+	}
+	s.Filter = f
+	s.FilterRev++
+}
+
+// FilteredAssets is the assets that survive the current filter, in model order.
+// It is the one implementation of "what the tree shows", so the header's count
+// and the tree's rows can never disagree.
+func (s *State) FilteredAssets() []*reportmodel.Asset {
+	if !s.Filter.Active() {
+		return s.Report.Assets
+	}
+	res := make([]*reportmodel.Asset, 0, len(s.Report.Assets))
+	for _, a := range s.Report.Assets {
+		if s.Filter.MatchAsset(a) {
+			res = append(res, a)
+		}
+	}
+	return res
+}
+
+// FilteredChecks is the checks of an asset that survive the current filter, in
+// model order.
+func (s *State) FilteredChecks(checks []*reportmodel.Check) []*reportmodel.Check {
+	if !s.Filter.Active() {
+		return checks
+	}
+	res := make([]*reportmodel.Check, 0, len(checks))
+	for _, c := range checks {
+		if s.Filter.MatchCheck(c) {
+			res = append(res, c)
+		}
+	}
+	return res
+}
+
+// Counts tallies the checks that survive the current filter across every asset,
+// so the header can report "showing N of M" without walking the tree itself.
+func (s *State) Counts() reportmodel.Counts {
+	if !s.Filter.Active() {
+		return s.Report.CheckCounts
+	}
+	var res reportmodel.Counts
+	for _, a := range s.Report.Assets {
+		for _, c := range s.FilteredChecks(a.Checks) {
+			res.Add(c.Status)
+		}
+	}
+	return res
+}

--- a/cli/reportview/theme.go
+++ b/cli/reportview/theme.go
@@ -1,0 +1,203 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Every color a finding is drawn in comes from here, and everything here comes
+// from tui.Ratings -- which is components.DefaultScoreRatingColors, the one
+// rating palette in this repo that is already expressed as lipgloss colors. A
+// pane must not pick its own color for a status or a severity:
+// cli/progress/todolist.go hand-copied that map once already and the launcher
+// picked its three by eye, and three disagreeing ideas of what "high" looks
+// like is two too many.
+//
+// The chrome the frame is drawn in -- the accent, the three text weights, the
+// bands, the border -- lives in cli/tui and is shared with the launcher, so the
+// two programs look like one. What is left here is the half that is about a
+// report: how an outcome and a severity turn into a color, a glyph and a badge.
+
+// StatusRating maps a check outcome onto the rating label whose color it should
+// be drawn in. It is the only place the two vocabularies meet.
+//
+// The mapping keeps all six outcomes apart, because they mean different things:
+// a check that could not run is not a check that passed, and a check nobody
+// scored is not a check that failed.
+func StatusRating(s reportmodel.Status) string {
+	switch s {
+	case reportmodel.StatusPass:
+		return policy.ScoreRatingTextNone
+	case reportmodel.StatusFail:
+		return policy.ScoreRatingTextCritical
+	case reportmodel.StatusError:
+		return policy.ScoreRatingTextError
+	case reportmodel.StatusSkipped:
+		return policy.ScoreRatingTextSkip
+	default: // UNSCORED, UNKNOWN
+		return policy.ScoreRatingTextUnrated
+	}
+}
+
+// StatusStyle is the lipgloss style a status is drawn in.
+func StatusStyle(s reportmodel.Status) lipgloss.Style {
+	return tui.Ratings.LipglossStyle(StatusRating(s))
+}
+
+// SeverityStyle is the lipgloss style a severity label is drawn in. The label is
+// one of the policy.ScoreRatingText* values, which is what
+// reportmodel.Check.Severity carries.
+func SeverityStyle(severity string) lipgloss.Style {
+	return tui.Ratings.LipglossStyle(severity)
+}
+
+// StatusIcon is the emoji for a status, from the model so the viewer and the
+// reporter show the same glyph. It is two cells wide for every status.
+//
+// That width is why no pane of this viewer draws it. A rendered line here is
+// exactly one terminal row of a known width, and an emoji is the one thing that
+// makes ansi.StringWidth and the terminal disagree: ✅ and ❌ are
+// Emoji_Presentation and measure two, ⚠️ and ⏭️ carry a variation selector that
+// some terminals honor and some ignore, and a glyph that is two cells here and
+// one cell there is a pane that is one column too wide on somebody else's
+// machine. StatusGlyph is what a row uses; this stays because the emoji is the
+// vocabulary of the reporter's markdown and json output, where width is nobody's
+// problem, and a caller wanting to match those should have it from one place.
+func StatusIcon(s reportmodel.Status) string {
+	return s.Icon()
+}
+
+// StatusGlyph renders a status as a single colored cell, which is what a list
+// of hundreds of rows can afford to spend on an outcome.
+//
+// # Why a mark for two of them and punctuation for the rest
+//
+// The six glyphs are not six arbitrary picks. A check either reached a verdict
+// or it did not, and the shape says which:
+//
+//	✓  PASS      the check ran and the answer was yes
+//	✗  FAIL      the check ran and the answer was no
+//	!  ERROR     it could not run, and that needs a human
+//	»  SKIPPED   it was stepped over on purpose
+//	i  UNSCORED  it reported, and nothing scores it
+//	?  UNKNOWN   nobody can say
+//
+// A tick and a cross are verdicts. The other four are punctuation because none
+// of them is a verdict -- an errored check has *proved* nothing, which is
+// exactly what reportmodel says about it -- and a reader who learns that one
+// rule can read a row they have never seen before. Colour then separates the
+// four further, but the shape alone already says "no answer here", which is the
+// thing a monochrome terminal has to be able to tell.
+//
+// The six stay six. They are six different facts and collapsing them into a
+// tick and a cross would say a check nobody scored is a check that failed.
+//
+// # Why not ⚠ for the error
+//
+// Because it is not reliably one cell. U+26A0 has Emoji_Presentation=No, so
+// ansi.StringWidth calls it narrow and the geometry tests would pass, but a
+// terminal that renders it in emoji presentation anyway draws it two cells wide
+// and every row below shifts. The same goes for ✔ and ✘ (U+2714/U+2718), which
+// are the emoji-presentation cousins of the two marks used here. ASCII cannot
+// be widened by anybody's font, so the three glyphs that carry the most risk of
+// being drawn as emoji are ASCII.
+func StatusGlyph(s reportmodel.Status) string {
+	return StatusStyle(s).Render(statusGlyph(s))
+}
+
+// statusGlyph is the uncolored cell, which is what the width and the
+// monochrome-readability tests measure.
+func statusGlyph(s reportmodel.Status) string {
+	switch s {
+	case reportmodel.StatusPass:
+		return "✓"
+	case reportmodel.StatusFail:
+		return "✗"
+	case reportmodel.StatusError:
+		return "!"
+	case reportmodel.StatusSkipped:
+		return "»"
+	case reportmodel.StatusUnscored:
+		return "i"
+	default: // UNKNOWN, and anything reportmodel grows later
+		return "?"
+	}
+}
+
+// StatusGlyphWidth is the rendered width of every glyph. It is one, and
+// TestStatusGlyphsAreOneCell holds it there: the pane's geometry budgets for a
+// column of these, and a two-cell glyph would push a row past the rect it was
+// measured for.
+const StatusGlyphWidth = 1
+
+// StatusLabel renders a status as a fixed-width colored word, so a column of
+// them lines up: "PASS    ", "ERROR   ", "UNSCORED".
+//
+// The detail pane and the plain-text fallback still spell the outcome out. They
+// are pages being read rather than lists being scanned, the word names the
+// outcome exactly, and it survives a grep of a captured session -- see the note
+// on statusRow in detail.go.
+func StatusLabel(s reportmodel.Status) string {
+	return StatusStyle(s).Render(tui.PadRight(string(s), statusLabelWidth))
+}
+
+// statusLabelWidth is the width of the longest status, UNSCORED.
+const statusLabelWidth = 8
+
+// StatusMark is the glyph and the word together: the cell a list row spends on
+// an outcome, with the word that says what it meant printed next to it.
+//
+// It is what the detail pane's status rows draw, and it is the only place in the
+// viewer where the two vocabularies meet on purpose. A reader arrives at that
+// row from a tree full of "✗" and leaves it knowing that "✗" is FAIL; a row that
+// carried only the word would send them back no wiser, and one that carried only
+// the glyph would leave the tree unexplained anywhere.
+func StatusMark(s reportmodel.Status) string {
+	return StatusGlyph(s) + " " + StatusLabel(s)
+}
+
+// StatusMarkWidth is the rendered width of every StatusMark, so a row built out
+// of one starts its next field in the same column whatever the outcome was.
+const StatusMarkWidth = StatusGlyphWidth + 1 + statusLabelWidth
+
+// SeverityMark is SeverityDots and SeverityBadge together, the severity half of
+// the same idea: the tree's four dots with the band named beside them.
+//
+// severity is one of the policy.ScoreRatingText* labels and empty for a check
+// that states none, realized is Status.IsFinding -- both exactly as SeverityDots
+// takes them, so the dots here and the dots in the tree cannot drift apart. An
+// empty severity draws blank on both halves rather than "NONE": nobody rating a
+// check is not somebody rating it harmless.
+func SeverityMark(severity string, realized bool) string {
+	return SeverityDots(severity, realized) + " " + SeverityBadge(severity)
+}
+
+// SeverityMarkWidth is the rendered width of every SeverityMark.
+const SeverityMarkWidth = SeverityDotsWidth + 1 + severityBadgeWidth
+
+// SeverityBadge renders a severity as a short colored tag: "CRIT", "HIGH",
+// "MED", "LOW", "NONE". It is always severityBadgeWidth cells wide, and blank
+// for a check with no severity at all.
+func SeverityBadge(severity string) string {
+	short := map[string]string{
+		policy.ScoreRatingTextCritical: "CRIT",
+		policy.ScoreRatingTextHigh:     "HIGH",
+		policy.ScoreRatingTextMedium:   "MED",
+		policy.ScoreRatingTextLow:      "LOW",
+		policy.ScoreRatingTextNone:     "NONE",
+	}[severity]
+	if short == "" {
+		return strings.Repeat(" ", severityBadgeWidth)
+	}
+	return SeverityStyle(severity).Render(tui.PadRight(short, severityBadgeWidth))
+}
+
+// severityBadgeWidth is the width of the longest severity badge.
+const severityBadgeWidth = 4

--- a/cli/reportview/theme_test.go
+++ b/cli/reportview/theme_test.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The one rule the palette exists for: a status or severity color comes from
+// components.DefaultScoreRatingColors, the rating palette the CLI already uses.
+// Picking one by hand is how cli/progress and the launcher ended up disagreeing
+// about what "high" looks like.
+func TestColorsComeFromTheRatingPalette(t *testing.T) {
+	for _, sev := range AllSeverities {
+		require.Equal(t,
+			components.DefaultScoreRatingColors.LipglossColor(sev),
+			SeverityStyle(sev).GetForeground(),
+			"severity %q", sev)
+	}
+
+	for _, s := range AllStatuses {
+		require.Equal(t,
+			components.DefaultScoreRatingColors.LipglossColor(StatusRating(s)),
+			StatusStyle(s).GetForeground(),
+			"status %q", s)
+	}
+}
+
+// All six outcomes have to stay distinguishable. Pass, fail, error and skip get
+// four different colors; unscored and unknown share the unrated color, which is
+// right -- both mean "nobody scored this" -- but neither is ever painted as a
+// pass.
+func TestStatusColorsDistinguishOutcomes(t *testing.T) {
+	require.Equal(t, policy.ScoreRatingTextNone, StatusRating(reportmodel.StatusPass))
+	require.Equal(t, policy.ScoreRatingTextCritical, StatusRating(reportmodel.StatusFail))
+	require.Equal(t, policy.ScoreRatingTextError, StatusRating(reportmodel.StatusError))
+	require.Equal(t, policy.ScoreRatingTextSkip, StatusRating(reportmodel.StatusSkipped))
+	require.Equal(t, policy.ScoreRatingTextUnrated, StatusRating(reportmodel.StatusUnscored))
+	require.Equal(t, policy.ScoreRatingTextUnrated, StatusRating(reportmodel.StatusUnknown))
+
+	pass := StatusStyle(reportmodel.StatusPass).GetForeground()
+	for _, s := range []reportmodel.Status{
+		reportmodel.StatusFail, reportmodel.StatusError,
+		reportmodel.StatusSkipped, reportmodel.StatusUnscored, reportmodel.StatusUnknown,
+	} {
+		require.NotEqual(t, pass, StatusStyle(s).GetForeground(), "%q must not look like a pass", s)
+	}
+}
+
+// Badges are fixed width so that a column of them lines up.
+func TestBadgeWidths(t *testing.T) {
+	for _, s := range AllStatuses {
+		require.Equal(t, statusLabelWidth, ansi.StringWidth(ansi.Strip(StatusLabel(s))), "status %q", s)
+	}
+	for _, sev := range AllSeverities {
+		require.Equal(t, severityBadgeWidth, ansi.StringWidth(ansi.Strip(SeverityBadge(sev))), "severity %q", sev)
+	}
+	require.Equal(t, severityBadgeWidth, ansi.StringWidth(SeverityBadge("")), "an unknown severity is blank, not narrow")
+}
+
+// Every status glyph is exactly one cell. This is not a style rule: a pane of
+// this viewer assumes one rendered line is one terminal row of a known width, so
+// a glyph the terminal draws two cells wide pushes the row past the rect it was
+// measured for and the frame drifts.
+//
+// It is measured rather than eyeballed because the runes that look right are
+// exactly the ones that are not safe. An emoji-presentation glyph -- ✅, ❌, and
+// any of the emoji sequences reportmodel.Status.Icon returns -- is two cells,
+// and ⚠, ✔ and ✘ are one cell by the standard and two on a terminal that
+// renders them as emoji anyway. The glyphs used here are two text-presentation
+// marks and three ASCII characters, none of which any font can widen.
+func TestStatusGlyphsAreOneCell(t *testing.T) {
+	for _, s := range AllStatuses {
+		require.Equal(t, StatusGlyphWidth, ansi.StringWidth(statusGlyph(s)), "status %q", s)
+		require.Equal(t, StatusGlyphWidth, ansi.StringWidth(ansi.Strip(StatusGlyph(s))), "status %q", s)
+	}
+	// A status nobody has heard of still gets its one cell rather than none.
+	require.Equal(t, StatusGlyphWidth, ansi.StringWidth(statusGlyph(reportmodel.Status("WAT"))))
+
+	// The emoji this replaced, for the record: two cells, which is why it is
+	// not what a row draws.
+	require.Equal(t, 2, ansi.StringWidth(StatusIcon(reportmodel.StatusPass)))
+}
+
+// The six outcomes stay six. Pass, fail, error, skipped, unscored and unknown
+// mean different things -- a check that could not run is not a check that
+// passed, and a check nobody scored is not a check that failed -- so no two of
+// them may share a glyph. reportmodel's own emoji already spends ℹ️ on two of
+// them, which is one reason the pane does not use it.
+func TestTheStatusGlyphKeepsTheOutcomesApart(t *testing.T) {
+	seen := map[string]reportmodel.Status{}
+	for _, s := range AllStatuses {
+		g := statusGlyph(s)
+		require.NotContains(t, seen, g, "%q and %q would both draw %q", seen[g], s, g)
+		seen[g] = s
+	}
+	require.Len(t, seen, len(AllStatuses))
+
+	// And the shape says which side of the line the outcome is on before the
+	// color does: a mark is a verdict, punctuation is the absence of one.
+	require.Equal(t, "✓", statusGlyph(reportmodel.StatusPass))
+	require.Equal(t, "✗", statusGlyph(reportmodel.StatusFail))
+	for _, s := range []reportmodel.Status{
+		reportmodel.StatusError, reportmodel.StatusSkipped,
+		reportmodel.StatusUnscored, reportmodel.StatusUnknown,
+	} {
+		require.NotContains(t, "✓✗", statusGlyph(s), "%s reached no verdict", s)
+	}
+}
+
+// The glyph is colored out of the shared rating palette, exactly as the word it
+// replaced was. A pane that picked its own color for an outcome would be the
+// fourth idea in this repo of what "high" looks like; see the note at the top of
+// theme.go.
+func TestTheStatusGlyphTakesItsColorFromTheStatusStyle(t *testing.T) {
+	for _, s := range AllStatuses {
+		require.Equal(t, StatusStyle(s).Render(statusGlyph(s)), StatusGlyph(s), "status %q", s)
+	}
+}

--- a/cli/reportview/tree.go
+++ b/cli/reportview/tree.go
@@ -1,0 +1,943 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The tree pane: asset -> policy -> check, collapsible.
+//
+// A scan is a tree and not a list, because a check belongs to a policy and a
+// policy ran on an asset, and the same check on two assets is two different
+// outcomes. Flattening that into one list of findings loses the only thing that
+// tells you where to go and fix something.
+//
+// Everything the pane needs to remember -- the cursor, the scroll offset, which
+// nodes are folded -- lives on treePane. Nothing about folding is in State,
+// because no other pane has any business knowing what this one has open.
+//
+// # What a row is
+//
+// The pane keeps a flat []row, rebuilt whenever the filter or the fold state
+// changes, and every visible row is exactly one terminal line and exactly one
+// Zone. Row i of the slice is drawn at y = rect.Y + i - scroll, and the zone
+// emitted for it carries Idx = i, which is what makes a click land on the thing
+// the user pointed at rather than on the thing that was there before the last
+// resize.
+//
+// # Folding
+//
+// fold records only what the user has explicitly opened or closed. Everything
+// else falls back to a default, which is what lets a single-asset report open
+// with its one asset already unfolded without that decision surviving as state
+// the user then has to undo. See treePane.open.
+//
+// # Order
+//
+// The tree opens on what is broken, not on what happens to come first in the
+// alphabet: see Order and the rank ladder below. The model hands the pane its
+// nodes in name order and the pane re-sorts a copy of them, so the order is the
+// viewer's decision and not something a later change to reportmodel can move.
+
+func init() {
+	RegisterTree(func(*State) Pane { return newTree() })
+}
+
+// nodeKind is the level of the tree a row sits at.
+type nodeKind int
+
+const (
+	nodeAsset nodeKind = iota
+	nodePolicy
+	nodeCheck
+)
+
+// tag is the Zone tag for rows of this kind. It is what a click handler reads to
+// know what it was given, and what a test reads to check that the click map and
+// the picture agree.
+func (k nodeKind) tag() string {
+	switch k {
+	case nodePolicy:
+		return "policy"
+	case nodeCheck:
+		return "check"
+	default:
+		return "asset"
+	}
+}
+
+// row is one line of the tree.
+//
+// key identifies the node across a rebuild: a fold state and a cursor are both
+// remembered by key rather than by index, so filtering something out from above
+// the cursor does not move the cursor onto a different check.
+type row struct {
+	kind  nodeKind
+	depth int
+	key   string
+	// parent is the key of the row this one hangs off, empty at the top level.
+	parent string
+	// branch says the node has children to show. An asset that failed to scan
+	// is not a branch: it is a leaf that says why, not an empty node that
+	// invites you to open nothing.
+	branch bool
+	// open says its children are currently shown.
+	open bool
+
+	asset  *reportmodel.Asset
+	policy *reportmodel.Policy
+	check  *reportmodel.Check
+}
+
+// treePane is the left pane.
+type treePane struct {
+	cursor int
+	// cursorKey is the identity of the row the cursor is on, so that a rebuild
+	// puts the cursor back on the same node rather than on the same index.
+	cursorKey string
+	scroll    tui.Scroll
+	// page is the number of rows the last render could show, which is what
+	// page up and page down move by. It is a render-time fact, so it is only
+	// ever written there.
+	page int
+
+	// fold holds the nodes the user has explicitly opened (true) or closed
+	// (false). A node that is not in here uses its default, see open.
+	fold map[string]bool
+	// order is how the rows are sorted. It starts at OrderOutcome, which is the
+	// whole point of the pane opening on findings rather than on the alphabet.
+	order Order
+	// revision is bumped by every change of the pane's own that alters the rows
+	// -- a fold or a change of order -- so build can tell in one comparison
+	// whether the rows it cached are still the rows to draw.
+	revision int
+
+	// rows is the flattened tree, and the three revisions below are what it was
+	// built from. Rebuilding is cheap but not free -- a large scan is tens of
+	// thousands of checks -- and Render is called on every mouse event.
+	rows      []row
+	built     bool
+	builtFor  *reportmodel.Report
+	filterRev int
+	builtRev  int
+}
+
+func newTree() *treePane {
+	return &treePane{fold: map[string]bool{}, page: defaultPage}
+}
+
+// defaultPage is what page up and page down move by before anything has been
+// rendered, i.e. only in a test that drives Update without a Render.
+const defaultPage = 10
+
+func (p *treePane) ID() PaneID       { return PaneTree }
+func (p *treePane) Focusable() bool  { return true }
+func (p *treePane) Claims() []string { return nil }
+
+// Hints name the keys of the pane. The sort hint says what the tree is sorted by
+// now rather than what the key will do next, because "outcome" is the answer to
+// the question a reader of an unfamiliar list actually has.
+func (p *treePane) Hints(*State) []Hint {
+	return []Hint{
+		{Key: "↑/↓", Label: "move"},
+		{Key: "←/→", Label: "fold"},
+		{Key: "enter", Label: "open"},
+		{Key: "⇧←/⇧→", Label: "fold all"},
+		{Key: "s", Label: "sort: " + p.order.Label()},
+	}
+}
+
+// --- building the rows ------------------------------------------------------
+
+// build returns the flattened tree for the current filter and fold state, and
+// puts the cursor back on the node it was on.
+func (p *treePane) build(st *State) []row {
+	if p.built && p.builtFor == st.Report && p.filterRev == st.FilterRev && p.builtRev == p.revision {
+		return p.rows
+	}
+
+	p.rows = p.flatten(st)
+	p.built = true
+	p.builtFor = st.Report
+	p.filterRev = st.FilterRev
+	p.builtRev = p.revision
+	p.locate()
+	return p.rows
+}
+
+func (p *treePane) flatten(st *State) []row {
+	assets := p.sortAssets(st.FilteredAssets())
+	// A single-asset report opens on its asset already unfolded: the top level
+	// of a one-asset tree carries no information the panel title does not
+	// already have, and making the user press right to get past it is a step
+	// that answers nothing. It stays a row, though -- it is where the asset's
+	// own status and platform live, and it is the only thing to select when the
+	// asset never scanned.
+	sole := len(assets) == 1
+
+	var rows []row
+	for _, a := range assets {
+		policies := p.policiesOf(st, a)
+		key := assetKey(a)
+		open := len(policies) > 0 && p.open(key, sole)
+		rows = append(rows, row{
+			kind: nodeAsset, key: key, branch: len(policies) > 0, open: open, asset: a,
+		})
+		if !open {
+			continue
+		}
+
+		// The same reasoning one level down: one asset with one policy is a
+		// chain of two rows that say nothing, so unfold through it.
+		solePolicy := sole && len(policies) == 1
+		for _, pol := range policies {
+			checks := p.sortChecks(st.FilteredChecks(pol.Checks))
+			pkey := key + "|p:" + policyKey(pol)
+			popen := len(checks) > 0 && p.open(pkey, solePolicy)
+			rows = append(rows, row{
+				kind: nodePolicy, depth: 1, key: pkey, parent: key,
+				branch: len(checks) > 0, open: popen, asset: a, policy: pol,
+			})
+			if !popen {
+				continue
+			}
+			for _, c := range checks {
+				rows = append(rows, row{
+					kind: nodeCheck, depth: 2, key: pkey + "|c:" + checkKey(c), parent: pkey,
+					asset: a, policy: pol, check: c,
+				})
+			}
+		}
+	}
+	return rows
+}
+
+// policiesOf is the asset's policies that survive the filter, in the pane's
+// order. What "survive" means is Filter.MatchPolicy's business, not this pane's:
+// the header edits the filter and the tree obeys it, and the two cannot disagree
+// about what it means if only one of them defines it.
+func (p *treePane) policiesOf(st *State, a *reportmodel.Asset) []*reportmodel.Policy {
+	if !st.Filter.Active() {
+		return p.sortPolicies(a.Policies)
+	}
+	res := make([]*reportmodel.Policy, 0, len(a.Policies))
+	for _, pol := range a.Policies {
+		if st.Filter.MatchPolicy(pol) {
+			res = append(res, pol)
+		}
+	}
+	return p.sortPolicies(res)
+}
+
+// open reports whether a node's children are shown: what the user last decided,
+// or the default when they have not decided anything.
+func (p *treePane) open(key string, byDefault bool) bool {
+	if v, ok := p.fold[key]; ok {
+		return v
+	}
+	return byDefault
+}
+
+func assetKey(a *reportmodel.Asset) string {
+	return "a:" + a.Mrn + "\x00" + a.Name
+}
+
+// policyKey identifies a policy within its asset. The synthetic "Other checks"
+// node has no MRN, hence the name as well.
+func policyKey(p *reportmodel.Policy) string {
+	return p.Mrn + "\x00" + p.Name
+}
+
+// checkKey identifies a check within its policy. A check has an MRN or, in an
+// unsigned bundle, only a code id.
+func checkKey(c *reportmodel.Check) string {
+	if c.Mrn != "" {
+		return c.Mrn
+	}
+	return c.CodeId
+}
+
+// locate puts the cursor back on the row it was on before the rebuild. When
+// that row is gone -- filtered out, or folded away inside a parent -- the cursor
+// keeps its index and adopts whatever is there now, which is the least
+// surprising thing a list can do.
+func (p *treePane) locate() {
+	if p.cursorKey != "" {
+		for i := range p.rows {
+			if p.rows[i].key == p.cursorKey {
+				p.cursor = i
+				return
+			}
+		}
+	}
+	p.clamp()
+	p.cursorKey = p.keyAt(p.cursor)
+}
+
+func (p *treePane) clamp() {
+	if p.cursor >= len(p.rows) {
+		p.cursor = len(p.rows) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+func (p *treePane) keyAt(i int) string {
+	if i < 0 || i >= len(p.rows) {
+		return ""
+	}
+	return p.rows[i].key
+}
+
+// --- ordering ---------------------------------------------------------------
+
+// Order is how the tree sorts what it draws. It is per-pane state: no other pane
+// cares, so it does not live in State.
+type Order int
+
+const (
+	// OrderOutcome is the default: the worst thing first, at every level of the
+	// tree. A scan is read to find what needs fixing, and a viewer that opens on
+	// a screen of PASS has made the reader do the scanning.
+	OrderOutcome Order = iota
+	// OrderName is the plain alphabet, which is what you want when you know the
+	// name of the check you are looking for and not its outcome. It is also the
+	// order reportmodel hands the nodes over in.
+	OrderName
+	// orderCount is the number of orders, so cycle wraps without a table.
+	orderCount
+)
+
+// Label names the order for the footer hint.
+func (o Order) Label() string {
+	if o == OrderName {
+		return "name"
+	}
+	return "outcome"
+}
+
+// The rank ladder: how loudly an outcome asks to be looked at. It is a named
+// list rather than a chain of comparisons inside a less function, because the
+// question it answers -- is a failure worse than an error? -- is a decision
+// about the product and belongs somewhere a reader can find it and argue with
+// it.
+//
+// FAIL outranks ERROR. Both are findings (reportmodel.Counts.Findings counts
+// them together) and both need a human, but a failing check has *proved* a
+// problem and names the thing to go and fix, while an errored check only proves
+// that the scan could not tell. Proof before doubt.
+//
+// Doubt still beats good news, though, so ERROR, SKIPPED, UNSCORED and UNKNOWN
+// all sort above PASS: each of them is a check that returned no verdict, which
+// is a gap in the scan and worth a glance. PASS is last because it is the only
+// outcome that asks nothing of the reader.
+//
+// This is the one place the six statuses are collapsed onto a single axis, and
+// they stay six everywhere else: the ladder orders rows, it never merges them.
+const (
+	rankFail = iota
+	rankError
+	rankSkipped
+	rankUnscored
+	rankUnknown
+	rankPass
+)
+
+// statusRank is one outcome's place on the ladder.
+func statusRank(s reportmodel.Status) int {
+	switch s {
+	case reportmodel.StatusFail:
+		return rankFail
+	case reportmodel.StatusError:
+		return rankError
+	case reportmodel.StatusSkipped:
+		return rankSkipped
+	case reportmodel.StatusUnscored:
+		return rankUnscored
+	case reportmodel.StatusPass:
+		return rankPass
+	default:
+		return rankUnknown
+	}
+}
+
+// severityRank orders the severities, worst first. It ranks the label rather
+// than the impact number so that it ranks exactly what the row draws -- the
+// label and riskBandDots read the same vocabulary, policy.ScoreRatingText*, so
+// the rank and the dot count move together, and an unrecognized label sorts last
+// rather than first.
+//
+// Drawing the band as dots did not change this. The sort is a display decision
+// about what the reader can see, and what they can see is still the band: four
+// dots above three above two. The label stays the key because it is the thing
+// both the rank and the count are derived from.
+func severityRank(severity string) int {
+	switch severity {
+	case policy.ScoreRatingTextCritical:
+		return 0
+	case policy.ScoreRatingTextHigh:
+		return 1
+	case policy.ScoreRatingTextMedium:
+		return 2
+	case policy.ScoreRatingTextLow:
+		return 3
+	default: // NONE, and anything the reporter grows later
+		return 4
+	}
+}
+
+// countsRank is where a node with children sits on the same ladder: the worst
+// outcome anything under it produced. A policy with one failing check outranks a
+// policy with fifty errored ones, exactly as one failing check outranks one
+// errored check -- the levels of the tree do not get to disagree about which
+// news is worse.
+//
+// A tally with nothing in it has no worst outcome and falls back to the node's
+// own status. That is the asset that never scanned: no checks at all, an ERROR
+// of its own, and therefore a place near the top rather than at the bottom of
+// the list with the clean assets.
+func countsRank(c reportmodel.Counts, own reportmodel.Status) int {
+	switch {
+	case c.Failed > 0:
+		return rankFail
+	case c.Errored > 0:
+		return rankError
+	case c.Skipped > 0:
+		return rankSkipped
+	case c.Unscored > 0:
+		return rankUnscored
+	case c.Unknown > 0:
+		return rankUnknown
+	case c.Passed > 0:
+		return rankPass
+	default:
+		return statusRank(own)
+	}
+}
+
+// The three sorts below copy before they sort. FilteredAssets, policiesOf and
+// FilteredChecks all hand back the model's own slice when no filter is active,
+// and sorting one of those in place would reorder the model underneath every
+// other reader of it.
+//
+// Each comparison ends in a total order over distinct nodes -- title or name,
+// then MRN, then code id -- so two rows that tie on outcome and severity always
+// come out the same way round. A list that reshuffles between renders is worse
+// than a list in the wrong order: the wrong order can at least be learned.
+
+func (p *treePane) sortAssets(in []*reportmodel.Asset) []*reportmodel.Asset {
+	out := append([]*reportmodel.Asset(nil), in...)
+	sort.SliceStable(out, func(i, j int) bool { return p.lessAsset(out[i], out[j]) })
+	return out
+}
+
+func (p *treePane) sortPolicies(in []*reportmodel.Policy) []*reportmodel.Policy {
+	out := append([]*reportmodel.Policy(nil), in...)
+	sort.SliceStable(out, func(i, j int) bool { return p.lessPolicy(out[i], out[j]) })
+	return out
+}
+
+func (p *treePane) sortChecks(in []*reportmodel.Check) []*reportmodel.Check {
+	out := append([]*reportmodel.Check(nil), in...)
+	sort.SliceStable(out, func(i, j int) bool { return p.lessCheck(out[i], out[j]) })
+	return out
+}
+
+// lessAsset orders the assets of a report: the worst first, then the one with
+// more findings in it, then the alphabet. An asset that failed to scan carries
+// no checks, so it is ranked on its own ERROR status and lands among the
+// errored assets rather than being sorted out of sight.
+func (p *treePane) lessAsset(a, b *reportmodel.Asset) bool {
+	if p.order == OrderOutcome {
+		if ra, rb := countsRank(a.Counts, a.Status), countsRank(b.Counts, b.Status); ra != rb {
+			return ra < rb
+		}
+		if fa, fb := a.Counts.Findings(), b.Counts.Findings(); fa != fb {
+			return fa > fb
+		}
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.Mrn < b.Mrn
+}
+
+// lessPolicy orders the policies of one asset the same way, and keeps the
+// synthetic "Other checks" node last among the policies it ties with: it is not
+// a policy anybody wrote, so it is the last place to look at any given rank.
+func (p *treePane) lessPolicy(a, b *reportmodel.Policy) bool {
+	if p.order == OrderOutcome {
+		if ra, rb := countsRank(a.Counts, a.Status), countsRank(b.Counts, b.Status); ra != rb {
+			return ra < rb
+		}
+		if fa, fb := a.Counts.Findings(), b.Counts.Findings(); fa != fb {
+			return fa > fb
+		}
+	}
+	if (a.Mrn == "") != (b.Mrn == "") {
+		return b.Mrn == ""
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.Mrn < b.Mrn
+}
+
+// lessCheck orders the checks of one policy: outcome, then severity, then title.
+//
+// Severity is compared as the band and not as Check.Impact, the number behind
+// it, on purpose. Impact is the finer key, but the row does not draw it:
+// ordering ten HIGH checks 89, 84, 70 puts them in an order that looks like no
+// order at all to someone reading ten identical rows of ●●●○. Every key this
+// sort uses is a thing the row shows, so a reader can see why the list is in the
+// order it is in and can predict where the next check will be.
+func (p *treePane) lessCheck(a, b *reportmodel.Check) bool {
+	if p.order == OrderOutcome {
+		if ra, rb := statusRank(a.Status), statusRank(b.Status); ra != rb {
+			return ra < rb
+		}
+		if ra, rb := severityRank(a.Severity), severityRank(b.Severity); ra != rb {
+			return ra < rb
+		}
+	}
+	if a.Title != b.Title {
+		return a.Title < b.Title
+	}
+	if a.Mrn != b.Mrn {
+		return a.Mrn < b.Mrn
+	}
+	return a.CodeId < b.CodeId
+}
+
+// cycle moves to the next order and rebuilds. The cursor is remembered by node
+// rather than by index, so re-sorting the list keeps the reader on the row they
+// were reading -- it moves under them, it does not swap for another one.
+func (p *treePane) cycle(st *State) {
+	p.order = (p.order + 1) % orderCount
+	p.revision++
+	p.resync(st)
+	st.Notice = "sorted by " + p.order.Label()
+}
+
+// --- rendering --------------------------------------------------------------
+
+func (p *treePane) Render(st *State, rect tui.Rect) Render {
+	rows := p.build(st)
+	if rect.H > 0 {
+		p.page = rect.H
+	}
+
+	// The cursor is followed here rather than where it moves, because this is
+	// the only place that knows how many rows fit.
+	p.scroll.EnsureVisible(p.cursor, len(rows), rect.H)
+	off := p.scroll.Apply(len(rows), rect.H)
+
+	res := Render{
+		Title:  p.title(st, rect),
+		Status: tui.Position(p.cursor, len(rows), rect.H),
+	}
+	if len(rows) == 0 {
+		res.Lines = []string{tui.StyleFaint.Render("no assets match")}
+		return res
+	}
+
+	for i := off; i < len(rows) && i < off+rect.H; i++ {
+		res.Lines = append(res.Lines, p.line(st, rows[i], i == p.cursor, rect.W))
+		res.Zones = append(res.Zones, Zone{
+			Rect: tui.Rect{X: rect.X, Y: rect.Y + i - off, W: rect.W, H: 1},
+			Idx:  i,
+			Tag:  rows[i].kind.tag(),
+		})
+	}
+	return res
+}
+
+// title names what is on screen: the asset, when there is only one, and the
+// count when there are several. It is truncated here rather than in the frame
+// because tui.PanelTop drops a title it cannot fit rather than cutting it.
+func (p *treePane) title(st *State, rect tui.Rect) string {
+	assets := st.FilteredAssets()
+	title := "Assets"
+	if len(assets) == 1 {
+		title = tui.Clean(assets[0].Name)
+	}
+	// The border eats two cells either side of the content and the position
+	// indicator sits at the other end of the same edge, so the title gets what
+	// is left of the content width rather than all of it.
+	room := rect.W - titleMargin
+	if room < 1 {
+		room = 1
+	}
+	return tui.Truncate(title, room)
+}
+
+// line renders one row into w cells.
+//
+// The selected row is a full-width band, and the band's own colors have to win,
+// so the styled line is stripped before it goes in. Stripping after the layout
+// rather than laying out twice is safe because an escape sequence is zero cells
+// wide: the stripped string is the same width as the styled one.
+func (p *treePane) line(st *State, r row, selected bool, w int) string {
+	left, right := p.parts(r)
+	out := rowLine(left, right, w)
+	if !selected {
+		return out
+	}
+	style := tui.BandInactive
+	if st.Focus == PaneTree {
+		style = tui.BandSelected
+	}
+	return tui.Bar(ansi.Strip(out), w, style)
+}
+
+// parts renders a row as its left-hand text and the right-aligned tag that
+// follows it. Both are styled; rowLine does the fitting.
+//
+// # Why the outcome is a glyph and not a word, on every kind of row
+//
+// The status column used to be eight cells of PASS/FAIL/ERROR/UNSCORED on every
+// row of the pane, which is a lot of a narrow pane to spend saying the same
+// half-dozen words a few hundred times. StatusGlyph says it in one, and the
+// seven cells go to the name -- which is the thing the pane was truncating.
+//
+// It changes on the asset and policy rows too, and not only on the check rows
+// this was asked for, because a status column that says "FAIL" on a policy and
+// "✗" on the checks inside it is one fact in two vocabularies, in one column, on
+// adjacent lines. A reader would have to learn both to read either. Nothing else
+// about those rows moves: the asset keeps its risk meter and the policy its
+// findings tally, which are the right-hand facts particular to each and are not
+// what this is about.
+func (p *treePane) parts(r row) (string, string) {
+	prefix := strings.Repeat(" ", r.depth*treeIndent) + p.twisty(r) + StatusGlyph(p.status(r)) + " "
+
+	switch r.kind {
+	case nodeAsset:
+		if !r.asset.Scanned() {
+			// An asset that failed to scan is not an asset with no findings,
+			// and the row itself has to say so: it is a leaf with an error, not
+			// an empty node someone will read as a clean bill of health. The
+			// label goes in the right-hand slot rather than after the name,
+			// where a long asset name would push it off the end of a narrow
+			// pane -- which is exactly the pane a fifteen-asset failure is read
+			// in.
+			return prefix + StatusStyle(reportmodel.StatusError).Render(tui.Clean(r.asset.Name)),
+				tui.StyleFaint.Render(notScanned)
+		}
+		name := tui.StyleText.Render(tui.Clean(r.asset.Name))
+		if r.asset.PlatformName != "" {
+			name += tui.StyleFaint.Render(" · " + tui.Clean(r.asset.PlatformName))
+		}
+		// The asset's risk meter goes in the right-hand slot, which was empty
+		// on this kind of row and is therefore the one place in this pane where
+		// a meter costs no width that was carrying something else. It is also
+		// the row where a meter is worth most: an asset is the thing a reader
+		// picks between, and "which of these fifteen machines first" is exactly
+		// the question one number and four dots answer. rowLine drops it on a
+		// pane too narrow for it, ahead of cutting the name.
+		return prefix + name, RiskMeter(r.asset.Score)
+
+	case nodePolicy:
+		// A policy row already spends its right-hand slot on the findings tally,
+		// which says more about a policy than its rolled-up risk does: "3/24" is
+		// how much of this policy needs work, and that is the number a reader
+		// descends into it for.
+		return prefix + tui.StyleText.Render(tui.Clean(r.policy.Name)), countTag(r.policy.Counts)
+
+	default:
+		// The check row draws its severity as dots rather than as the words
+		// CRIT, HIGH, MED and LOW. The four cells are the same either way, so
+		// this buys no width -- it buys the glance. A column of words has to be
+		// read a row at a time;
+		// a column of dots has a shape, and the shape is the answer to "where in
+		// this policy is the damage", which is the question the pane is open
+		// for. The dots are colored only where the severity was realized, so a
+		// screen of passes goes grey and the findings are the only color on it.
+		// See the note above SeverityDots for the whole of that reasoning.
+		//
+		// It is still severity and not risk: the count is what the check is
+		// worth, so a passing critical check keeps its four dots. The realized
+		// number is a keystroke away in the detail pane, on a row with the room
+		// to label it as such.
+		return prefix + SeverityDots(checkSeverity(r.check), r.check.Status.IsFinding()) + " " +
+			tui.StyleText.Render(tui.Clean(r.check.Title)), ""
+	}
+}
+
+// checkSeverity is the severity band a check states, and empty when it states
+// none at all.
+//
+// reportmodel derives Check.Severity from Check.Impact, and an unset impact is
+// 0, which RiskSeverityLabel reads as NONE -- so Severity alone cannot tell a
+// check nobody rated from a check somebody rated as harmless. HasImpact can, and
+// the two get drawn differently: blank against ○○○○. See SeverityDots.
+func checkSeverity(c *reportmodel.Check) string {
+	if !c.HasImpact {
+		return ""
+	}
+	return c.Severity
+}
+
+const (
+	// treeIndent is the indent per level, and also the width of the fold-marker
+	// column that follows it: an asset's status begins at column 2, a policy's
+	// at column 4 and a check's at column 6.
+	treeIndent = 2
+	// notScanned is what an asset that never ran says about itself.
+	notScanned = "not scanned"
+)
+
+// twisty is the fold marker, treeIndent cells wide so that a row with one and a
+// row without line up. A leaf has none, which is the difference between "there
+// is nothing here" and "there is nothing here yet".
+func (p *treePane) twisty(r row) string {
+	switch {
+	case !r.branch:
+		return "  "
+	case r.open:
+		return tui.StyleAccent.Render("▾") + " "
+	default:
+		return tui.StyleDim.Render("▸") + " "
+	}
+}
+
+// status is the outcome a row is drawn with. A check row shows the check's own
+// outcome, a policy row the policy's, an asset row the asset's.
+func (p *treePane) status(r row) reportmodel.Status {
+	switch r.kind {
+	case nodeAsset:
+		return r.asset.Status
+	case nodePolicy:
+		return r.policy.Status
+	default:
+		return r.check.Status
+	}
+}
+
+// countTag is the "3/24" a policy row carries: how many of its checks need
+// attention out of how many ran. The findings half is drawn in the failure color
+// when there are any, because that is the number the eye is looking for.
+func countTag(c reportmodel.Counts) string {
+	if c.Total == 0 {
+		return ""
+	}
+	if f := c.Findings(); f > 0 {
+		return StatusStyle(reportmodel.StatusFail).Render(strconv.Itoa(f)) +
+			tui.StyleFaint.Render("/"+strconv.Itoa(c.Total))
+	}
+	return tui.StyleFaint.Render(strconv.Itoa(c.Total))
+}
+
+// rowLine fits a left-hand string and a right-aligned tag into w cells. The
+// right-hand tag is dropped rather than allowed to squeeze the left one to
+// nothing, and the result is always at most w cells wide.
+func rowLine(left, right string, w int) string {
+	if w < 1 {
+		return ""
+	}
+	rw := tui.Width(right)
+	if rw == 0 || rw+minLeftWidth >= w {
+		return tui.Truncate(left, w)
+	}
+	left = tui.Truncate(left, w-rw-1)
+	return left + strings.Repeat(" ", w-rw-tui.Width(left)) + right
+}
+
+// minLeftWidth is how much room the left-hand text needs before a right-aligned
+// tag is worth drawing at all.
+const minLeftWidth = 12
+
+// titleMargin is the room the position indicator and the border corners need at
+// the other end of the top edge the title is inlaid into.
+const titleMargin = 8
+
+// --- keys and clicks --------------------------------------------------------
+
+func (p *treePane) Update(st *State, msg tea.Msg) (tea.Cmd, bool) {
+	rows := p.build(st)
+
+	switch msg := msg.(type) {
+	case ClickMsg:
+		return p.click(st, msg, rows)
+
+	case tea.MouseMsg:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			p.scroll.Move(-wheelRows, len(rows), p.page)
+			return nil, true
+		case tea.MouseButtonWheelDown:
+			p.scroll.Move(wheelRows, len(rows), p.page)
+			return nil, true
+		}
+		return nil, false
+
+	case tea.KeyMsg:
+		return p.key(st, msg, rows)
+	}
+	return nil, false
+}
+
+// wheelRows is how far one notch of the wheel scrolls.
+const wheelRows = 3
+
+func (p *treePane) click(st *State, msg ClickMsg, rows []row) (tea.Cmd, bool) {
+	if msg.Zone.Idx < 0 || msg.Zone.Idx >= len(rows) {
+		return nil, false
+	}
+	p.moveTo(st, msg.Zone.Idx, rows)
+
+	// A click on the fold marker folds; a click anywhere else on the row only
+	// selects. Both select, so a click can never move the cursor somewhere the
+	// detail pane is not looking.
+	r := rows[msg.Zone.Idx]
+	if col := msg.Mouse.X - msg.Zone.Rect.X - r.depth*treeIndent; r.branch && col >= 0 && col < treeIndent {
+		p.toggle(st, r)
+	}
+	return nil, true
+}
+
+func (p *treePane) key(st *State, msg tea.KeyMsg, rows []row) (tea.Cmd, bool) {
+	if len(rows) == 0 {
+		return nil, false
+	}
+	cur := rows[p.cursor]
+
+	switch msg.String() {
+	case "up", "k", "ctrl+p":
+		p.moveTo(st, p.cursor-1, rows)
+	case "down", "j", "ctrl+n":
+		p.moveTo(st, p.cursor+1, rows)
+	case "pgup", "ctrl+u":
+		p.moveTo(st, p.cursor-p.page, rows)
+	case "pgdown", "ctrl+d":
+		p.moveTo(st, p.cursor+p.page, rows)
+	case "home", "g":
+		p.moveTo(st, 0, rows)
+	case "end", "G":
+		p.moveTo(st, len(rows)-1, rows)
+
+	case "right", "l":
+		// Right walks in: it opens a closed node, steps into an open one, and
+		// hands a leaf over to the detail pane, which is where the reading is.
+		switch {
+		case cur.branch && !cur.open:
+			p.toggle(st, cur)
+		case cur.branch:
+			p.moveTo(st, p.cursor+1, p.build(st))
+		default:
+			st.Focus = PaneDetail
+		}
+
+	case "left", "h":
+		// And left walks back out: it closes an open node and otherwise goes up
+		// to the parent, so repeating it always ends at the top of the tree.
+		switch {
+		case cur.branch && cur.open:
+			p.toggle(st, cur)
+		case cur.parent != "":
+			p.moveToKey(st, cur.parent)
+		}
+
+	case "enter", " ", "space":
+		if cur.branch {
+			p.toggle(st, cur)
+			return nil, true
+		}
+		p.selectRow(st, cur)
+		st.Focus = PaneDetail
+
+	case "shift+right":
+		p.foldAll(st, true)
+	case "shift+left":
+		p.foldAll(st, false)
+
+	case "s":
+		p.cycle(st)
+
+	default:
+		return nil, false
+	}
+	return nil, true
+}
+
+// moveTo puts the cursor on a row and selects it. Every cursor movement goes
+// through here, which is what keeps the detail pane showing what the cursor is
+// on rather than what it was on two keys ago.
+func (p *treePane) moveTo(st *State, idx int, rows []row) {
+	if len(rows) == 0 {
+		return
+	}
+	p.cursor = idx
+	p.clamp()
+	p.cursorKey = p.keyAt(p.cursor)
+	p.selectRow(st, rows[p.cursor])
+}
+
+func (p *treePane) moveToKey(st *State, key string) {
+	for i := range p.rows {
+		if p.rows[i].key == key {
+			p.moveTo(st, i, p.rows)
+			return
+		}
+	}
+}
+
+// selectRow publishes what the cursor is on. A check selects all three levels, a
+// policy the asset and the policy, an asset only itself -- which is exactly what
+// Selection documents, and what an asset that never scanned can offer.
+func (p *treePane) selectRow(st *State, r row) {
+	switch r.kind {
+	case nodeCheck:
+		st.SelectCheck(r.asset, r.policy, r.check)
+	case nodePolicy:
+		st.Select(Selection{Asset: r.asset, Policy: r.policy})
+	default:
+		st.SelectAsset(r.asset)
+	}
+}
+
+// toggle folds or unfolds one node.
+func (p *treePane) toggle(st *State, r row) {
+	if !r.branch {
+		return
+	}
+	p.fold[r.key] = !r.open
+	p.revision++
+	p.resync(st)
+}
+
+// foldAll opens or closes every asset and policy of the tree, not only the ones
+// currently on screen: "collapse all" that left a node open three levels down
+// would be a lie the next keypress exposes.
+func (p *treePane) foldAll(st *State, open bool) {
+	for _, a := range st.FilteredAssets() {
+		key := assetKey(a)
+		p.fold[key] = open
+		for _, pol := range p.policiesOf(st, a) {
+			p.fold[key+"|p:"+policyKey(pol)] = open
+		}
+	}
+	p.revision++
+	p.resync(st)
+}
+
+// resync rebuilds after a fold change and publishes whatever the cursor ended up
+// on. Folding a subtree away moves the cursor, and a selection left pointing at
+// a check nobody can see any more is a detail pane showing something the tree
+// does not.
+func (p *treePane) resync(st *State) {
+	rows := p.build(st)
+	if len(rows) > 0 {
+		p.selectRow(st, rows[p.cursor])
+	}
+}

--- a/cli/reportview/tree_test.go
+++ b/cli/reportview/tree_test.go
@@ -1,0 +1,1051 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportview
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reportmodel"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The tree pane is tested the way the launcher is: against rendered line counts,
+// widths and the zone-to-row map, never against a screenshot. A screenshot test
+// fails when a colour changes and passes when the pane draws a row nobody can
+// click.
+
+// treeFor builds a pane and the state it draws, with nothing else in between.
+func treeFor(t *testing.T, fixture string) (*treePane, *State) {
+	t.Helper()
+	return newTree(), NewState(loadReport(t, fixture))
+}
+
+// treeRect is a left pane the size the frame gives it on a 120-column terminal.
+var treeRect = tui.Rect{X: 2, Y: 1, W: 41, H: 20}
+
+// treeKey builds the key messages the pane binds, including the ones the frame's
+// own helper does not need.
+func treeKey(s string) tea.KeyMsg {
+	types := map[string]tea.KeyType{
+		"up": tea.KeyUp, "down": tea.KeyDown,
+		"left": tea.KeyLeft, "right": tea.KeyRight,
+		"shift+left": tea.KeyShiftLeft, "shift+right": tea.KeyShiftRight,
+		"enter": tea.KeyEnter, "home": tea.KeyHome, "end": tea.KeyEnd,
+		"pgup": tea.KeyPgUp, "pgdown": tea.KeyPgDown, " ": tea.KeySpace,
+	}
+	if kt, ok := types[s]; ok {
+		return tea.KeyMsg{Type: kt}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+// send presses keys and insists the pane consumed each of them.
+func send(t *testing.T, p *treePane, st *State, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		_, ok := p.Update(st, treeKey(k))
+		require.True(t, ok, "the tree should consume %q", k)
+	}
+}
+
+func rowKinds(rows []row) []nodeKind {
+	res := make([]nodeKind, len(rows))
+	for i, r := range rows {
+		res[i] = r.kind
+	}
+	return res
+}
+
+// --- geometry ---------------------------------------------------------------
+
+// The invariant the whole viewer rests on: one element of Render.Lines is one
+// terminal row, and no row is wider than the rect it was given. A pane that
+// breaks either one scrolls the alt-screen buffer or wraps a line, and both push
+// the layout off by a row that nothing afterwards can recover.
+func TestTreeRowsAreOneLineAndFitTheRect(t *testing.T) {
+	for _, fixture := range []string{fixtureUbuntu, fixtureK8s} {
+		for _, unfold := range []bool{false, true} {
+			p, st := treeFor(t, fixture)
+			if unfold {
+				p.foldAll(st, true)
+			}
+			// Widths from "one cell" upwards: the narrow end is where a
+			// truncation that measures bytes instead of cells shows up.
+			for _, w := range []int{1, 2, 3, 5, 8, 12, 20, 30, 41, 46, 80, 200} {
+				for _, h := range []int{1, 2, 5, 20, 60} {
+					rect := tui.Rect{X: 2, Y: 1, W: w, H: h}
+					res := p.Render(st, rect)
+
+					require.LessOrEqual(t, len(res.Lines), h,
+						"%s w=%d h=%d: more lines than the rect is tall", fixture, w, h)
+					for i, ln := range res.Lines {
+						require.NotContains(t, ln, "\n",
+							"%s w=%d h=%d: line %d holds a newline", fixture, w, h, i)
+						require.LessOrEqual(t, tui.Width(ln), w,
+							"%s w=%d h=%d: line %d is %d cells wide", fixture, w, h, i, tui.Width(ln))
+					}
+					require.LessOrEqual(t, tui.Width(res.Title), w,
+						"%s w=%d: the title must fit the panel it is inlaid into", fixture, w)
+
+					for _, z := range res.Zones {
+						require.Equal(t, rect.X, z.Rect.X)
+						require.Equal(t, rect.W, z.Rect.W)
+						require.Equal(t, 1, z.Rect.H, "a row is one line, so a zone is one line")
+						require.GreaterOrEqual(t, z.Rect.Y, rect.Y)
+						require.Less(t, z.Rect.Y, rect.Y+rect.H)
+					}
+				}
+			}
+		}
+	}
+}
+
+// What the glyph bought, measured rather than asserted. The status column was
+// eight cells of PASS/FAIL/ERROR/UNSCORED on every row of the pane and is one
+// now, and the seven cells went to the name -- which is the thing the pane was
+// truncating, and the whole point of the change.
+//
+// This is pinned at a width where the titles are actually cut, because that is
+// where it matters: at 41 columns, which is the left pane of a 120-column
+// terminal, seven more cells is seven more characters of every check title.
+func TestTheTitleGainsWhatTheStatusWordCost(t *testing.T) {
+	require.Equal(t, 7, statusLabelWidth-StatusGlyphWidth,
+		"the word cost eight cells and the glyph costs one")
+
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+	rows := p.build(st)
+
+	// The prefix a check row spends before its title: the indent, the fold
+	// column, the glyph and the dots, each with the space after it that keeps
+	// the columns apart.
+	const prefix = 2*treeIndent + treeIndent + StatusGlyphWidth + 1 + SeverityDotsWidth + 1
+	require.Equal(t, 13, prefix)
+
+	for _, w := range []int{41, 74} {
+		res := p.Render(st, tui.Rect{X: 0, Y: 0, W: w, H: 40})
+		for i, r := range rows {
+			if r.kind != nodeCheck {
+				continue
+			}
+			line := ansi.Strip(res.Lines[i])
+			// Every title starts at the same column, and gets everything left.
+			require.Equal(t, min(tui.Width(r.check.Title), w-prefix), tui.Width(line)-prefix,
+				"w=%d row %d: %q", w, i, line)
+		}
+	}
+}
+
+// Every zone names the row that was drawn where it points. The two come out of
+// one pass over one rect, and this is what proves they did not drift: zone k
+// sits on line k and its Idx is the row that produced that line.
+func TestTreeZonesMapToTheRowsTheyDraw(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	// Wide enough that nothing is truncated, so the assertion is about which
+	// row was drawn rather than about how much of it fits.
+	rect := tui.Rect{X: 4, Y: 2, W: 120, H: 12}
+	rows := p.build(st)
+	res := p.Render(st, rect)
+
+	require.Len(t, res.Zones, len(res.Lines), "one zone per drawn row, no more and no less")
+	require.Len(t, res.Lines, rect.H)
+
+	for k, z := range res.Zones {
+		require.Equal(t, rect.Y+k, z.Rect.Y, "zone %d must sit on line %d", k, k)
+		require.Equal(t, res.Zones[0].Idx+k, z.Idx, "zones follow the rows in order")
+
+		r := rows[z.Idx]
+		line := ansi.Strip(res.Lines[k])
+		require.Equal(t, r.kind.tag(), z.Tag)
+		require.Contains(t, line, statusGlyph(p.status(r)), "row %d draws its own status", z.Idx)
+
+		switch r.kind {
+		case nodeAsset:
+			require.Contains(t, line, r.asset.Name)
+		case nodePolicy:
+			require.Contains(t, line, r.policy.Name)
+		default:
+			require.Contains(t, line, r.check.Title)
+		}
+	}
+}
+
+// Scrolling moves which rows are drawn, not which row a zone claims: after a
+// jump to the end, zone k still names the row on line k.
+func TestTreeZonesFollowScrolling(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	rect := tui.Rect{X: 2, Y: 1, W: 60, H: 5}
+
+	p.Render(st, rect) // the render is what tells the pane how many rows fit
+	send(t, p, st, "end")
+	rows := p.build(st)
+	res := p.Render(st, rect)
+
+	require.Len(t, res.Lines, 5)
+	require.Len(t, res.Zones, 5)
+	require.Positive(t, p.scroll.Off, "fifteen assets do not fit in five lines")
+	require.Equal(t, len(rows)-1, p.cursor)
+
+	for k, z := range res.Zones {
+		require.Equal(t, p.scroll.Off+k, z.Idx)
+		require.Equal(t, rect.Y+k, z.Rect.Y)
+		require.Contains(t, ansi.Strip(res.Lines[k]), rows[z.Idx].asset.Name)
+	}
+	// And the cursor is one of the rows on screen, which is the point of
+	// following it in the first place.
+	require.Equal(t, p.cursor, res.Zones[len(res.Zones)-1].Idx)
+}
+
+// A pane one cell wide still renders: it is what a terminal dragged to nothing
+// gives, and the answer has to be a short line rather than a panic.
+func TestTreeSurvivesAOneCellRect(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 1, H: 1})
+	require.Len(t, res.Lines, 1)
+	require.LessOrEqual(t, tui.Width(res.Lines[0]), 1)
+
+	require.Empty(t, rowLine("anything", "12", 0), "a rect with no width draws no row")
+}
+
+// --- what the tree is made of -----------------------------------------------
+
+// An asset that failed to scan is not an asset with no findings. The k8s fixture
+// is fifteen of them, with no bundle at all: fifteen rows, every one of them
+// labelled, and not one of them an empty node that invites you to open nothing.
+func TestErroredAssetsAreLabelledLeaves(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	rows := p.build(st)
+
+	require.Len(t, rows, 15)
+	for _, r := range rows {
+		require.Equal(t, nodeAsset, r.kind)
+		require.False(t, r.branch, "an asset that never scanned has nothing to unfold")
+		require.False(t, r.asset.Scanned())
+		require.Equal(t, reportmodel.StatusError, r.asset.Status)
+	}
+
+	// Unfolding everything cannot conjure children for them either.
+	p.foldAll(st, true)
+	require.Len(t, p.build(st), 15)
+
+	// Wide enough that the longest asset name is not cut, so the assertion is
+	// about what the row says rather than about how much of it fits.
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 80, H: 20})
+	require.Len(t, res.Lines, 15)
+	require.Len(t, res.Zones, 15)
+	for i, ln := range res.Lines {
+		line := ansi.Strip(ln)
+		require.Contains(t, line, statusGlyph(reportmodel.StatusError), "row %d", i)
+		require.Contains(t, line, "not scanned", "row %d must say why it is empty", i)
+		require.Contains(t, line, rows[i].asset.Name)
+	}
+}
+
+// One asset is not a level worth walking through, so a single-asset report opens
+// with its asset already unfolded. Several assets are, so they start folded and
+// the tree opens as a list of assets.
+func TestSingleAssetOpensUnfolded(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	rows := p.build(st)
+
+	require.Equal(t, []nodeKind{nodeAsset, nodePolicy, nodePolicy}, rowKinds(rows),
+		"the one asset is open and its policies are the level you land on")
+	require.True(t, rows[0].open)
+	require.True(t, rows[0].branch)
+	for _, r := range rows[1:] {
+		require.False(t, r.open, "the policies themselves start folded")
+		require.True(t, r.branch)
+	}
+
+	multi, mst := treeFor(t, fixtureK8s)
+	for _, r := range multi.build(mst) {
+		require.False(t, r.open, "several assets start folded, so the tree opens as a list")
+	}
+}
+
+// The tree keeps all six outcomes apart. A check that could not run is not a
+// check that passed, and a viewer that folds the two together is worse than one
+// that shows nothing.
+func TestStatusesStayDistinct(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	var counts reportmodel.Counts
+	for _, r := range p.build(st) {
+		if r.kind == nodeCheck {
+			counts.Add(p.status(r))
+		}
+	}
+	require.Equal(t, st.Report.Assets[0].Counts, counts)
+	require.Equal(t, 24, counts.Total)
+	require.Equal(t, 18, counts.Passed)
+	require.Equal(t, 2, counts.Failed)
+	require.Equal(t, 4, counts.Errored)
+
+	// And the rows say so in a shape, not only in colour: colour is the first
+	// thing a pipe, a screenshot or a colour-blind reader loses. The row draws
+	// its outcome as one glyph now rather than as a word, and the glyphs are six
+	// distinct shapes for exactly this reason -- see
+	// TestTheStatusGlyphKeepsTheOutcomesApart.
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 80, H: 40})
+	var passed, failed, errored int
+	for _, ln := range res.Lines {
+		// The fold marker leads the row, so it comes off before the glyph.
+		switch fields := strings.Fields(strings.TrimLeft(ansi.Strip(ln), " ▾▸")); fields[0] {
+		case statusGlyph(reportmodel.StatusPass):
+			passed++
+		case statusGlyph(reportmodel.StatusFail):
+			failed++
+		case statusGlyph(reportmodel.StatusError):
+			errored++
+		}
+	}
+	require.Equal(t, 18, passed)
+	require.Equal(t, 4+1, errored, "four errored checks and the policy they belong to")
+	require.Equal(t, 2+1+1, failed, "two failing checks, their policy, and the asset")
+}
+
+// --- ordering ---------------------------------------------------------------
+
+// treeText renders the pane wide enough that nothing is truncated and reduces
+// each row to its words, so the assertions below are about what a row says and
+// where it sits rather than about where the padding fell.
+func treeText(t *testing.T, p *treePane, st *State) []string {
+	t.Helper()
+	res := p.Render(st, tui.Rect{X: 0, Y: 0, W: 74, H: 40})
+	out := make([]string, len(res.Lines))
+	for i, ln := range res.Lines {
+		out[i] = strings.Join(strings.Fields(ansi.Strip(ln)), " ")
+	}
+	return out
+}
+
+func checkTitles(rows []row) []string {
+	var res []string
+	for _, r := range rows {
+		if r.kind == nodeCheck {
+			res = append(res, r.check.Title)
+		}
+	}
+	return res
+}
+
+func policyNames(rows []row) []string {
+	var res []string
+	for _, r := range rows {
+		if r.kind == nodePolicy {
+			res = append(res, r.policy.Name)
+		}
+	}
+	return res
+}
+
+func assetNames(rows []row) []string {
+	var res []string
+	for _, r := range rows {
+		if r.kind == nodeAsset {
+			res = append(res, r.asset.Name)
+		}
+	}
+	return res
+}
+
+// The default order, pinned. This is the whole point of the pane: a scan is
+// opened to find out what is broken, and the two failing checks of the ubuntu
+// fixture are the first two checks on the screen rather than lines 12 and 16 of
+// a wall of PASS.
+//
+// Every key the sort uses is a column the row draws -- outcome, then the
+// severity band, then the title -- so this listing is also the proof that a
+// reader can see why the list is in the order it is in. Both of those columns
+// are now drawn rather than spelled: "✗" is FAIL and "●●●●" is CRITICAL, and the
+// listing below is what the ladder looks like once they are, with ●●●● above
+// ●●●○ inside each run of one outcome.
+//
+// The asset row carries its risk meter at the right, which is the one row kind
+// that does: see treePane.parts for why the policy and check rows do not. Its
+// four dots are the asset's realized risk and not a severity -- the two are told
+// apart by which end of the row they are on, and by the number in front of them.
+func TestTheDefaultOrderLeadsWithFindings(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	require.Equal(t, []string{
+		"▾ ✗ ubuntu:24.04 · Ubuntu 24.04.2 LTS 100 ●●●●",
+		"▾ ✗ Mondoo Linux Security 2/20",
+		"✗ ●●●● Ensure secure permissions on /etc/group- are set",
+		"✗ ●●●● Ensure secure permissions on /etc/passwd- are set",
+		"✓ ●●●● Ensure X Window System is not installed",
+		"✓ ●●●● Ensure root group is empty",
+		"✓ ●●●● Ensure secure permissions on /etc/group are set",
+		"✓ ●●●● Ensure secure permissions on /etc/gshadow are set",
+		"✓ ●●●● Ensure secure permissions on /etc/gshadow- are set",
+		"✓ ●●●● Ensure secure permissions on /etc/passwd are set",
+		"✓ ●●●● Ensure secure permissions on /etc/shadow are set",
+		"✓ ●●●● Ensure secure permissions on /etc/shadow- are set",
+		"✓ ●●●○ Ensure all GIDs in /etc/passwd exist in /etc/group",
+		"✓ ●●●○ Ensure default group for the root account is GID 0",
+		"✓ ●●●○ Ensure each user is a member of a group",
+	}, treeText(t, p, st)[:15])
+
+	// And the tail of the same listing, which is where the two cases the
+	// severity column has to keep apart both live: four errored checks that
+	// state no severity at all, drawn blank, under a policy row that says the
+	// same thing with "!" and a 4/4 tally. treeText squeezes the runs of spaces
+	// out, so the blank column shows up here as the absence of any dots --
+	// TestACheckWithNoSeverityDrawsNoDots measures the cells.
+	require.Equal(t, []string{
+		"▾ ! Mondoo SSH Server Security 4/4",
+		"! Enable strict mode",
+		"! Only use strong Ciphers",
+		"! Set the port to 22",
+		"! Set the protocol to 2",
+	}, treeText(t, p, st)[22:])
+
+	// The errored policy comes after the failing one, and its checks with it.
+	require.Equal(t, []string{"Mondoo Linux Security", "Mondoo SSH Server Security"},
+		policyNames(p.build(st)))
+}
+
+// A list that reshuffles between renders is worse than a list in the wrong
+// order, because the wrong order can at least be learned. Every tie is broken by
+// title and then by MRN, so the sequence is the same on every pass -- from the
+// same pane, and from a pane that has never drawn anything.
+func TestTheOrderIsIdenticalOnEveryRender(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	want := treeText(t, p, st)
+	require.Len(t, want, 27)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, want, treeText(t, p, st), "render %d drew a different list", i)
+	}
+
+	// A fold round-trip goes through a rebuild rather than through the cache,
+	// which is where a sort that depended on the incoming order would show up.
+	p.foldAll(st, false)
+	p.foldAll(st, true)
+	require.Equal(t, want, treeText(t, p, st))
+
+	// And a second pane over a second load of the same fixture agrees, so the
+	// order is a function of the report and of nothing else.
+	fresh, fst := treeFor(t, fixtureUbuntu)
+	fresh.foldAll(fst, true)
+	require.Equal(t, want, treeText(t, fresh, fst))
+}
+
+// The pane sorts a copy. reportmodel hands out its own slices when no filter is
+// active, and a sort in place would reorder the model under the header, the
+// detail pane and the next reader of Report.Assets.
+func TestSortingDoesNotReorderTheModel(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	asset := st.Report.Assets[0]
+
+	before := append([]*reportmodel.Check(nil), asset.Checks...)
+	policies := append([]*reportmodel.Policy(nil), asset.Policies...)
+	own := append([]*reportmodel.Check(nil), asset.Policies[0].Checks...)
+
+	p.foldAll(st, true)
+	p.build(st)
+
+	require.Equal(t, before, asset.Checks, "the model's checks are still in model order")
+	require.Equal(t, policies, asset.Policies)
+	require.Equal(t, own, asset.Policies[0].Checks)
+	require.IsIncreasing(t, checkTitlesOf(before), "and model order is still the alphabet")
+}
+
+func checkTitlesOf(checks []*reportmodel.Check) []string {
+	res := make([]string, len(checks))
+	for i, c := range checks {
+		res[i] = c.Title
+	}
+	return res
+}
+
+// The ladder, spelled out. Which outcome is worse than which is a decision about
+// the product rather than an accident of a comparison function, so it is a named
+// list in tree.go and this is the test that says what the list means.
+//
+// FAIL outranks ERROR: both are findings, but a failing check has proved a
+// problem and named the thing to fix, while an errored check has only proved
+// that the scan could not tell. Everything that returned no verdict at all still
+// sorts above PASS, which is last because it is the only outcome that asks
+// nothing of the reader.
+func TestTheRankLadderRunsFromFailToPass(t *testing.T) {
+	ladder := []reportmodel.Status{
+		reportmodel.StatusFail,
+		reportmodel.StatusError,
+		reportmodel.StatusSkipped,
+		reportmodel.StatusUnscored,
+		reportmodel.StatusUnknown,
+		reportmodel.StatusPass,
+	}
+	ranks := make([]int, len(ladder))
+	for i, s := range ladder {
+		ranks[i] = statusRank(s)
+	}
+	require.IsIncreasing(t, ranks, "the six outcomes are six distinct ranks, in this order")
+	require.Equal(t, rankUnknown, statusRank(reportmodel.Status("something new")))
+
+	// Severity is ranked as the badge the row draws, not as the impact number
+	// behind it, so the order is one a reader can see.
+	sev := []int{
+		severityRank(policy.ScoreRatingTextCritical),
+		severityRank(policy.ScoreRatingTextHigh),
+		severityRank(policy.ScoreRatingTextMedium),
+		severityRank(policy.ScoreRatingTextLow),
+		severityRank(policy.ScoreRatingTextNone),
+	}
+	require.IsIncreasing(t, sev)
+	require.Equal(t, severityRank(policy.ScoreRatingTextNone), severityRank("whatever comes next"))
+}
+
+// A node with children is ranked by the worst outcome under it, so the levels of
+// the tree cannot disagree about which news is worse. A tally with nothing in it
+// falls back to the node's own status, which is all an asset that never scanned
+// has to offer.
+func TestCountsRankIsTheWorstOutcomeUnderTheNode(t *testing.T) {
+	tally := func(pass, fail, errored, skipped int) reportmodel.Counts {
+		var c reportmodel.Counts
+		for i := 0; i < pass; i++ {
+			c.Add(reportmodel.StatusPass)
+		}
+		for i := 0; i < fail; i++ {
+			c.Add(reportmodel.StatusFail)
+		}
+		for i := 0; i < errored; i++ {
+			c.Add(reportmodel.StatusError)
+		}
+		for i := 0; i < skipped; i++ {
+			c.Add(reportmodel.StatusSkipped)
+		}
+		return c
+	}
+
+	require.Equal(t, rankFail, countsRank(tally(99, 1, 50, 0), reportmodel.StatusPass),
+		"one failure outranks fifty errors, exactly as one failing check does")
+	require.Equal(t, rankError, countsRank(tally(99, 0, 1, 0), reportmodel.StatusPass))
+	require.Equal(t, rankSkipped, countsRank(tally(99, 0, 0, 1), reportmodel.StatusPass))
+	require.Equal(t, rankPass, countsRank(tally(1, 0, 0, 0), reportmodel.StatusPass))
+	require.Equal(t, rankError, countsRank(reportmodel.Counts{}, reportmodel.StatusError),
+		"no checks at all is the asset that never scanned, and it is an ERROR")
+}
+
+// --- ordering: the levels above a check -------------------------------------
+
+// The model nodes below are built by hand rather than loaded, because the
+// fixtures hold one shape each and the ordering has to be shown on a report
+// where the alphabet and the findings disagree. They are model data only: an
+// Asset built this way has no report behind it, so these tests read rows and
+// never render them.
+
+func synthCheck(title string, status reportmodel.Status) *reportmodel.Check {
+	return &reportmodel.Check{
+		Mrn: "//check/" + title, CodeId: title, Title: title,
+		Status: status, Severity: policy.ScoreRatingTextNone,
+	}
+}
+
+func synthPolicy(mrn, name string, statuses ...reportmodel.Status) *reportmodel.Policy {
+	p := &reportmodel.Policy{Mrn: mrn, Name: name, Status: reportmodel.StatusPass}
+	for i, s := range statuses {
+		p.Checks = append(p.Checks, synthCheck(name+"/"+strconv.Itoa(i), s))
+		p.Counts.Add(s)
+	}
+	return p
+}
+
+func synthAsset(name string, status reportmodel.Status, policies ...*reportmodel.Policy) *reportmodel.Asset {
+	a := &reportmodel.Asset{Mrn: "//asset/" + name, Name: name, Status: status}
+	for _, p := range policies {
+		a.Policies = append(a.Policies, p)
+		a.Checks = append(a.Checks, p.Checks...)
+		for _, c := range p.Checks {
+			a.Counts.Add(c.Status)
+		}
+	}
+	return a
+}
+
+func synthState(assets ...*reportmodel.Asset) *State {
+	return NewState(&reportmodel.Report{Assets: assets})
+}
+
+// Policies are ordered like the checks inside them: the worst outcome first,
+// then the one carrying more findings, then the alphabet. The synthetic "Other
+// checks" node keeps its place at the back of whatever rank it lands in -- it is
+// not a policy anybody wrote, so it is the last place to look at that rank.
+func TestPoliciesLeadWithTheirWorstOutcome(t *testing.T) {
+	pass, fail, erred := reportmodel.StatusPass, reportmodel.StatusFail, reportmodel.StatusError
+	asset := synthAsset("host", fail,
+		synthPolicy("//p/a", "aaa clean", pass, pass),
+		synthPolicy("//p/b", "bbb errored", erred),
+		synthPolicy("//p/c", "ccc one failure", fail, pass),
+		synthPolicy("//p/d", "ddd three failures", fail, fail, fail),
+		synthPolicy("", reportmodel.UngroupedPolicyName, fail, pass),
+	)
+
+	p := newTree()
+	st := synthState(asset)
+	require.Equal(t, []string{
+		"ddd three failures",
+		"ccc one failure",
+		reportmodel.UngroupedPolicyName,
+		"bbb errored",
+		"aaa clean",
+	}, policyNames(p.build(st)))
+
+	// And the alphabet is still there for anyone who wants it, synthetic node
+	// last as the model has it.
+	send(t, p, st, "s")
+	require.Equal(t, []string{
+		"aaa clean", "bbb errored", "ccc one failure", "ddd three failures",
+		reportmodel.UngroupedPolicyName,
+	}, policyNames(p.build(st)))
+}
+
+// Assets are ordered the same way, and an asset that never scanned is ranked on
+// the only outcome it has: its own ERROR. It lands among the errored assets --
+// visible, and above everything that is merely clean -- rather than sorted into
+// oblivion at the bottom of the list.
+func TestAssetsLeadWithTheirWorstOutcome(t *testing.T) {
+	pass, fail, erred := reportmodel.StatusPass, reportmodel.StatusFail, reportmodel.StatusError
+	st := synthState(
+		synthAsset("alpha clean", pass, synthPolicy("//p/a", "policy", pass, pass)),
+		synthAsset("bravo never scanned", erred),
+		synthAsset("charlie one failure", fail, synthPolicy("//p/c", "policy", fail, pass)),
+		synthAsset("delta two failures", fail, synthPolicy("//p/d", "policy", fail, fail)),
+	)
+
+	p := newTree()
+	require.Equal(t, []string{
+		"delta two failures",
+		"charlie one failure",
+		"bravo never scanned",
+		"alpha clean",
+	}, assetNames(p.build(st)))
+
+	// The asset with no checks is a leaf, and it is still one of the four rows.
+	rows := p.build(st)
+	require.Len(t, rows, 4, "several assets start folded, so this is the whole tree")
+	require.False(t, rows[2].branch, "an asset that never scanned has nothing to unfold")
+
+	send(t, p, st, "s")
+	require.Equal(t, []string{
+		"alpha clean", "bravo never scanned", "charlie one failure", "delta two failures",
+	}, assetNames(p.build(st)))
+}
+
+// The fifteen assets of the k8s fixture all errored, so the outcome key cannot
+// separate them and the tie-break has to: fifteen rows, in name order, the same
+// fifteen rows the alphabet gives.
+func TestAllErroredAssetsFallBackToTheAlphabet(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	byOutcome := assetNames(p.build(st))
+	require.Len(t, byOutcome, 15)
+	require.IsIncreasing(t, byOutcome)
+
+	send(t, p, st, "s")
+	require.Equal(t, byOutcome, assetNames(p.build(st)))
+}
+
+// --- ordering: getting the alphabet back ------------------------------------
+
+// One good default is not quite enough: a reader who knows the name of the check
+// they want should not have to read an outcome-ordered list to find it. "s"
+// cycles, the footer says which order is showing, and the cursor stays on the
+// row it was on -- the list moves under the reader rather than handing them a
+// different row.
+func TestTheSortKeyCyclesTheOrder(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	byOutcome := treeText(t, p, st)
+	require.Equal(t, OrderOutcome, p.order, "the tree opens on findings")
+	require.Contains(t, p.Hints(st), Hint{Key: "s", Label: "sort: outcome"})
+
+	// Park the cursor on the second failing check, which the alphabet puts
+	// somewhere in the middle of the passes.
+	rows := p.build(st)
+	p.moveTo(st, 3, rows)
+	want := st.Sel.Check
+	require.Equal(t, reportmodel.StatusFail, want.Status)
+
+	send(t, p, st, "s")
+	require.Equal(t, OrderName, p.order)
+	require.Equal(t, "sorted by name", st.Notice, "the footer says what just happened")
+	require.Contains(t, p.Hints(st), Hint{Key: "s", Label: "sort: name"})
+
+	rows = p.build(st)
+	require.Equal(t, want, rows[p.cursor].check, "the cursor stayed on the check it was on")
+	require.Equal(t, want, st.Sel.Check, "and the detail pane is still showing it")
+	require.Greater(t, p.cursor, 3, "which the alphabet has moved down the list")
+
+	// Name order is the model's own order: titles ascending within each policy.
+	require.Equal(t, checkTitlesOf(st.Report.Assets[0].Policies[0].Checks),
+		checkTitles(rows)[:20])
+	require.NotEqual(t, byOutcome, treeText(t, p, st))
+
+	send(t, p, st, "s")
+	require.Equal(t, OrderOutcome, p.order, "and cycles back round")
+	require.Equal(t, byOutcome, treeText(t, p, st), "to exactly the list it started with")
+	require.Equal(t, want, st.Sel.Check)
+}
+
+// The sort key has to be the tree's alone. The header claims "/" and "f" from
+// anywhere, and a key two panes both want is a key that does something different
+// depending on where the focus happens to be.
+func TestTheSortKeyCollidesWithNothing(t *testing.T) {
+	st := NewState(loadReport(t, fixtureUbuntu))
+	for _, id := range []PaneID{PaneHeader, PaneDetail} {
+		require.NotContains(t, buildPane(id, st).Claims(), "s",
+			"the %s pane claims the tree's sort key", id)
+	}
+
+	// And it is not one of the frame's own bindings either: the tree consumes
+	// it, so the frame never sees it.
+	p := newTree()
+	_, consumed := p.Update(st, treeKey("s"))
+	require.True(t, consumed)
+}
+
+// --- folding ----------------------------------------------------------------
+
+// Right opens a node, steps into an open one and hands a leaf to the detail
+// pane; left closes it again and otherwise climbs back out. Repeating left ends
+// at the top of the tree rather than somewhere in the middle of it.
+func TestFoldingWithTheArrowKeys(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	require.Len(t, p.build(st), 3)
+
+	send(t, p, st, "down") // onto the first policy
+	require.Equal(t, nodePolicy, p.build(st)[p.cursor].kind)
+
+	send(t, p, st, "right")
+	rows := p.build(st)
+	require.Len(t, rows, 3+20, "the first policy holds twenty checks")
+	require.Equal(t, 1, p.cursor, "opening a node does not move the cursor off it")
+	require.True(t, rows[1].open)
+
+	send(t, p, st, "right")
+	require.Equal(t, 2, p.cursor, "right again steps into the open node")
+	require.Equal(t, nodeCheck, p.build(st)[p.cursor].kind)
+
+	send(t, p, st, "left")
+	require.Equal(t, 1, p.cursor, "left climbs from a leaf to its parent")
+
+	send(t, p, st, "left")
+	require.Len(t, p.build(st), 3, "and closes the parent it climbed to")
+
+	send(t, p, st, "left")
+	require.Equal(t, 0, p.cursor, "left again climbs to the asset")
+	send(t, p, st, "left")
+	require.Len(t, p.build(st), 1, "which folds away to a single row")
+}
+
+// Enter and space toggle a branch, which is the other half of the same idea for
+// anyone who reaches for a mouse-shaped key rather than an arrow.
+func TestEnterAndSpaceToggleABranch(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	send(t, p, st, "down", "enter")
+	require.Len(t, p.build(st), 23)
+	send(t, p, st, "enter")
+	require.Len(t, p.build(st), 3)
+	send(t, p, st, " ")
+	require.Len(t, p.build(st), 23)
+}
+
+// Fold-all works on the whole tree and not only on what is on screen, so the
+// answer does not depend on where the cursor happened to be.
+func TestFoldAllOpensAndClosesEverything(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+
+	send(t, p, st, "shift+right")
+	require.Len(t, p.build(st), 1+2+24, "the asset, both policies and every check")
+
+	send(t, p, st, "shift+left")
+	require.Len(t, p.build(st), 1, "and back to the asset alone")
+	require.Equal(t, 0, p.cursor)
+	require.Equal(t, st.Report.Assets[0], st.Sel.Asset)
+	require.Nil(t, st.Sel.Check, "folding away the selected check must not leave it selected")
+}
+
+// --- selection --------------------------------------------------------------
+
+// Moving the cursor is what the detail pane watches, so every level of the tree
+// has to publish what it is: a check selects all three levels, a policy two and
+// an asset one.
+func TestSelectionFollowsTheCursor(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+	rows := p.build(st)
+	before := st.SelectionRev
+
+	send(t, p, st, "home")
+	require.Equal(t, rows[0].asset, st.Sel.Asset)
+	require.Nil(t, st.Sel.Policy)
+	require.Nil(t, st.Sel.Check)
+
+	send(t, p, st, "down")
+	require.Equal(t, nodePolicy, rows[1].kind)
+	require.Equal(t, rows[1].policy, st.Sel.Policy)
+	require.Nil(t, st.Sel.Check)
+
+	send(t, p, st, "down")
+	require.Equal(t, nodeCheck, rows[2].kind)
+	require.Equal(t, rows[2].asset, st.Sel.Asset)
+	require.Equal(t, rows[2].policy, st.Sel.Policy)
+	require.Equal(t, rows[2].check, st.Sel.Check)
+	require.Greater(t, st.SelectionRev, before)
+
+	// Re-selecting the same row is not a selection change: a detail pane that
+	// scrolled back to the top on every keypress would be unusable.
+	rev := st.SelectionRev
+	send(t, p, st, "down", "up")
+	require.Equal(t, rev+2, st.SelectionRev)
+	p.Update(st, treeKey("down"))
+	p.Update(st, treeKey("up"))
+	require.Equal(t, rev+4, st.SelectionRev)
+	send(t, p, st, "home")
+	rev = st.SelectionRev
+	send(t, p, st, "home")
+	require.Equal(t, rev, st.SelectionRev, "the cursor did not move, so nothing was reselected")
+}
+
+// A leaf has nothing to open, so opening it means reading it: the tree hands the
+// keyboard to the detail pane.
+func TestALeafHandsOffToTheDetailPane(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	st.Focus = PaneTree
+
+	send(t, p, st, "enter")
+	require.Equal(t, PaneDetail, st.Focus)
+	require.Equal(t, st.Report.Assets[0], st.Sel.Asset)
+
+	st.Focus = PaneTree
+	send(t, p, st, "right")
+	require.Equal(t, PaneDetail, st.Focus, "right on a leaf reads it as well")
+
+	// A branch is a different matter: enter opens it and focus stays put.
+	tree, ust := treeFor(t, fixtureUbuntu)
+	ust.Focus = PaneTree
+	send(t, tree, ust, "down", "enter")
+	require.Equal(t, PaneTree, ust.Focus)
+}
+
+// --- filtering --------------------------------------------------------------
+
+// Filtering is the frame's, and the tree only obeys it. Restricting to one
+// status leaves the checks of that status, the policies that hold them and the
+// assets they ran on -- and nothing else.
+func TestFilterNarrowsTheTree(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusFail: true}})
+	rows := p.build(st)
+	require.Equal(t, []nodeKind{nodeAsset, nodePolicy, nodeCheck, nodeCheck}, rowKinds(rows),
+		"one asset and one policy left, so the tree unfolds through both")
+	for _, r := range rows {
+		if r.kind == nodeCheck {
+			require.Equal(t, reportmodel.StatusFail, r.check.Status)
+		}
+	}
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusError: true}})
+	rows = p.build(st)
+	require.Len(t, rows, 1+1+4, "the four errored checks are a different policy")
+	for _, r := range rows {
+		if r.kind == nodeCheck {
+			require.Equal(t, reportmodel.StatusError, r.check.Status)
+		}
+	}
+
+	st.SetFilter(Filter{})
+	require.Len(t, p.build(st), 3, "clearing the filter restores the tree")
+}
+
+// The cursor is remembered by node, not by index, so filtering something out
+// from above it does not silently move it onto a different check.
+func TestTheCursorSurvivesAFilterChange(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	p.foldAll(st, true)
+
+	// Park the cursor on a failing check somewhere down the list.
+	rows := p.build(st)
+	var want *reportmodel.Check
+	for i, r := range rows {
+		if r.kind == nodeCheck && r.check.Status == reportmodel.StatusFail {
+			p.moveTo(st, i, rows)
+			want = r.check
+			break
+		}
+	}
+	require.NotNil(t, want)
+	require.Positive(t, p.cursor)
+
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusFail: true}})
+	rows = p.build(st)
+	require.Equal(t, want, rows[p.cursor].check, "the cursor stayed on the same check")
+
+	// And when the cursor's row is filtered away it keeps its place in the list
+	// rather than jumping to the top or off the end.
+	st.SetFilter(Filter{Statuses: map[reportmodel.Status]bool{reportmodel.StatusPass: true}})
+	rows = p.build(st)
+	require.GreaterOrEqual(t, p.cursor, 0)
+	require.Less(t, p.cursor, len(rows))
+	require.Equal(t, rows[p.cursor].key, p.cursorKey)
+}
+
+// A filter that matches nothing draws one honest line and no zones, rather than
+// an empty panel that reads as a clean bill of health.
+func TestAnEmptyTreeSaysSo(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	st.SetFilter(Filter{Search: "no-check-is-called-this"})
+
+	require.Empty(t, p.build(st))
+	res := p.Render(st, treeRect)
+	require.Len(t, res.Lines, 1)
+	require.Contains(t, ansi.Strip(res.Lines[0]), "no assets match")
+	require.Empty(t, res.Zones)
+	require.Equal(t, "0", res.Status)
+
+	// And the keys do not panic on it.
+	for _, k := range []string{"down", "up", "right", "left", "enter", "end"} {
+		_, consumed := p.Update(st, treeKey(k))
+		require.False(t, consumed, "%q has nothing to act on", k)
+	}
+}
+
+// --- mouse ------------------------------------------------------------------
+
+// A click selects the row it landed on; a click on the fold marker of a branch
+// selects it and folds it, so the pointer can do what the arrow keys do.
+func TestClickSelectsAndTheTwistyFolds(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	res := p.Render(st, treeRect)
+	require.Len(t, res.Zones, 3)
+
+	// Somewhere in the middle of the second row: the policy, not its marker.
+	z := res.Zones[1]
+	_, consumed := p.Update(st, ClickMsg{Zone: z, Mouse: tea.MouseMsg{X: z.Rect.X + 10, Y: z.Rect.Y}})
+	require.True(t, consumed)
+	require.Equal(t, 1, p.cursor)
+	require.Equal(t, p.build(st)[1].policy, st.Sel.Policy)
+	require.Len(t, p.build(st), 3, "a click on the row itself does not unfold it")
+
+	// And now on the marker of the same row, which sits at the row's own indent.
+	_, consumed = p.Update(st, ClickMsg{
+		Zone:  z,
+		Mouse: tea.MouseMsg{X: z.Rect.X + treeIndent, Y: z.Rect.Y},
+	})
+	require.True(t, consumed)
+	require.Len(t, p.build(st), 23, "the marker unfolds")
+	require.Equal(t, 1, p.cursor)
+
+	// A zone that names a row the tree no longer has is ignored rather than
+	// indexed into.
+	_, consumed = p.Update(st, ClickMsg{Zone: Zone{Idx: 9999, Tag: "check"}})
+	require.False(t, consumed)
+}
+
+// The wheel scrolls what the pointer is over without moving the cursor: taking
+// the selection along would mean looking at a list changes what is open in the
+// pane next to it.
+func TestTheWheelScrollsWithoutMovingTheCursor(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	rect := tui.Rect{X: 0, Y: 0, W: 60, H: 5}
+	p.Render(st, rect)
+
+	_, consumed := p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	require.True(t, consumed)
+	require.Equal(t, 0, p.cursor)
+	require.Equal(t, st.Report.Assets[0], st.Sel.Asset)
+
+	// The render that follows pulls the offset back to the cursor, so the check
+	// is on the offset the pane holds rather than on what it draws next.
+	require.Positive(t, p.scroll.Off)
+
+	_, consumed = p.Update(st, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	require.True(t, consumed)
+	require.Equal(t, 0, p.scroll.Off)
+
+	_, consumed = p.Update(st, tea.MouseMsg{Button: tea.MouseButtonMiddle})
+	require.False(t, consumed, "the tree has no use for the other buttons")
+}
+
+// --- plumbing ---------------------------------------------------------------
+
+// The pane installs itself in the tree slot, and does it without a State: the
+// frame builds panes before it has anything to draw.
+func TestTreeRegistersItself(t *testing.T) {
+	require.IsType(t, &treePane{}, buildPane(PaneTree, nil))
+
+	p := newTree()
+	require.Equal(t, PaneTree, p.ID())
+	require.True(t, p.Focusable())
+	require.Nil(t, p.Claims(), "the tree needs no key while another pane has focus")
+	require.NotEmpty(t, p.Hints(nil))
+}
+
+// A key the tree does not bind falls through to the frame, which is how "?" and
+// "q" keep working while the tree has focus.
+func TestUnboundKeysFallThrough(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	for _, k := range []string{"?", "q", "esc", "tab", "/"} {
+		_, consumed := p.Update(st, treeKey(k))
+		require.False(t, consumed, "%q belongs to the frame", k)
+	}
+	_, consumed := p.Update(st, struct{ custom string }{"hello"})
+	require.False(t, consumed)
+}
+
+// The title names what is on screen, and is short enough for the border it is
+// inlaid into: tui.PanelTop drops a title it cannot fit rather than cutting it.
+func TestTitleNamesWhatIsOnScreen(t *testing.T) {
+	p, st := treeFor(t, fixtureUbuntu)
+	require.Equal(t, "ubuntu:24.04", p.Render(st, treeRect).Title)
+
+	k8s, kst := treeFor(t, fixtureK8s)
+	res := k8s.Render(kst, treeRect)
+	require.Equal(t, "Assets", res.Title)
+	require.Equal(t, "15", res.Status, "everything fits, so the count is the whole story")
+	require.Equal(t, "1/15", k8s.Render(kst, tui.Rect{X: 0, Y: 0, W: 41, H: 5}).Status,
+		"and when it does not, where the cursor is in it")
+
+	for _, w := range []int{6, 10, 41} {
+		title := p.Render(st, tui.Rect{X: 0, Y: 0, W: w, H: 4}).Title
+		require.LessOrEqual(t, tui.Width(title), w)
+	}
+}
+
+// Page up and page down move by what the last render could show, so a taller
+// terminal pages further. Home and end go to the ends of the list.
+func TestPagingMovesByAScreen(t *testing.T) {
+	p, st := treeFor(t, fixtureK8s)
+	p.Render(st, tui.Rect{X: 0, Y: 0, W: 60, H: 4})
+
+	send(t, p, st, "pgdown")
+	require.Equal(t, 4, p.cursor)
+	send(t, p, st, "pgdown")
+	require.Equal(t, 8, p.cursor)
+	send(t, p, st, "pgup")
+	require.Equal(t, 4, p.cursor)
+
+	send(t, p, st, "end")
+	require.Equal(t, 14, p.cursor)
+	send(t, p, st, "pgdown")
+	require.Equal(t, 14, p.cursor, "the end of the list is the end of the list")
+	send(t, p, st, "home")
+	require.Equal(t, 0, p.cursor)
+	send(t, p, st, "pgup")
+	require.Equal(t, 0, p.cursor)
+}

--- a/cli/tui/band.go
+++ b/cli/tui/band.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import "strings"
+
+// A band is a full-width line with something at each end of it: the launcher's
+// header, the viewer's summary row, the line that says what is being filtered.
+//
+// There were three implementations of this arithmetic and two of them were line
+// for line identical. That is cheap to let happen and expensive to leave: the
+// hit-tester for the launcher's header has to agree with the renderer about the
+// column the right-hand fragment starts in, and it can only do that if both ask
+// the same function. BandRightX is that agreement.
+
+// Band lays a left and a right fragment across w cells, dropping the right one
+// when there is not room for both. The result is always at most w cells wide.
+//
+// The right fragment is dropped whole rather than squeezed. A band whose two
+// ends are touching says less than one that shows only its left end, and the
+// left end is the side that carries the identity.
+func Band(left, right string, w int) string {
+	gap := w - Width(left) - Width(right)
+	if gap < 1 {
+		return Truncate(left, w)
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+// BandRightX is the column Band draws right at, or -1 when Band would drop it.
+// A caller registering a click zone over the right-hand fragment reads its
+// position from here, so a click can never land on something that was not
+// drawn.
+func BandRightX(left, right string, w int) int {
+	if w-Width(left)-Width(right) < 1 {
+		return -1
+	}
+	return w - Width(right)
+}
+
+// Band3 is Band with an optional fragment between the two, dropped whenever it
+// would leave the band looking crowded rather than laid out.
+func Band3(left, mid, right string, w int) string {
+	if mid != "" {
+		if gap := w - Width(left) - Width(mid) - Width(right); gap >= 4 {
+			l := gap / 2
+			return left + strings.Repeat(" ", l) + mid + strings.Repeat(" ", gap-l) + right
+		}
+	}
+	return Band(left, right, w)
+}

--- a/cli/tui/band_test.go
+++ b/cli/tui/band_test.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBandFillsExactlyTheWidth(t *testing.T) {
+	require.Equal(t, "left      right", Band("left", "right", 15))
+	require.Equal(t, "l         r", Band("l", "r", 11))
+	for _, w := range []int{1, 3, 9, 10, 11, 40} {
+		require.LessOrEqual(t, Width(Band("left side", "right", w)), w, "width %d", w)
+	}
+}
+
+// The right-hand fragment is dropped whole rather than squeezed: a band whose
+// two ends are touching says less than one showing only its left end, and the
+// left end carries the identity.
+func TestBandDropsTheRightSideWhenItCannotFit(t *testing.T) {
+	require.Equal(t, "left", Band("left", "right", 4))
+	require.NotContains(t, Band("left side here", "right", 14), "right")
+}
+
+// The renderer and the hit-tester have to agree on the column, which they can
+// only do by asking the same function. -1 is how "nothing was drawn there" is
+// said, so a click cannot land on a fragment that is not on screen.
+func TestBandRightXAgreesWithBand(t *testing.T) {
+	left, right := StyleDim.Render("✦ cnspec"), StyleAccent.Render("● connected")
+	for w := 1; w <= 60; w++ {
+		x := BandRightX(left, right, w)
+		out := Band(left, right, w)
+		if x < 0 {
+			require.NotContains(t, ansi.Strip(out), ansi.Strip(right), "width %d dropped the right side", w)
+			continue
+		}
+		require.Equal(t, x, Width(ansi.Strip(out))-Width(ansi.Strip(right)),
+			"width %d: the right side must start where BandRightX says", w)
+	}
+}
+
+// The middle fragment is a luxury: it appears only when the band has room to
+// look laid out rather than crowded, and never at the cost of the other two.
+func TestBand3DropsTheMiddleWhenTheBandIsTight(t *testing.T) {
+	left, mid, right := "left", "middle", "right"
+	require.Contains(t, Band3(left, mid, right, 40), mid)
+	require.NotContains(t, Band3(left, mid, right, 16), mid)
+	require.Equal(t, Band(left, right, 16), Band3(left, mid, right, 16))
+	for w := 1; w <= 60; w++ {
+		require.LessOrEqual(t, Width(Band3(left, mid, right, w)), w, "width %d", w)
+	}
+	require.Equal(t, Band(left, right, 40), Band3(left, "", right, 40),
+		"no middle fragment is the two-fragment band")
+}
+
+// A band measures cells, not bytes, so a styled fragment must not push it over.
+func TestBandMeasuresRenderedWidth(t *testing.T) {
+	left := StyleAccent.Render(strings.Repeat("a", 10))
+	right := StyleDim.Render(strings.Repeat("b", 10))
+	require.Equal(t, 30, Width(ansi.Strip(Band(left, right, 30))))
+}

--- a/cli/tui/form/field.go
+++ b/cli/tui/form/field.go
@@ -1,0 +1,395 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package form is the input screen a terminal UI puts between choosing
+// something to run and running it: a list of questions, the answers, and the
+// command line the two produce.
+//
+// It knows nothing about connectors, providers or credentials sources. That is
+// the point of it being a package: the function every field of every connector
+// passes through on its way to argv used to open with a test for one cloud
+// provider's profile picker, and there was no boundary to stop the second one
+// being added beside it.
+package form
+
+import (
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Kind is what a field is answered with, which decides both the widget it gets
+// and how its answer becomes a command-line word.
+type Kind int
+
+const (
+	KindText        Kind = iota // free text
+	KindBool                    // a toggle
+	KindChoice                  // one of Options, or free text
+	KindMultiChoice             // any number of Options
+	KindKeyValue                // KEY=VALUE pairs, comma separated
+
+	// KindCredentialState shows whether an ambient credential is present and
+	// where it came from: an environment variable, a config file, or nothing.
+	// It is not typed into -- the value it carries is a description of the
+	// state, not the credential -- so it swallows keys rather than editing.
+	KindCredentialState
+	// KindPaste takes a secret the user pastes in, for the providers whose
+	// credential is ambient or nothing: there is no list to pick from and the
+	// only alternative is a shell they have already left.
+	//
+	// A paste field must be marked Secret or Special by whoever creates it.
+	// The kind decides how it is drawn; only those two decide whether its
+	// value can reach the command line, and Args reads them, not the kind.
+	KindPaste
+)
+
+// Sections group fields on screen, in this order.
+const (
+	SectionTarget     = "TARGET"
+	SectionCredential = "CREDENTIAL"
+	SectionOptions    = "OPTIONS"
+)
+
+var sectionOrder = []string{SectionTarget, SectionCredential, SectionOptions}
+
+// Emit maps a value as a field displays it to the value a command line takes.
+// A value it maps to "" contributes nothing at all.
+type Emit func(display string) string
+
+// Decl is the question a field asks: what it is called, where it sits, what it
+// offers, and what it contributes to the command. It is inert data the caller
+// composes, and it is exported for exactly that reason -- hiding it behind
+// nineteen accessors would buy nothing, because none of it is a decision this
+// package makes.
+//
+// What the *user* did with the question is not in here. See Field.
+type Decl struct {
+	// Label is what the user sees.
+	Label string
+	// Desc is the one-line help.
+	Desc string
+	// Flag is the long flag name this field emits. Empty for a positional
+	// argument, whose place is given by Pos instead.
+	Flag string
+	Pos  int
+
+	Kind    Kind
+	Options []string
+
+	Required bool
+	// Secret marks a field whose value must never reach the command line.
+	Secret bool
+	// Reference marks a field that names a file holding a credential rather
+	// than holding one, so it becomes a path in an inventory rather than a
+	// value.
+	Reference bool
+	// Special marks a field the caller owns rather than one the connector
+	// declared, so it never reaches the command line -- neither as a flag nor
+	// as a positional argument.
+	Special string
+	// Env names the environment variable this field's value travels in, for a
+	// target that has no flag to carry it.
+	Env string
+
+	// The next three implement a selector: one field choosing what kind of
+	// thing the target is, and the field after it adapting. The choice is a UI
+	// distinction that changes which values are offered -- it must not put
+	// extra words on the command line, which is what Emit is for.
+
+	// SourceBy picks this field's value source from the value of the field
+	// named by DependsOn.
+	SourceBy map[string]string
+	// LiveSourceBy picks the live source from the selector, the way SourceBy
+	// picks the cheap one. Without this a live list stays attached across a
+	// change of selector, and an organization id would be offered a list of
+	// projects.
+	LiveSourceBy map[string]string
+	// DiscoverBy preselects discovery targets for a chosen value.
+	DiscoverBy map[string][]string
+	DependsOn  int
+
+	Section string
+	// LiveSource names a second picker, run only when the field is opened,
+	// whose values are merged into the first's. It exists because the two
+	// halves of "what can I scan" do not always come from the same place: a
+	// cheap local read gives the obvious answer immediately, while the full
+	// list needs the network and the user's patience.
+	LiveSource string
+	// ShowIf hides this field unless the field named by DependsOn holds one of
+	// these values. This is what makes a form guided: choosing a live cluster
+	// asks for a cluster, choosing a manifest asks for a path, and neither
+	// screen shows the other's questions.
+	ShowIf []string
+	// Strict marks a choice whose Options are the only valid values, as opposed
+	// to a picker that suggests what is on this machine but still accepts
+	// anything typed.
+	Strict bool
+}
+
+// Field is one row of a form: the question, and the answer to it.
+//
+// The answer is unexported and reachable only through the methods below, and
+// that is the whole of what this boundary is for. Every accessor is a rule
+// somebody has already got wrong by reading a member directly: Emitted is not
+// Value, because a picker annotates what it found and a selector emits nothing
+// at all; Display is not Value, because a secret is drawn as bullets; IsSet is
+// not `!= ""`, because a toggle and a multi-choice answer differently.
+//
+// source and emit are unexported for the same reason and travel together, which
+// SetSource is what enforces: a picker attached without its mapping puts the
+// annotation on the command line, and the failure is a scan against something
+// the provider has never heard of rather than anything the UI reports.
+type Field struct {
+	Decl
+
+	// value holds text, choice and key/value input; on holds a toggle; picks
+	// holds a multi-choice selection.
+	value string
+	on    bool
+	picks map[string]bool
+
+	// source names the value picker this field's options come from. It is an
+	// opaque id: this package never resolves it, it only keeps it beside the
+	// mapping the resolver handed back.
+	source string
+	emit   Emit
+
+	// optCursor points at the option under the cursor for choice and
+	// multi-choice fields.
+	optCursor int
+	// prefilled explains why this field filled itself in -- "current",
+	// "default", "only one" -- so a value the user did not type is not a small
+	// mystery.
+	prefilled string
+	// resolvedKey is the selector value the *By maps were last applied for, so
+	// a user's own choices are not overwritten on every keystroke.
+	resolvedKey string
+}
+
+// NewField builds a field from its declaration. A multi-choice starts with an
+// empty selection rather than a nil one, because a nil map is not writable and
+// the picker writes to it on the first keystroke.
+func NewField(d Decl) Field {
+	f := Field{Decl: d}
+	if d.Kind == KindMultiChoice {
+		f.picks = map[string]bool{}
+	}
+	return f
+}
+
+// Value is what the user typed or chose, as it is displayed. It is not what
+// reaches the command line; see Emitted.
+func (f Field) Value() string { return f.value }
+
+// SetValue records an answer, and clears the note saying the field filled
+// itself in -- once a user has typed here, "(default)" is no longer true.
+func (f *Field) SetValue(v string) {
+	f.value = v
+	f.prefilled = ""
+}
+
+// Prefill records an answer the field derived for the user, and why.
+func (f *Field) Prefill(v, why string) {
+	f.value = v
+	f.prefilled = why
+}
+
+// Prefilled is why this field filled itself in, or "" when the user did.
+func (f Field) Prefilled() string { return f.prefilled }
+
+// SetPrefilled overrides the note without touching the value, for a readout
+// whose value and reason are derived together.
+func (f *Field) SetPrefilled(why string) { f.prefilled = why }
+
+// On is a toggle's state.
+func (f Field) On() bool { return f.on }
+
+// SetOn sets a toggle, for a declared default.
+func (f *Field) SetOn(on bool) { f.on = on }
+
+// Toggle flips a toggle.
+func (f *Field) Toggle() { f.on = !f.on }
+
+// Picked reports whether a multi-choice option is selected.
+func (f Field) Picked(option string) bool { return f.picks[option] }
+
+// TogglePick adds or removes one option from a multi-choice selection.
+func (f *Field) TogglePick(option string) {
+	if f.picks == nil {
+		f.picks = map[string]bool{}
+	}
+	if f.picks[option] {
+		delete(f.picks, option)
+		return
+	}
+	f.picks[option] = true
+}
+
+// SetPicks replaces a multi-choice selection wholesale.
+func (f *Field) SetPicks(picks map[string]bool) { f.picks = picks }
+
+// OptCursor is the option under the cursor.
+func (f Field) OptCursor() int { return f.optCursor }
+
+// SetOptCursor moves the cursor over the options.
+func (f *Field) SetOptCursor(i int) { f.optCursor = i }
+
+// Source names the value picker this field's options come from, or "".
+func (f Field) Source() string { return f.source }
+
+// SetSource points a field at a value picker, and takes the picker's own answer
+// to what its displayed values mean on a command line along with it.
+//
+// The two are one argument list because they are one decision. A picker may
+// annotate what it found -- a cloud profile listed with the account id it names,
+// because "which account is that?" is the question a profile name rarely
+// answers -- and the annotation is not something the receiving command accepts.
+// Passing nil says the picker's values are already the words the command takes.
+func (f *Field) SetSource(id string, emit Emit) {
+	f.source = id
+	f.emit = emit
+}
+
+// SetEmit declares this field's own value mapping, for a selector whose options
+// are fixed and some of which steer the screen without adding a word.
+//
+// A field never carries both this and a picker's mapping: a declaration cannot
+// enumerate what a picker will find, so the two never describe the same field.
+func (f *Field) SetEmit(e Emit) { f.emit = e }
+
+// Emitted is what a field contributes to the command line, which is not always
+// what it displays: a selector that only steers the UI emits nothing.
+func (f Field) Emitted() string {
+	if f.emit != nil {
+		return f.emit(f.value)
+	}
+	return f.value
+}
+
+// IsSet reports whether this field has been answered.
+func (f Field) IsSet() bool {
+	switch f.Kind {
+	case KindBool:
+		return f.on
+	case KindMultiChoice:
+		return len(f.picks) > 0
+	case KindCredentialState:
+		// A credential-state field is set when a credential was found. The
+		// value it carries describes where, which is exactly what makes an
+		// empty one mean "nothing ambient here".
+		return f.value != ""
+	case KindPaste:
+		return f.value != ""
+	default:
+		return f.value != ""
+	}
+}
+
+// Display is the field's current value as shown on screen.
+func (f Field) Display() string {
+	switch f.Kind {
+	case KindBool:
+		if f.on {
+			return "yes"
+		}
+		return "no"
+	case KindMultiChoice:
+		return strings.Join(f.Selected(), ", ")
+	case KindCredentialState:
+		// The value is already a sentence about where the credential came
+		// from, so it is shown as it stands. Masking it would hide the one
+		// thing this field exists to say.
+		return f.value
+	case KindPaste:
+		if f.value != "" {
+			return strings.Repeat("•", len(f.value))
+		}
+	case KindText, KindChoice, KindKeyValue:
+		if f.Secret && f.value != "" {
+			return strings.Repeat("•", len(f.value))
+		}
+	}
+	return f.value
+}
+
+// Placeholder is the hint shown in an empty field: its own description, or the
+// first thing a picker found, so the user can see what shape of value fits.
+func (f Field) Placeholder() string {
+	if f.Desc != "" {
+		return f.Desc
+	}
+	if len(f.Options) > 0 {
+		return "e.g. " + f.Options[0]
+	}
+	return ""
+}
+
+// Selected returns a multi-choice field's picks in the options' own order, so
+// the rendered value is stable rather than map-ordered.
+func (f Field) Selected() []string {
+	if len(f.picks) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(f.picks))
+	for _, o := range f.Options {
+		if f.picks[o] {
+			out = append(out, o)
+		}
+	}
+	// Anything picked that is not in Options (a curated addition) goes last.
+	if len(out) != len(f.picks) {
+		extra := make([]string, 0)
+		for p := range f.picks {
+			if !slices.Contains(f.Options, p) {
+				extra = append(extra, p)
+			}
+		}
+		sort.Strings(extra)
+		out = append(out, extra...)
+	}
+	return out
+}
+
+// Identity names a field independently of its position, so the same question
+// can be recognised across a rebuild of the form.
+func (f Field) Identity() string {
+	switch {
+	case f.Special != "":
+		return "s:" + f.Special
+	case f.Flag != "":
+		return "f:" + f.Flag
+	default:
+		return "p:" + strconv.Itoa(f.Pos)
+	}
+}
+
+// MatchesIdentity reports whether a field is the one a declaration names.
+//
+// The canonical spelling is Identity -- "f:context", "p:0", "s:token" -- and a
+// bare name is accepted as shorthand for a flag, because that is how a source's
+// dependency has always spelled itself and there is no reason to break it. The
+// shorthand is deliberately flags only: "0" meaning the first positional would
+// be a name a flag could also have.
+func MatchesIdentity(f Field, want string) bool {
+	if want == "" {
+		return false
+	}
+	if f.Identity() == want {
+		return true
+	}
+	return !strings.ContainsRune(want, ':') && f.Flag == want
+}
+
+// PromoteToChoice turns a plain text field into a picker once something has
+// given it values to offer.
+//
+// Only a plain text field is promoted, which is also what keeps the kinds a
+// caller owns -- a credential-state readout, a paste box -- from being turned
+// into pickers by an overlay that only meant to attach a list.
+func (f *Field) PromoteToChoice() {
+	if f.Kind == KindText {
+		f.Kind = KindChoice
+	}
+}

--- a/cli/tui/form/form.go
+++ b/cli/tui/form/form.go
@@ -1,0 +1,428 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package form
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Form is a screen full of fields and the cursor moving over them.
+type Form struct {
+	subject string
+	fields  []Field
+	cursor  int
+}
+
+// New builds a form over the given fields. The subject is whatever the caller
+// calls the thing being configured, and is carried only so a rebuilt form can
+// recognise whether it is still the same screen; see CarryOver. This package
+// never interprets it.
+func New(subject string, fields []Field) Form {
+	return Form{subject: subject, fields: fields}
+}
+
+// Subject is what this form is asking about.
+func (f Form) Subject() string { return f.subject }
+
+// Fields are the form's rows, in order. The slice header is a copy but the rows
+// are the form's own, so a caller may edit a field's declaration through it --
+// which is what an overlay does -- and still cannot reach an answer except
+// through Field's methods.
+func (f Form) Fields() []Field { return f.fields }
+
+// SetFields replaces the rows wholesale, for an overlay that reorders or
+// replaces what the generic layer derived.
+func (f *Form) SetFields(fields []Field) { f.fields = fields }
+
+// Cursor is the row the keyboard is on.
+func (f Form) Cursor() int { return f.cursor }
+
+// SetCursor moves the keyboard to a row.
+func (f *Form) SetCursor(i int) { f.cursor = i }
+
+// Visible reports whether a field applies given what has been chosen so far.
+func (f Form) Visible(i int) bool {
+	fd := f.fields[i]
+	if len(fd.ShowIf) == 0 {
+		return true
+	}
+	if fd.DependsOn < 0 || fd.DependsOn >= len(f.fields) {
+		return true
+	}
+	return slices.Contains(fd.ShowIf, f.fields[fd.DependsOn].value)
+}
+
+// VisibleIndices are the fields that apply, in order.
+func (f Form) VisibleIndices() []int {
+	out := make([]int, 0, len(f.fields))
+	for i := range f.fields {
+		if f.Visible(i) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// TypeEmptyLists turns a list field with nothing to pick from into one that can
+// be typed into.
+//
+// A list flag becomes a multi-choice, and a multi-choice with no options is a
+// row no keystroke can fill: a picker declines to open empty, and the shared
+// input refuses to write itself back into a multi-choice. Six of helm's flags,
+// mcp's --env and nd-ssh's --system-transport-args were all in that state, and
+// the only answer available to the specs that met it was to hide the row --
+// which is a reasonable thing to do about a field that cannot be filled and a
+// poor thing to do about a field that matters.
+//
+// Comma-separated is not a convention invented here: pflag's own StringSlice
+// splits its value on commas, which is how `--values a.yaml,b.yaml` already
+// reaches a provider from a shell. So the typed form and the picked form
+// produce the same command line, and Args already joins a multi-choice's picks
+// the same way.
+//
+// A list that does have options -- a discovery flag always does, and an overlay
+// may add choices -- keeps its picker. The two are not exclusive in principle,
+// and letting a picker also take typed entries is a bigger change to the modal
+// than this is; a list with options at least has a keystroke that works.
+func (f *Form) TypeEmptyLists() {
+	for i := range f.fields {
+		fd := &f.fields[i]
+		if fd.Kind != KindMultiChoice {
+			continue
+		}
+		if len(fd.Options) > 0 || fd.source != "" || fd.LiveSource != "" ||
+			fd.SourceBy != nil || fd.LiveSourceBy != nil {
+			continue
+		}
+		fd.Kind = KindText
+		fd.value = strings.Join(fd.Selected(), ",")
+		fd.picks = nil
+		if fd.Desc != "" && !strings.Contains(strings.ToLower(fd.Desc), "comma") {
+			fd.Desc += " (comma separated)"
+		}
+	}
+}
+
+// visibleLabels is the set of labels the current choices leave on screen. A
+// field the choices have hidden is not part of the command: a manifest path
+// left over from before "live cluster" was chosen must not travel with it.
+func (f Form) visibleLabels() map[string]bool {
+	out := make(map[string]bool, len(f.fields))
+	for _, i := range f.VisibleIndices() {
+		out[f.fields[i].Label] = true
+	}
+	return out
+}
+
+// Positional is the form's positional arguments, in argument order.
+//
+// An unset one is skipped rather than emitted empty. Several connectors lead
+// with an optional selector -- `terraform [plan|state] PATH` -- where leaving
+// it blank has to collapse to just the path. A positional that must not be
+// skipped is marked Required and caught by Validate.
+func (f Form) Positional() []string {
+	visible := f.visibleLabels()
+	ordered := append([]Field(nil), f.fields...)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Pos < ordered[j].Pos })
+
+	var pos []string
+	for _, fd := range ordered {
+		// A caller-owned field is not an argument either. Special was only
+		// honoured in the flag loop below, which was harmless while every such
+		// field carried a flag -- but the ambient-credential widgets do not,
+		// and a readout saying where a token came from would otherwise be
+		// handed to the child as the thing to scan.
+		if fd.Flag != "" || fd.Special != "" || !visible[fd.Label] {
+			continue
+		}
+		if v := fd.Emitted(); v != "" {
+			pos = append(pos, v)
+		}
+	}
+	return pos
+}
+
+// FlagFields are the answered flag-carrying rows, in declaration order,
+// secrets included.
+//
+// Secrets are included here and excluded by Args, and the difference is the
+// whole point of this method existing. A secret does travel to the provider --
+// it just travels in a protobuf field over the plugin's gRPC connection rather
+// than in a word on a command line that `ps auxww` publishes. The two callers
+// need the same answer to "which rows are part of this command" and disagree
+// only about that one hop.
+func (f Form) FlagFields() []Field {
+	visible := f.visibleLabels()
+	var out []Field
+	for _, fd := range f.fields {
+		if fd.Flag == "" || fd.Special != "" || !fd.IsSet() || !visible[fd.Label] {
+			continue
+		}
+		out = append(out, fd)
+	}
+	return out
+}
+
+// Args emits the command line the form describes: positional arguments in
+// order, then flags. Secret fields are skipped -- they travel by inventory
+// file, never on the command line.
+func (f Form) Args() []string {
+	var flags []string
+	for _, fd := range f.FlagFields() {
+		if fd.Secret {
+			continue
+		}
+		switch fd.Kind {
+		case KindBool:
+			flags = append(flags, "--"+fd.Flag)
+		case KindMultiChoice:
+			flags = append(flags, "--"+fd.Flag, strings.Join(fd.Selected(), ","))
+		default:
+			flags = append(flags, "--"+fd.Flag, fd.Emitted())
+		}
+	}
+	return append(f.Positional(), flags...)
+}
+
+// Secrets returns the fields carrying a secret value, which decide how a launch
+// delivers a credential and whether it can at all.
+//
+// Only visible fields count, the same rule Args applies. A value typed into a
+// field that a later choice hid is not part of what the user is asking for, and
+// counting it produced an outcome nobody could see the cause of: a unifi user
+// who typed a password, switched the credential selector to "API key" and typed
+// a key was told the launcher could not carry the credential on a screen
+// showing exactly one. The stale value decided the route while being invisible
+// -- which is also why this is a bug rather than a policy question. The form
+// says what the command is; a row that is not on it is not part of the command.
+func (f Form) Secrets() []Field {
+	var out []Field
+	for _, i := range f.VisibleIndices() {
+		if fd := f.fields[i]; fd.Secret && fd.IsSet() {
+			out = append(out, fd)
+		}
+	}
+	return out
+}
+
+// ResolveSources points every dependent field at the picker its selector
+// currently calls for, so choosing "local image" swaps the reference field from
+// listing containers to listing images.
+//
+// emitFor is asked what a newly attached picker's displayed values mean on a
+// command line. It is a parameter rather than a registry lookup because this
+// package does not know what a picker is: it holds an opaque id and the mapping
+// that came with it, and the two must never be separated. See Field.SetSource.
+func (f *Form) ResolveSources(emitFor func(source string) Emit) {
+	for i := range f.fields {
+		fd := &f.fields[i]
+		if fd.SourceBy == nil && fd.LiveSourceBy == nil && fd.DiscoverBy == nil {
+			continue
+		}
+		key := ""
+		if fd.DependsOn >= 0 && fd.DependsOn < len(f.fields) {
+			key = f.fields[fd.DependsOn].value
+		}
+		if key == fd.resolvedKey {
+			continue
+		}
+		fd.resolvedKey = key
+
+		if fd.SourceBy != nil {
+			// The offered values belong to the old picker; drop them rather
+			// than suggest a container when an image was asked for.
+			src := fd.SourceBy[key]
+			fd.SetSource(src, emitFor(src))
+			fd.Options = nil
+			fd.optCursor = 0
+		}
+		if fd.LiveSourceBy != nil {
+			fd.LiveSource = fd.LiveSourceBy[key]
+		}
+		if targets, ok := fd.DiscoverBy[key]; ok {
+			f.setDiscover(targets)
+		}
+	}
+}
+
+// setDiscover preselects the discovery flag's targets.
+func (f *Form) setDiscover(targets []string) {
+	for i := range f.fields {
+		fd := &f.fields[i]
+		if fd.Flag != "discover" {
+			continue
+		}
+		fd.picks = map[string]bool{}
+		for _, t := range targets {
+			fd.picks[t] = true
+		}
+	}
+}
+
+// Validate reports the first problem that would make the assembled command
+// fail, so a caller can say so in place instead of tearing the screen down to
+// show a usage error.
+func (f Form) Validate() error {
+	for _, i := range f.VisibleIndices() {
+		if fd := f.fields[i]; fd.Required && !fd.IsSet() {
+			return fmt.Errorf("%s is required", fd.Label)
+		}
+	}
+	return nil
+}
+
+// Ordered returns the fields grouped into their sections, in section order,
+// paired with the index each field has in the form so the cursor and the click
+// zones keep referring to the same thing.
+func (f Form) Ordered() (sections []string, bySection map[string][]int) {
+	bySection = map[string][]int{}
+	for i, fd := range f.fields {
+		bySection[fd.Section] = append(bySection[fd.Section], i)
+	}
+	for _, s := range sectionOrder {
+		if len(bySection[s]) > 0 {
+			sections = append(sections, s)
+		}
+	}
+	return sections, bySection
+}
+
+// CarryOver copies what the user entered on old onto this freshly built form.
+//
+// A form can be rebuilt underneath the user: a provider install lands
+// asynchronously and the real metadata replaces the placeholder.
+// Rebuilding is right -- the new form has fields the old one could not know
+// about -- but discarding a half-typed target along the way is experienced as
+// the launcher eating input.
+//
+// Only values the user is responsible for are carried. A prefilled value is
+// the rebuild's own business: it re-derives it, possibly better, now that it
+// has the provider's metadata.
+func (f *Form) CarryOver(old Form) {
+	if old.subject != f.subject || len(old.fields) == 0 {
+		return
+	}
+	prev := make(map[string]Field, len(old.fields))
+	for _, fd := range old.fields {
+		prev[fd.Identity()] = fd
+	}
+	for i := range f.fields {
+		o, ok := prev[f.fields[i].Identity()]
+		if !ok || o.prefilled != "" {
+			continue
+		}
+		if o.value != "" {
+			f.fields[i].value = o.value
+			f.fields[i].prefilled = ""
+		}
+		if o.on {
+			f.fields[i].on = true
+		}
+		if len(o.picks) > 0 {
+			f.fields[i].picks = o.picks
+		}
+	}
+	if old.cursor > 0 && old.cursor < len(f.fields) {
+		f.cursor = old.cursor
+	}
+}
+
+// IndexOfFlag finds the field emitting a flag, or -1. A flag named "" is no
+// flag: a positional field would otherwise match it.
+func (f Form) IndexOfFlag(flag string) int {
+	if flag == "" {
+		return -1
+	}
+	for i := range f.fields {
+		if f.fields[i].Flag == flag {
+			return i
+		}
+	}
+	return -1
+}
+
+// IndexOfSpecial finds a caller-owned field by its marker, or -1.
+func (f Form) IndexOfSpecial(special string) int {
+	if special == "" {
+		return -1
+	}
+	for i := range f.fields {
+		if f.fields[i].Special == special {
+			return i
+		}
+	}
+	return -1
+}
+
+// InsertField puts a field at an index, keeping every DependsOn pointing at the
+// field it was pointing at before.
+//
+// Those indices are what make a form guided -- a selector at index 0 deciding
+// which values the field after it offers -- and they are plain ints, so
+// inserting anything ahead of one silently re-points it at its neighbour. Only
+// a field that actually uses DependsOn is adjusted: the rest carry a zero that
+// means nothing, and moving it would only make it look meaningful.
+func (f *Form) InsertField(at int, fd Field) {
+	if at < 0 || at > len(f.fields) {
+		at = len(f.fields)
+	}
+	f.fields = append(f.fields, Field{})
+	copy(f.fields[at+1:], f.fields[at:])
+	f.fields[at] = fd
+
+	for i := range f.fields {
+		g := &f.fields[i]
+		if g.ShowIf == nil && g.SourceBy == nil && g.LiveSourceBy == nil && g.DiscoverBy == nil {
+			continue
+		}
+		if g.DependsOn >= at {
+			g.DependsOn++
+		}
+	}
+}
+
+// SortFields orders fields by section, then by an overlay's ranking, then by
+// whatever order they arrived in.
+func SortFields(fields []Field, rank map[string]int) {
+	sectionRank := map[string]int{}
+	for i, s := range sectionOrder {
+		sectionRank[s] = i
+	}
+	// Insertion sort keeps it stable and the slices here are tiny.
+	for i := 1; i < len(fields); i++ {
+		for j := i; j > 0; j-- {
+			a, b := fields[j-1], fields[j]
+			if fieldLess(b, a, sectionRank, rank) {
+				fields[j-1], fields[j] = b, a
+				continue
+			}
+			break
+		}
+	}
+}
+
+func fieldLess(a, b Field, sectionRank, rank map[string]int) bool {
+	if sa, sb := sectionRank[a.Section], sectionRank[b.Section]; sa != sb {
+		return sa < sb
+	}
+	// Positional fields always lead their section, in argument order.
+	if (a.Flag == "") != (b.Flag == "") {
+		return a.Flag == ""
+	}
+	if a.Flag == "" && b.Flag == "" {
+		return a.Pos < b.Pos
+	}
+	ra, aok := rank[a.Flag]
+	rb, bok := rank[b.Flag]
+	if aok != bok {
+		return aok
+	}
+	if aok && bok {
+		return ra < rb
+	}
+	return false
+}

--- a/cli/tui/form/form_test.go
+++ b/cli/tui/form/form_test.go
@@ -1,0 +1,146 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package form
+
+import (
+	"strings"
+	"testing"
+)
+
+// What this package is for is the difference between the three ways of asking a
+// field for its answer. Reading the wrong one is the bug the boundary exists to
+// make unavailable, so each is stated here rather than only in the launcher's
+// own suite.
+func TestValueDisplayAndEmittedAreThreeDifferentQuestions(t *testing.T) {
+	fd := NewField(Decl{Label: "profile", Flag: "profile", Kind: KindChoice})
+	fd.SetSource("profiles", func(display string) string {
+		return strings.TrimSuffix(display, "  (123456789012)")
+	})
+	fd.SetValue("prod  (123456789012)")
+
+	if got := fd.Value(); got != "prod  (123456789012)" {
+		t.Errorf("Value = %q, want what the user chose", got)
+	}
+	if got := fd.Display(); got != "prod  (123456789012)" {
+		t.Errorf("Display = %q, want what the user chose", got)
+	}
+	if got := fd.Emitted(); got != "prod" {
+		t.Errorf("Emitted = %q, want the annotation stripped", got)
+	}
+
+	secret := NewField(Decl{Label: "password", Flag: "password", Kind: KindText, Secret: true})
+	secret.SetValue("<PLACEHOLDER-not-a-real-secret>")
+	if got := secret.Display(); got != strings.Repeat("•", len("<PLACEHOLDER-not-a-real-secret>")) {
+		t.Errorf("a secret rendered as %q", got)
+	}
+	if got := secret.Value(); got != "<PLACEHOLDER-not-a-real-secret>" {
+		t.Errorf("Value = %q, want the secret itself -- it has to reach a vault", got)
+	}
+}
+
+// A secret never reaches the command line, whatever else the form is asked for.
+func TestArgsNeverCarryASecret(t *testing.T) {
+	password := NewField(Decl{Label: "password", Flag: "password", Kind: KindText, Secret: true})
+	password.SetValue("<PLACEHOLDER-not-a-real-secret>")
+	host := NewField(Decl{Label: "host", Pos: 0, Kind: KindText})
+	host.SetValue("example.com")
+
+	f := New("ssh", []Field{host, password})
+	line := strings.Join(f.Args(), " ")
+	if strings.Contains(line, "<PLACEHOLDER-not-a-real-secret>") {
+		t.Fatalf("the secret reached argv: %q", line)
+	}
+	if line != "example.com" {
+		t.Fatalf("args = %q, want just the target", line)
+	}
+	if got := f.Secrets(); len(got) != 1 || got[0].Flag != "password" {
+		t.Fatalf("Secrets = %v, want the one filled secret", got)
+	}
+}
+
+// A selector steers the screen without putting its own words on the command
+// line, which is what a declared mapping to "" is for.
+func TestASelectorCanEmitNothing(t *testing.T) {
+	kind := NewField(Decl{Label: "kind", Pos: 0, Kind: KindChoice,
+		Options: []string{"live cluster", "manifest file"}})
+	kind.SetEmit(func(display string) string {
+		return map[string]string{"live cluster": "", "manifest file": ""}[display]
+	})
+	kind.SetValue("live cluster")
+	path := NewField(Decl{Label: "path", Pos: 1, Kind: KindText,
+		ShowIf: []string{"manifest file"}, DependsOn: 0})
+	path.SetValue("./left-over.yaml")
+
+	f := New("k8s", []Field{kind, path})
+	if got := f.Args(); len(got) != 0 {
+		// The path is hidden by the selector, so it is not part of the command
+		// either -- a value the user cannot see is not one they are asking for.
+		t.Fatalf("args = %v, want nothing at all", got)
+	}
+}
+
+// Inserting a row ahead of a selector must not silently re-point it at its new
+// neighbour, which is what plain int indices invite.
+func TestInsertFieldKeepsDependenciesPointingAtTheSameField(t *testing.T) {
+	f := New("test", []Field{
+		NewField(Decl{Label: "selector"}),
+		NewField(Decl{Label: "dependent", ShowIf: []string{"x"}, DependsOn: 0}),
+	})
+	f.InsertField(0, NewField(Decl{Label: "readout", Kind: KindCredentialState}))
+
+	if got := f.Fields()[2].DependsOn; got != 1 {
+		t.Errorf("the dependent now points at field %d, want 1", got)
+	}
+	if got := f.Fields()[0].DependsOn; got != 0 {
+		t.Errorf("the inserted row gained a dependency: %d", got)
+	}
+}
+
+// A picker and the mapping that says what its values mean travel together, so
+// switching a selector cannot leave the old mapping behind.
+func TestResolveSourcesSwapsTheMappingWithThePicker(t *testing.T) {
+	emitters := map[string]Emit{
+		"annotated": func(display string) string { return strings.TrimSuffix(display, " (x)") },
+		"plain":     nil,
+	}
+	f := New("test", []Field{
+		NewField(Decl{Label: "kind", Pos: 0, Kind: KindChoice}),
+		NewField(Decl{Label: "thing", Flag: "thing", Kind: KindChoice,
+			SourceBy: map[string]string{"a": "annotated", "p": "plain"}}),
+	})
+
+	f.Fields()[0].SetValue("a")
+	f.ResolveSources(func(id string) Emit { return emitters[id] })
+	f.Fields()[1].SetValue("name (x)")
+	if got := f.Fields()[1].Emitted(); got != "name" {
+		t.Fatalf("Emitted = %q, want the annotated picker's mapping applied", got)
+	}
+
+	f.Fields()[0].SetValue("p")
+	f.ResolveSources(func(id string) Emit { return emitters[id] })
+	if got := f.Fields()[1].Emitted(); got != "name (x)" {
+		t.Fatalf("Emitted = %q, want the old mapping gone with the old picker", got)
+	}
+}
+
+// A multi-choice with nothing to pick from is a row no keystroke can fill, so
+// it becomes a text box that takes the same comma-separated value.
+func TestAnUnfillableListBecomesTypeable(t *testing.T) {
+	f := New("helm", []Field{
+		NewField(Decl{Label: "values", Flag: "values", Kind: KindMultiChoice, Desc: "value files"}),
+		NewField(Decl{Label: "discover", Flag: "discover", Kind: KindMultiChoice,
+			Options: []string{"auto", "all"}}),
+	})
+	f.TypeEmptyLists()
+
+	if got := f.Fields()[0].Kind; got != KindText {
+		t.Errorf("an optionless list is still a %v", got)
+	}
+	if got := f.Fields()[0].Desc; !strings.Contains(got, "comma") {
+		t.Errorf("nothing tells the user how to type several: %q", got)
+	}
+	if got := f.Fields()[1].Kind; got != KindMultiChoice {
+		t.Errorf("a list with options lost its picker: %v", got)
+	}
+}

--- a/cli/tui/form/secret.go
+++ b/cli/tui/form/secret.go
@@ -1,0 +1,110 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package form
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Identifying which flags carry a secret is the single most important thing
+// the form layer does, because a value the launcher gets wrong here ends up in
+// the process table where every user on the machine can read it.
+//
+// FlagOption_Password cannot be the answer. A sweep of the installed provider
+// set found 60 secret-carrying flags across 45 providers that leave Option
+// unset -- azure --client-secret, github --token, okta --private-key,
+// alicloud --access-key-secret, and so on. Only the database family and os/ssh
+// set the bit. So the bit is one signal among several, and the classifier errs
+// toward marking: a false positive costs a temp file, a false negative leaks a
+// credential.
+//
+// The word lists below are shared by every connector, which makes them the
+// wrong place to fix one connector's odd flag: widening a word to catch it
+// re-classifies every other flag that happens to contain it. A spec says so
+// about its own flag instead, with FormSpec.Secret and FormSpec.NotSecret, and
+// those override everything here.
+
+// strongSecretWords end a flag name whose value is unambiguously a credential.
+// A name ending this way is a secret even when it also mentions a certificate:
+// --certificate-secret is the passphrase for the certificate, not the
+// certificate.
+var strongSecretWords = []string{
+	"secret", "password", "passwd", "passphrase", "token", "api-key", "apikey",
+}
+
+// weakSecretWords suggest a credential but are just as often part of the name
+// of something that merely points at one, so they are only trusted after the
+// reference checks below have had their say.
+var weakSecretWords = []string{"private-key", "credential"}
+
+// referenceWords mark a flag that names *where* a credential lives rather than
+// holding one: a path, a file, an identifier, a mode. Those are safe on the
+// command line and have to stay there, because that is how the provider
+// expects to receive them.
+var referenceWords = []string{
+	"-path", "-file", "-name", "-id", "-mode", "-method", "-url", "-type",
+}
+
+// IsSecretFlag reports whether a flag's value must be kept off the command
+// line.
+//
+// It takes no connector, and that is the design rather than an omission: every
+// per-connector correction is a FormSpec.Secret or FormSpec.NotSecret entry in
+// the file that curates the connector, beside the reason it is needed --
+// datadog's --app-key, stackit's --service-account-key, okta's --private-key.
+// A name here would invite those corrections back into word lists that every
+// other connector's flags are read through.
+func IsSecretFlag(fl plugin.Flag) bool {
+	// A toggle or a number cannot carry a secret. This is what keeps the
+	// --ask-pass and --ask-api-key family -- whose whole purpose is to make the
+	// child process prompt, the safest option available -- from being misread.
+	if fl.Type == plugin.FlagType_Bool || fl.Type == plugin.FlagType_Int {
+		return false
+	}
+	if fl.Option&plugin.FlagOption_Password != 0 {
+		return true
+	}
+	if IsSecretReference(fl) {
+		return false
+	}
+
+	name := strings.ToLower(fl.Long)
+	for _, w := range strongSecretWords {
+		if strings.HasSuffix(name, w) || strings.Contains(name, w+"-") {
+			return true
+		}
+	}
+	// Certificate and CA material is public by construction, and only reaches
+	// here once the strong words above have been ruled out.
+	if strings.Contains(name, "cert") || strings.HasSuffix(name, "-ca") {
+		return false
+	}
+	for _, w := range weakSecretWords {
+		if strings.Contains(name, w) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSecretReference reports whether a flag names a file rather than holding a
+// value. The name usually says so, but not always -- github's
+// --app-private-key is a path and only its description admits it -- so the
+// description is consulted too.
+func IsSecretReference(fl plugin.Flag) bool {
+	name := strings.ToLower(fl.Long)
+	for _, ref := range referenceWords {
+		if strings.Contains(name, ref) {
+			return true
+		}
+	}
+	desc := strings.ToLower(fl.Desc)
+	if strings.Contains(desc, "path to") || strings.Contains(desc, "file path") ||
+		strings.Contains(desc, "path of") {
+		return true
+	}
+	return false
+}

--- a/cli/tui/layout.go
+++ b/cli/tui/layout.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+// Geometry is computed in exactly one place per view, and both the renderer
+// (to draw) and the update loop (to hit-test mouse clicks) derive from it.
+// Because they share the same numbers, a drawn element and the region that
+// responds to it cannot drift apart.
+//
+// The invariant that makes this work: every row a view draws is exactly one
+// terminal line. No style may carry a margin, because a margin adds a line that
+// the arithmetic here cannot see -- which is how a list that "obviously" fits
+// ends up scrolling the screen.
+
+// Rect is a region of the terminal in cells.
+type Rect struct{ X, Y, W, H int }
+
+// Hit reports whether (x,y) falls inside the rect.
+func (r Rect) Hit(x, y int) bool {
+	return x >= r.X && x < r.X+r.W && y >= r.Y && y < r.Y+r.H
+}
+
+// ZoneKind identifies what a clickable region does.
+type ZoneKind int
+
+const (
+	ZoneNone     ZoneKind = iota
+	ZoneEntry             // a row in the left list; Idx is its selectable index
+	ZoneField             // an input field in the detail pane; Idx is its field index
+	ZoneMore              // the row that reveals the options
+	ZoneRun               // the run button
+	ZoneUpstream          // the reporting badge in the header
+)
+
+// Zone is a clickable region and the action it stands for.
+type Zone struct {
+	Rect Rect
+	Kind ZoneKind
+	Idx  int
+}
+
+// Chrome that frames the body: one header line at the top, one footer line at
+// the bottom.
+const (
+	HeaderLines = 1
+	FooterLines = 1
+	// Inside the left panel, the first rows are the search field and a spacer.
+	ListChromeLines = 2
+	// Below this width the two panes are too narrow to be readable, so only the
+	// focused one is shown.
+	MinTwoPaneWidth = 76
+)
+
+// Layout is the pane geometry of a two-pane view plus the zones drawn into it.
+type Layout struct {
+	Width, Height int
+
+	TwoPane bool
+	LeftW   int
+	RightW  int
+	RightX  int
+
+	BodyTop int // first body line
+	BodyH   int // lines available to each pane
+
+	ListTop int // absolute y of the first list row
+	ListH   int // list rows that fit
+
+	Zones []Zone
+}
+
+// Dims derives the pane geometry from the terminal size. It is the only place
+// that turns a terminal size into pane sizes.
+func Dims(width, height int) Layout {
+	l := Layout{Width: width, Height: height}
+
+	l.BodyTop = HeaderLines
+	l.BodyH = height - HeaderLines - FooterLines
+	if l.BodyH < 3 {
+		l.BodyH = 3
+	}
+
+	l.TwoPane = width >= MinTwoPaneWidth
+	if l.TwoPane {
+		l.LeftW = width * 38 / 100
+		if l.LeftW < 30 {
+			l.LeftW = 30
+		}
+		if l.LeftW > 46 {
+			l.LeftW = 46
+		}
+		l.RightW = width - l.LeftW - 1
+		l.RightX = l.LeftW + 1
+	} else {
+		l.LeftW = width
+		l.RightW = width
+		l.RightX = 0
+	}
+
+	// Panels draw a border, so the list starts one line below the body top and
+	// loses a line at the bottom as well.
+	l.ListTop = l.BodyTop + 1 + ListChromeLines
+	l.ListH = InnerHeight(l.BodyH) - ListChromeLines
+	if l.ListH < 1 {
+		l.ListH = 1
+	}
+	return l
+}
+
+// HitZone returns the topmost zone containing (x,y). Zones are appended in
+// render order, so walk in reverse and let later ones win.
+func (l Layout) HitZone(x, y int) Zone {
+	for i := len(l.Zones) - 1; i >= 0; i-- {
+		if l.Zones[i].Rect.Hit(x, y) {
+			return l.Zones[i]
+		}
+	}
+	return Zone{Kind: ZoneNone}
+}

--- a/cli/tui/layout_test.go
+++ b/cli/tui/layout_test.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func ansiStrip(s string) string { return ansi.Strip(s) }
+
+// termSizes covers the sizes that actually break things: the 80x24 default, a
+// window too narrow for two panes, and one short enough that the header, the
+// body and the footer cannot all have the room they want.
+var termSizes = []struct{ w, h int }{
+	{80, 24}, {100, 30}, {120, 40}, {200, 60}, {76, 24}, {70, 24}, {60, 15}, {40, 10}, {30, 6}, {20, 3},
+}
+
+// Panel is the promise the whole layout rests on: exactly h lines of exactly w
+// cells, whatever it is handed. Content that is too short, too long, too wide or
+// full of escape sequences all have to come out the same shape, because the
+// caller has already budgeted the rows.
+func TestPanelIsExactlyTheSizeItWasAsked(t *testing.T) {
+	contents := [][]string{
+		nil,
+		{"one"},
+		{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve"},
+		{strings.Repeat("x", 400)},
+		{StyleAccent.Render("styled") + " " + StyleDim.Render(strings.Repeat("wide ", 50))},
+	}
+	for _, content := range contents {
+		for _, s := range termSizes {
+			out := Panel(StyleAccent.Render("Title"), StyleFaint.Render("9/99"), content, s.w, s.h, ColAccent)
+			lines := strings.Split(out, "\n")
+			require.Len(t, lines, s.h, "%dx%d", s.w, s.h)
+			for i, ln := range lines {
+				require.LessOrEqual(t, Width(ln), s.w, "%dx%d line %d", s.w, s.h, i)
+			}
+		}
+	}
+}
+
+// The box has a floor, and it is the border. A rounded box cannot be drawn in
+// fewer than three lines or two columns, so below that Panel draws the smallest
+// box there is rather than something that is not a box. Nothing asks it to: Dims
+// clamps BodyH at 3 and a pane is never narrower than a third of a terminal.
+// The floor is asserted so that a caller that does ask knows what it gets.
+func TestPanelHasAFloorOfOneBorderedRow(t *testing.T) {
+	for _, s := range []struct{ w, h int }{{1, 1}, {2, 2}, {0, 0}} {
+		lines := strings.Split(Panel("t", "s", []string{"x"}, s.w, s.h, ColAccent), "\n")
+		require.Len(t, lines, BorderLines+1, "%dx%d", s.w, s.h)
+	}
+}
+
+// A title too long for the top edge must not widen the box; the status is
+// dropped first, and then the title is, so the frame stays a frame.
+func TestPanelTopSurvivesAnOversizedTitle(t *testing.T) {
+	bs := lipgloss.NewStyle().Foreground(ColAccentD)
+	for _, w := range []int{2, 4, 8, 20, 80} {
+		out := PanelTop(strings.Repeat("title ", 20), strings.Repeat("status ", 5), w, bs)
+		require.LessOrEqual(t, Width(out), w, "width %d", w)
+	}
+}
+
+func TestBarIsExactlyOneLineOfTheGivenWidth(t *testing.T) {
+	for _, w := range []int{1, 5, 40} {
+		out := Bar("a row that is definitely longer than five cells", w, BandSelected)
+		require.NotContains(t, out, "\n")
+		require.Equal(t, w, Width(ansi.Strip(out)), "width %d", w)
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	require.Equal(t, "ab  ", PadRight("ab", 4))
+	require.Equal(t, "abcd", PadRight("abcd", 2), "a string already that wide is left alone")
+	require.Equal(t, 4, Width(ansi.Strip(PadRight(StyleDim.Render("ab"), 4))),
+		"padding measures cells, not bytes")
+}
+
+func TestInnerDimensionsNeverGoBelowOne(t *testing.T) {
+	for _, n := range []int{-5, 0, 1, 2, 3, 4, 5, 40} {
+		require.GreaterOrEqual(t, InnerWidth(n), 1, "InnerWidth(%d)", n)
+		require.GreaterOrEqual(t, InnerHeight(n), 1, "InnerHeight(%d)", n)
+	}
+	require.Equal(t, 36, InnerWidth(40))
+	require.Equal(t, 38, InnerHeight(40))
+}
+
+// Dims is the only place a terminal size becomes pane sizes, so the invariants
+// the renderers assume have to hold for every size, not just the comfortable
+// ones.
+func TestDimsKeepsThePanesInsideTheTerminal(t *testing.T) {
+	for _, s := range termSizes {
+		l := Dims(s.w, s.h)
+		require.GreaterOrEqual(t, l.ListH, 1, "%dx%d", s.w, s.h)
+		require.GreaterOrEqual(t, l.BodyH, 3, "%dx%d", s.w, s.h)
+		if l.TwoPane {
+			require.Equal(t, s.w, l.LeftW+1+l.RightW, "%dx%d: the two panes and the gutter are the width", s.w, s.h)
+			require.Equal(t, l.LeftW+1, l.RightX, "%dx%d", s.w, s.h)
+			require.GreaterOrEqual(t, s.w, MinTwoPaneWidth)
+		} else {
+			require.Equal(t, s.w, l.LeftW, "%dx%d: one pane is the whole width", s.w, s.h)
+			require.Less(t, s.w, MinTwoPaneWidth)
+		}
+	}
+}
+
+// A click has to land on the thing that was drawn there. Zones are appended in
+// render order, so the last one wins where two overlap.
+func TestHitZoneTakesTheTopmost(t *testing.T) {
+	l := Layout{Zones: []Zone{
+		{Rect: Rect{X: 0, Y: 0, W: 10, H: 3}, Kind: ZoneEntry, Idx: 1},
+		{Rect: Rect{X: 2, Y: 1, W: 4, H: 1}, Kind: ZoneField, Idx: 7},
+	}}
+	require.Equal(t, ZoneField, l.HitZone(3, 1).Kind)
+	require.Equal(t, 7, l.HitZone(3, 1).Idx)
+	require.Equal(t, ZoneEntry, l.HitZone(9, 1).Kind)
+	require.Equal(t, ZoneNone, l.HitZone(50, 50).Kind, "a click outside every zone does nothing")
+}
+
+func TestRectHit(t *testing.T) {
+	r := Rect{X: 2, Y: 3, W: 4, H: 2}
+	require.True(t, r.Hit(2, 3))
+	require.True(t, r.Hit(5, 4))
+	require.False(t, r.Hit(6, 4), "the right edge is exclusive")
+	require.False(t, r.Hit(5, 5), "the bottom edge is exclusive")
+	require.False(t, r.Hit(1, 3))
+}

--- a/cli/tui/panel.go
+++ b/cli/tui/panel.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package tui holds the terminal primitives shared by cnspec's interactive
+// programs -- the connector launcher and the report viewer. Nothing here knows
+// about a particular model or view, so the two draw the same boxes, measure the
+// same panes, scroll the same way and are colored out of the same palette, and
+// end up looking like one program.
+//
+// It lives under cli/ because that is where this repo keeps reusable CLI
+// components. It began under apps/cnspec/cmd/ holding only the box drawing and
+// the pane split, and everything above geometry was written twice while it sat
+// there: two palettes that disagreed on two colours, two text vocabularies, five
+// scroll clamps, two justified bands, and a pad function defined locally in a
+// file that already imported the package exporting it.
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Box primitives. These draw their own borders rather than using lipgloss's
+// Border(), for two reasons: a title and a status can be inlaid into the top
+// edge, and the result is guaranteed to be exactly the requested number of
+// lines, which is what the layout arithmetic depends on.
+
+const (
+	// BorderLines is the top and bottom edge; BorderCols is the left and right
+	// edge plus one space of padding on each side.
+	BorderLines = 2
+	BorderCols  = 4
+	// InnerX is the column where a panel's content starts, relative to the
+	// panel's left edge: the border character plus one space of padding.
+	InnerX = 2
+)
+
+// InnerWidth is the usable content width of a panel that is w columns wide.
+func InnerWidth(w int) int {
+	if w < BorderCols+1 {
+		return 1
+	}
+	return w - BorderCols
+}
+
+// InnerHeight is the usable content height of a panel that is h lines tall.
+func InnerHeight(h int) int {
+	if h < BorderLines+1 {
+		return 1
+	}
+	return h - BorderLines
+}
+
+// Panel draws a rounded box exactly w columns by h lines, with title inlaid at
+// the top left and status at the top right. content supplies the inner lines;
+// missing lines are blank and extra lines are dropped, so the caller cannot
+// change the panel's height by accident.
+func Panel(title, status string, content []string, w, h int, border lipgloss.Color) string {
+	bs := lipgloss.NewStyle().Foreground(border)
+	iw := InnerWidth(w)
+	ih := InnerHeight(h)
+
+	var b strings.Builder
+	b.WriteString(PanelTop(title, status, w, bs))
+	b.WriteString("\n")
+
+	for i := 0; i < ih; i++ {
+		line := ""
+		if i < len(content) {
+			line = content[i]
+		}
+		b.WriteString(bs.Render("│") + " " + PadRight(Truncate(line, iw), iw) + " " + bs.Render("│"))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(bs.Render("╰" + strings.Repeat("─", max(w-2, 0)) + "╯"))
+	return b.String()
+}
+
+// PanelTop builds the top edge, fitting the title and status into it and
+// falling back to a plain rule when there is not enough room for both.
+func PanelTop(title, status string, w int, bs lipgloss.Style) string {
+	rule := func(n int) string { return bs.Render(strings.Repeat("─", max(n, 0))) }
+
+	left, right := "", ""
+	if title != "" {
+		left = bs.Render("─ ") + title + " "
+	}
+	if status != "" {
+		right = " " + status + bs.Render(" ─")
+	}
+
+	fill := w - 2 - Width(left) - Width(right)
+	if fill < 0 {
+		// Not enough room for both; keep the title and drop the status.
+		right = ""
+		fill = w - 2 - Width(left)
+	}
+	if fill < 0 {
+		return bs.Render("╭") + rule(w-2) + bs.Render("╮")
+	}
+	return bs.Render("╭") + left + rule(fill) + right + bs.Render("╮")
+}
+
+// Bar renders text as a full-width band, used for a selected row or a command
+// line. The text must be unstyled: the band's own colors have to win.
+func Bar(text string, w int, style lipgloss.Style) string {
+	return style.Width(w).MaxWidth(w).Render(Truncate(text, w))
+}
+
+// Pill renders a small label with its own background, for status chips.
+func Pill(text string, fg, bg lipgloss.Color) string {
+	return lipgloss.NewStyle().Foreground(fg).Background(bg).Bold(true).Render(" " + text + " ")
+}
+
+// PadRight pads s with spaces so it occupies w cells, leaving it alone when it
+// is already at least that wide.
+func PadRight(s string, w int) string {
+	if d := w - Width(s); d > 0 {
+		return s + strings.Repeat(" ", d)
+	}
+	return s
+}

--- a/cli/tui/scroll.go
+++ b/cli/tui/scroll.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Scroll is the scroll offset of a pane. Every pane scrolls the same way because
+// they all use this: the alternative is three subtly different clamps and one of
+// them being off by one at the end of the list.
+//
+// A Scroll knows nothing about what it scrolls. The pane passes in the total
+// number of rows and how many are visible, both of which it recomputes each
+// frame, so a resize can never leave the pane scrolled past its end.
+type Scroll struct {
+	Off int
+}
+
+// Clamp returns the offset to render at, given the current geometry. It never
+// mutates: call Apply to store the clamped value.
+func (s Scroll) Clamp(total, visible int) int {
+	maxOff := total - visible
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	off := s.Off
+	if off > maxOff {
+		off = maxOff
+	}
+	if off < 0 {
+		off = 0
+	}
+	return off
+}
+
+// Apply clamps the stored offset in place and returns it.
+func (s *Scroll) Apply(total, visible int) int {
+	s.Off = s.Clamp(total, visible)
+	return s.Off
+}
+
+// Move scrolls by n rows and clamps.
+func (s *Scroll) Move(n, total, visible int) {
+	s.Off = Scroll{Off: s.Off + n}.Clamp(total, visible)
+}
+
+// EnsureVisible scrolls the minimum amount that brings row idx into view.
+func (s *Scroll) EnsureVisible(idx, total, visible int) {
+	if visible < 1 {
+		visible = 1
+	}
+	if idx < s.Off {
+		s.Off = idx
+	} else if idx >= s.Off+visible {
+		s.Off = idx - visible + 1
+	}
+	s.Apply(total, visible)
+}
+
+// Position renders the "12/240" indicator for a pane's title bar, or the plain
+// total when everything fits.
+func Position(cursor, total, visible int) string {
+	if total == 0 {
+		return "0"
+	}
+	if total <= visible {
+		return strconv.Itoa(total)
+	}
+	return strconv.Itoa(cursor+1) + "/" + strconv.Itoa(total)
+}
+
+// ClampIndex holds a cursor inside a list of n rows. An empty list leaves the
+// cursor at 0 rather than at -1, so a caller that clamps before it checks for
+// emptiness does not index out of range.
+func ClampIndex(i, n int) int {
+	if i >= n {
+		i = n - 1
+	}
+	if i < 0 {
+		i = 0
+	}
+	return i
+}
+
+// Window is the slice of a list a box with room for rows lines can show, with
+// the cursor kept near the middle of it so paging through the list does not pin
+// it to an edge. It returns the half-open range [start, end).
+//
+// Both modal pickers in cnspec computed this, down to the same three clamps in
+// the same order and the same "n more" marker underneath -- see MoreRow.
+func Window(cursor, total, rows int) (start, end int) {
+	start = cursor - rows/2
+	if start > total-rows {
+		start = total - rows
+	}
+	if start < 0 {
+		start = 0
+	}
+	end = start + rows
+	if end > total {
+		end = total
+	}
+	return start, end
+}
+
+// MoreRow is the line a windowed list puts under itself to say how much of the
+// list is out of view. It answers empty for a window that hid nothing, so a
+// caller can append it unconditionally.
+//
+// The count is what is hidden, not what the list holds: a marker reading "12
+// more" under a window showing all twelve is worse than no marker at all.
+func MoreRow(hidden int) string {
+	if hidden <= 0 {
+		return ""
+	}
+	return StyleFaint.Render(fmt.Sprintf("  %d more", hidden))
+}

--- a/cli/tui/scroll_test.go
+++ b/cli/tui/scroll_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClampIndex(t *testing.T) {
+	require.Equal(t, 3, ClampIndex(3, 10))
+	require.Equal(t, 9, ClampIndex(40, 10))
+	require.Equal(t, 0, ClampIndex(-5, 10))
+	// An empty list leaves the cursor at 0 rather than at -1: three callers
+	// clamp before they check for emptiness, and -1 is an index.
+	require.Equal(t, 0, ClampIndex(4, 0))
+	require.Equal(t, 0, ClampIndex(0, 0))
+}
+
+// Window is what both modal pickers compute. The rules it has to keep are that
+// the cursor is always inside the window, the window never runs off either end
+// of the list, and it is never wider than the list.
+func TestWindowKeepsTheCursorInside(t *testing.T) {
+	for _, total := range []int{0, 1, 2, 5, 12, 40} {
+		for _, rows := range []int{1, 2, 4, 10, 60} {
+			for cursor := 0; cursor < total; cursor++ {
+				start, end := Window(cursor, total, rows)
+				require.GreaterOrEqual(t, start, 0, "total=%d rows=%d cursor=%d", total, rows, cursor)
+				require.LessOrEqual(t, end, total, "total=%d rows=%d cursor=%d", total, rows, cursor)
+				require.LessOrEqual(t, end-start, rows, "total=%d rows=%d cursor=%d", total, rows, cursor)
+				require.GreaterOrEqual(t, cursor, start, "total=%d rows=%d cursor=%d", total, rows, cursor)
+				require.Less(t, cursor, end, "total=%d rows=%d cursor=%d", total, rows, cursor)
+			}
+		}
+	}
+}
+
+// The cursor sits near the middle rather than being pinned to an edge, which is
+// what makes paging through a long list readable.
+func TestWindowCentresTheCursor(t *testing.T) {
+	start, end := Window(20, 100, 10)
+	require.Equal(t, 15, start)
+	require.Equal(t, 25, end)
+
+	start, end = Window(0, 100, 10)
+	require.Equal(t, 0, start, "the top of the list does not scroll off the top")
+	require.Equal(t, 10, end)
+
+	start, end = Window(99, 100, 10)
+	require.Equal(t, 90, start, "nor the bottom off the bottom")
+	require.Equal(t, 100, end)
+
+	start, end = Window(2, 4, 10)
+	require.Equal(t, 0, start, "a list shorter than the window is shown whole")
+	require.Equal(t, 4, end)
+}
+
+// The marker counts what is hidden, not what the list holds. "12 more" under a
+// window showing all twelve is worse than no marker at all.
+func TestMoreRow(t *testing.T) {
+	require.Equal(t, "", MoreRow(0))
+	require.Equal(t, "", MoreRow(-3))
+	require.Equal(t, "  4 more", ansi.Strip(MoreRow(4)))
+}

--- a/cli/tui/text.go
+++ b/cli/tui/text.go
@@ -1,0 +1,150 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Text helpers shared by every pane of both UIs, so that the rule "one element
+// of a []string is exactly one terminal line" is enforced in one place rather
+// than in each of them.
+
+// Clean makes an arbitrary string safe to put in a rendered line. It normalizes
+// carriage returns and expands tabs.
+//
+// It is also what keeps a fixed-height layout fixed. The launcher assigned
+// err.Error() straight into its footer and rendered it through ansi.Truncate,
+// which cuts a line to width and leaves every newline in it: a three-line
+// provider error made the view 26 rows in a 24-row terminal and pushed the
+// footer off the screen. Truncation does not remove newlines; this does.
+//
+// This is not optional for anything that came out of cli/reporter: its
+// NewLineCharacter is "\r\n" on Windows, and a carriage return inside a line
+// makes ansi.StringWidth disagree with what the terminal does, which shows up as
+// a panel one column too wide and a layout that drifts. reportmodel already
+// normalizes what it returns; anything pulled from elsewhere goes through here.
+func Clean(s string) string {
+	if strings.ContainsAny(s, "\r\t") {
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		s = strings.ReplaceAll(s, "\r", "\n")
+		s = strings.ReplaceAll(s, "\t", "    ")
+	}
+	return s
+}
+
+// Lines splits a string into rendered lines, cleaning it first. A string with no
+// newlines yields one line; an empty string yields none, so a caller can append
+// the result of an empty section without leaving a blank row behind.
+func Lines(s string) []string {
+	s = Clean(s)
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+// Wrap breaks a string into lines no wider than w cells, preserving the
+// newlines it already has. Words longer than w (a URL, an MRN) are broken rather
+// than allowed to overflow.
+func Wrap(s string, w int) []string {
+	if w < 1 {
+		w = 1
+	}
+	var res []string
+	for _, para := range Lines(s) {
+		if para == "" {
+			res = append(res, "")
+			continue
+		}
+		for _, line := range strings.Split(ansi.Wrap(para, w, ""), "\n") {
+			if ansi.StringWidth(line) <= w {
+				res = append(res, line)
+				continue
+			}
+			// ansi.Wrap prefers to break at a word boundary and gives up on a
+			// token it cannot fit -- an MRN or a URL at a narrow width. Those
+			// get cut mid-token rather than allowed to overflow the pane.
+			res = append(res, strings.Split(ansi.Hardwrap(line, w, false), "\n")...)
+		}
+	}
+	return res
+}
+
+// Fit forces a slice of lines to be exactly n lines long, padding with blanks
+// and dropping the excess. The frame uses it on every pane, which is what makes
+// a miscounting pane a cosmetic bug rather than a scrolled terminal.
+func Fit(lines []string, n int) []string {
+	if n < 0 {
+		n = 0
+	}
+	if len(lines) > n {
+		return lines[:n]
+	}
+	for len(lines) < n {
+		lines = append(lines, "")
+	}
+	return lines
+}
+
+// Width is the rendered width of a line in terminal cells. Escape sequences
+// count as nothing, which is why a pane must measure with this rather than with
+// len.
+func Width(s string) int {
+	return ansi.StringWidth(s)
+}
+
+// Truncate cuts a line to w cells, appending an ellipsis when it had to cut. It
+// is ANSI-aware, so a styled line keeps its styling.
+func Truncate(s string, w int) string {
+	if w < 1 {
+		return ""
+	}
+	return ansi.Truncate(s, w, "…")
+}
+
+// WrapWords breaks plain prose to width on word boundaries, collapsing the
+// whitespace it finds. It is the wrapper for a sentence written in Go source --
+// a modal's explanation of what an option means -- where the line breaks are
+// the wrapper's business and there is no formatting to preserve.
+//
+// Wrap is the one to reach for otherwise: it keeps the newlines a string
+// already has, which is what report text needs and what this deliberately
+// throws away.
+func WrapWords(s string, width int) []string {
+	if width < 8 {
+		width = 8
+	}
+	var out []string
+	var line string
+	for _, word := range strings.Fields(s) {
+		switch {
+		case line == "":
+			line = word
+		case Width(line)+1+Width(word) <= width:
+			line += " " + word
+		default:
+			out = append(out, line)
+			line = word
+		}
+	}
+	if line != "" {
+		out = append(out, line)
+	}
+	return out
+}
+
+// OneLine flattens an arbitrary string into a single rendered line: cleaned,
+// with every run of whitespace -- newlines included -- collapsed to one space.
+//
+// It is what an error message goes through before it is drawn into a
+// fixed-height layout. Truncating to a width does not remove a newline, so a
+// three-line error rendered into a one-line footer is three rows, and the row
+// budget the whole layout is built on is off by two. Clean alone is not enough:
+// it normalizes a newline, it does not remove one.
+func OneLine(s string) string {
+	return strings.Join(strings.Fields(Clean(s)), " ")
+}

--- a/cli/tui/text_test.go
+++ b/cli/tui/text_test.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// A carriage return inside a rendered line makes ansi.StringWidth disagree with
+// the terminal, which is how a panel ends up one column wider than the layout
+// believes. reporter.NewLineCharacter is "\r\n" on Windows, so this is the
+// everyday case there, not an exotic one.
+func TestCleanRemovesCarriageReturns(t *testing.T) {
+	require.Equal(t, "a\nb", Clean("a\r\nb"))
+	require.Equal(t, "a\nb", Clean("a\rb"))
+	require.Equal(t, "a    b", Clean("a\tb"))
+	require.Equal(t, "plain", Clean("plain"))
+
+	for _, ln := range Lines("one\r\ntwo\r\n") {
+		require.NotContains(t, ln, "\r")
+	}
+}
+
+func TestLines(t *testing.T) {
+	require.Empty(t, Lines(""))
+	require.Equal(t, []string{"one"}, Lines("one"))
+	require.Len(t, Lines("a\nb\nc"), 3)
+}
+
+// Wrap must never return a line wider than the limit, whatever it is given: a
+// long word, a URL, an MRN, or a paragraph that already has newlines in it.
+func TestWrapNeverExceedsWidth(t *testing.T) {
+	inputs := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"//policy.api.mondoo.com/policies/mondoo-linux-security/queries/mondoo-linux-security-ensure-secure-permissions",
+		"first line\r\nsecond line that is quite a lot longer than the first one",
+		strings.Repeat("x", 300),
+		"",
+	}
+	for _, in := range inputs {
+		for _, w := range []int{1, 5, 20, 40, 80} {
+			for i, ln := range Wrap(in, w) {
+				require.LessOrEqual(t, ansi.StringWidth(ln), w,
+					"width %d, line %d of %q", w, i, in)
+				require.NotContains(t, ln, "\n")
+			}
+		}
+	}
+}
+
+func TestFitIsExact(t *testing.T) {
+	require.Len(t, Fit([]string{"a", "b", "c"}, 5), 5)
+	require.Len(t, Fit([]string{"a", "b", "c"}, 2), 2)
+	require.Empty(t, Fit([]string{"a"}, 0))
+	require.Empty(t, Fit(nil, -3))
+	require.Equal(t, []string{"", ""}, Fit(nil, 2))
+}
+
+func TestTruncate(t *testing.T) {
+	require.Equal(t, "", Truncate("hello", 0))
+	require.Equal(t, "hello", Truncate("hello", 10))
+	require.LessOrEqual(t, ansi.StringWidth(Truncate("hello world", 5)), 5)
+}
+
+func TestScrollClamps(t *testing.T) {
+	var s Scroll
+	s.Move(10, 3, 10)
+	require.Equal(t, 0, s.Off, "everything fits, so there is nothing to scroll")
+
+	s = Scroll{}
+	s.Move(100, 50, 10)
+	require.Equal(t, 40, s.Off)
+	s.Move(-1000, 50, 10)
+	require.Equal(t, 0, s.Off)
+
+	// A window that grows past the end of the list scrolls back rather than
+	// leaving a view of nothing.
+	s = Scroll{Off: 40}
+	require.Equal(t, 0, s.Apply(50, 50))
+}
+
+func TestScrollEnsureVisible(t *testing.T) {
+	s := Scroll{}
+	s.EnsureVisible(30, 100, 10)
+	require.Equal(t, 21, s.Off, "the row must be the last visible one")
+	s.EnsureVisible(30, 100, 10)
+	require.Equal(t, 21, s.Off, "a row already in view does not scroll")
+	s.EnsureVisible(5, 100, 10)
+	require.Equal(t, 5, s.Off, "scrolling up puts the row at the top")
+	s.EnsureVisible(99, 100, 10)
+	require.Equal(t, 90, s.Off)
+}
+
+func TestPosition(t *testing.T) {
+	require.Equal(t, "0", Position(0, 0, 10))
+	require.Equal(t, "7", Position(3, 7, 10), "everything fits, so only the total is worth saying")
+	require.Equal(t, "4/70", Position(3, 70, 10))
+}
+
+// WrapWords is the plain-prose wrapper. It breaks between words and never
+// inside one, so every line it returns is within the limit unless a single word
+// was already over it -- which is the right trade for the prose it is for, and
+// the reason Wrap (which hard-breaks a URL or an MRN) is a separate function.
+func TestWrapWordsBreaksBetweenWords(t *testing.T) {
+	inputs := []string{
+		"Findings are uploaded, so they appear in the console, feed compliance reports, and are visible to your team.",
+		"Nothing\nleaves\tthis   computer.",
+		"",
+	}
+	for _, in := range inputs {
+		for _, w := range []int{8, 20, 40, 80} {
+			for i, ln := range WrapWords(in, w) {
+				require.NotContains(t, ln, "\n", "width %d, line %d of %q", w, i, in)
+				if words := strings.Fields(ln); len(words) > 1 {
+					require.LessOrEqual(t, ansi.StringWidth(ln), w,
+						"width %d, line %d of %q", w, i, in)
+				}
+			}
+		}
+	}
+
+	// A word of its own on a line, over the limit, is left over the limit
+	// rather than cut: the caller truncates to the pane, and a mid-word break
+	// here would be a second place deciding that.
+	require.Equal(t, []string{strings.Repeat("y", 200)}, WrapWords(strings.Repeat("y", 200), 20))
+
+	// A width below the floor is raised to it rather than producing a column of
+	// single letters.
+	require.Equal(t, WrapWords("a bb ccc dddd", 8), WrapWords("a bb ccc dddd", 1))
+}
+
+// The two wrappers are not interchangeable, and the difference is the reason
+// both exist: Wrap keeps the newlines a string already has, WrapWords collapses
+// them. Report text needs the first; a sentence written in Go source needs the
+// second.
+func TestWrapKeepsNewlinesAndWrapWordsDoesNot(t *testing.T) {
+	require.Equal(t, []string{"one", "two"}, Wrap("one\ntwo", 20))
+	require.Equal(t, []string{"one two"}, WrapWords("one\ntwo", 20))
+}
+
+// OneLine is what stands between an error string somebody else wrote and a
+// fixed-height layout. Truncating to a width does not remove a newline, which is
+// how a three-line error made a 24-row terminal render 26 rows.
+func TestOneLineFlattensEverything(t *testing.T) {
+	require.Equal(t, "a b c", OneLine("a\nb\nc"))
+	require.Equal(t, "a b", OneLine("a\r\n\r\nb"))
+	require.Equal(t, "a b", OneLine("  a\t\tb  "))
+	require.Equal(t, "", OneLine("\n\n"))
+	require.Equal(t, "plain", OneLine("plain"))
+
+	// Clean on its own is not enough, and that is the trap: it normalizes a
+	// newline rather than removing one.
+	require.Contains(t, Clean("a\r\nb"), "\n")
+	require.NotContains(t, OneLine("a\r\nb"), "\n")
+}

--- a/cli/tui/theme.go
+++ b/cli/tui/theme.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// One palette for every terminal UI cnspec draws, in two halves.
+//
+// # Chrome
+//
+// Violet is the brand accent and marks whatever has focus; cyan is the command
+// line and the key hints; the greys are the three weights of body text. These
+// are frame furniture rather than meaning, so they are named here as literals
+// and nowhere else. The launcher and the report viewer each carried their own
+// copy of these seven colors -- identical in name and value, which is how it
+// stayed unnoticed -- and two copies of a palette is one copy too many.
+//
+// None of the styles below carries a margin. A margin adds a line the layout
+// arithmetic cannot see, and every panel here is sized in exact lines.
+var (
+	// ColAccent is the focus accent.
+	ColAccent = lipgloss.Color("141")
+	// ColAccentD is the dimmer violet an unfocused border is drawn in.
+	ColAccentD = lipgloss.Color("97")
+	// ColCyan is the command line and the key names in a hint.
+	ColCyan = lipgloss.Color("87")
+	// ColInk is text drawn on top of a colored band.
+	ColInk = lipgloss.Color("16")
+	// ColText, ColDim and ColFaint are the three weights of body text.
+	ColText  = lipgloss.Color("252")
+	ColDim   = lipgloss.Color("245")
+	ColFaint = lipgloss.Color("240")
+)
+
+// Ratings is the one rating palette in this repo, and the second half of the
+// answer: every color that carries *meaning* -- a severity, an outcome, an
+// install state -- resolves through it rather than being picked by eye.
+//
+// It was picked by eye three times before this. cli/progress/todolist.go
+// hand-copied the map with a comment saying it matched
+// cli/components/rating.go, and the launcher chose green 78, amber 214 and red
+// 203 against the palette's 78, 212 and 204 -- matching on one and missing on
+// two, which is the signature of hand-picking rather than of a decision. A
+// comment claiming two tables agree is an import that was not written.
+var Ratings = components.DefaultScoreRatingColors
+
+// The three semantic colors a chrome element needs: something is fine,
+// something wants attention, something is wrong. They are the rating palette's
+// own NONE, HIGH and CRITICAL, so a green dot in the launcher and a green
+// severity in the viewer are the same green.
+var (
+	ColGood = Ratings.LipglossColor(policy.ScoreRatingTextNone)
+	ColWarn = Ratings.LipglossColor(policy.ScoreRatingTextHigh)
+	ColBad  = Ratings.LipglossColor(policy.ScoreRatingTextCritical)
+)
+
+var (
+	// StyleText is the default body text of a pane.
+	StyleText = lipgloss.NewStyle().Foreground(ColText)
+	// StyleDim is secondary text: counts, platform names, paths.
+	StyleDim = lipgloss.NewStyle().Foreground(ColDim)
+	// StyleFaint is tertiary text: rules, section labels, hints.
+	StyleFaint = lipgloss.NewStyle().Foreground(ColFaint)
+	// StyleAccent marks the focused thing.
+	StyleAccent = lipgloss.NewStyle().Foreground(ColAccent).Bold(true)
+	// StyleKey renders a key name in a hint.
+	StyleKey = lipgloss.NewStyle().Foreground(ColCyan)
+	// StyleLabel is a small-caps section label inside a pane.
+	StyleLabel = lipgloss.NewStyle().Foreground(ColFaint).Bold(true)
+
+	// StyleGood, StyleWarn and StyleBad are the semantic colors as text styles.
+	StyleGood = lipgloss.NewStyle().Foreground(ColGood)
+	StyleWarn = lipgloss.NewStyle().Foreground(ColWarn)
+	StyleBad  = lipgloss.NewStyle().Foreground(ColBad)
+
+	// BandSelected is the full-width band a selected row is drawn as, in the
+	// focused pane; BandInactive is the same row in a pane without focus. Use
+	// them with Bar, which is what keeps the band exactly one line wide.
+	BandSelected = lipgloss.NewStyle().Foreground(ColInk).Background(ColAccent).Bold(true)
+	BandInactive = lipgloss.NewStyle().Foreground(ColText).Background(lipgloss.Color("237"))
+)
+
+// BorderColor is the color of a panel border, which is both UIs' primary signal
+// for where the keys will land.
+func BorderColor(focused bool) lipgloss.Color {
+	if focused {
+		return ColAccent
+	}
+	return ColAccentD
+}
+
+// HintSep separates two key hints in a footer.
+const HintSep = "   "
+
+// Kbd renders one key hint, e.g. `↑/↓ move`.
+func Kbd(key, label string) string {
+	return StyleKey.Render(key) + " " + StyleFaint.Render(label)
+}

--- a/cli/tui/theme_test.go
+++ b/cli/tui/theme_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// The rule this package exists to make enforceable: a colour that carries
+// meaning comes out of the rating palette, never out of a literal.
+//
+// It was broken three ways before. cli/progress/todolist.go held a hand-copied
+// map with a comment saying it matched cli/components/rating.go; the launcher
+// picked green 78, amber 214 and red 203 against that palette's 78, 212 and 204.
+// Matching on one colour and missing on two is the signature of hand-picking
+// rather than of a decision, and it is exactly what a test can hold shut.
+func TestSemanticColorsComeFromTheRatingPalette(t *testing.T) {
+	require.Equal(t, components.DefaultScoreRatingColors, Ratings,
+		"tui.Ratings must be the palette itself, not a copy of it")
+
+	for _, tc := range []struct {
+		name   string
+		got    lipgloss.Color
+		rating string
+	}{
+		{"good", ColGood, policy.ScoreRatingTextNone},
+		{"warn", ColWarn, policy.ScoreRatingTextHigh},
+		{"bad", ColBad, policy.ScoreRatingTextCritical},
+	} {
+		require.Equal(t, Ratings.LipglossColor(tc.rating), tc.got, "col%s", tc.name)
+	}
+
+	// And the three text styles are those three colours, so a caller reaching
+	// for the style cannot end up somewhere else than a caller reaching for the
+	// colour.
+	require.Equal(t, ColGood, StyleGood.GetForeground())
+	require.Equal(t, ColWarn, StyleWarn.GetForeground())
+	require.Equal(t, ColBad, StyleBad.GetForeground())
+}
+
+// The three of them have to stay apart. "fine", "look at this" and "this is
+// wrong" are three facts, and a palette that renders two of them the same has
+// stopped carrying the third.
+func TestSemanticColorsAreDistinct(t *testing.T) {
+	require.NotEqual(t, ColGood, ColWarn)
+	require.NotEqual(t, ColWarn, ColBad)
+	require.NotEqual(t, ColGood, ColBad)
+}
+
+// No style in this package may carry a margin. A margin adds a line the layout
+// arithmetic cannot see, which is how a panel that "obviously" fits ends up
+// scrolling the terminal -- and the panels here are sized in exact lines.
+func TestNoStyleCarriesAMargin(t *testing.T) {
+	for name, st := range map[string]lipgloss.Style{
+		"StyleText":    StyleText,
+		"StyleDim":     StyleDim,
+		"StyleFaint":   StyleFaint,
+		"StyleAccent":  StyleAccent,
+		"StyleKey":     StyleKey,
+		"StyleLabel":   StyleLabel,
+		"StyleGood":    StyleGood,
+		"StyleWarn":    StyleWarn,
+		"StyleBad":     StyleBad,
+		"BandSelected": BandSelected,
+		"BandInactive": BandInactive,
+	} {
+		require.Zero(t, st.GetMarginTop(), name)
+		require.Zero(t, st.GetMarginBottom(), name)
+		require.Zero(t, st.GetMarginLeft(), name)
+		require.Zero(t, st.GetMarginRight(), name)
+	}
+}
+
+func TestBorderColorFollowsFocus(t *testing.T) {
+	require.Equal(t, ColAccent, BorderColor(true))
+	require.Equal(t, ColAccentD, BorderColor(false))
+	require.NotEqual(t, BorderColor(true), BorderColor(false),
+		"the border is the only signal for where the keys will land")
+}
+
+func TestKbdPutsTheKeyFirst(t *testing.T) {
+	require.Equal(t, "^r reporting", ansiStrip(Kbd("^r", "reporting")))
+}

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,14 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/abiosoft/colima v0.10.3
+	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/cockroachdb/errors v1.14.0
 	github.com/glebarez/go-sqlite v1.23.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -26,6 +29,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.25.3
 	github.com/hashicorp/terraform-json v0.28.0
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
+	github.com/kevinburke/ssh_config v1.6.0
 	github.com/mattn/go-isatty v0.0.24
 	github.com/mergestat/timediff v0.0.4
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -49,6 +53,7 @@ require (
 	github.com/stretchr/testify v1.12.1
 	github.com/tliron/glsp v0.2.2
 	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/yuin/goldmark v1.7.13
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260819000633-f705b63814ae
 	go.mondoo.com/mql v0.0.0-20260820153852-05e74586f59d
@@ -97,15 +102,14 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/alecthomas/participle v0.3.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
-	github.com/alecthomas/repr v0.5.1 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v17 v17.0.1 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.43.6 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.36 // indirect
@@ -132,6 +136,7 @@ require (
 	github.com/aws/smithy-go v1.27.8 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b // indirect
@@ -139,8 +144,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
@@ -158,6 +163,7 @@ require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/cli v29.7.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
@@ -201,6 +207,7 @@ require (
 	github.com/google/wire v0.7.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.21 // indirect
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -234,7 +241,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f // indirect
@@ -251,6 +257,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.28 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/miekg/dns v1.1.73 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -334,6 +341,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
+	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.45.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
+github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
 github.com/alecthomas/participle v0.3.0 h1:e8vhrYR1nDjzDxyDwpLO27TWOYWilaT+glkwbPadj50=
 github.com/alecthomas/participle v0.3.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
@@ -244,6 +246,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -275,6 +279,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
+github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
@@ -283,6 +289,8 @@ github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMx
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf h1:rLG0Yb6MQSDKdB52aGX55JT1oi0P0Kuaj7wi1bLUpnI=
+github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf/go.mod h1:B3UgsnsBZS/eX42BlaNiJkD1pPOUa+oF1IYC6Yd2CEU=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -349,6 +357,8 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v29.7.2+incompatible h1:dlkwallR8XqfeVnA2ELEhdwvb4lsSwuB4IgsG8Q9cLY=
 github.com/docker/cli v29.7.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.8 h1:bIREROb7So6PRlq6KTtdS9MPEjC29OQRkFNlvK2OX8Q=
@@ -577,6 +587,8 @@ github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
 github.com/gopherjs/gopherjs v1.20.1 h1:22uLWFvVcxhJ+j3dJ99NNfwGyHynxCmjhYsrcwqbY60=
 github.com/gopherjs/gopherjs v1.20.1/go.mod h1:h+FTmmLgbXMmmtuZFp9bUqXciN429Wx0sJEJuMnpyfM=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
@@ -781,6 +793,8 @@ github.com/mattn/go-runewidth v0.0.28/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0I
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mergestat/timediff v0.0.4 h1:NZ3sqG/6K9flhTubdltmRx3RBfIiYv6LsGP+4FlXMM8=
 github.com/mergestat/timediff v0.0.4/go.mod h1:yvMUaRu2oetc+9IbPLYBJviz6sA7xz8OXMDfhBl7YSI=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
@@ -1086,6 +1100,10 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
+github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.19.0 h1:IV8WdqYZc2c5rLX9bEoLNXKojBAp0MZPBHMIrCoa/s4=
 github.com/zclconf/go-cty v1.19.0/go.mod h1:12W89jGn3JCOIQi7infWr9m80rOkb5RNYJqXMZcN4c8=

--- a/internal/connectorgen/analyze.go
+++ b/internal/connectorgen/analyze.go
@@ -1,0 +1,1280 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Reading providers/<name>/provider/*.go for the two facts nothing else
+// carries: which environment variable backs which flag, and which literal words
+// a positional argument is compared against.
+//
+// Both are ordinary Go control flow, and the shape is the same everywhere:
+// a local variable is filled from the flag map, and if it is still empty it is
+// filled from the environment.
+//
+//	token := ""
+//	if x, ok := flags["token"]; ok && len(x.Value) != 0 {
+//		token = string(x.Value)
+//	}
+//	if token == "" && len(os.Getenv("GITHUB_TOKEN")) != 0 {
+//		token = os.Getenv("GITHUB_TOKEN")
+//	}
+//
+// So the association is transitive through local variables: `x` holds
+// flags["token"], `token` holds `x`, `token` holds GITHUB_TOKEN, therefore
+// --token travels in GITHUB_TOKEN. What the walk below does is propagate flag
+// names and variable names along assignments until they meet.
+//
+// The trap is that `x` is a name providers reuse. github binds it to
+// flags["token"] in one if statement and to the app private key flag in
+// another, and a walk that keyed variables by name alone would conclude that
+// --token travels in GITHUB_APP_PRIVATE_KEY. Variables are therefore keyed by
+// their declaration position and resolved through a scope stack, which is why
+// this is an explicit statement walker rather than an ast.Inspect.
+
+// providerAnalysis is what one provider package yielded.
+type providerAnalysis struct {
+	Env        []FlagEnv
+	Positional []Positional
+	Gaps       []Gap
+	// Unbound are environment variables read but tied to no key, collected
+	// rather than reported one at a time. Only the connection walk fills it.
+	Unbound []string
+}
+
+// entry points whose reachability makes an environment read attributable. A
+// variable read anywhere they lead to is read while parsing a command line;
+// one read elsewhere is read at some other time, by something the CLI has no
+// say over, and this tool will not claim to know which flag it belongs to.
+var analysisRoots = []string{"ParseCLI", "Connect", "MockConnect"}
+
+// analyzeProviderPkg walks a provider package.
+//
+// It walks it twice. The first pass learns what each package-local function
+// returns -- mistral's envToken() returns MISTRAL_API_KEY and takes no argument
+// that says so -- and the second pass uses those summaries at the call sites,
+// which is what lets a variable holding --token meet a variable name declared
+// two functions away.
+func analyzeProviderPkg(sy *symbols, files []*ast.File, where func(ast.Node) string, key keySource) providerAnalysis {
+	helpers := findHelpers(files, key)
+
+	var decls []*ast.FuncDecl
+	byName := map[string][]*ast.FuncDecl{}
+	for _, f := range files {
+		for _, d := range f.Decls {
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			decls = append(decls, fd)
+			byName[fd.Name.Name] = append(byName[fd.Name.Name], fd)
+		}
+	}
+	// In a provider package the command-line parser is the entry point and
+	// anything it does not reach is read at some other time. A connection
+	// package has no such entry point -- every exported function there runs
+	// while connecting -- so all of it counts.
+	reachable := map[string]bool{}
+	if key.reportUnbound {
+		reachable = reachableFuncs(byName, analysisRoots)
+	} else {
+		for name := range byName {
+			reachable[name] = true
+		}
+	}
+
+	// A stable walk order, so a regeneration diff is about the source rather
+	// than about map iteration.
+	sort.SliceStable(decls, func(i, j int) bool { return decls[i].Pos() < decls[j].Pos() })
+
+	argsParams := argumentSliceParams(byName)
+
+	newAnalyzer := func(fd *ast.FuncDecl, summaries map[string]funcSummary) *funcAnalyzer {
+		args := map[string]bool{}
+		for name := range argsParams[fd.Name.Name] {
+			args[name] = true
+		}
+		return &funcAnalyzer{
+			sy:          sy,
+			helpers:     helpers,
+			summaries:   summaries,
+			key:         key,
+			fn:          fd.Name.Name,
+			where:       where,
+			vars:        map[string]*varInfo{},
+			flagsIdents: map[string]bool{},
+			argsIdents:  args,
+		}
+	}
+
+	summaries := map[string]funcSummary{}
+	for _, fd := range decls {
+		if !stringReturning(fd.Type.Results) {
+			continue
+		}
+		a := newAnalyzer(fd, nil)
+		a.run(fd)
+		if s := a.summary(); len(s.flags) > 0 || len(s.envs) > 0 {
+			summaries[fd.Name.Name] = s
+		}
+	}
+
+	var out providerAnalysis
+	envByFlag := map[string]*FlagEnv{}
+	var flagOrder []string
+	posByIndex := map[int][]string{}
+	var posFunc = map[int]string{}
+	boundEnvs := map[string]bool{}
+
+	for _, fd := range decls {
+		a := newAnalyzer(fd, summaries)
+		a.run(fd)
+
+		if !reachable[fd.Name.Name] {
+			// An environment read the command-line parser never reaches. The
+			// variable is real, the flag it belongs to is not knowable here.
+			if len(a.envsSeen) > 0 {
+				out.Gaps = append(out.Gaps, Gap{
+					Kind: GapEnvOutsideParseCLI,
+					Detail: fmt.Sprintf("%s reads %s but is not reached from %s, so no flag can be attributed",
+						fd.Name.Name, strings.Join(a.envsSeen, ", "), strings.Join(analysisRoots, "/")),
+					Where: where(fd),
+				})
+			}
+			out.Gaps = append(out.Gaps, a.gaps...)
+			continue
+		}
+
+		// results() is what resolves the walk, and resolving is what raises the
+		// ambiguous-binding and alternative-branch gaps, so a.gaps is read
+		// after it rather than before.
+		resolved := a.results()
+		for _, fe := range resolved {
+			for _, v := range fe.Vars {
+				boundEnvs[v] = true
+			}
+			existing, ok := envByFlag[fe.Flag]
+			if !ok {
+				copied := fe
+				envByFlag[fe.Flag] = &copied
+				flagOrder = append(flagOrder, fe.Flag)
+				continue
+			}
+			for _, v := range fe.Vars {
+				existing.Vars = appendUnique(existing.Vars, v)
+			}
+			existing.Composed = existing.Composed || fe.Composed
+		}
+		for _, idx := range a.posOrder {
+			for _, v := range a.positional[idx] {
+				posByIndex[idx] = appendUnique(posByIndex[idx], v)
+			}
+			if _, seen := posFunc[idx]; !seen {
+				posFunc[idx] = fd.Name.Name
+			}
+		}
+		// An environment variable read while parsing that never met a flag.
+		for _, name := range a.envsSeen {
+			if boundEnvs[name] {
+				continue
+			}
+			if a.boundLater(name) {
+				continue
+			}
+			// A function that returns the value is not losing it; its caller
+			// is where the pairing happens, and the caller is walked too.
+			if _, summarised := summaries[fd.Name.Name]; summarised && contains(a.summary().envs, name) {
+				continue
+			}
+			if !key.reportUnbound {
+				// The caller reports the connection package's loose variables
+				// as one finding rather than one per function.
+				out.Unbound = appendUnique(out.Unbound, name)
+				continue
+			}
+			out.Gaps = append(out.Gaps, Gap{
+				Kind:   GapUnboundEnv,
+				Detail: fmt.Sprintf("%s reads %s but its value never meets a flag", fd.Name.Name, name),
+				Where:  where(fd),
+			})
+		}
+		out.Gaps = append(out.Gaps, a.gaps...)
+	}
+
+	for _, flag := range flagOrder {
+		out.Env = append(out.Env, *envByFlag[flag])
+	}
+	sort.SliceStable(out.Env, func(i, j int) bool { return out.Env[i].Flag < out.Env[j].Flag })
+
+	var indexes []int
+	for idx := range posByIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Ints(indexes)
+	for _, idx := range indexes {
+		out.Positional = append(out.Positional, Positional{
+			Index:  idx,
+			Values: posByIndex[idx],
+			Func:   posFunc[idx],
+		})
+	}
+	return out
+}
+
+// reachableFuncs is the set of package-local function names the roots lead to.
+//
+// It is a name-level call graph, which is exactly as much as syntax supports:
+// a call through an interface or a stored function value is invisible here.
+// That imprecision only ever widens the set, and a widened set means an
+// association is recorded rather than dropped, so the tool's mistakes land on
+// the side of reporting rather than of silence.
+func reachableFuncs(byName map[string][]*ast.FuncDecl, roots []string) map[string]bool {
+	seen := map[string]bool{}
+	queue := append([]string(nil), roots...)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		for _, fd := range byName[name] {
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				switch fn := call.Fun.(type) {
+				case *ast.Ident:
+					if _, local := byName[fn.Name]; local && !seen[fn.Name] {
+						queue = append(queue, fn.Name)
+					}
+				case *ast.SelectorExpr:
+					// A method on the service, s.connect(...), is local too.
+					if _, local := byName[fn.Sel.Name]; local && !seen[fn.Sel.Name] {
+						queue = append(queue, fn.Sel.Name)
+					}
+				}
+				return true
+			})
+		}
+	}
+	return seen
+}
+
+// argumentSliceParams finds the parameters that receive the positional argument
+// slice, per package-local function.
+//
+// aws is why this exists. Its ParseCLI compares req.Args[0] against "ec2" and
+// then hands the whole slice to handleAwsEc2Subcommands, which compares the
+// next word against the rest of the vocabulary. Without following the slice
+// into that function the artifact would record aws as accepting exactly one
+// sub-command -- a complete-looking answer that is wrong, which is the one
+// outcome this tool is built to avoid.
+//
+// It iterates because the slice is passed on again: ParseCLI to one function,
+// that function to another.
+func argumentSliceParams(byName map[string][]*ast.FuncDecl) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+
+	isArgs := func(fn string, e ast.Expr) bool {
+		if id, ok := e.(*ast.Ident); ok {
+			return out[fn][id.Name]
+		}
+		return readsField(e, "Args")
+	}
+
+	for range len(byName) + 1 {
+		changed := false
+		for name, decls := range byName {
+			for _, fd := range decls {
+				ast.Inspect(fd.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					var callee string
+					switch f := call.Fun.(type) {
+					case *ast.Ident:
+						callee = f.Name
+					case *ast.SelectorExpr:
+						callee = f.Sel.Name
+					default:
+						return true
+					}
+					target, local := byName[callee]
+					if !local || len(target) == 0 {
+						return true
+					}
+					params := flatParams(target[0].Type.Params)
+					for i, arg := range call.Args {
+						if i >= len(params) || params[i].name == "" {
+							continue
+						}
+						if !isArgs(name, arg) {
+							continue
+						}
+						if out[callee] == nil {
+							out[callee] = map[string]bool{}
+						}
+						if !out[callee][params[i].name] {
+							out[callee][params[i].name] = true
+							changed = true
+						}
+					}
+					return true
+				})
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return out
+}
+
+// factGroup is what one assignment's right-hand side contributed.
+type factGroup struct {
+	flags []string
+	envs  []string
+	refs  []string
+	// selected counts the environment variables this expression chose between
+	// rather than joined. An accessor called as stringFlag(flags, "region",
+	// "ALIBABA_CLOUD_REGION", "ALIBABA_CLOUD_REGION_ID") returns the first that
+	// is set, so two variables there are a fallback chain, while two variables
+	// concatenated by a "+" are a composition. The two need opposite advice --
+	// set either one, or set both -- so they are counted apart.
+	selected int
+}
+
+// branchChain records one name declared by more than one arm of a single
+// if/else chain.
+type branchChain struct {
+	name string
+	keys []string
+}
+
+// varInfo accumulates what a single local variable came to hold.
+type varInfo struct {
+	name   string
+	groups []factGroup
+	flags  []string
+	envs   []string
+}
+
+// funcAnalyzer walks one function body.
+type funcAnalyzer struct {
+	sy        *symbols
+	helpers   map[string]helperSig
+	summaries map[string]funcSummary
+	key       keySource
+	fn        string
+	where     func(ast.Node) string
+
+	scopes      []map[string]string
+	vars        map[string]*varInfo
+	order       []string
+	flagsIdents map[string]bool
+	argsIdents  map[string]bool
+
+	// direct are associations read straight off a helper call, which need no
+	// variable to travel through.
+	direct []FlagEnv
+	// envsSeen is every environment variable this function reads, in order.
+	envsSeen []string
+
+	positional map[int][]string
+	posOrder   []int
+
+	gaps []Gap
+
+	// branchChains are the names one if/else chain declared in more than one
+	// arm, which computeResults reads for the alternative-branch gap.
+	branchChains []branchChain
+	// explained are environment variables a gap already accounts for, so the
+	// broad "never meets a flag" report does not repeat a finding the specific
+	// one already made.
+	explained []string
+
+	// returns are the facts flowing to this function's own return statements,
+	// which is what summary() reports to callers. Only the outermost function's
+	// returns count, so closures do not contribute.
+	returns  []factGroup
+	litDepth int
+
+	// resolved and cached memoise results(): resolving raises gaps, and a
+	// second call would raise every one of them twice.
+	resolved bool
+	cached   []FlagEnv
+}
+
+func (a *funcAnalyzer) run(fd *ast.FuncDecl) {
+	a.positional = map[int][]string{}
+	a.push()
+	a.declareParams(fd.Type.Params)
+	for _, st := range fd.Body.List {
+		a.stmt(st)
+	}
+	a.pop()
+	a.fixpoint()
+}
+
+// declareParams binds a function's parameters, so a flag name that is a
+// parameter reads as a value the call site supplies rather than as a constant
+// that failed to resolve.
+func (a *funcAnalyzer) declareParams(fl *ast.FieldList) {
+	for _, p := range flatParams(fl) {
+		if p.name == "" || p.name == "_" {
+			continue
+		}
+		key := p.name + "#param"
+		if len(a.scopes) > 0 {
+			a.scopes[len(a.scopes)-1][p.name] = key
+		}
+		if _, ok := a.vars[key]; !ok {
+			a.vars[key] = &varInfo{name: p.name}
+			a.order = append(a.order, key)
+		}
+		if a.key.typeOK != nil && a.key.typeOK(p.typ) {
+			a.flagsIdents[p.name] = true
+		}
+	}
+}
+
+// summary is what a caller learns by calling this function: the flag names and
+// environment variables that flow into what it returns.
+func (a *funcAnalyzer) summary() funcSummary {
+	var s funcSummary
+	for _, g := range a.returns {
+		addAll(&s.flags, g.flags)
+		addAll(&s.envs, g.envs)
+		for _, ref := range g.refs {
+			if v, ok := a.vars[ref]; ok {
+				addAll(&s.flags, v.flags)
+				addAll(&s.envs, v.envs)
+			}
+		}
+	}
+	return s
+}
+
+// localBinding reports whether an expression is an identifier bound inside this
+// function -- a parameter, a local, a range variable.
+//
+// It is what separates a flag name the syntax genuinely does not know from one
+// the call site supplies. `flags[name]` inside an accessor is not a gap: the
+// name is an argument, and the argument is read where the accessor is called.
+// `flags[someConstant]` that failed to resolve is a gap, because nothing else
+// will supply it.
+func (a *funcAnalyzer) localBinding(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return a.resolve(id.Name) != id.Name
+}
+
+func (a *funcAnalyzer) gap(kind, detail string, n ast.Node) {
+	a.gaps = append(a.gaps, Gap{Kind: kind, Detail: detail, Where: a.where(n)})
+}
+
+// --- scopes -------------------------------------------------------------
+
+func (a *funcAnalyzer) push() { a.scopes = append(a.scopes, map[string]string{}) }
+func (a *funcAnalyzer) pop()  { a.scopes = a.scopes[:len(a.scopes)-1] }
+
+// declare binds a name to a fresh key for the innermost scope. The key carries
+// the declaration offset, which is what keeps github's two `x` variables apart.
+func (a *funcAnalyzer) declare(id *ast.Ident) string {
+	key := id.Name + "#" + strconv.Itoa(int(id.Pos()))
+	if len(a.scopes) > 0 {
+		a.scopes[len(a.scopes)-1][id.Name] = key
+	}
+	if _, ok := a.vars[key]; !ok {
+		a.vars[key] = &varInfo{name: id.Name}
+		a.order = append(a.order, key)
+	}
+	return key
+}
+
+// resolve finds the innermost binding of a name, or returns the bare name for
+// something declared outside this function.
+func (a *funcAnalyzer) resolve(name string) string {
+	for i := len(a.scopes) - 1; i >= 0; i-- {
+		if key, ok := a.scopes[i][name]; ok {
+			return key
+		}
+	}
+	return name
+}
+
+// --- statements ---------------------------------------------------------
+
+func (a *funcAnalyzer) stmt(s ast.Stmt) {
+	switch x := s.(type) {
+	case nil:
+		return
+	case *ast.BlockStmt:
+		a.push()
+		for _, st := range x.List {
+			a.stmt(st)
+		}
+		a.pop()
+	case *ast.IfStmt:
+		a.ifChain(x)
+	case *ast.ForStmt:
+		a.push()
+		a.stmt(x.Init)
+		a.expr(x.Cond)
+		a.stmt(x.Post)
+		a.stmt(x.Body)
+		a.pop()
+	case *ast.RangeStmt:
+		a.push()
+		if x.Tok == token.DEFINE {
+			for _, e := range []ast.Expr{x.Key, x.Value} {
+				if id, ok := e.(*ast.Ident); ok && id.Name != "_" {
+					a.declare(id)
+				}
+			}
+		}
+		a.expr(x.X)
+		a.stmt(x.Body)
+		a.pop()
+	case *ast.SwitchStmt:
+		a.push()
+		a.stmt(x.Init)
+		a.switchStmt(x)
+		a.pop()
+	case *ast.TypeSwitchStmt:
+		a.push()
+		a.stmt(x.Init)
+		a.stmt(x.Assign)
+		a.stmt(x.Body)
+		a.pop()
+	case *ast.SelectStmt:
+		a.stmt(x.Body)
+	case *ast.CaseClause:
+		a.push()
+		for _, e := range x.List {
+			a.expr(e)
+		}
+		for _, st := range x.Body {
+			a.stmt(st)
+		}
+		a.pop()
+	case *ast.CommClause:
+		a.push()
+		a.stmt(x.Comm)
+		for _, st := range x.Body {
+			a.stmt(st)
+		}
+		a.pop()
+	case *ast.LabeledStmt:
+		a.stmt(x.Stmt)
+	case *ast.AssignStmt:
+		a.assign(x)
+	case *ast.DeclStmt:
+		a.declStmt(x)
+	case *ast.ExprStmt:
+		a.expr(x.X)
+	case *ast.ReturnStmt:
+		for _, e := range x.Results {
+			g := a.facts(e)
+			if a.litDepth == 0 {
+				a.returns = append(a.returns, g)
+			}
+		}
+	case *ast.GoStmt:
+		a.expr(x.Call)
+	case *ast.DeferStmt:
+		a.expr(x.Call)
+	case *ast.IncDecStmt:
+		a.expr(x.X)
+	case *ast.SendStmt:
+		a.expr(x.Chan)
+		a.expr(x.Value)
+	default:
+		// Anything else contributes no binding; walk it for the side effects
+		// facts() records -- an environment read, a positional comparison.
+		ast.Inspect(s, func(n ast.Node) bool {
+			if e, ok := n.(ast.Expr); ok {
+				a.expr(e)
+				return false
+			}
+			return true
+		})
+	}
+}
+
+// ifChain walks an if / else-if / else chain, and while doing so notes the
+// names each arm declares in its own init statement.
+//
+// Three AI providers write their credential this way:
+//
+//	if token := stringFlag(flags, connection.OptionToken); token != "" {
+//		conf.Credentials = append(...)
+//	} else if token := envToken(); token != "" {
+//		conf.Credentials = append(...)
+//	}
+//
+// Those are two different variables that happen to share a name. The flag and
+// the variable never meet in one value, so nothing in the syntax says they are
+// the same credential -- only the author's choice of the same name does, and a
+// name is not a fact. The chain is recorded here and reported as a gap in
+// computeResults rather than resolved into an association.
+func (a *funcAnalyzer) ifChain(root *ast.IfStmt) {
+	byName := map[string][]string{}
+	var order []string
+
+	var walk func(s *ast.IfStmt)
+	walk = func(s *ast.IfStmt) {
+		a.push()
+		if init, ok := s.Init.(*ast.AssignStmt); ok && init.Tok == token.DEFINE {
+			a.assign(init)
+			for _, lhs := range init.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok || id.Name == "_" {
+					continue
+				}
+				if _, seen := byName[id.Name]; !seen {
+					order = append(order, id.Name)
+				}
+				byName[id.Name] = appendUnique(byName[id.Name], a.resolve(id.Name))
+			}
+		} else {
+			a.stmt(s.Init)
+		}
+		a.expr(s.Cond)
+		a.stmt(s.Body)
+		switch next := s.Else.(type) {
+		case *ast.IfStmt:
+			walk(next)
+		case nil:
+		default:
+			a.stmt(s.Else)
+		}
+		a.pop()
+	}
+	walk(root)
+
+	for _, name := range order {
+		if len(byName[name]) > 1 {
+			a.branchChains = append(a.branchChains, branchChain{name: name, keys: byName[name]})
+		}
+	}
+}
+
+func (a *funcAnalyzer) switchStmt(sw *ast.SwitchStmt) {
+	idx, isArgs := -1, false
+	if sw.Tag != nil {
+		idx, isArgs = a.argsIndex(sw.Tag)
+		if !isArgs {
+			a.expr(sw.Tag)
+		}
+	}
+	for _, st := range sw.Body.List {
+		cc, ok := st.(*ast.CaseClause)
+		if !ok {
+			a.stmt(st)
+			continue
+		}
+		for _, e := range cc.List {
+			if !isArgs {
+				a.expr(e)
+				continue
+			}
+			v, ok := a.sy.str(e)
+			if !ok {
+				a.gap(GapComputedPositional,
+					fmt.Sprintf("%s switches on positional argument %d against something other than a literal", a.fn, idx), e)
+				continue
+			}
+			if v != "" {
+				a.recordPositional(idx, v)
+			}
+		}
+		a.push()
+		for _, s := range cc.Body {
+			a.stmt(s)
+		}
+		a.pop()
+	}
+}
+
+func (a *funcAnalyzer) declStmt(d *ast.DeclStmt) {
+	gd, ok := d.Decl.(*ast.GenDecl)
+	if !ok || gd.Tok != token.VAR {
+		return
+	}
+	for _, spec := range gd.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, name := range vs.Names {
+			key := a.declare(name)
+			if i < len(vs.Values) {
+				a.attach(key, a.facts(vs.Values[i]))
+			}
+		}
+	}
+}
+
+func (a *funcAnalyzer) assign(as *ast.AssignStmt) {
+	// `flags := req.Flags` and `args := req.Args` make a local name mean the
+	// thing the rest of the function indexes.
+	for i, lhs := range as.Lhs {
+		id, ok := lhs.(*ast.Ident)
+		if !ok || i >= len(as.Rhs) {
+			continue
+		}
+		if a.isFlagsExpr(as.Rhs[i]) {
+			a.flagsIdents[id.Name] = true
+		}
+		if a.isArgsExpr(as.Rhs[i]) {
+			a.argsIdents[id.Name] = true
+		}
+	}
+
+	groups := make([]factGroup, len(as.Rhs))
+	for i := range as.Rhs {
+		groups[i] = a.facts(as.Rhs[i])
+		if isConstruction(as.Rhs[i]) {
+			// A struct built out of values is not one of those values. The
+			// connection packages assemble everything into one object -- a
+			// connection holding both an API key read from the environment and
+			// a base URL read from an option -- and propagating through that
+			// object would pair the two and report a credential route that does
+			// not exist. The expression is still walked, so what it reads is
+			// still recorded; only the flow into the name on the left stops.
+			groups[i] = factGroup{}
+		}
+	}
+
+	for i, lhs := range as.Lhs {
+		id, ok := lhs.(*ast.Ident)
+		if !ok {
+			a.expr(lhs)
+			continue
+		}
+		if id.Name == "_" {
+			continue
+		}
+		var key string
+		if as.Tok == token.DEFINE {
+			key = a.declare(id)
+		} else {
+			key = a.resolve(id.Name)
+			if _, known := a.vars[key]; !known {
+				a.vars[key] = &varInfo{name: id.Name}
+				a.order = append(a.order, key)
+			}
+		}
+		switch {
+		case len(groups) == len(as.Lhs):
+			a.attach(key, groups[i])
+		case len(groups) == 1:
+			// A multi-value call or a comma-ok: every name on the left is fed
+			// by the one expression on the right.
+			a.attach(key, groups[0])
+		}
+	}
+}
+
+func (a *funcAnalyzer) attach(key string, g factGroup) {
+	if len(g.flags) == 0 && len(g.envs) == 0 && len(g.refs) == 0 {
+		return
+	}
+	v, ok := a.vars[key]
+	if !ok {
+		v = &varInfo{name: key}
+		a.vars[key] = v
+		a.order = append(a.order, key)
+	}
+	v.groups = append(v.groups, g)
+}
+
+// --- expressions --------------------------------------------------------
+
+func (a *funcAnalyzer) expr(e ast.Expr) {
+	if e == nil {
+		return
+	}
+	a.facts(e)
+}
+
+// facts reads one expression for the four things that matter: flag names taken
+// out of the flag map, environment variables read, other variables referenced,
+// and positional comparisons.
+func (a *funcAnalyzer) facts(e ast.Expr) factGroup {
+	var g factGroup
+	var visit func(n ast.Node) bool
+	visit = func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncLit:
+			// A closure is code that runs in this function's scope, so its
+			// reads are this function's reads. hcp declares its whole flag
+			// accessor as one.
+			a.litDepth++
+			a.push()
+			a.declareParams(x.Type.Params)
+			for _, st := range x.Body.List {
+				a.stmt(st)
+			}
+			a.pop()
+			a.litDepth--
+			return false
+		case *ast.IndexExpr:
+			if !a.isFlagsExpr(x.X) {
+				return true
+			}
+			name, ok := a.sy.str(x.Index)
+			if !ok {
+				if !a.localBinding(x.Index) {
+					a.gap(GapUnresolvedConstant,
+						fmt.Sprintf("%s indexes the flag map with something that did not resolve to a string", a.fn), x.Index)
+				}
+				return false
+			}
+			g.flags = appendUnique(g.flags, name)
+			return false
+		case *ast.CallExpr:
+			if arg, ok := getenvArg(x); ok {
+				name, ok := a.sy.str(arg)
+				if !ok {
+					if !a.localBinding(arg) {
+						a.gap(GapDynamicGetenv,
+							fmt.Sprintf("%s calls os.Getenv with a value the syntax does not name", a.fn), arg)
+					}
+					return false
+				}
+				g.envs = appendUnique(g.envs, name)
+				a.envsSeen = appendUnique(a.envsSeen, name)
+				return false
+			}
+			if id, ok := x.Fun.(*ast.Ident); ok {
+				if sig, known := a.helpers[id.Name]; known {
+					if fe, flag, ok := a.helperCall(sig, x); ok {
+						if flag != "" {
+							g.flags = appendUnique(g.flags, flag)
+						}
+						for _, v := range fe.Vars {
+							g.envs = appendUnique(g.envs, v)
+							a.envsSeen = appendUnique(a.envsSeen, v)
+						}
+						g.selected += len(fe.Vars)
+						if fe.Flag != "" && len(fe.Vars) > 0 {
+							a.direct = append(a.direct, fe)
+						}
+						return false
+					}
+				}
+				if s, known := a.summaries[id.Name]; known {
+					addAll(&g.flags, s.flags)
+					for _, v := range s.envs {
+						g.envs = appendUnique(g.envs, v)
+						a.envsSeen = appendUnique(a.envsSeen, v)
+					}
+					g.selected += len(s.envs)
+					return false
+				}
+			}
+			// Any other call. A call with one value going in and one coming
+			// out carries that value -- string(x.Value),
+			// strings.TrimSpace(os.Getenv("X")), strings.TrimLeft(v, `\`) --
+			// and its facts belong to whatever the result is assigned to. A
+			// call with two values going in combines them into something new,
+			// and portainer is where that matters: connect() calls
+			// newClient(address, accessToken), and letting both flow into the
+			// client made --address look as though it travelled in
+			// PORTAINER_ACCESS_TOKEN. The arguments are still walked, so what
+			// they read is still recorded; only the flow into the result stops.
+			var carried []factGroup
+			for _, arg := range x.Args {
+				sub := a.facts(arg)
+				if len(sub.flags) > 0 || len(sub.envs) > 0 || len(sub.refs) > 0 {
+					carried = append(carried, sub)
+				}
+			}
+			if len(carried) == 1 {
+				addAll(&g.flags, carried[0].flags)
+				addAll(&g.envs, carried[0].envs)
+				addAll(&g.refs, carried[0].refs)
+				g.selected += carried[0].selected
+			}
+			return false
+		case *ast.BinaryExpr:
+			if x.Op == token.EQL || x.Op == token.NEQ {
+				a.comparePositional(x)
+			}
+			return true
+		case *ast.SelectorExpr:
+			// `x.Value` refers to x; the field name is not a variable.
+			ast.Inspect(x.X, visit)
+			return false
+		case *ast.Ident:
+			if x.Name == "_" || x.Name == "nil" {
+				return false
+			}
+			g.refs = appendUnique(g.refs, a.resolve(x.Name))
+			return false
+		}
+		return true
+	}
+	ast.Inspect(e, visit)
+	return g
+}
+
+// helperCall reads a recognised accessor's arguments.
+//
+// It reports the flag name separately from the association because the two are
+// separately useful: an accessor that only names a flag -- artifactory's
+// flagValue -- still tells the caller which flag the returned value belongs to,
+// and the caller's own os.Getenv completes the pair.
+func (a *funcAnalyzer) helperCall(sig helperSig, call *ast.CallExpr) (fe FlagEnv, flag string, ok bool) {
+	if sig.flagArg >= 0 && sig.flagArg < len(call.Args) {
+		v, resolved := a.sy.str(call.Args[sig.flagArg])
+		if !resolved {
+			if !a.localBinding(call.Args[sig.flagArg]) {
+				a.gap(GapUnresolvedConstant,
+					fmt.Sprintf("%s passes a flag name to an accessor that did not resolve to a string", a.fn),
+					call.Args[sig.flagArg])
+			}
+		} else {
+			flag = v
+		}
+	}
+
+	var vars []string
+	readEnvArg := func(e ast.Expr) {
+		if v, resolved := a.sy.str(e); resolved {
+			vars = appendUnique(vars, v)
+			return
+		}
+		if !a.localBinding(e) {
+			a.gap(GapDynamicGetenv,
+				fmt.Sprintf("%s passes an environment variable name the syntax does not name", a.fn), e)
+		}
+	}
+	if sig.envVariadic && len(sig.envArgs) > 0 {
+		for i := sig.envArgs[0]; i < len(call.Args); i++ {
+			readEnvArg(call.Args[i])
+		}
+	} else {
+		for _, idx := range sig.envArgs {
+			if idx < len(call.Args) {
+				readEnvArg(call.Args[idx])
+			}
+		}
+	}
+
+	if flag == "" && len(vars) == 0 {
+		return FlagEnv{}, "", false
+	}
+	return FlagEnv{Flag: flag, Vars: vars, Func: a.fn, Via: a.key.via}, flag, true
+}
+
+// isFlagsExpr reports whether an expression is the CLI flag map.
+func (a *funcAnalyzer) isFlagsExpr(e ast.Expr) bool {
+	if id, ok := e.(*ast.Ident); ok {
+		return a.flagsIdents[id.Name]
+	}
+	return readsField(e, a.key.field)
+}
+
+// isArgsExpr reports whether an expression is the positional argument slice.
+func (a *funcAnalyzer) isArgsExpr(e ast.Expr) bool {
+	if id, ok := e.(*ast.Ident); ok {
+		return a.argsIdents[id.Name]
+	}
+	return readsField(e, "Args")
+}
+
+// pureStringFuncs are the wrappers a provider puts around a positional argument
+// before comparing it. Seeing through them is what turns `switch
+// strings.ToLower(req.Args[0])` into a vocabulary rather than a gap.
+var pureStringFuncs = map[string]bool{
+	"ToLower": true, "ToUpper": true, "TrimSpace": true, "Trim": true, "Title": true,
+}
+
+// argsIndex reports which positional argument an expression reads.
+func (a *funcAnalyzer) argsIndex(e ast.Expr) (int, bool) {
+	switch x := e.(type) {
+	case *ast.ParenExpr:
+		return a.argsIndex(x.X)
+	case *ast.CallExpr:
+		if sel, ok := x.Fun.(*ast.SelectorExpr); ok && pureStringFuncs[sel.Sel.Name] && len(x.Args) > 0 {
+			return a.argsIndex(x.Args[0])
+		}
+	case *ast.IndexExpr:
+		if !a.isArgsExpr(x.X) {
+			return 0, false
+		}
+		n, ok := uintValue(x.Index)
+		if !ok {
+			return 0, false
+		}
+		return int(n), true
+	}
+	return 0, false
+}
+
+func (a *funcAnalyzer) comparePositional(be *ast.BinaryExpr) {
+	for _, pair := range [][2]ast.Expr{{be.X, be.Y}, {be.Y, be.X}} {
+		idx, ok := a.argsIndex(pair[0])
+		if !ok {
+			continue
+		}
+		v, ok := a.sy.str(pair[1])
+		if !ok {
+			a.gap(GapComputedPositional,
+				fmt.Sprintf("%s compares positional argument %d against something other than a literal", a.fn, idx), pair[1])
+			return
+		}
+		if v != "" {
+			a.recordPositional(idx, v)
+		}
+		return
+	}
+}
+
+func (a *funcAnalyzer) recordPositional(idx int, value string) {
+	if _, seen := a.positional[idx]; !seen {
+		a.posOrder = append(a.posOrder, idx)
+	}
+	a.positional[idx] = appendUnique(a.positional[idx], value)
+}
+
+// --- resolution ---------------------------------------------------------
+
+// fixpoint propagates flag names and variable names along variable references
+// until nothing more moves. The chains are short -- two or three hops -- so the
+// naive repetition is cheaper than building a graph.
+func (a *funcAnalyzer) fixpoint() {
+	for range len(a.order) + 1 {
+		changed := false
+		for _, key := range a.order {
+			v := a.vars[key]
+			for _, g := range v.groups {
+				changed = addAll(&v.flags, g.flags) || changed
+				changed = addAll(&v.envs, g.envs) || changed
+				for _, ref := range g.refs {
+					src, ok := a.vars[ref]
+					if !ok || src == v {
+						continue
+					}
+					changed = addAll(&v.flags, src.flags) || changed
+					changed = addAll(&v.envs, src.envs) || changed
+				}
+			}
+		}
+		if !changed {
+			return
+		}
+	}
+}
+
+func contains(list []string, v string) bool {
+	for _, existing := range list {
+		if existing == v {
+			return true
+		}
+	}
+	return false
+}
+
+// isConstruction reports whether an expression assembles a new value out of
+// other values, rather than reading or choosing one.
+func isConstruction(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.CompositeLit:
+		return true
+	case *ast.UnaryExpr:
+		return x.Op == token.AND && isConstruction(x.X)
+	case *ast.CallExpr:
+		id, ok := x.Fun.(*ast.Ident)
+		return ok && id.Name == "append"
+	}
+	return false
+}
+
+// addAll unions src into dst, reporting whether anything moved.
+func addAll(dst *[]string, src []string) bool {
+	changed := false
+	for _, v := range src {
+		before := len(*dst)
+		*dst = appendUnique(*dst, v)
+		changed = changed || len(*dst) != before
+	}
+	return changed
+}
+
+// results are the flag-to-environment associations this function established.
+//
+// It is computed once: the walk raises gaps while resolving, and a second call
+// would raise them again.
+func (a *funcAnalyzer) results() []FlagEnv {
+	if a.resolved {
+		return a.cached
+	}
+	a.resolved = true
+	a.cached = a.computeResults()
+	return a.cached
+}
+
+func (a *funcAnalyzer) computeResults() []FlagEnv {
+	out := append([]FlagEnv(nil), a.direct...)
+
+	for _, key := range a.order {
+		v := a.vars[key]
+		if len(v.flags) == 0 || len(v.envs) == 0 {
+			continue
+		}
+		if len(v.flags) > 1 {
+			// Two flag names in one variable. Either could be the one the
+			// variable travels for, and picking is exactly the failure mode
+			// this tool exists to avoid.
+			//
+			// Unless nothing was lost: a value assembled from several already
+			// paired flags -- activedirectory builds one credential out of
+			// --user and --password after each has met its own variable -- is
+			// an aggregate, not an unresolved binding, and reporting it would
+			// bury the three real ones under the structures that carry them.
+			if !a.allPairedElsewhere(v, out) {
+				a.gaps = append(a.gaps, Gap{
+					Kind: GapAmbiguousBinding,
+					Detail: fmt.Sprintf("%s: %q holds flags %s and variables %s, so no pairing can be read",
+						a.fn, v.name, strings.Join(v.flags, ", "), strings.Join(v.envs, ", ")),
+				})
+			}
+			continue
+		}
+		out = append(out, FlagEnv{
+			Flag:     v.flags[0],
+			Vars:     v.envs,
+			Func:     a.fn,
+			Via:      a.key.via,
+			Composed: a.composed(v),
+		})
+	}
+
+	for _, chain := range a.branchChains {
+		var flags, envs []string
+		bothInOne := false
+		for _, key := range chain.keys {
+			v, ok := a.vars[key]
+			if !ok {
+				continue
+			}
+			if len(v.flags) > 0 && len(v.envs) > 0 {
+				bothInOne = true
+			}
+			addAll(&flags, v.flags)
+			addAll(&envs, v.envs)
+		}
+		if bothInOne || len(flags) != 1 || len(envs) == 0 {
+			continue
+		}
+		for _, e := range envs {
+			a.explained = appendUnique(a.explained, e)
+		}
+		a.gaps = append(a.gaps, Gap{
+			Kind: GapAlternativeBranches,
+			Detail: fmt.Sprintf("%s: %q is declared by two arms of one if/else chain, one holding flag %q and the other %s; nothing but the shared name says they are the same credential",
+				a.fn, chain.name, flags[0], strings.Join(envs, ", ")),
+		})
+	}
+
+	// Merge, keeping first-seen variable order.
+	merged := map[string]*FlagEnv{}
+	var order []string
+	for _, fe := range out {
+		existing, ok := merged[fe.Flag]
+		if !ok {
+			copied := fe
+			merged[fe.Flag] = &copied
+			order = append(order, fe.Flag)
+			continue
+		}
+		for _, v := range fe.Vars {
+			existing.Vars = appendUnique(existing.Vars, v)
+		}
+		existing.Composed = existing.Composed || fe.Composed
+	}
+	final := make([]FlagEnv, 0, len(order))
+	for _, flag := range order {
+		final = append(final, *merged[flag])
+	}
+	return final
+}
+
+// allPairedElsewhere reports whether every flag in an aggregate value already
+// has its own association from this function.
+func (a *funcAnalyzer) allPairedElsewhere(v *varInfo, found []FlagEnv) bool {
+	for _, flag := range v.flags {
+		paired := false
+		for _, fe := range found {
+			if fe.Flag == flag {
+				paired = true
+				break
+			}
+		}
+		if !paired {
+			return false
+		}
+	}
+	return true
+}
+
+// composed reports whether a single assignment gathered more than one
+// environment variable into this value, as opposed to the value being chosen
+// from a list of fallbacks.
+//
+// The difference matters to anyone acting on the result. okta builds its
+// organization from OKTA_ORG_NAME and OKTA_BASE_URL joined by a ".", so setting
+// only the first produces "acme." and a connection to nothing; alicloud's
+// region falls back from ALIBABA_CLOUD_REGION to ALIBABA_CLOUD_REGION_ID, and
+// setting only the first is exactly right.
+func (a *funcAnalyzer) composed(v *varInfo) bool {
+	for _, g := range v.groups {
+		count := len(g.envs) - g.selected
+		for _, ref := range g.refs {
+			if src, ok := a.vars[ref]; ok && src != v {
+				count += len(src.envs)
+			}
+		}
+		if count > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// boundLater reports whether an environment variable this function read is
+// already accounted for -- either attached to a flag, or named by a more
+// specific gap. It exists so the broad unbound-env report says only what
+// nothing else has said.
+func (a *funcAnalyzer) boundLater(name string) bool {
+	for _, fe := range a.results() {
+		for _, v := range fe.Vars {
+			if v == name {
+				return true
+			}
+		}
+	}
+	for _, v := range a.explained {
+		if v == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectorgen/carry.go
+++ b/internal/connectorgen/carry.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// A regeneration must not lose a connector.
+//
+// The mql checkout is not a superset of what a person has installed. Three
+// connectors in the recorded snapshot are not in the source tree at all:
+// equinix ships as a built provider with no config package, and anthropic and
+// clickhouse are earlier names for providers the tree now calls claude and
+// clickhousedb. Overwriting the artifact with only what the source yields would
+// delete three connectors' worth of metadata that was established by running
+// the binaries, and the tests that depend on them would start skipping rather
+// than failing -- which is the failure mode that costs the most to notice.
+//
+// So a regeneration keeps what it can no longer derive, marks it, and files a
+// gap for it. A carried entry is visible in the diff and in the report every
+// time, so it is a question that keeps getting asked rather than a fact that
+// quietly rots.
+
+// CarryForward adds connectors from a previous artifact that this extraction
+// did not produce.
+//
+// It reads both the current envelope and the bare array the launcher's snapshot
+// used before this tool existed, because the first regeneration reads the
+// second.
+func CarryForward(art *Artifact, previousPath string) error {
+	data, err := os.ReadFile(previousPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "cannot read the previous artifact %s", previousPath)
+	}
+
+	previous, err := parsePrevious(data)
+	if err != nil {
+		return err
+	}
+
+	have := map[string]bool{}
+	for _, c := range art.Connectors {
+		have[c.Provider+"/"+c.Name] = true
+	}
+
+	var carried []Connector
+	for _, c := range previous {
+		if have[c.Provider+"/"+c.Name] {
+			continue
+		}
+		c.CarriedForward = true
+		carried = append(carried, c)
+		art.Gaps = append(art.Gaps, Gap{
+			Provider:  c.Provider,
+			Connector: c.Name,
+			Kind:      GapCarriedForward,
+			Detail:    "not found in the source that was read; its metadata is the previously recorded one and nothing here re-derived it",
+		})
+	}
+	if len(carried) == 0 {
+		return nil
+	}
+
+	art.Connectors = append(art.Connectors, carried...)
+	sort.SliceStable(art.Connectors, func(i, j int) bool {
+		if art.Connectors[i].Name != art.Connectors[j].Name {
+			return art.Connectors[i].Name < art.Connectors[j].Name
+		}
+		return art.Connectors[i].Provider < art.Connectors[j].Provider
+	})
+	sortGaps(art.Gaps)
+	return nil
+}
+
+// parsePrevious reads either artifact format.
+func parsePrevious(data []byte) ([]Connector, error) {
+	var envelope Artifact
+	if err := json.Unmarshal(data, &envelope); err == nil && envelope.Schema != 0 {
+		return envelope.Connectors, nil
+	}
+	var bare []Connector
+	if err := json.Unmarshal(data, &bare); err != nil {
+		return nil, errors.Wrap(err, "the previous artifact is neither an artifact nor a connector list")
+	}
+	for i := range bare {
+		if bare[i].Provider == "" || bare[i].Name == "" {
+			return nil, fmt.Errorf("the previous artifact has an entry with no name or provider")
+		}
+	}
+	return bare, nil
+}

--- a/internal/connectorgen/config.go
+++ b/internal/connectorgen/config.go
@@ -1,0 +1,265 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"fmt"
+	"go/ast"
+	"sort"
+)
+
+// Reading the plugin.Provider literal out of providers/<name>/config/config.go.
+//
+// Everything here is also obtainable from an installed provider's <name>.json,
+// which is a verbatim json.Marshal of the same struct. It is extracted anyway
+// so one artifact describes every connector rather than only the ones the
+// person running the generator happened to have installed, and so the env and
+// positional facts -- which have no runtime source -- sit beside the flags they
+// belong to.
+
+// declaredProvider is one parsed plugin.Provider literal.
+type declaredProvider struct {
+	// Name is the provider's own Name field, which is not always its directory
+	// name: the provider in providers/claude declares itself "claude".
+	Name       string
+	Connectors []Connector
+	Gaps       []Gap
+}
+
+// parseConfig reads the plugin.Provider literal from a package's files.
+//
+// It returns ok=false when no such literal is there at all, which is not a gap:
+// most directories under providers/ hold no config, and a caller that reported
+// each of them would bury the gaps that matter.
+func parseConfig(sy *symbols, files []*ast.File, where func(ast.Node) string) (declaredProvider, bool) {
+	var lit *ast.CompositeLit
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			if lit != nil {
+				return false
+			}
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok || !isQualifiedType(cl.Type, "plugin", "Provider") {
+				return true
+			}
+			lit = cl
+			return false
+		})
+		if lit != nil {
+			break
+		}
+	}
+	if lit == nil {
+		return declaredProvider{}, false
+	}
+
+	var out declaredProvider
+	gap := func(kind, detail string, n ast.Node) {
+		out.Gaps = append(out.Gaps, Gap{Kind: kind, Detail: detail, Where: where(n)})
+	}
+
+	for _, field := range fieldsOf(lit) {
+		switch field.name {
+		case "Name":
+			v, ok := sy.str(field.value)
+			if !ok {
+				gap(GapUnresolvedConstant, "provider Name is not a resolvable string", field.value)
+				continue
+			}
+			out.Name = v
+		case "Connectors":
+			cl, ok := field.value.(*ast.CompositeLit)
+			if !ok {
+				gap(GapConfigNotLiteral, "Connectors is not a composite literal, so no connector could be read", field.value)
+				continue
+			}
+			for _, el := range cl.Elts {
+				ecl, ok := unwrapCompositeLit(el)
+				if !ok {
+					gap(GapConfigNotLiteral, "a Connectors entry is not a composite literal", el)
+					continue
+				}
+				out.Connectors = append(out.Connectors, parseConnector(sy, ecl, where, &out.Gaps))
+			}
+		}
+	}
+	// Every gap raised while reading the literal belongs to this provider.
+	for i := range out.Gaps {
+		out.Gaps[i].Provider = out.Name
+	}
+	return out, true
+}
+
+// parseConnector reads one plugin.Connector literal.
+func parseConnector(sy *symbols, lit *ast.CompositeLit, where func(ast.Node) string, gaps *[]Gap) Connector {
+	var c Connector
+	gap := func(kind, detail string, n ast.Node) {
+		*gaps = append(*gaps, Gap{Connector: c.Name, Kind: kind, Detail: detail, Where: where(n)})
+	}
+	// Name first, so every gap raised below can name the connector it is about.
+	for _, field := range fieldsOf(lit) {
+		if field.name != "Name" {
+			continue
+		}
+		if v, ok := sy.str(field.value); ok {
+			c.Name = v
+		}
+	}
+
+	for _, field := range fieldsOf(lit) {
+		switch field.name {
+		case "Name":
+			if c.Name == "" {
+				gap(GapUnresolvedConstant, "connector Name is not a resolvable string", field.value)
+			}
+		case "Use":
+			c.Use = mustStr(sy, field.value, "Use", gap)
+		case "Short":
+			c.Short = mustStr(sy, field.value, "Short", gap)
+		case "Long":
+			c.Long = mustStr(sy, field.value, "Long", gap)
+		case "Maturity":
+			c.Maturity = mustStr(sy, field.value, "Maturity", gap)
+		case "MinArgs":
+			if v, ok := uintValue(field.value); ok {
+				c.MinArgs = v
+			} else {
+				gap(GapConfigNotLiteral, "MinArgs is not an integer literal", field.value)
+			}
+		case "MaxArgs":
+			if v, ok := uintValue(field.value); ok {
+				c.MaxArgs = v
+			} else {
+				gap(GapConfigNotLiteral, "MaxArgs is not an integer literal", field.value)
+			}
+		case "IsHidden":
+			if v, ok := boolValue(field.value); ok {
+				c.IsHidden = v
+			}
+		case "Aliases":
+			v, complete := sy.strList(field.value)
+			c.Aliases = v
+			if !complete {
+				gap(GapUnresolvedConstant, "some Aliases entries did not resolve to strings", field.value)
+			}
+		case "Discovery":
+			v, complete := sy.strList(field.value)
+			c.Discovery = v
+			if !complete {
+				gap(GapUnresolvedConstant, "some Discovery entries did not resolve to strings", field.value)
+			}
+		case "Flags":
+			cl, ok := field.value.(*ast.CompositeLit)
+			if !ok {
+				gap(GapConfigNotLiteral, "Flags is not a composite literal, so no flag could be read", field.value)
+				continue
+			}
+			for _, el := range cl.Elts {
+				fcl, ok := unwrapCompositeLit(el)
+				if !ok {
+					gap(GapConfigNotLiteral, "a Flags entry is not a composite literal", el)
+					continue
+				}
+				c.Flags = append(c.Flags, parseFlag(sy, fcl, where, gap))
+			}
+		}
+	}
+	// Sorted by name, matching the order the launcher's own snapshot records,
+	// so a regeneration diff shows what changed rather than how the author
+	// reordered the literal.
+	sort.Slice(c.Flags, func(i, j int) bool { return c.Flags[i].Long < c.Flags[j].Long })
+	return c
+}
+
+func parseFlag(sy *symbols, lit *ast.CompositeLit, where func(ast.Node) string, gap func(kind, detail string, n ast.Node)) Flag {
+	var fl Flag
+	for _, field := range fieldsOf(lit) {
+		switch field.name {
+		case "Long":
+			fl.Long = mustStr(sy, field.value, "flag Long", gap)
+		case "Short":
+			fl.Short = mustStr(sy, field.value, "flag Short", gap)
+		case "Default":
+			fl.Default = mustStr(sy, field.value, "flag Default", gap)
+		case "Desc":
+			fl.Desc = mustStr(sy, field.value, "flag Desc", gap)
+		case "ConfigEntry":
+			fl.Config = mustStr(sy, field.value, "flag ConfigEntry", gap)
+		case "Type":
+			v, ok := enumValue(field.value, flagTypes)
+			if !ok {
+				gap(GapUnresolvedConstant, fmt.Sprintf("flag %q has a Type this walk cannot read", fl.Long), field.value)
+				continue
+			}
+			fl.Type = int32(v)
+		case "Option":
+			v, ok := enumValue(field.value, flagOptions)
+			if !ok {
+				gap(GapUnresolvedConstant, fmt.Sprintf("flag %q has an Option this walk cannot read", fl.Long), field.value)
+				continue
+			}
+			fl.Option = int32(v)
+		}
+	}
+	_ = where
+	return fl
+}
+
+// mustStr resolves a string field, recording a gap when it cannot. An empty
+// value from an unresolved identifier and a declared empty value are different
+// facts, and collapsing them is how a form ends up with a blank label nobody
+// can explain.
+func mustStr(sy *symbols, e ast.Expr, what string, gap func(kind, detail string, n ast.Node)) string {
+	v, ok := sy.str(e)
+	if !ok {
+		gap(GapUnresolvedConstant, what+" is not a resolvable string", e)
+		return ""
+	}
+	return v
+}
+
+// keyed is one Key: Value pair of a composite literal.
+type keyed struct {
+	name  string
+	value ast.Expr
+}
+
+// fieldsOf returns the keyed fields of a struct literal, in source order.
+func fieldsOf(lit *ast.CompositeLit) []keyed {
+	out := make([]keyed, 0, len(lit.Elts))
+	for _, el := range lit.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		out = append(out, keyed{name: key.Name, value: kv.Value})
+	}
+	return out
+}
+
+// unwrapCompositeLit reaches the literal behind an optional &.
+func unwrapCompositeLit(e ast.Expr) (*ast.CompositeLit, bool) {
+	if u, ok := e.(*ast.UnaryExpr); ok {
+		e = u.X
+	}
+	cl, ok := e.(*ast.CompositeLit)
+	return cl, ok
+}
+
+// isQualifiedType reports whether a literal's type is pkg.Name, allowing for a
+// pointer or a slice element.
+func isQualifiedType(e ast.Expr, pkg, name string) bool {
+	switch x := e.(type) {
+	case *ast.SelectorExpr:
+		id, ok := x.X.(*ast.Ident)
+		return ok && id.Name == pkg && x.Sel.Name == name
+	case *ast.StarExpr:
+		return isQualifiedType(x.X, pkg, name)
+	}
+	return false
+}

--- a/internal/connectorgen/extract.go
+++ b/internal/connectorgen/extract.go
@@ -1,0 +1,568 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Root is one source tree to read: the mql monorepo, or the enterprise provider
+// repository beside it.
+type Root struct {
+	// Name is the short name recorded in the artifact, e.g. "mql".
+	Name string
+	// Path is the checkout to read.
+	Path string
+}
+
+// Extract reads every provider under every root and returns the artifact.
+//
+// It refuses rather than degrades when a root is not a provider checkout. The
+// artifact is checked in, so a run that quietly produced half of it would
+// replace a complete file with an incomplete one and nothing downstream would
+// notice; a run that stops leaves the checked-in file alone.
+func Extract(roots []Root) (*Artifact, error) {
+	if len(roots) == 0 {
+		return nil, errors.New("no source tree given: point the generator at an mql checkout")
+	}
+
+	art := &Artifact{
+		Schema:      SchemaVersion,
+		GeneratedBy: "go.mondoo.com/cnspec/internal/connectorgen",
+	}
+	seen := map[string]string{}
+
+	for _, root := range roots {
+		providersDir := filepath.Join(root.Path, "providers")
+		info, err := os.Stat(providersDir)
+		if err != nil || !info.IsDir() {
+			return nil, errors.Newf("%s is not a provider checkout: no %s directory", root.Path, providersDir)
+		}
+
+		src := Source{Name: root.Name}
+		src.Commit, src.Dirty = gitState(root.Path)
+
+		found, gaps, err := extractRoot(root, providersDir)
+		if err != nil {
+			return nil, err
+		}
+		src.Providers = len(found)
+		art.Sources = append(art.Sources, src)
+		art.Gaps = append(art.Gaps, gaps...)
+
+		for _, c := range found {
+			key := c.Provider + "/" + c.Name
+			if from, dup := seen[key]; dup {
+				art.Gaps = append(art.Gaps, Gap{
+					Provider:  c.Provider,
+					Connector: c.Name,
+					Kind:      GapConfigNotLiteral,
+					Detail:    fmt.Sprintf("declared in both %s and %s; the first was kept", from, root.Name),
+				})
+				continue
+			}
+			seen[key] = root.Name
+			art.Connectors = append(art.Connectors, c)
+		}
+	}
+
+	if len(art.Connectors) == 0 {
+		return nil, errors.New("no connectors found: the checkout has providers/ but no plugin.Provider literal in it")
+	}
+
+	sort.SliceStable(art.Connectors, func(i, j int) bool {
+		if art.Connectors[i].Name != art.Connectors[j].Name {
+			return art.Connectors[i].Name < art.Connectors[j].Name
+		}
+		return art.Connectors[i].Provider < art.Connectors[j].Provider
+	})
+	sortGaps(art.Gaps)
+
+	// Each connector carries its own share of the gaps, so a consumer reading
+	// one connector sees what is missing from it without joining two lists.
+	byConnector := map[string][]Gap{}
+	for _, g := range art.Gaps {
+		if g.Connector == "" {
+			continue
+		}
+		byConnector[g.Provider+"/"+g.Connector] = append(byConnector[g.Provider+"/"+g.Connector], g)
+	}
+	for i := range art.Connectors {
+		c := &art.Connectors[i]
+		for _, g := range byConnector[c.Provider+"/"+c.Name] {
+			// Repeated inside the connector, so provider and connector would
+			// only say twice what the position in the file already says.
+			g.Provider, g.Connector = "", ""
+			c.Gaps = append(c.Gaps, g)
+		}
+	}
+	return art, nil
+}
+
+// extractRoot walks one checkout's providers directory.
+func extractRoot(root Root, providersDir string) ([]Connector, []Gap, error) {
+	entries, err := os.ReadDir(providersDir)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "cannot read %s", providersDir)
+	}
+
+	var connectors []Connector
+	var gaps []Gap
+
+	// The providers that live in their own directory. Their name comes from
+	// the literal rather than the directory: providers/claude declares itself
+	// "claude", and a walk keying on the directory would mislabel any provider
+	// whose two names differ.
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(providersDir, e.Name())
+		cfgDir := filepath.Join(dir, "config")
+		if _, err := os.Stat(filepath.Join(cfgDir, "config.go")); err != nil {
+			// A directory holding a built artifact or a resource schema but no
+			// config is a provider whose source is not in this checkout --
+			// equinix is one here. Saying so is the difference between a
+			// connector that is missing for a reason and one that is missing
+			// silently.
+			if looksLikeProvider(dir) {
+				gaps = append(gaps, Gap{
+					Provider: e.Name(),
+					Kind:     GapSourceAbsent,
+					Detail:   "the directory holds a built provider but no config package, so nothing about it could be read",
+					Where:    relPath(root, dir),
+				})
+			}
+			continue
+		}
+		cs, gs, err := extractProvider(root, dir, cfgDir, filepath.Join(dir, "provider"))
+		if err != nil {
+			return nil, nil, err
+		}
+		connectors = append(connectors, cs...)
+		gaps = append(gaps, gs...)
+	}
+
+	// The built-in providers, declared in files directly under providers/
+	// rather than in a provider directory. sbom is one, and it is a connector a
+	// user can select, so leaving it out would make the artifact quietly
+	// smaller than the launcher's list.
+	cs, gs, err := extractBuiltins(root, providersDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	connectors = append(connectors, cs...)
+	gaps = append(gaps, gs...)
+
+	return connectors, gaps, nil
+}
+
+// extractProvider reads one providers/<dir> tree.
+func extractProvider(root Root, dir, cfgDir, provDir string) ([]Connector, []Gap, error) {
+	fset := token.NewFileSet()
+	sy := newSymbols(fset)
+	// The whole provider tree, because the config literal names constants that
+	// live in the connection and resources packages beside it.
+	if err := sy.scanTree(dir); err != nil {
+		return nil, nil, err
+	}
+	where := positionFunc(fset, root)
+
+	declared, ok := parseConfig(sy, sy.files[cfgDir], where)
+	if !ok {
+		return nil, nil, nil
+	}
+	if declared.Name == "" {
+		declared.Name = filepath.Base(dir)
+	}
+	// Every package under connection/, not just the top one: atlassian splits
+	// its two products into connection/jira and connection/confluence, and each
+	// reads its own token.
+	return assemble(sy, declared, sy.files[provDir], sy.filesUnder(filepath.Join(dir, "connection")),
+		where, relPath(root, provDir))
+}
+
+// extractBuiltins reads the provider literals declared directly under
+// providers/, which have no config package and no provider package of their
+// own: ParseCLI for those sits in the same package.
+func extractBuiltins(root Root, providersDir string) ([]Connector, []Gap, error) {
+	fset := token.NewFileSet()
+	sy := newSymbols(fset)
+	entries, err := os.ReadDir(providersDir)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "cannot read %s", providersDir)
+	}
+	var files []*ast.File
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, perr := parseOne(fset, filepath.Join(providersDir, e.Name()))
+		if perr != nil {
+			continue
+		}
+		files = append(files, f)
+		sy.record(f)
+	}
+	if len(files) == 0 {
+		return nil, nil, nil
+	}
+	where := positionFunc(fset, root)
+
+	var connectors []Connector
+	var gaps []Gap
+	for _, f := range files {
+		declared, ok := parseConfig(sy, []*ast.File{f}, where)
+		if !ok || declared.Name == "" {
+			continue
+		}
+		// providers/defaults.go is an auto-generated list of every provider
+		// with the flags, argument counts and discovery targets stripped -- the
+		// air-gapped fallback. It is the very thing the launcher's catalog
+		// degrades to when nothing is installed, so reading it as a source of
+		// truth would replace 81 real declarations with 81 empty ones.
+		if !declaresMetadata(declared.Connectors) {
+			continue
+		}
+		// The provider package is the one file, not everything under
+		// providers/: the coordinator lives there too, and reading its
+		// environment lookups as though they belonged to a connector produced
+		// four providers that all claimed to read PROVIDERS_PATH.
+		cs, gs, err := assemble(sy, declared, []*ast.File{f}, nil, where, relPath(root, providersDir))
+		if err != nil {
+			return nil, nil, err
+		}
+		connectors = append(connectors, cs...)
+		gaps = append(gaps, gs...)
+	}
+	return connectors, gaps, nil
+}
+
+// assemble joins what the config declared to what the provider package does
+// with it, and records everything the join could not settle.
+func assemble(sy *symbols, declared declaredProvider, provFiles, connFiles []*ast.File, where func(ast.Node) string, provDir string) ([]Connector, []Gap, error) {
+	gaps := declared.Gaps
+
+	var analysis providerAnalysis
+	switch {
+	case len(provFiles) == 0:
+		gaps = append(gaps, Gap{
+			Provider: declared.Name,
+			Kind:     GapNoProviderPkg,
+			Detail:   "no provider package beside the config, so no ParseCLI to read environment variables or sub-commands out of",
+			Where:    provDir,
+		})
+	default:
+		analysis = analyzeProviderPkg(sy, provFiles, where, flagKeys)
+		if !hasFunc(provFiles, "ParseCLI") {
+			gaps = append(gaps, Gap{
+				Provider: declared.Name,
+				Kind:     GapNoParseCLI,
+				Detail:   "the provider package declares no ParseCLI",
+				Where:    provDir,
+			})
+		}
+	}
+
+	// The connection package is the second place a credential arrives from, and
+	// for roughly a fifth of the tree it is the only place: zoom, tailscale and
+	// openstack read their tokens at connect time out of the options map rather
+	// than in ParseCLI. The option names there are not flag names in general,
+	// so only the ones a connector actually declares are kept; the rest are
+	// reported.
+	var connAnalysis providerAnalysis
+	if len(connFiles) > 0 {
+		connAnalysis = analyzeProviderPkg(sy, connFiles, where, optionKeys)
+	}
+
+	for i := range analysis.Gaps {
+		analysis.Gaps[i].Provider = declared.Name
+	}
+	gaps = append(gaps, analysis.Gaps...)
+
+	// Which connector does an association belong to? The one that declares the
+	// flag. A provider shipping several connectors -- os ships eight -- has one
+	// ParseCLI serving all of them, so the flag name is the only thing in the
+	// syntax that distinguishes them, and it is a fact rather than a guess.
+	declaresFlag := func(c Connector, flag string) bool {
+		for _, fl := range c.Flags {
+			if fl.Long == flag {
+				return true
+			}
+		}
+		return false
+	}
+
+	out := make([]Connector, 0, len(declared.Connectors))
+	for _, c := range declared.Connectors {
+		c.Provider = declared.Name
+		for _, fe := range analysis.Env {
+			if !declaresFlag(c, fe.Flag) {
+				continue
+			}
+			fe.Declared = true
+			c.Env = append(c.Env, fe)
+		}
+		for _, fe := range connAnalysis.Env {
+			if !declaresFlag(c, fe.Flag) || hasFlagEnv(c.Env, fe.Flag) {
+				continue
+			}
+			fe.Declared = true
+			c.Env = append(c.Env, fe)
+		}
+		sort.SliceStable(c.Env, func(i, j int) bool { return c.Env[i].Flag < c.Env[j].Flag })
+		out = append(out, c)
+	}
+
+	// What the connection walk found and nothing could use. Reported as one
+	// finding per provider: a variable read there may back an option that is
+	// not a flag, or a value the CLI has no way to pass at all, and either way
+	// the launcher cannot offer a field for it.
+	var loose []string
+	for _, fe := range connAnalysis.Env {
+		used := false
+		for _, c := range out {
+			if declaresFlag(c, fe.Flag) {
+				used = true
+				break
+			}
+		}
+		if !used {
+			loose = appendUnique(loose, fmt.Sprintf("%s (option %q)", strings.Join(fe.Vars, ", "), fe.Flag))
+		}
+	}
+	for _, name := range connAnalysis.Unbound {
+		// A variable the connection package also reads while parsing is not
+		// loose; it already has its route, and repeating it here would make the
+		// gap list longer than the thing it is reporting on.
+		if attachedAnywhere(out, name) {
+			continue
+		}
+		loose = appendUnique(loose, name)
+	}
+	if len(loose) > 0 {
+		gaps = append(gaps, Gap{
+			Provider: declared.Name,
+			Kind:     GapEnvOutsideParseCLI,
+			Detail: fmt.Sprintf("the connection package reads %s, which no declared flag accounts for",
+				strings.Join(loose, "; ")),
+		})
+	}
+
+	for _, fe := range analysis.Env {
+		attached := false
+		for _, c := range out {
+			if declaresFlag(c, fe.Flag) {
+				attached = true
+				break
+			}
+		}
+		if attached {
+			continue
+		}
+		// A value the provider reads from the environment for a flag no
+		// connector declares. Either the flag was removed and the read was
+		// left behind, or the value has no command-line route at all -- which
+		// is exactly the case a launcher needs told, because it cannot offer a
+		// field for it.
+		gaps = append(gaps, Gap{
+			Provider: declared.Name,
+			Kind:     GapUndeclaredFlag,
+			Detail: fmt.Sprintf("%s reads %q from %s but no connector declares that flag",
+				fe.Func, fe.Flag, strings.Join(fe.Vars, ", ")),
+		})
+	}
+
+	gaps = append(gaps, attributePositional(&out, declared.Name, analysis.Positional)...)
+
+	return out, gaps, nil
+}
+
+// attributePositional hands the sub-command vocabulary to the connector it
+// belongs to, and says so when it cannot tell which one that is.
+func attributePositional(connectors *[]Connector, provider string, found []Positional) []Gap {
+	var gaps []Gap
+	list := *connectors
+
+	// One ParseCLI serves every connector a provider ships, so a vocabulary
+	// found there belongs to whichever of them takes positional arguments. When
+	// exactly one does, that is a fact rather than a guess: the others cannot
+	// receive an argument at all.
+	var takesArgs []int
+	for i := range list {
+		if list[i].MaxArgs > 0 {
+			takesArgs = append(takesArgs, i)
+		}
+	}
+	if len(takesArgs) == 1 {
+		list[takesArgs[0]].Positional = found
+	} else if len(takesArgs) == 0 && len(found) > 0 {
+		gaps = append(gaps, Gap{
+			Provider: provider,
+			Kind:     GapComputedPositional,
+			Detail:   "ParseCLI compares positional arguments that no connector declares it takes",
+		})
+	} else if len(found) > 0 {
+		words := make([]string, 0, len(found))
+		for _, p := range found {
+			words = append(words, fmt.Sprintf("argument %d: %s", p.Index, strings.Join(p.Values, "|")))
+		}
+		gaps = append(gaps, Gap{
+			Provider: provider,
+			Kind:     GapPositionalAmbiguous,
+			Detail: fmt.Sprintf("one ParseCLI serves %d connectors that take positional arguments, so %s cannot be attributed to one of them",
+				len(takesArgs), strings.Join(words, "; ")),
+		})
+	}
+
+	// A connector taking two or more arguments is the sub-command shape: the
+	// first word selects and the rest are its value. `mongo <host>` takes one
+	// argument and has no vocabulary to find, so only the two-argument shape is
+	// reported when nothing was found -- otherwise every host connector in the
+	// catalog would file a gap saying its hostname is not a keyword.
+	for i := range list {
+		if list[i].MinArgs >= 2 && len(list[i].Positional) == 0 {
+			gaps = append(gaps, Gap{
+				Provider:  provider,
+				Connector: list[i].Name,
+				Kind:      GapNoPositionalVocabulary,
+				Detail: fmt.Sprintf("takes %d arguments but no literal comparison against them was found, so the words it accepts are documented only in its help text",
+					list[i].MinArgs),
+			})
+		}
+	}
+	return gaps
+}
+
+// looksLikeProvider reports whether a directory under providers/ is a provider
+// whose source is missing, rather than something else that happens to live
+// there.
+func looksLikeProvider(dir string) bool {
+	for _, marker := range []string{"dist", "resources"} {
+		if info, err := os.Stat(filepath.Join(dir, marker)); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// declaresMetadata reports whether any connector carries its own declaration,
+// as opposed to being a bare name in a fallback list. It is the same question
+// the launcher's own catalog asks of an installed provider.
+func declaresMetadata(connectors []Connector) bool {
+	for _, c := range connectors {
+		if len(c.Flags) > 0 || c.MaxArgs > 0 || len(c.Discovery) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFunc(files []*ast.File, name string) bool {
+	for _, f := range files {
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// positionFunc renders a node's position relative to the checkout, prefixed
+// with the repository name so a gap from the enterprise tree is not mistaken
+// for one from mql.
+func positionFunc(fset *token.FileSet, root Root) func(ast.Node) string {
+	return func(n ast.Node) string {
+		if n == nil {
+			return ""
+		}
+		p := fset.Position(n.Pos())
+		rel, err := filepath.Rel(root.Path, p.Filename)
+		if err != nil {
+			rel = p.Filename
+		}
+		return fmt.Sprintf("%s:%s:%d", root.Name, filepath.ToSlash(rel), p.Line)
+	}
+}
+
+func relPath(root Root, path string) string {
+	rel, err := filepath.Rel(root.Path, path)
+	if err != nil {
+		return path
+	}
+	return root.Name + ":" + filepath.ToSlash(rel)
+}
+
+func sortGaps(gaps []Gap) {
+	sort.SliceStable(gaps, func(i, j int) bool {
+		a, b := gaps[i], gaps[j]
+		if a.Provider != b.Provider {
+			return a.Provider < b.Provider
+		}
+		if a.Connector != b.Connector {
+			return a.Connector < b.Connector
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Detail != b.Detail {
+			return a.Detail < b.Detail
+		}
+		return a.Where < b.Where
+	})
+}
+
+// gitState reports the checkout's revision, so the artifact says what it was
+// generated from. A tree that is not a git repository is not an error: the
+// commit is provenance, not input.
+func gitState(path string) (commit string, dirty bool) {
+	out, err := exec.Command("git", "-C", path, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", false
+	}
+	commit = strings.TrimSpace(string(out))
+	// Scoped to providers/, because that is the only part of the tree this
+	// reads. It still counts untracked files there, some of which the walk
+	// skips: overstating the dirtiness of a provenance field costs a reader a
+	// second look, understating it costs them a wrong answer.
+	status, err := exec.Command("git", "-C", path, "status", "--porcelain", "--", "providers").Output()
+	if err != nil {
+		return commit, false
+	}
+	return commit, len(strings.TrimSpace(string(status))) > 0
+}
+
+// attachedAnywhere reports whether an environment variable already backs a flag
+// on some connector of this provider.
+func attachedAnywhere(connectors []Connector, envVar string) bool {
+	for _, c := range connectors {
+		for _, fe := range c.Env {
+			if contains(fe.Vars, envVar) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasFlagEnv reports whether a flag already has an association, so the
+// connection walk does not restate what ParseCLI already settled.
+func hasFlagEnv(list []FlagEnv, flag string) bool {
+	for _, fe := range list {
+		if fe.Flag == flag {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectorgen/extract_test.go
+++ b/internal/connectorgen/extract_test.go
@@ -1,0 +1,387 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// The extractor is checked against a stand-in provider under testdata rather
+// than against a real mql checkout, because CI has no mql checkout and a test
+// that skips itself there would be protecting nothing. The fixture holds one
+// instance of each shape the real tree uses, and each assertion below names the
+// shape it is about.
+
+const fixtureRoot = "testdata/repo"
+
+func extractFixture(t *testing.T) *Artifact {
+	t.Helper()
+	art, err := Extract([]Root{{Name: "demo", Path: fixtureRoot}})
+	if err != nil {
+		t.Fatalf("extracting the fixture: %v", err)
+	}
+	return art
+}
+
+func connectorNamed(t *testing.T, art *Artifact, name string) Connector {
+	t.Helper()
+	for _, c := range art.Connectors {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("the fixture yielded no connector named %q", name)
+	return Connector{}
+}
+
+func envFor(c Connector, flag string) (FlagEnv, bool) {
+	for _, fe := range c.Env {
+		if fe.Flag == flag {
+			return fe, true
+		}
+	}
+	return FlagEnv{}, false
+}
+
+func gapKinds(gaps []Gap) map[string][]string {
+	out := map[string][]string{}
+	for _, g := range gaps {
+		out[g.Kind] = append(out[g.Kind], g.Detail)
+	}
+	return out
+}
+
+// The config literal, including the parts that are not literals: a constant
+// from a sibling package, an enum identifier, an OR of two options, and a Long
+// assembled with fmt.Sprintf.
+func TestExtractReadsTheConfigLiteral(t *testing.T) {
+	c := connectorNamed(t, extractFixture(t), "demo")
+
+	if c.Provider != "demo" || c.Use != "demo" || c.Short != "a demonstration target" {
+		t.Errorf("connector header wrong: %+v", c)
+	}
+	if c.MinArgs != 2 || c.MaxArgs != 2 {
+		t.Errorf("argument counts: got %d..%d, want 2..2", c.MinArgs, c.MaxArgs)
+	}
+	if len(c.Aliases) != 1 || c.Aliases[0] != "dem" {
+		t.Errorf("aliases: got %v, want [dem]", c.Aliases)
+	}
+	// Discovery entries are constants in the connection package, so an empty
+	// list here means the cross-package resolution stopped working.
+	if strings.Join(c.Discovery, ",") != "all,units" {
+		t.Errorf("discovery: got %v, want [all units]", c.Discovery)
+	}
+	// The Long is a fmt.Sprintf whose argument is the variable name. Resolving
+	// the call is what keeps the sentence a user reads out of the blanks.
+	if !strings.Contains(c.Long, "DEMO_TOKEN") {
+		t.Errorf("Long did not resolve its Sprintf arguments: %q", c.Long)
+	}
+
+	byName := map[string]Flag{}
+	for _, fl := range c.Flags {
+		byName[fl.Long] = fl
+	}
+	if len(byName) != 6 {
+		t.Fatalf("got %d flags, want 6: %+v", len(byName), c.Flags)
+	}
+	if got := byName["token"].Type; got != int32(plugin.FlagType_String) {
+		t.Errorf("--token type: got %d, want %d", got, plugin.FlagType_String)
+	}
+	wantOption := int32(plugin.FlagOption_Password | plugin.FlagOption_Required)
+	if got := byName["password"].Option; got != wantOption {
+		t.Errorf("--password option: got %d, want %d (the OR of two identifiers)", got, wantOption)
+	}
+	if got := byName["region"].Config; got != "-" {
+		t.Errorf("--region ConfigEntry: got %q, want %q", got, "-")
+	}
+	if got := byName["legacy"].Option; got != int32(plugin.FlagOption_Hidden) {
+		t.Errorf("--legacy option: got %d, want Hidden", got)
+	}
+
+	// Sorted by name, because the checked-in artifact's diff has to be about
+	// what changed rather than how the literal was ordered.
+	for i := 1; i < len(c.Flags); i++ {
+		if c.Flags[i-1].Long > c.Flags[i].Long {
+			t.Fatalf("flags are not sorted: %q before %q", c.Flags[i-1].Long, c.Flags[i].Long)
+		}
+	}
+}
+
+// The four ways a provider ties a flag to a variable, and the one way it must
+// not be tied.
+func TestExtractReadsEnvironmentRoutes(t *testing.T) {
+	c := connectorNamed(t, extractFixture(t), "demo")
+
+	cases := []struct {
+		flag     string
+		vars     []string
+		composed bool
+		via      string
+		why      string
+	}{
+		{
+			flag: "token", vars: []string{"DEMO_TOKEN"}, via: "parse-cli",
+			why: "the longhand chain: flags[\"token\"] into x, x into token, DEMO_TOKEN into token",
+		},
+		{
+			flag: "region", vars: []string{"DEMO_REGION", "DEMO_REGION_ID"}, via: "parse-cli",
+			why: "the variadic accessor, whose variables are a fallback list rather than a composition",
+		},
+		{
+			flag: "password", vars: []string{"DEMO_PASSWORD"}, via: "parse-cli",
+			why: "a flag-only accessor plus a variable returned by another function",
+		},
+		{
+			flag: "organization", vars: []string{"DEMO_ORG_NAME", "DEMO_BASE_URL"}, composed: true, via: "parse-cli",
+			why: "two variables joined by a \".\", so setting only the first will not work",
+		},
+		{
+			flag: "endpoint", vars: []string{"DEMO_ENDPOINT"}, via: "connection",
+			why: "read at connect time out of the options map, not while parsing",
+		},
+	}
+
+	for _, tc := range cases {
+		fe, ok := envFor(c, tc.flag)
+		if !ok {
+			t.Errorf("--%s has no environment route; %s", tc.flag, tc.why)
+			continue
+		}
+		if strings.Join(fe.Vars, ",") != strings.Join(tc.vars, ",") {
+			t.Errorf("--%s travels in %v, want %v (%s)", tc.flag, fe.Vars, tc.vars, tc.why)
+		}
+		if fe.Composed != tc.composed {
+			t.Errorf("--%s composed=%v, want %v (%s)", tc.flag, fe.Composed, tc.composed, tc.why)
+		}
+		if fe.Via != tc.via {
+			t.Errorf("--%s via=%q, want %q", tc.flag, fe.Via, tc.via)
+		}
+		if !fe.Declared {
+			t.Errorf("--%s is declared by the connector but was not marked so", tc.flag)
+		}
+	}
+
+	if len(c.Env) != len(cases) {
+		t.Errorf("got %d routes, want %d: %+v", len(c.Env), len(cases), c.Env)
+	}
+}
+
+// The two ways a wrong route gets invented, both of which the fixture baits.
+func TestExtractInventsNoRoute(t *testing.T) {
+	c := connectorNamed(t, extractFixture(t), "demo")
+
+	// ParseCLI binds `x` twice, to --token and to --organization. A walk that
+	// keyed variables by name would hand --token the organization's variables.
+	if fe, ok := envFor(c, "token"); ok {
+		for _, v := range fe.Vars {
+			if strings.HasPrefix(v, "DEMO_ORG") || v == "DEMO_BASE_URL" {
+				t.Errorf("--token was given %s, which belongs to --organization: "+
+					"the two `x` bindings were not kept apart", v)
+			}
+		}
+	}
+
+	// newClient(region, password) combines two values. Neither may pick up the
+	// other's variable through the client.
+	if fe, ok := envFor(c, "region"); ok {
+		for _, v := range fe.Vars {
+			if v == "DEMO_PASSWORD" {
+				t.Error("--region was given DEMO_PASSWORD: a value built from two others was treated as one of them")
+			}
+		}
+	}
+
+	// demolite declares only --endpoint, so nothing else may reach it.
+	lite := connectorNamed(t, extractFixture(t), "demolite")
+	for _, fe := range lite.Env {
+		if fe.Flag != "endpoint" {
+			t.Errorf("demolite was given a route for --%s, a flag it does not declare", fe.Flag)
+		}
+	}
+}
+
+// The sub-command vocabulary, which exists only as case labels.
+func TestExtractReadsTheSubCommandVocabulary(t *testing.T) {
+	art := extractFixture(t)
+	c := connectorNamed(t, art, "demo")
+
+	if len(c.Positional) != 1 {
+		t.Fatalf("got %d positional entries, want 1: %+v", len(c.Positional), c.Positional)
+	}
+	p := c.Positional[0]
+	if p.Index != 0 {
+		t.Errorf("vocabulary is for argument %d, want 0", p.Index)
+	}
+	if strings.Join(p.Values, "|") != "unit|group" {
+		t.Errorf("vocabulary: got %v, want [unit group]", p.Values)
+	}
+}
+
+// What the walk could not settle. Each of these is a claim about the fixture,
+// so a gap that stops being raised is a change in behaviour rather than an
+// improvement in the source.
+func TestExtractReportsItsGaps(t *testing.T) {
+	art := extractFixture(t)
+	kinds := gapKinds(art.Gaps)
+
+	// The connection package reads DEMO_TAILNET for an option that is not a
+	// flag, so no field could ever carry it.
+	outside := strings.Join(kinds[GapEnvOutsideParseCLI], " ")
+	if !strings.Contains(outside, "DEMO_TAILNET") {
+		t.Errorf("DEMO_TAILNET is read for an option no connector declares and was not reported: %q", outside)
+	}
+
+	// providers/shipped holds a built provider and no source.
+	absent := strings.Join(kinds[GapSourceAbsent], " ")
+	if len(kinds[GapSourceAbsent]) == 0 {
+		t.Error("a provider directory with a dist/ and no config was not reported as source-absent")
+	} else if !strings.Contains(absent, "no config package") {
+		t.Errorf("source-absent gap says something unexpected: %q", absent)
+	}
+	found := false
+	for _, g := range art.Gaps {
+		if g.Kind == GapSourceAbsent && g.Provider == "shipped" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the source-absent gap does not name the provider it is about")
+	}
+}
+
+// A gap that belongs to a connector is repeated on it, so reading one connector
+// shows what is missing from it.
+func TestConnectorGapsAreRepeatedOnTheConnector(t *testing.T) {
+	art := extractFixture(t)
+	for _, c := range art.Connectors {
+		for _, g := range c.Gaps {
+			if g.Provider != "" || g.Connector != "" {
+				t.Errorf("%s repeats a gap that still names its subject: %+v", c.Name, g)
+			}
+			if g.Kind == "" || g.Detail == "" {
+				t.Errorf("%s has a gap with no kind or no detail: %+v", c.Name, g)
+			}
+		}
+	}
+}
+
+// Nothing to read is an error, not an empty artifact: the artifact is checked
+// in, and a run that produced an empty one would replace a complete file with
+// nothing.
+func TestExtractRefusesATreeWithNoProviders(t *testing.T) {
+	if _, err := Extract(nil); err == nil {
+		t.Error("extracting from no root at all succeeded")
+	}
+	if _, err := Extract([]Root{{Name: "empty", Path: t.TempDir()}}); err == nil {
+		t.Error("extracting from a directory with no providers/ succeeded")
+	}
+}
+
+// A regeneration never loses a connector: what the source no longer covers is
+// kept, marked, and reported.
+func TestCarryForwardKeepsWhatTheSourceDropped(t *testing.T) {
+	art := extractFixture(t)
+
+	previous := Artifact{
+		Schema:     SchemaVersion,
+		Connectors: append([]Connector{{Name: "gone", Provider: "gone", MaxArgs: 1}}, art.Connectors...),
+	}
+	data, err := json.MarshalIndent(previous, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "connectors.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CarryForward(art, path); err != nil {
+		t.Fatalf("carrying forward: %v", err)
+	}
+
+	c := connectorNamed(t, art, "gone")
+	if !c.CarriedForward {
+		t.Error("a carried connector was not marked as one, so nothing in the diff says its metadata is stale")
+	}
+	kinds := gapKinds(art.Gaps)
+	if len(kinds[GapCarriedForward]) != 1 {
+		t.Errorf("got %d carried-forward gaps, want 1", len(kinds[GapCarriedForward]))
+	}
+	for i := 1; i < len(art.Connectors); i++ {
+		if art.Connectors[i-1].Name > art.Connectors[i].Name {
+			t.Fatalf("carrying forward broke the ordering: %q before %q",
+				art.Connectors[i-1].Name, art.Connectors[i].Name)
+		}
+	}
+
+	// A missing previous artifact is the first run, not a failure.
+	if err := CarryForward(art, filepath.Join(t.TempDir(), "absent.json")); err != nil {
+		t.Errorf("carrying forward from a file that does not exist: %v", err)
+	}
+}
+
+// The bare array the launcher's snapshot used before this tool existed, which
+// the first regeneration has to read.
+func TestCarryForwardReadsTheOldFormat(t *testing.T) {
+	art := extractFixture(t)
+	data := []byte(`[{"name":"legacy","provider":"legacy","max_args":1}]`)
+	path := filepath.Join(t.TempDir(), "connectors.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := CarryForward(art, path); err != nil {
+		t.Fatalf("carrying forward from the old format: %v", err)
+	}
+	if c := connectorNamed(t, art, "legacy"); !c.CarriedForward {
+		t.Error("an entry from the old format was not carried forward")
+	}
+}
+
+// The report is the deliverable, so it has to name every gap it counted.
+func TestReportNamesEveryGap(t *testing.T) {
+	art := extractFixture(t)
+	var buf bytes.Buffer
+	WriteReport(&buf, art)
+	out := buf.String()
+
+	s := Summarise(art)
+	if s.Connectors != len(art.Connectors) {
+		t.Errorf("the summary counted %d connectors, the artifact has %d", s.Connectors, len(art.Connectors))
+	}
+	for kind := range s.GapsByKind {
+		if !strings.Contains(out, kind) {
+			t.Errorf("the report counts %q but never lists it", kind)
+		}
+	}
+	for _, g := range art.Gaps {
+		if !strings.Contains(out, g.Detail) {
+			t.Errorf("the report omits a gap: %s", g.Detail)
+		}
+	}
+}
+
+// The artifact is checked in, so its encoding has to be stable and readable.
+func TestWriteJSONIsStable(t *testing.T) {
+	art := extractFixture(t)
+	var first, second bytes.Buffer
+	if err := WriteJSON(&first, art); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteJSON(&second, art); err != nil {
+		t.Fatal(err)
+	}
+	if first.String() != second.String() {
+		t.Error("two encodings of one artifact differ, so a regeneration diff would be noise")
+	}
+	if !bytes.HasSuffix(first.Bytes(), []byte("\n")) {
+		t.Error("the artifact does not end in a newline")
+	}
+}

--- a/internal/connectorgen/gen/main.go
+++ b/internal/connectorgen/gen/main.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Command gen regenerates the connector metadata artifact from an mql checkout.
+//
+// It is run by hand, not by the build:
+//
+//	make connectors/generate MQL=../mql
+//
+// cnspec has to compile with no mql source present, so the artifact is the
+// contract and this command is how it is refreshed. With no checkout to read it
+// refuses and changes nothing, which leaves the checked-in artifact -- the one
+// every downstream test reads -- intact.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/internal/connectorgen"
+)
+
+func main() {
+	mqlPath := flag.String("mql", "", "path to an mql checkout (required)")
+	enterprisePath := flag.String("enterprise", "",
+		"path to an mql-enterprise-providers checkout (optional; without it those connectors are absent from the artifact)")
+	out := flag.String("out", "internal/connectors/connectors.json", "artifact to write")
+	reportOnly := flag.Bool("report", false, "print the extraction report and write nothing")
+	flag.Parse()
+
+	if err := run(*mqlPath, *enterprisePath, *out, *reportOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "connectorgen:", err)
+		os.Exit(1)
+	}
+}
+
+func run(mqlPath, enterprisePath, out string, reportOnly bool) error {
+	if mqlPath == "" {
+		// Refusing, rather than writing an empty artifact: the checked-in file
+		// is what every downstream test reads, and leaving it alone is the only
+		// safe thing to do with no source to regenerate it from.
+		fmt.Fprintln(os.Stderr,
+			"connectorgen reads mql provider source and cannot run without a checkout of it.\n"+
+				"  Clone one with `make prep/repos`, then run `make connectors/generate MQL=./mql`.\n"+
+				"  The artifact is checked in, so not running this breaks nothing downstream.")
+		return errors.New("no mql checkout given")
+	}
+
+	roots := []connectorgen.Root{{Name: "mql", Path: mqlPath}}
+	if enterprisePath != "" {
+		roots = append(roots, connectorgen.Root{Name: "mql-enterprise-providers", Path: enterprisePath})
+	}
+
+	art, err := connectorgen.Extract(roots)
+	if err != nil {
+		return err
+	}
+
+	// Anything the checkout no longer covers is kept rather than dropped, so a
+	// regeneration cannot silently shrink the artifact. Done for -report too,
+	// so the report describes the file that would be written rather than a
+	// smaller one nobody will see.
+	if err := connectorgen.CarryForward(art, out); err != nil {
+		return err
+	}
+
+	// The report goes to stderr so `-report` can be read while the artifact
+	// goes to a file, and so a redirect of stdout never swallows the gap list.
+	connectorgen.WriteReport(os.Stderr, art)
+	if reportOnly {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := connectorgen.WriteJSON(f, art); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "\nwrote %d connectors to %s\n", len(art.Connectors), out)
+	return f.Close()
+}

--- a/internal/connectorgen/helpers.go
+++ b/internal/connectorgen/helpers.go
@@ -1,0 +1,392 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"go/ast"
+)
+
+// Almost no provider writes the flag-then-environment fallback out longhand.
+// It writes a small accessor and calls it once per credential, and there are
+// three shapes of accessor across the tree:
+//
+//	clientSecret := flagOrEnv(flags, "client-secret", "JAMF_CLIENT_SECRET")
+//	if v := stringFlag(flags, "region", "ALIBABA_CLOUD_REGION", "ALIBABA_CLOUD_REGION_ID"); v != ""
+//	token := flagValue(flags, "token"); if token == "" { token = os.Getenv("ARTIFACTORY_TOKEN") }
+//
+// The first two carry the whole fact in the call's arguments. The third carries
+// only half -- the flag -- and leaves the variable to the caller, so a walk that
+// only understood the first two would see artifactory read ARTIFACTORY_TOKEN
+// into a value it could not name.
+//
+// So an accessor is recognised by what its body does with its own parameters,
+// not by its name and not by whether it also reads the environment: a function
+// that indexes the flag map by one of its parameters tells the call site which
+// flag that argument names, and that is worth knowing on its own. Matching on
+// the name would have found two of them; requiring an os.Getenv would have
+// found six.
+//
+// Closures count. hcp declares its accessor inside ParseCLI and closes over the
+// flag map rather than taking it as a parameter, so the flag map has to be
+// recognised by name as well as by type.
+
+// keySource says where an accessor's keys come from: the CLI flag map that
+// ParseCLI is handed, or the connection options map that the connection package
+// reads back at connect time.
+//
+// The second exists because roughly a fifth of the tree reads its credentials
+// there rather than in ParseCLI. zoom's accessor is
+//
+//	getOptionValueFrom(options map[string]string, envVar string, option string)
+//
+// which is the same shape one package over, with the option name standing in
+// for the flag name. Those two names are not the same thing in general, so an
+// association found this way is kept only when the option name is also a flag
+// the connector declares -- see assemble.
+type keySource struct {
+	// field is the request or config field the map is read from: "Flags" or
+	// "Options".
+	field string
+	// typeOK recognises the map as a parameter type.
+	typeOK func(ast.Expr) bool
+	// via labels associations found this way in the artifact.
+	via string
+	// reportUnbound says whether an environment variable that meets no key is
+	// worth a gap of its own. In ParseCLI it is; in the connection package the
+	// caller reports the whole set at once instead, because half of them are
+	// read for reasons that have nothing to do with a flag.
+	reportUnbound bool
+}
+
+// flagKeys reads the CLI flag map inside a provider package.
+var flagKeys = keySource{field: "Flags", typeOK: isFlagMapType, via: "parse-cli", reportUnbound: true}
+
+// optionKeys reads the connection options map inside a connection package.
+var optionKeys = keySource{field: "Options", typeOK: isOptionMapType, via: "connection"}
+
+// helperSig describes a recognised flag accessor.
+type helperSig struct {
+	// flagArg is the parameter position holding the flag name, or -1 when the
+	// accessor names no flag.
+	flagArg int
+	// envArgs are the parameter positions holding environment variable names,
+	// in the order the body consults them.
+	envArgs []int
+	// envVariadic marks an accessor whose last parameter is `envs ...string`,
+	// so every argument from envArgs[0] onward is a variable name.
+	envVariadic bool
+}
+
+// findHelpers recognises the flag accessors declared in a package, whether as
+// functions or as closures assigned to a name.
+func findHelpers(files []*ast.File, key keySource) map[string]helperSig {
+	flagMaps := flagMapNames(files, key)
+	out := map[string]helperSig{}
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.FuncDecl:
+				if x.Body == nil || x.Recv != nil {
+					return true
+				}
+				if sig, ok := helperSignature(x.Type.Params, x.Body, flagMaps, key); ok {
+					out[x.Name.Name] = sig
+				}
+			case *ast.AssignStmt:
+				// `flagOrEnv := func(name, env string) string { ... }`
+				for i, rhs := range x.Rhs {
+					lit, ok := rhs.(*ast.FuncLit)
+					if !ok || i >= len(x.Lhs) {
+						continue
+					}
+					id, ok := x.Lhs[i].(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if sig, ok := helperSignature(lit.Type.Params, lit.Body, flagMaps, key); ok {
+						out[id.Name] = sig
+					}
+				}
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// flagMapNames collects the identifiers a package uses for the CLI flag map, so
+// a closure that captures one can be recognised. It is deliberately generous:
+// a name wrongly included here can only cause an accessor to be recognised that
+// takes a flag name it does not have, and the flag would then fail to match any
+// declared flag and be reported rather than believed.
+func flagMapNames(files []*ast.File, key keySource) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.AssignStmt:
+				for i, rhs := range x.Rhs {
+					if i >= len(x.Lhs) {
+						break
+					}
+					if !readsField(rhs, key.field) {
+						continue
+					}
+					if id, ok := x.Lhs[i].(*ast.Ident); ok {
+						out[id.Name] = true
+					}
+				}
+			case *ast.FuncDecl:
+				for _, p := range flatParams(x.Type.Params) {
+					if p.name != "" && key.typeOK(p.typ) {
+						out[p.name] = true
+					}
+				}
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// helperSignature reports whether a function body reads a flag out of the CLI
+// flag map using one of its own parameters as the key.
+func helperSignature(params *ast.FieldList, body *ast.BlockStmt, flagMaps map[string]bool, key keySource) (helperSig, bool) {
+	flat := flatParams(params)
+	if len(flat) == 0 || body == nil {
+		return helperSig{}, false
+	}
+
+	byName := map[string]int{}
+	variadic := map[string]int{}
+	local := map[string]bool{}
+	for i, p := range flat {
+		if p.name == "" {
+			continue
+		}
+		byName[p.name] = i
+		if p.variadic {
+			variadic[p.name] = i
+		}
+		if key.typeOK(p.typ) {
+			local[p.name] = true
+		}
+	}
+	isFlagMap := func(e ast.Expr) bool {
+		if id, ok := e.(*ast.Ident); ok {
+			return local[id.Name] || flagMaps[id.Name]
+		}
+		return readsField(e, key.field)
+	}
+
+	// Range variables bound to a parameter, so `for _, e := range envs` makes
+	// os.Getenv(e) a read of the envs parameter.
+	rangeOf := map[string]int{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		rs, ok := n.(*ast.RangeStmt)
+		if !ok {
+			return true
+		}
+		src, ok := rs.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		idx, ok := byName[src.Name]
+		if !ok {
+			return true
+		}
+		if v, ok := rs.Value.(*ast.Ident); ok {
+			rangeOf[v.Name] = idx
+		}
+		return true
+	})
+
+	sig := helperSig{flagArg: -1}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncLit:
+			// A nested closure has its own parameters; attributing its reads to
+			// this signature's argument positions would be wrong.
+			return false
+		case *ast.IndexExpr:
+			if !isFlagMap(x.X) {
+				return true
+			}
+			if key, ok := x.Index.(*ast.Ident); ok {
+				if idx, ok := byName[key.Name]; ok && sig.flagArg == -1 {
+					sig.flagArg = idx
+				}
+			}
+		case *ast.CallExpr:
+			arg, ok := getenvArg(x)
+			if !ok {
+				return true
+			}
+			// `os.Getenv(envs[i])` is a read of the envs parameter just as
+			// `os.Getenv(e)` after a range over it is.
+			if ix, isIndex := arg.(*ast.IndexExpr); isIndex {
+				arg = ix.X
+			}
+			id, ok := arg.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if idx, ok := byName[id.Name]; ok {
+				sig.envArgs = appendUnique(sig.envArgs, idx)
+				if _, isVariadic := variadic[id.Name]; isVariadic {
+					sig.envVariadic = true
+				}
+				return true
+			}
+			if idx, ok := rangeOf[id.Name]; ok {
+				sig.envArgs = appendUnique(sig.envArgs, idx)
+				for _, vidx := range variadic {
+					if vidx == idx {
+						sig.envVariadic = true
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	if sig.flagArg == -1 && len(sig.envArgs) == 0 {
+		return helperSig{}, false
+	}
+	return sig, true
+}
+
+// funcSummary is what calling a package-local function contributes when the
+// values it returns are named in its own body rather than passed in.
+//
+// mistral is the case that needs it: `envToken()` takes no arguments and
+// returns MISTRAL_API_KEY or MISTRAL_KEY, and ParseCLI writes `if token == ""
+// { token = envToken() }`. Without following the call, the variable holding
+// --token never meets a variable name and mistral reports as having no
+// credential route at all.
+type funcSummary struct {
+	flags []string
+	envs  []string
+}
+
+// stringReturning reports whether every result of a function is a string. The
+// summary is applied only to those: a function returning a connection or an
+// asset also reads the environment for its own reasons, and letting those reads
+// flow into a caller's variable is how a wrong credential route gets invented.
+func stringReturning(results *ast.FieldList) bool {
+	if results == nil || len(results.List) == 0 {
+		return false
+	}
+	for _, f := range results.List {
+		id, ok := f.Type.(*ast.Ident)
+		if !ok || id.Name != "string" {
+			return false
+		}
+	}
+	return true
+}
+
+// param is one flattened function parameter.
+type param struct {
+	name     string
+	typ      ast.Expr
+	variadic bool
+}
+
+// flatParams expands `flag, env string` into one entry per name, which is what
+// an argument position means at a call site.
+func flatParams(fl *ast.FieldList) []param {
+	if fl == nil {
+		return nil
+	}
+	var out []param
+	for _, f := range fl.List {
+		typ := f.Type
+		isVariadic := false
+		if ell, ok := typ.(*ast.Ellipsis); ok {
+			typ = ell.Elt
+			isVariadic = true
+		}
+		if len(f.Names) == 0 {
+			out = append(out, param{typ: typ, variadic: isVariadic})
+			continue
+		}
+		for _, n := range f.Names {
+			out = append(out, param{name: n.Name, typ: typ, variadic: isVariadic})
+		}
+	}
+	return out
+}
+
+// readsField reports whether an expression reads a named field of a request:
+// either `req.Flags` or the generated getter `req.GetFlags()`. Both spellings
+// are in the tree, and activedirectory uses only the second.
+func readsField(e ast.Expr, field string) bool {
+	switch x := e.(type) {
+	case *ast.SelectorExpr:
+		return x.Sel.Name == field
+	case *ast.CallExpr:
+		sel, ok := x.Fun.(*ast.SelectorExpr)
+		return ok && len(x.Args) == 0 && sel.Sel.Name == "Get"+field
+	}
+	return false
+}
+
+// isFlagMapType reports whether a parameter type is the CLI flag map,
+// map[string]*llx.Primitive.
+//
+// The pointer element is what makes this a test rather than a guess: the os
+// provider passes map[string]struct{} around, and a rule that accepted any map
+// read `detectors[name]` as a flag lookup.
+func isFlagMapType(t ast.Expr) bool {
+	m, ok := t.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	if key, ok := m.Key.(*ast.Ident); !ok || key.Name != "string" {
+		return false
+	}
+	_, isPtr := m.Value.(*ast.StarExpr)
+	return isPtr
+}
+
+// isOptionMapType reports whether a parameter type is the connection options
+// map, map[string]string.
+func isOptionMapType(t ast.Expr) bool {
+	m, ok := t.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	key, ok := m.Key.(*ast.Ident)
+	if !ok || key.Name != "string" {
+		return false
+	}
+	val, ok := m.Value.(*ast.Ident)
+	return ok && val.Name == "string"
+}
+
+// getenvArg returns the argument of an os.Getenv call.
+func getenvArg(call *ast.CallExpr) (ast.Expr, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Getenv" {
+		return nil, false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return nil, false
+	}
+	if len(call.Args) != 1 {
+		return nil, false
+	}
+	return call.Args[0], true
+}
+
+func appendUnique[T comparable](list []T, v T) []T {
+	for _, existing := range list {
+		if existing == v {
+			return list
+		}
+	}
+	return append(list, v)
+}

--- a/internal/connectorgen/model.go
+++ b/internal/connectorgen/model.go
@@ -1,0 +1,238 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package connectorgen extracts connector metadata from mql provider source.
+//
+// The interactive launcher builds an input form per connector. Three facts
+// decide what that form looks like, and only one of them is available at
+// runtime:
+//
+//   - What the connector declares -- flags, argument counts, discovery targets.
+//     A provider ships this as <name>.json, a verbatim json.Marshal of
+//     plugin.Provider, so cnspec can already read it from an installed
+//     provider.
+//   - Which environment variable backs which flag. This exists only as Go
+//     control flow inside the provider's own ParseCLI.
+//   - The sub-command vocabulary -- `github org <ORG>` versus `github repo
+//     <ORG>/<REPO>`. This exists only as `case "org":` in the same function and
+//     as prose in the connector's Long text.
+//
+// The last two were previously established by reading provider source by hand
+// and running provider binaries, then hand-copying the result into cnspec. This
+// package reads them mechanically instead.
+//
+// It parses source with go/ast and nothing else: no go/types, no module
+// resolution, no compilation. There are 81 provider modules in the mql monorepo
+// and a dozen more in a second repository pinned to an older SDK, each with its
+// own go.mod, so loading them is not viable. Everything below is therefore a
+// syntactic claim about the source, and everything the syntax does not settle
+// is recorded as a Gap rather than guessed at. A plausible-looking wrong
+// credential route drops the secret in silence; an honest "could not determine"
+// does not.
+package connectorgen
+
+// SchemaVersion is the artifact format version. Bump it when a consumer would
+// have to change, not for an added optional field.
+const SchemaVersion = 1
+
+// Artifact is the whole generated file: what was read, what came out, and what
+// could not be determined.
+type Artifact struct {
+	Schema int `json:"schema"`
+	// GeneratedBy names the tool, so someone finding the file knows not to edit
+	// it by hand.
+	GeneratedBy string `json:"generated_by"`
+	// Sources records the repositories the facts came from. It carries the
+	// commit rather than the path: a checked-in artifact whose diff depends on
+	// whose laptop ran the generator is not reviewable.
+	Sources []Source `json:"sources"`
+	// Connectors is the extraction, sorted by name then provider.
+	Connectors []Connector `json:"connectors"`
+	// Gaps is what the walk could not determine, and is the point of the
+	// exercise: it is the specification for what the provider SDK would have to
+	// carry for cnspec to stop reading Go source at all.
+	Gaps []Gap `json:"gaps"`
+}
+
+// Source is one repository the extraction read.
+type Source struct {
+	// Name is the repository's short name, e.g. "mql".
+	Name string `json:"name"`
+	// Commit is the checked-out revision, or empty when the tree is not a git
+	// repository.
+	Commit string `json:"commit,omitempty"`
+	// Dirty reports that the tree had uncommitted changes, which makes Commit
+	// an incomplete description of what was read.
+	Dirty bool `json:"dirty,omitempty"`
+	// Providers is how many provider declarations were found in this tree.
+	Providers int `json:"providers"`
+}
+
+// Connector is one selectable target: a (provider, connector) pair. The first
+// block of fields mirrors plugin.Connector and is also obtainable from an
+// installed provider; the second block is what only the source carries.
+type Connector struct {
+	Name     string `json:"name"`
+	Provider string `json:"provider"`
+	Use      string `json:"use,omitempty"`
+	Short    string `json:"short,omitempty"`
+	// Long is the connector's full help text. Several providers document their
+	// sub-command shape nowhere else.
+	Long     string   `json:"long,omitempty"`
+	Aliases  []string `json:"aliases,omitempty"`
+	MinArgs  uint     `json:"min_args,omitempty"`
+	MaxArgs  uint     `json:"max_args,omitempty"`
+	IsHidden bool     `json:"is_hidden,omitempty"`
+	Maturity string   `json:"maturity,omitempty"`
+	// Flags are sorted by Long, so a regeneration diff shows what changed
+	// rather than how the author reordered the literal.
+	Flags     []Flag   `json:"flags,omitempty"`
+	Discovery []string `json:"discovery,omitempty"`
+
+	// Env names the environment variables the provider reads a flag's value
+	// from, in the order ParseCLI consults them.
+	Env []FlagEnv `json:"env,omitempty"`
+	// Positional is the sub-command vocabulary: the literal words the provider
+	// compares a positional argument against.
+	Positional []Positional `json:"positional,omitempty"`
+	// CarriedForward marks a connector this extraction did not produce, kept
+	// from the previous artifact so a regeneration never loses one. Its
+	// metadata is as old as whenever it was last derived.
+	CarriedForward bool `json:"carried_forward,omitempty"`
+	// Gaps are this connector's share of Artifact.Gaps, repeated here so a
+	// consumer reading one connector sees what is missing from it.
+	Gaps []Gap `json:"gaps,omitempty"`
+}
+
+// Flag mirrors plugin.Flag. Type and Option are the numeric enum values, the
+// same ones the runtime metadata carries, because that is what a consumer
+// compares against plugin.FlagType_String.
+type Flag struct {
+	Long    string `json:"long"`
+	Short   string `json:"short,omitempty"`
+	Default string `json:"default,omitempty"`
+	Type    int32  `json:"type,omitempty"`
+	Option  int32  `json:"option,omitempty"`
+	Desc    string `json:"desc,omitempty"`
+	// Config is the flag's ConfigEntry. It decides whether a value can be
+	// delivered through MONDOO_<FLAG> at all: mql reads that variable only for
+	// a flag declaring no config mapping, and "-" means the flag comes from
+	// cobra alone.
+	Config string `json:"config,omitempty"`
+}
+
+// FlagEnv is one flag and the environment variables that back it.
+type FlagEnv struct {
+	// Flag is the flag's Long name. It is not necessarily declared by this
+	// connector -- see Declared.
+	Flag string `json:"flag"`
+	// Vars are the variables consulted, in the order the source consults them.
+	// More than one is a fallback chain, and the first is what the provider
+	// prefers.
+	Vars []string `json:"vars"`
+	// Func is the function the association was read out of.
+	Func string `json:"func"`
+	// Via says where the provider reads the variable: "parse-cli" when it is
+	// read while parsing the command line, "connection" when the connection
+	// package reads it at connect time from the environment directly.
+	//
+	// The distinction is not cosmetic. A "parse-cli" variable is consulted only
+	// when the flag is absent, so a launcher may set either. A "connection"
+	// variable is read by the process that connects, and several of them take
+	// precedence over the flag rather than yielding to it, so a launcher that
+	// sets one is overriding whatever the user typed.
+	Via string `json:"via,omitempty"`
+	// Declared reports whether this connector declares a flag by that name. A
+	// false here is a real finding rather than noise: it means the provider
+	// reads a value the CLI has no way to pass.
+	Declared bool `json:"declared"`
+	// Composed marks an association where the variable is built from more than
+	// one environment variable rather than chosen from them -- okta joins
+	// OKTA_ORG_NAME and OKTA_BASE_URL with a "." -- so Vars is not a fallback
+	// list and setting only the first of them will not work.
+	Composed bool `json:"composed,omitempty"`
+}
+
+// Positional is the vocabulary for one positional argument.
+type Positional struct {
+	// Index is the argument position, counted the way the provider counts it:
+	// req.Args[0] is index 0.
+	Index int `json:"index"`
+	// Values are the literal words compared against, in source order.
+	Values []string `json:"values"`
+	// Func is the function the comparison was read out of.
+	Func string `json:"func"`
+}
+
+// Gap is one thing the walk could not determine, or determined only partly.
+//
+// Kind is a stable machine-readable label so the report can be grouped and so
+// one run can be diffed against the next; Detail is the human sentence. Both
+// are needed: the label alone does not say which flag, and the sentence alone
+// cannot be counted.
+type Gap struct {
+	Provider  string `json:"provider,omitempty"`
+	Connector string `json:"connector,omitempty"`
+	Kind      string `json:"kind"`
+	Detail    string `json:"detail"`
+	// Where is the source position, relative to the repository root, so the gap
+	// can be opened.
+	Where string `json:"where,omitempty"`
+}
+
+// The gap kinds. Each names a distinct reason the source did not settle a
+// question, because "could not determine" collected into one bucket cannot be
+// turned into a list of SDK changes.
+const (
+	// GapNoProviderPkg: the provider declares connectors but ships no provider/
+	// package next to its config, so there is no ParseCLI to read.
+	GapNoProviderPkg = "no-provider-package"
+	// GapNoParseCLI: the provider package has no ParseCLI function.
+	GapNoParseCLI = "no-parsecli"
+	// GapCarriedForward: a connector the previous artifact had and this
+	// extraction did not produce, kept rather than dropped.
+	GapCarriedForward = "carried-forward"
+	// GapSourceAbsent: a provider directory is in the tree but its source is
+	// not -- only a built artifact or a resource schema. Nothing about that
+	// connector can be read here, and it will simply be missing.
+	GapSourceAbsent = "provider-source-absent"
+	// GapDynamicGetenv: os.Getenv was called with something other than a
+	// literal or a resolvable constant, so the variable name is not knowable
+	// from the syntax.
+	GapDynamicGetenv = "dynamic-getenv"
+	// GapEnvOutsideParseCLI: an environment variable is read in the provider
+	// package but in a function neither ParseCLI nor Connect reaches, so
+	// nothing says which flag it belongs to.
+	GapEnvOutsideParseCLI = "env-outside-parsecli"
+	// GapUnboundEnv: an environment variable is read inside ParseCLI but its
+	// value never meets a flag, so it backs no flag this tool can name.
+	GapUnboundEnv = "unbound-env"
+	// GapAmbiguousBinding: a variable carries more than one flag name, so
+	// pairing it with an environment variable would be a guess.
+	GapAmbiguousBinding = "ambiguous-binding"
+	// GapAlternativeBranches: the flag and the environment variable are the two
+	// arms of one if/else chain and never meet in a single value, so only the
+	// author's intent -- not the syntax -- says they are the same credential.
+	GapAlternativeBranches = "alternative-branches"
+	// GapUndeclaredFlag: the provider reads a flag name no connector declares.
+	GapUndeclaredFlag = "undeclared-flag"
+	// GapConfigNotLiteral: some part of the plugin.Provider literal is not a
+	// composite literal -- a function call, or a value assembled elsewhere.
+	GapConfigNotLiteral = "config-not-literal"
+	// GapUnresolvedConstant: an identifier used as a flag name, a discovery
+	// target or a literal value did not resolve to a string in the source that
+	// was read.
+	GapUnresolvedConstant = "unresolved-constant"
+	// GapNoPositionalVocabulary: the connector takes positional arguments but
+	// no literal comparison against them was found, so the words it accepts are
+	// not knowable from the syntax.
+	GapNoPositionalVocabulary = "no-positional-vocabulary"
+	// GapComputedPositional: a positional argument is compared against
+	// something other than a literal -- a slice, a map lookup, a regexp -- so
+	// the vocabulary is computed rather than written down.
+	GapComputedPositional = "computed-positional"
+	// GapPositionalAmbiguous: the provider ships several connectors and one
+	// ParseCLI, so a vocabulary found there cannot be attributed to one of
+	// them.
+	GapPositionalAmbiguous = "positional-ambiguous"
+)

--- a/internal/connectorgen/report.go
+++ b/internal/connectorgen/report.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// WriteJSON renders the artifact.
+//
+// Indented and newline-terminated, because it is checked in and its diff is
+// what a reviewer reads. The ordering is settled in Extract; nothing here
+// re-sorts, so a difference in this file is a difference in the source it was
+// generated from.
+func WriteJSON(w io.Writer, art *Artifact) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(art); err != nil {
+		return errors.Wrap(err, "cannot encode the connector artifact")
+	}
+	return nil
+}
+
+// Summary counts what came out, per gap kind.
+type Summary struct {
+	Connectors int
+	// WithEnv is how many connectors got at least one flag-to-variable
+	// association.
+	WithEnv int
+	// EnvVars is how many distinct environment variables were attributed.
+	EnvVars int
+	// WithPositional is how many connectors got a sub-command vocabulary.
+	WithPositional int
+	// CarriedForward is how many connectors came from the previous artifact
+	// because the source read here does not cover them.
+	CarriedForward int
+	// GapsByKind counts the gaps, which is the number that decides whether the
+	// metadata needs an SDK change before anything is built on it.
+	GapsByKind map[string]int
+}
+
+// Summarise counts the artifact.
+func Summarise(art *Artifact) Summary {
+	s := Summary{Connectors: len(art.Connectors), GapsByKind: map[string]int{}}
+	vars := map[string]bool{}
+	for _, c := range art.Connectors {
+		if len(c.Env) > 0 {
+			s.WithEnv++
+		}
+		for _, fe := range c.Env {
+			for _, v := range fe.Vars {
+				vars[v] = true
+			}
+		}
+		if len(c.Positional) > 0 {
+			s.WithPositional++
+		}
+		if c.CarriedForward {
+			s.CarriedForward++
+		}
+	}
+	s.EnvVars = len(vars)
+	for _, g := range art.Gaps {
+		s.GapsByKind[g.Kind]++
+	}
+	return s
+}
+
+// WriteReport prints the extraction summary and the gap list.
+//
+// The gap list is the output that matters. Everything the artifact does carry
+// is also recoverable from an installed provider or was already hand-written;
+// what could not be determined is the part that is new, and it is the
+// specification for what the provider SDK would have to declare for cnspec to
+// stop reading Go source at all.
+func WriteReport(w io.Writer, art *Artifact) {
+	s := Summarise(art)
+
+	fmt.Fprintf(w, "connectors:      %d\n", s.Connectors)
+	fmt.Fprintf(w, "with env vars:   %d connectors, %d distinct variables\n", s.WithEnv, s.EnvVars)
+	fmt.Fprintf(w, "with positional: %d connectors\n", s.WithPositional)
+	if s.CarriedForward > 0 {
+		fmt.Fprintf(w, "carried forward:  %d connectors the source no longer covers\n", s.CarriedForward)
+	}
+	for _, src := range art.Sources {
+		commit := src.Commit
+		if commit == "" {
+			commit = "(not a git checkout)"
+		} else if len(commit) > 12 {
+			commit = commit[:12]
+		}
+		dirty := ""
+		if src.Dirty {
+			dirty = " (dirty)"
+		}
+		fmt.Fprintf(w, "source %-12s %s%s, %d providers\n", src.Name, commit, dirty, src.Providers)
+	}
+
+	fmt.Fprintf(w, "\ngaps: %d\n", len(art.Gaps))
+	kinds := make([]string, 0, len(s.GapsByKind))
+	for k := range s.GapsByKind {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	for _, k := range kinds {
+		fmt.Fprintf(w, "  %-26s %d\n", k, s.GapsByKind[k])
+	}
+
+	for _, k := range kinds {
+		fmt.Fprintf(w, "\n== %s ==\n", k)
+		for _, g := range art.Gaps {
+			if g.Kind != k {
+				continue
+			}
+			subject := g.Provider
+			if g.Connector != "" && g.Connector != g.Provider {
+				subject += "/" + g.Connector
+			}
+			if subject == "" {
+				subject = "-"
+			}
+			line := fmt.Sprintf("  %-24s %s", subject, g.Detail)
+			if g.Where != "" {
+				line += "  [" + g.Where + "]"
+			}
+			fmt.Fprintln(w, strings.TrimRight(line, " "))
+		}
+	}
+}

--- a/internal/connectorgen/testdata/repo/providers/demo/config/config.go
+++ b/internal/connectorgen/testdata/repo/providers/demo/config/config.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// A stand-in provider config, holding one instance of every shape the real tree
+// uses: a constant from a sibling package, a discovery list built from
+// constants, a flag whose Type and Option are enum identifiers, an Option
+// spelled as an OR, and a Long assembled with fmt.Sprintf out of the very
+// environment variable names the provider reads.
+//
+// It lives under testdata so the Go tool ignores it. It is never compiled, and
+// it does not have to be: the extractor only parses.
+package config
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/demo/connection"
+)
+
+var Config = plugin.Provider{
+	Name:            "demo",
+	ID:              "go.mondoo.com/mql/providers/demo",
+	ConnectionTypes: []string{"demo"},
+	Connectors: []plugin.Connector{
+		{
+			Name:    "demo",
+			Use:     "demo",
+			Short:   "a demonstration target",
+			Aliases: []string{"dem"},
+			Long: fmt.Sprintf(`Use the demo provider.
+
+Supply the token with %s.`, connection.EnvToken),
+			MinArgs: 2,
+			MaxArgs: 2,
+			Discovery: []string{
+				connection.DiscoveryAll,
+				connection.DiscoveryUnits,
+			},
+			Flags: []plugin.Flag{
+				{
+					Long: "token",
+					Type: plugin.FlagType_String,
+					Desc: "API token",
+				},
+				{
+					Long:   "password",
+					Type:   plugin.FlagType_String,
+					Option: plugin.FlagOption_Password | plugin.FlagOption_Required,
+					Desc:   "account password",
+				},
+				{
+					Long:        "region",
+					Type:        plugin.FlagType_String,
+					ConfigEntry: "-",
+					Desc:        "region to query",
+				},
+				{
+					Long: "endpoint",
+					Type: plugin.FlagType_String,
+					Desc: "API endpoint",
+				},
+				{
+					Long: "organization",
+					Type: plugin.FlagType_String,
+					Desc: "organization",
+				},
+				{
+					Long:   "legacy",
+					Type:   plugin.FlagType_Bool,
+					Option: plugin.FlagOption_Hidden,
+					Desc:   "does nothing",
+				},
+			},
+		},
+		{
+			Name:  "demolite",
+			Use:   "demolite",
+			Short: "the same target, without a token or an argument",
+			Flags: []plugin.Flag{
+				{
+					Long: "endpoint",
+					Type: plugin.FlagType_String,
+					Desc: "API endpoint",
+				},
+			},
+		},
+	},
+}

--- a/internal/connectorgen/testdata/repo/providers/demo/connection/connection.go
+++ b/internal/connectorgen/testdata/repo/providers/demo/connection/connection.go
@@ -1,0 +1,45 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// The connection half of the stand-in provider: the constants the config names,
+// and the connect-time reads that a fifth of the real tree does instead of
+// reading anything in ParseCLI.
+package connection
+
+import (
+	"os"
+)
+
+const (
+	EnvToken       = "DEMO_TOKEN"
+	DiscoveryAll   = "all"
+	DiscoveryUnits = "units"
+
+	OptionEndpoint = "endpoint"
+	EnvEndpoint    = "DEMO_ENDPOINT"
+	EnvTailnet     = "DEMO_TAILNET"
+)
+
+// getOptionValueFrom is the accessor shape zoom and tailscale use: the option
+// name and the variable name side by side, one package away from ParseCLI.
+func getOptionValueFrom(options map[string]string, envVar string, option string) (string, bool) {
+	value := ""
+	if v, ok := options[option]; ok && len(v) != 0 {
+		value = v
+	}
+	if envVal := os.Getenv(envVar); envVal != "" {
+		value = envVal
+	}
+	return value, len(value) != 0
+}
+
+// Endpoint is read at connect time rather than while parsing.
+func Endpoint(options map[string]string) (string, bool) {
+	return getOptionValueFrom(options, EnvEndpoint, OptionEndpoint)
+}
+
+// Tailnet reads a variable that backs an option no connector declares as a
+// flag, which is a gap rather than an association.
+func Tailnet(options map[string]string) (string, bool) {
+	return getOptionValueFrom(options, EnvTailnet, "tailnet")
+}

--- a/internal/connectorgen/testdata/repo/providers/demo/provider/provider.go
+++ b/internal/connectorgen/testdata/repo/providers/demo/provider/provider.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// The parsing half of the stand-in provider. Every function below is one shape
+// the extractor has to get right, and the comments say which.
+package provider
+
+import (
+	"os"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/demo/connection"
+)
+
+type Service struct {
+	*plugin.Service
+}
+
+// stringFlag is the variadic accessor: one flag, then a fallback list of
+// variables it tries in order.
+func stringFlag(flags map[string]*llx.Primitive, name string, envs ...string) string {
+	if x, ok := flags[name]; ok && len(x.Value) != 0 {
+		return string(x.Value)
+	}
+	for _, e := range envs {
+		if v := os.Getenv(e); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// flagValue is the accessor that names a flag and nothing else. Its caller
+// supplies the variable.
+func flagValue(flags map[string]*llx.Primitive, name string) string {
+	if x, ok := flags[name]; ok && len(x.Value) != 0 {
+		return string(x.Value)
+	}
+	return ""
+}
+
+// envPassword returns a variable and takes no argument that says so, which is
+// the shape mistral uses.
+func envPassword() string {
+	return strings.TrimSpace(os.Getenv("DEMO_PASSWORD"))
+}
+
+func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error) {
+	flags := req.Flags
+
+	conf := &inventory.Config{
+		Type:    req.Connector,
+		Options: map[string]string{},
+	}
+
+	// The longhand chain, with the reused `x` that makes scope matter: the
+	// second binding must not give --token the organization's variable.
+	token := ""
+	if x, ok := flags["token"]; ok && len(x.Value) != 0 {
+		token = string(x.Value)
+	}
+	if token == "" {
+		token = os.Getenv(connection.EnvToken)
+	}
+
+	organization := ""
+	if x, ok := flags["organization"]; ok && len(x.Value) != 0 {
+		organization = string(x.Value)
+	}
+	if organization == "" {
+		// Two variables joined rather than chosen between, which is okta's
+		// shape: setting only the first one produces a broken value.
+		organization = strings.TrimSpace(os.Getenv("DEMO_ORG_NAME")) + "." + strings.TrimSpace(os.Getenv("DEMO_BASE_URL"))
+	}
+
+	// The variadic accessor: a fallback list, not a composition.
+	region := stringFlag(flags, "region", "DEMO_REGION", "DEMO_REGION_ID")
+
+	// The half accessor plus an inline fallback.
+	password := flagValue(flags, "password")
+	if password == "" {
+		password = envPassword()
+	}
+
+	// A value assembled out of two others. Nothing here may make --region look
+	// as though it travelled in DEMO_PASSWORD.
+	client := newClient(region, password)
+	_ = client
+
+	// The sub-command vocabulary, which exists nowhere but here.
+	switch req.Args[0] {
+	case "unit":
+		conf.Options["unit"] = req.Args[1]
+	case "group":
+		conf.Options["group"] = req.Args[1]
+	default:
+		return nil, errNoSuchKind
+	}
+
+	conf.Options["token"] = token
+	conf.Options["organization"] = organization
+	conf.Options["region"] = region
+
+	asset := inventory.Asset{Connections: []*inventory.Config{conf}}
+	return &plugin.ParseCLIRes{Asset: &asset}, nil
+}

--- a/internal/connectorgen/testdata/repo/providers/shipped/resources/README.md
+++ b/internal/connectorgen/testdata/repo/providers/shipped/resources/README.md
@@ -1,0 +1,7 @@
+A provider directory holding a resource schema and no source, which is how
+equinix appears in the real tree. The extractor has to say the connector is
+missing for a reason rather than leave it out silently.
+
+The marker is `resources/` rather than `dist/` because the repository's
+.gitignore drops every `dist/`, and a fixture directory that never gets
+committed makes the test that depends on it pass everywhere except here.

--- a/internal/connectorgen/values.go
+++ b/internal/connectorgen/values.go
@@ -1,0 +1,419 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectorgen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// A provider's config literal is full of identifiers rather than strings:
+// `Discovery: []string{connection.DiscoveryRepos, ...}`, `flags[connection.
+// OPTION_APP_ID]`. Resolving them is the difference between extracting github's
+// ten discovery targets and extracting ten blanks.
+//
+// With no type checker the resolution is by name, over every package in the
+// provider's own tree. That is sound as long as a name means one thing there,
+// and where it does not -- the same identifier declared twice with different
+// values in two sibling packages -- the table refuses to answer rather than
+// picking one, and the caller records an unresolved-constant gap.
+
+// symbols is a by-name table of the string and []string constants declared
+// anywhere in one provider's source tree.
+type symbols struct {
+	// strs maps both "Name" and "pkg.Name" to a string value.
+	strs map[string]string
+	// lists maps the same keys to a []string value.
+	lists map[string][]string
+	// ambiguous holds keys that resolved to more than one distinct value, and
+	// which the table therefore declines to answer for.
+	ambiguous map[string]bool
+	// files are the parsed files, keyed by directory, so a caller can walk the
+	// same trees without re-reading them.
+	files map[string][]*ast.File
+	fset  *token.FileSet
+}
+
+func newSymbols(fset *token.FileSet) *symbols {
+	return &symbols{
+		strs:      map[string]string{},
+		lists:     map[string][]string{},
+		ambiguous: map[string]bool{},
+		files:     map[string][]*ast.File{},
+		fset:      fset,
+	}
+}
+
+// scanTree parses every non-test Go file under root and records the string
+// constants it finds. Unparseable files are skipped rather than fatal: a
+// provider tree pinned to an older SDK may hold a file this toolchain cannot
+// read, and losing one file's constants is better than losing the provider.
+func (s *symbols) scanTree(root string) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Vendored trees and testdata hold other people's constants.
+			switch d.Name() {
+			case "vendor", "testdata", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parseOne(s.fset, path)
+		if perr != nil {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		s.files[dir] = append(s.files[dir], f)
+		s.record(f)
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "cannot walk %s", root)
+	}
+	return nil
+}
+
+// filesUnder returns every parsed file in a directory and its subdirectories,
+// in a stable order.
+//
+// The packages under connection/ are separate packages, so this mixes them.
+// That is deliberate and safe for what it is used for: the walk over them looks
+// for an option name paired with an environment variable, and both are string
+// literals rather than cross-package references.
+func (s *symbols) filesUnder(root string) []*ast.File {
+	var dirs []string
+	for dir := range s.files {
+		if dir == root || strings.HasPrefix(dir, root+string(filepath.Separator)) {
+			dirs = append(dirs, dir)
+		}
+	}
+	sort.Strings(dirs)
+	var out []*ast.File
+	for _, dir := range dirs {
+		out = append(out, s.files[dir]...)
+	}
+	return out
+}
+
+// parseOne parses a single file for its syntax only. Object resolution is
+// skipped because nothing here needs it and it is the expensive half.
+func parseOne(fset *token.FileSet, path string) (*ast.File, error) {
+	return parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+}
+
+// record adds one file's package-level string and []string declarations.
+func (s *symbols) record(f *ast.File) {
+	pkg := f.Name.Name
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || (gd.Tok != token.CONST && gd.Tok != token.VAR) {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				if v, ok := literalString(vs.Values[i]); ok {
+					s.put(pkg, name.Name, v)
+					continue
+				}
+				if v, ok := literalStringList(vs.Values[i]); ok {
+					s.putList(pkg, name.Name, v)
+				}
+			}
+		}
+	}
+}
+
+func (s *symbols) put(pkg, name, val string) {
+	for _, key := range []string{name, pkg + "." + name} {
+		if old, seen := s.strs[key]; seen && old != val {
+			s.ambiguous[key] = true
+			continue
+		}
+		s.strs[key] = val
+	}
+}
+
+func (s *symbols) putList(pkg, name string, val []string) {
+	for _, key := range []string{name, pkg + "." + name} {
+		if old, seen := s.lists[key]; seen && !equalStrings(old, val) {
+			s.ambiguous[key] = true
+			continue
+		}
+		s.lists[key] = val
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// str resolves an expression to a string.
+//
+// It handles the three shapes a provider config actually uses -- a literal, an
+// identifier or qualified identifier naming a constant, and a concatenation of
+// those -- and refuses everything else. Refusing is the point: a name it cannot
+// resolve becomes a gap, not an empty string that reads like a declared empty
+// value.
+func (s *symbols) str(e ast.Expr) (string, bool) {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return literalString(x)
+	case *ast.Ident:
+		return s.lookup(x.Name)
+	case *ast.SelectorExpr:
+		if pkg, ok := x.X.(*ast.Ident); ok {
+			return s.lookup(pkg.Name + "." + x.Sel.Name)
+		}
+		return "", false
+	case *ast.ParenExpr:
+		return s.str(x.X)
+	case *ast.CallExpr:
+		// fmt.Sprintf, which is how seven providers write a Long help text that
+		// names the environment variables it reads: the variable names are
+		// constants passed as arguments. Resolving the call is what turns that
+		// help text from an unresolved blank into the sentence a user reads.
+		// string(pkg.Const), which is how a provider compares a positional
+		// argument against a typed constant. atlassian spells one of its four
+		// sub-commands that way, and without this its vocabulary comes out
+		// three words long with no sign that a fourth was dropped.
+		if id, ok := x.Fun.(*ast.Ident); ok && id.Name == "string" && len(x.Args) == 1 {
+			return s.str(x.Args[0])
+		}
+		sel, ok := x.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Sprintf" {
+			return "", false
+		}
+		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "fmt" || len(x.Args) == 0 {
+			return "", false
+		}
+		format, ok := s.str(x.Args[0])
+		if !ok {
+			return "", false
+		}
+		args := make([]any, 0, len(x.Args)-1)
+		for _, a := range x.Args[1:] {
+			v, ok := s.str(a)
+			if !ok {
+				return "", false
+			}
+			args = append(args, v)
+		}
+		return fmt.Sprintf(format, args...), true
+	case *ast.BinaryExpr:
+		if x.Op != token.ADD {
+			return "", false
+		}
+		left, leftOK := s.str(x.X)
+		right, rightOK := s.str(x.Y)
+		if !leftOK || !rightOK {
+			return "", false
+		}
+		return left + right, true
+	}
+	return "", false
+}
+
+func (s *symbols) lookup(key string) (string, bool) {
+	if s.ambiguous[key] {
+		return "", false
+	}
+	v, ok := s.strs[key]
+	return v, ok
+}
+
+// strList resolves an expression to a list of strings, reporting the entries it
+// could resolve and whether every entry resolved. A partly resolved list is
+// still worth keeping -- nine of ten discovery targets is nine more than none
+// -- so the caller records the shortfall as a gap and uses what it got.
+func (s *symbols) strList(e ast.Expr) (out []string, complete bool) {
+	complete = true
+	switch x := e.(type) {
+	case *ast.CompositeLit:
+		for _, el := range x.Elts {
+			if v, ok := s.str(el); ok {
+				out = append(out, v)
+				continue
+			}
+			if nested, sub := s.strList(el); len(nested) > 0 {
+				out = append(out, nested...)
+				complete = complete && sub
+				continue
+			}
+			complete = false
+		}
+		return out, complete
+	case *ast.Ident:
+		if v, ok := s.lists[x.Name]; ok && !s.ambiguous[x.Name] {
+			return append([]string(nil), v...), true
+		}
+	case *ast.SelectorExpr:
+		if pkg, ok := x.X.(*ast.Ident); ok {
+			key := pkg.Name + "." + x.Sel.Name
+			if v, ok := s.lists[key]; ok && !s.ambiguous[key] {
+				return append([]string(nil), v...), true
+			}
+		}
+	case *ast.CallExpr:
+		// append(base, extra...) shows up in a couple of discovery lists.
+		if id, ok := x.Fun.(*ast.Ident); ok && id.Name == "append" {
+			for _, arg := range x.Args {
+				if v, ok := s.str(arg); ok {
+					out = append(out, v)
+					continue
+				}
+				nested, sub := s.strList(arg)
+				out = append(out, nested...)
+				complete = complete && sub
+			}
+			return out, complete
+		}
+	}
+	return nil, false
+}
+
+// literalString unquotes a string literal.
+func literalString(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// literalStringList reads a []string{...} of literals.
+func literalStringList(e ast.Expr) ([]string, bool) {
+	cl, ok := e.(*ast.CompositeLit)
+	if !ok {
+		return nil, false
+	}
+	at, ok := cl.Type.(*ast.ArrayType)
+	if !ok {
+		return nil, false
+	}
+	if id, ok := at.Elt.(*ast.Ident); !ok || id.Name != "string" {
+		return nil, false
+	}
+	out := make([]string, 0, len(cl.Elts))
+	for _, el := range cl.Elts {
+		v, ok := literalString(el)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, v)
+	}
+	return out, true
+}
+
+// uintValue reads an unsigned integer literal.
+func uintValue(e ast.Expr) (uint, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.INT {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(lit.Value, 0, 64)
+	if err != nil {
+		return 0, false
+	}
+	return uint(v), true
+}
+
+// boolValue reads a bool literal.
+func boolValue(e ast.Expr) (bool, bool) {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return false, false
+	}
+	switch id.Name {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	}
+	return false, false
+}
+
+// flagTypes and flagOptions map the SDK's enum identifiers to their values.
+//
+// They are written out rather than reflected over because the mapping is what
+// makes the artifact comparable to runtime metadata, and because naming the
+// constants here means a rename in the SDK breaks this build instead of
+// silently producing a flag with type 0. The plugin package is the SDK, which
+// cnspec already depends on; it is the providers that cannot be imported.
+var flagTypes = map[string]plugin.FlagType{
+	"FlagType_Bool":     plugin.FlagType_Bool,
+	"FlagType_Int":      plugin.FlagType_Int,
+	"FlagType_String":   plugin.FlagType_String,
+	"FlagType_List":     plugin.FlagType_List,
+	"FlagType_KeyValue": plugin.FlagType_KeyValue,
+}
+
+var flagOptions = map[string]plugin.FlagOption{
+	"FlagOption_Hidden":     plugin.FlagOption_Hidden,
+	"FlagOption_Deprecated": plugin.FlagOption_Deprecated,
+	"FlagOption_Required":   plugin.FlagOption_Required,
+	"FlagOption_Password":   plugin.FlagOption_Password,
+	"FlagOption_AskInput":   plugin.FlagOption_AskInput,
+}
+
+// enumValue resolves plugin.FlagType_String, or an OR of flag options, to its
+// numeric value.
+func enumValue[T ~byte](e ast.Expr, table map[string]T) (T, bool) {
+	var zero T
+	switch x := e.(type) {
+	case *ast.SelectorExpr:
+		v, ok := table[x.Sel.Name]
+		return v, ok
+	case *ast.Ident:
+		v, ok := table[x.Name]
+		return v, ok
+	case *ast.ParenExpr:
+		return enumValue(x.X, table)
+	case *ast.BinaryExpr:
+		if x.Op != token.OR {
+			return zero, false
+		}
+		left, leftOK := enumValue(x.X, table)
+		right, rightOK := enumValue(x.Y, table)
+		if !leftOK || !rightOK {
+			return zero, false
+		}
+		return left | right, true
+	}
+	return zero, false
+}

--- a/internal/connectors/connectors.go
+++ b/internal/connectors/connectors.go
@@ -1,0 +1,190 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package connectors is the read side of the connector metadata artifact.
+//
+// internal/connectorgen writes connectors.json by walking an mql checkout; this
+// package embeds that file and hands it to production code. The two halves are
+// deliberately separate packages: the generator imports go/ast and go/parser to
+// do its job, and nothing that ships in the cnspec binary should depend on a
+// source-extraction tool to read its own data.
+//
+// # Why an embedded JSON rather than generated Go source
+//
+// The repo has a *_gen.go convention and it would have been the other obvious
+// choice. It is not used here, for four reasons:
+//
+//   - Size. The artifact is ~190KB describing 106 connectors. As a Go literal
+//     that is several thousand lines, which is larger than the hand-written
+//     metadata this exists to replace, and every provider change would produce
+//     a diff of that size for a human to scroll past.
+//   - One representation. The JSON is already the contract. The generator
+//     writes it, `make connectors/generate` produces it, and the launcher's
+//     existing tests parse it. Emitting Go source as well would create a second
+//     shape of the same facts and a second thing to keep in step.
+//   - The build guarantee is unchanged either way. cnspec must compile with no
+//     mql checkout present, and it does because the artifact is checked in --
+//     which is true of an embedded file exactly as it is of generated source.
+//   - The one thing generated source buys is that a malformed artifact fails at
+//     compile time rather than at run time. That is bought here instead by
+//     TestArtifactParses, which runs in CI with no providers installed. The
+//     file is generated and checked in, so the only way it can be malformed is
+//     a hand edit, and a hand edit is what that test is looking for.
+//
+// The types below are a projection of internal/connectorgen's Artifact rather
+// than a copy of it: they carry the fields a consumer reads and drop the
+// provenance the generator records for its own report. TestProjectionIsFaithful
+// in this package is what keeps the projection honest when the generator's
+// schema grows.
+package connectors
+
+import (
+	_ "embed"
+	"encoding/json"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+)
+
+//go:embed connectors.json
+var raw []byte
+
+// Artifact is the generated file as a consumer reads it.
+type Artifact struct {
+	// Schema is connectorgen.SchemaVersion at the time of generation.
+	Schema int `json:"schema"`
+	// Connectors is the extraction, sorted by name then provider.
+	Connectors []Connector `json:"connectors"`
+}
+
+// Connector is one (provider, connector) pair as the artifact records it.
+//
+// The first block is also obtainable from an installed provider. The second is
+// what only the provider's Go source carries, and is the whole reason this file
+// exists: neither fact survives into the shipped provider metadata.
+type Connector struct {
+	Name      string   `json:"name"`
+	Provider  string   `json:"provider"`
+	Use       string   `json:"use,omitempty"`
+	Short     string   `json:"short,omitempty"`
+	Long      string   `json:"long,omitempty"`
+	Aliases   []string `json:"aliases,omitempty"`
+	MinArgs   uint     `json:"min_args,omitempty"`
+	MaxArgs   uint     `json:"max_args,omitempty"`
+	Flags     []Flag   `json:"flags,omitempty"`
+	Discovery []string `json:"discovery,omitempty"`
+
+	// Env names the environment variables the provider reads a flag's value
+	// from, in the order its source consults them.
+	//
+	// This is detection data, not delivery data. Knowing that a provider reads
+	// OPENAI_API_KEY lets a form say "already set in your environment" instead
+	// of drawing an empty box; it is not a licence to put a secret into a
+	// variable and hand it to a child process. Providers resolve the inventory
+	// first and the environment last, so the environment is the weakest route
+	// available, not the strongest.
+	Env []FlagEnv `json:"env,omitempty"`
+	// Positional is the sub-command vocabulary -- the literal words the
+	// provider compares a positional argument against, which is how `github
+	// org <ORG>` differs from `github repo <ORG>/<REPO>`.
+	Positional []Positional `json:"positional,omitempty"`
+	// CarriedForward marks a connector this extraction did not re-derive; its
+	// metadata is as old as whenever it last was.
+	CarriedForward bool `json:"carried_forward,omitempty"`
+}
+
+// Flag mirrors plugin.Flag. Type and Option are the numeric enum values, so a
+// consumer compares them against plugin.FlagType_String and
+// plugin.FlagOption_Password directly.
+type Flag struct {
+	Long    string `json:"long"`
+	Short   string `json:"short,omitempty"`
+	Default string `json:"default,omitempty"`
+	Type    int32  `json:"type,omitempty"`
+	Option  int32  `json:"option,omitempty"`
+	Desc    string `json:"desc,omitempty"`
+	Config  string `json:"config,omitempty"`
+}
+
+// FlagEnv is one flag and the environment variables that back it.
+type FlagEnv struct {
+	Flag string   `json:"flag"`
+	Vars []string `json:"vars"`
+	// Via is "parse-cli" when the variable is consulted while parsing the
+	// command line and "connection" when the connection package reads it at
+	// connect time. A parse-cli variable yields to the flag; a connection one
+	// often overrides it.
+	Via string `json:"via,omitempty"`
+	// Declared reports whether this connector declares a flag by that name. A
+	// false is a finding, not noise: the provider reads a value the CLI has no
+	// way to pass.
+	Declared bool `json:"declared"`
+	// Composed marks variables that are joined rather than chosen between, so
+	// setting only the first will not work.
+	Composed bool `json:"composed,omitempty"`
+}
+
+// Positional is the vocabulary for one positional argument.
+type Positional struct {
+	// Index is the argument position as the provider counts it: req.Args[0] is
+	// index 0.
+	Index int `json:"index"`
+	// Values are the literal words compared against, in source order.
+	Values []string `json:"values"`
+}
+
+// load parses the embedded artifact once.
+//
+// A parse failure here is a corrupt checked-in file rather than anything a user
+// did, so it is carried rather than panicked on: the launcher degrades to the
+// metadata the installed providers declare, which is the same screen it drew
+// before this package existed.
+var load = sync.OnceValues(func() (*Artifact, error) {
+	var art Artifact
+	if err := json.Unmarshal(raw, &art); err != nil {
+		return nil, errors.Wrap(err, "cannot parse the embedded connector artifact")
+	}
+	if len(art.Connectors) == 0 {
+		return nil, errors.New("the embedded connector artifact describes no connectors")
+	}
+	return &art, nil
+})
+
+var index = sync.OnceValue(func() map[string]Connector {
+	art, err := load()
+	if err != nil {
+		return map[string]Connector{}
+	}
+	out := make(map[string]Connector, len(art.Connectors))
+	for _, c := range art.Connectors {
+		// First wins, matching the artifact's own sort: a connector name is
+		// unique across providers today, and if that ever stops being true the
+		// duplicate is a generator bug rather than something to resolve here.
+		if _, taken := out[c.Name]; !taken {
+			out[c.Name] = c
+		}
+	}
+	return out
+})
+
+// Load returns the parsed artifact.
+func Load() (*Artifact, error) { return load() }
+
+// ByName returns the recorded metadata for one connector.
+func ByName(name string) (Connector, bool) {
+	c, ok := index()[name]
+	return c, ok
+}
+
+// All returns every recorded connector, in the artifact's order.
+func All() []Connector {
+	art, err := load()
+	if err != nil {
+		return nil
+	}
+	return art.Connectors
+}
+
+// Raw returns the embedded bytes, for a consumer that needs a field this
+// projection drops.
+func Raw() []byte { return raw }

--- a/internal/connectors/connectors.json
+++ b/internal/connectors/connectors.json
@@ -1,0 +1,5404 @@
+{
+  "schema": 1,
+  "generated_by": "go.mondoo.com/cnspec/internal/connectorgen",
+  "sources": [
+    {
+      "name": "mql",
+      "commit": "683517226c89f1aea2d14a1dce6a05d323ad9eda",
+      "dirty": true,
+      "providers": 91
+    },
+    {
+      "name": "mql-enterprise-providers",
+      "commit": "e9199bef071007da46e92c0e80d4202e78b7a4fa",
+      "dirty": true,
+      "providers": 12
+    }
+  ],
+  "connectors": [
+    {
+      "name": "activedirectory",
+      "provider": "activedirectory",
+      "use": "activedirectory",
+      "short": "an Active Directory domain",
+      "long": "Use the activedirectory provider to query Active Directory Domain Services via LDAP.\n\n\tExamples:\n  cnspec shell activedirectory --dc dc01.corp.local --user admin@corp.local --password \u003cPASSWORD\u003e\n  cnspec scan activedirectory --dc dc01.corp.local --user admin@corp.local --password \u003cPASSWORD\u003e\n  cnspec shell activedirectory --dc dc01.corp.local --kerberos --user admin@CORP.LOCAL --password \u003cPASSWORD\u003e\n  cnspec shell activedirectory --dc dc01.corp.local --kerberos --keytab /etc/krb5.keytab --user admin@CORP.LOCAL\n  cnspec shell activedirectory --dc dc01.corp.local --kerberos\n\n\tNotes:\n  LDAPS (port 636) is the default transport. Use --starttls for LDAP+StartTLS on port 389, or --plain-ldap only for labs that cannot use TLS.\n  Kerberos authentication supports keytabs, credential caches, user/password, and on Windows the current logon session when no explicit credentials are supplied.\n  When no krb5.conf is found (for example on Windows, which has no /etc/krb5.conf), one is generated automatically from --dc, --domain, and the user's realm; pass --krb5conf to use your own for complex or multi-forest topologies.\n",
+      "aliases": [
+        "ad"
+      ],
+      "flags": [
+        {
+          "long": "backend",
+          "default": "ldap",
+          "type": 3,
+          "desc": "Backend to use: ldap (default) or rsat (Windows only, not yet implemented)"
+        },
+        {
+          "long": "base-dn",
+          "type": 3,
+          "desc": "Base DN for LDAP searches (auto-detected from RootDSE if omitted)"
+        },
+        {
+          "long": "ccache",
+          "type": 3,
+          "desc": "Path to Kerberos credential cache file (requires --kerberos)"
+        },
+        {
+          "long": "dc",
+          "type": 3,
+          "desc": "Domain controller hostname or IP address"
+        },
+        {
+          "long": "domain",
+          "type": 3,
+          "desc": "Domain DNS name (auto-detected from RootDSE if omitted)"
+        },
+        {
+          "long": "insecure",
+          "type": 1,
+          "desc": "Skip TLS certificate verification"
+        },
+        {
+          "long": "kerberos",
+          "type": 1,
+          "desc": "Use Kerberos/GSSAPI authentication instead of simple bind (on Windows, omit explicit credentials to use the current logon session)"
+        },
+        {
+          "long": "keytab",
+          "type": 3,
+          "desc": "Path to Kerberos keytab file (requires --kerberos and --user)"
+        },
+        {
+          "long": "krb5conf",
+          "type": 3,
+          "desc": "Path to krb5.conf (defaults to KRB5_CONFIG env or /etc/krb5.conf; when none exists, a config is generated from --dc/--domain/--user)"
+        },
+        {
+          "long": "ldaps",
+          "type": 1,
+          "desc": "Use LDAPS (TLS, port 636). This is the default transport."
+        },
+        {
+          "long": "password",
+          "type": 3,
+          "desc": "Password for LDAP bind or Kerberos AS exchange"
+        },
+        {
+          "long": "plain-ldap",
+          "type": 1,
+          "desc": "Use plaintext LDAP on port 389 (explicit opt-in; credentials are exposed without TLS)"
+        },
+        {
+          "long": "port",
+          "type": 2,
+          "desc": "LDAP port (default: 636 for LDAPS, 389 for StartTLS/plain LDAP)"
+        },
+        {
+          "long": "starttls",
+          "type": 1,
+          "desc": "Upgrade plain LDAP on port 389 to TLS via StartTLS (mutually exclusive with --ldaps and --plain-ldap)"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "Username (user@domain.com or DOMAIN\\user for simple bind; user@REALM for Kerberos)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "dc",
+          "vars": [
+            "LOGONSERVER"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "domain",
+          "vars": [
+            "USERDNSDOMAIN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "krb5conf",
+          "vars": [
+            "KRB5_CONFIG"
+          ],
+          "func": "loadOrGenerateKrb5Config",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "user",
+          "vars": [
+            "USERDNSDOMAIN",
+            "USERNAME"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true,
+          "composed": true
+        }
+      ]
+    },
+    {
+      "name": "alicloud",
+      "provider": "alicloud",
+      "use": "alicloud",
+      "short": "an Alibaba Cloud account",
+      "long": "Use the alicloud provider to query resources in an Alibaba Cloud account, including ECS instances, VPC networks, OSS buckets, RAM identities, and managed databases.\n\nCredentials are read from the flags below, then from the standard Alibaba Cloud environment variables (ALIBABA_CLOUD_ACCESS_KEY_ID, ALIBABA_CLOUD_ACCESS_KEY_SECRET, ALIBABA_CLOUD_SECURITY_TOKEN), then from the shared credentials file (~/.alibabacloud/credentials), and finally from an ECS instance RAM role when running inside Alibaba Cloud.\n\nExamples:\n  cnspec shell alicloud --access-key-id \u003cid\u003e --access-key-secret \u003csecret\u003e\n  cnspec scan alicloud --region cn-hangzhou\n  cnspec scan alicloud --regions cn-hangzhou,ap-southeast-1\n  cnspec scan alicloud --role-arn acs:ram::\u003cuid\u003e:role/\u003crole-name\u003e --access-key-id \u003cid\u003e --access-key-secret \u003csecret\u003e\n",
+      "flags": [
+        {
+          "long": "access-key-id",
+          "type": 3,
+          "desc": "Alibaba Cloud AccessKey ID"
+        },
+        {
+          "long": "access-key-secret",
+          "type": 3,
+          "desc": "Alibaba Cloud AccessKey secret"
+        },
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter discovered assets, e.g., --filters regions=cn-hangzhou,ap-southeast-1 --filters exclude:regions=cn-beijing --filters tag:Environment=production --filters exclude:tag:Environment=dev"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "Default region for account resolution (e.g. cn-hangzhou)"
+        },
+        {
+          "long": "regions",
+          "type": 3,
+          "desc": "Comma-separated list of regions to scan (default: all enabled regions)"
+        },
+        {
+          "long": "role-arn",
+          "type": 3,
+          "desc": "RAM role ARN to assume (acs:ram::\u003cuid\u003e:role/\u003cname\u003e)"
+        },
+        {
+          "long": "role-session-name",
+          "type": 3,
+          "desc": "Session name to use when assuming a RAM role"
+        },
+        {
+          "long": "sts-token",
+          "type": 3,
+          "desc": "STS security token, for temporary credentials"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "accounts",
+        "k8s-clusters",
+        "albs",
+        "nlbs",
+        "vpcs",
+        "waf",
+        "cloud-firewall",
+        "oss-buckets",
+        "rds-instances"
+      ],
+      "env": [
+        {
+          "flag": "access-key-id",
+          "vars": [
+            "ALIBABA_CLOUD_ACCESS_KEY_ID",
+            "ALICLOUD_ACCESS_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "access-key-secret",
+          "vars": [
+            "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+            "ALICLOUD_SECRET_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "region",
+          "vars": [
+            "ALIBABA_CLOUD_REGION",
+            "ALIBABA_CLOUD_REGION_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "ansible",
+      "provider": "ansible",
+      "use": "ansible PATH",
+      "short": "an Ansible playbook or project",
+      "long": "Use the ansible provider to statically analyze Ansible infrastructure as code.\n\nPoint PATH at a single playbook file to query its plays, tasks, handlers, and\nvariables. Point PATH at a project directory to additionally query roles,\ninventory and host/group variables, Galaxy requirements, ansible.cfg, and\nvault-encrypted files.\n\nExamples:\n  cnspec shell ansible \u003cplaybook.yml\u003e\n  cnspec shell ansible \u003cproject-dir\u003e\n  cnspec scan ansible \u003cproject-dir\u003e\n",
+      "min_args": 1,
+      "max_args": 1
+    },
+    {
+      "name": "anthropic",
+      "provider": "anthropic",
+      "flags": [
+        {
+          "long": "admin-token",
+          "type": 3,
+          "desc": "Anthropic Admin API key for organization resources (or set ANTHROPIC_ADMIN_API_KEY env var)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Anthropic API key (or set ANTHROPIC_API_KEY env var)"
+        }
+      ],
+      "carried_forward": true
+    },
+    {
+      "name": "arista",
+      "provider": "arista",
+      "use": "arista user@host",
+      "short": "an Arista EOS device",
+      "long": "Use the arista provider to query resources on an Arista EOS network device, including system information, interfaces, and configuration.\n\nExamples:\n  cnspec shell arista \u003cuser@host\u003e\n  cnspec scan arista \u003cuser@host\u003e --ask-pass\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "artifactory",
+      "provider": "artifactory",
+      "use": "artifactory [url]",
+      "short": "a JFrog Artifactory instance",
+      "long": "Use the artifactory provider to query the configuration of a JFrog Artifactory instance.\n\nThe URL is the JFrog platform base URL. A cloud instance is\nhttps://\u003cname\u003e.jfrog.io, a self-hosted instance is the host the platform is\nserved on. The /artifactory suffix the web interface shows is accepted and\nremoved.\n\nThe credential is an access token or a legacy API key. Reading permission\ntargets, users, groups, tokens, and the instance configuration requires an\nadministrator, so a token issued for a normal account reports those as errors.\n\nExamples:\n  cnspec shell artifactory --url https://example.jfrog.io --token \u003caccess_token\u003e\n  cnspec scan artifactory --url https://artifactory.example.com --token \u003caccess_token\u003e\n\nNotes:\n  If you set the ARTIFACTORY_URL environment variable, you can omit the url flag.\n  If you set the ARTIFACTORY_TOKEN environment variable, you can omit the token flag.\n",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "Artifactory API key for authentication, an alternative to the access token"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Artifactory access token for authentication"
+        },
+        {
+          "long": "url",
+          "type": 3,
+          "desc": "JFrog platform base URL (for example https://example.jfrog.io)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "api-key",
+          "vars": [
+            "ARTIFACTORY_API_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "ARTIFACTORY_TOKEN",
+            "JFROG_ACCESS_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "url",
+          "vars": [
+            "ARTIFACTORY_URL",
+            "JFROG_URL"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "atlassian",
+      "provider": "atlassian",
+      "use": "atlassian",
+      "short": "an Atlassian Cloud Jira, Confluence or Bitbucket instance",
+      "long": "Use the atlassian provider to query resources within Atlassian Cloud, including Jira, Confluence, and SCIM.\n\nAvailable commands:\n  admin                     Atlassian administrative instance\n  jira                      Jira instance\n  confluence                Confluence instance\n  scim                      SCIM instance\n\nExamples:\n  cnspec shell atlassian admin --admin-token \u003ctoken\u003e\n  cnspec shell atlassian jira --host \u003chost\u003e --user \u003cuser\u003e --user-token \u003ctoken\u003e\n  cnspec shell atlassian confluence --host \u003chost\u003e --user \u003cuser\u003e --user-token \u003ctoken\u003e\n  cnspec shell atlassian scim \u003cdirectory-id\u003e --scim-token \u003ctoken\u003e\n\nNotes:\n  If you set the ATLASSIAN_ADMIN_TOKEN environment variable, you can omit the admin-token flag. \n\t\n  If you set the ATLASSIAN_USER, ATLASSIAN_HOST, and ATLASSIAN_USER_TOKEN environment variables, you can omit the user, host, and user-token flags.\n\n  For the SCIM token and the directory-id values: \n  Atlassian provides these values when you set up an identity provider.\n",
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "admin-token",
+          "type": 3,
+          "desc": "Atlassian admin API token (used for Atlassian admin)"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Atlassian hostname (e.g. https://example.atlassian.net)"
+        },
+        {
+          "long": "scim-token",
+          "type": 3,
+          "desc": "Atlassian SCIM API token (used for SCIM)"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "Atlassian user name (e.g. example@example.com)"
+        },
+        {
+          "long": "user-token",
+          "type": 3,
+          "desc": "Atlassian user API token (used for Jira or Confluence)"
+        }
+      ],
+      "discovery": [
+        "organization"
+      ],
+      "env": [
+        {
+          "flag": "admin-token",
+          "vars": [
+            "ATLASSIAN_ADMIN_TOKEN"
+          ],
+          "func": "NewConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "host",
+          "vars": [
+            "ATLASSIAN_HOST"
+          ],
+          "func": "NewConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "scim-token",
+          "vars": [
+            "ATLASSIAN_SCIM_TOKEN"
+          ],
+          "func": "NewConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "user",
+          "vars": [
+            "ATLASSIAN_USER"
+          ],
+          "func": "NewConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "user-token",
+          "vars": [
+            "ATLASSIAN_USER_TOKEN"
+          ],
+          "func": "NewConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "scim",
+            "admin",
+            "jira",
+            "confluence"
+          ],
+          "func": "ParseCLI"
+        }
+      ]
+    },
+    {
+      "name": "auth0",
+      "provider": "auth0",
+      "use": "auth0",
+      "short": "an Auth0 tenant",
+      "long": "\nUse the auth0 provider to query applications, connections, users, roles,\nactions, log streams, and attack-protection settings of an Auth0 tenant.\n\nAuthentication uses a machine-to-machine (M2M) application's client\ncredentials:\n\n  cnspec shell auth0 --domain \u003ctenant.us.auth0.com\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n\nYou can also use the default environment variables 'AUTH0_DOMAIN', 'AUTH0_CLIENT_ID',\nand 'AUTH0_CLIENT_SECRET' to provide your credentials.\n",
+      "flags": [
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Auth0 machine-to-machine application client ID"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Auth0 machine-to-machine application client secret"
+        },
+        {
+          "long": "domain",
+          "type": 3,
+          "desc": "Auth0 tenant domain (e.g. your-tenant.us.auth0.com)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "AUTH0_CLIENT_ID"
+          ],
+          "func": "NewAuth0Connection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "domain",
+          "vars": [
+            "AUTH0_DOMAIN"
+          ],
+          "func": "NewAuth0Connection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "aws",
+      "provider": "aws",
+      "use": "aws",
+      "short": "an AWS account",
+      "long": "Use the aws provider to query the resources in an AWS account.\n\nTo query or scan AWS resources, you must have an AWS credentials file. To learn how to create one, read https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html. Mondoo uses the default profile in the credentials file unless you specify a different one using the --profile flag.\n\nAvailable commands:\n  ec2                  \t\tQuery or scan an AWS EC2 instance\n\t\t\t\t\t\t\t\t\t\t\t\t\tSubcommands:\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tinstance-connect\t\t\tAccess the EC2 instance using Amazon EC2 Instance Connect\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tProvide \u003cuser@host\u003e\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tssm\t\t\t\t\t\t\t\t\t\tAccess the EC2 instance using AWS Systems Manager\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tProvide a path to the identity file\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t--identity-file \u003cpath\u003e\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tebs\t\t\t\t\t\t\t\t\t\tQuery or scan an EBS volume\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tProvide the volume ID\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tebs snapshot\t\t\t\t\tQuery or scan an EBS volume snapshot\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tProvide the snapshot ID\n\nExamples:\n  cnspec shell aws\n\tcnspec scan aws\n\tcnspec scan aws -f mondoo-aws-incident-response.mql.yaml --querypack mondoo-incident-response-aws\n\tcnspec shell aws --role \u003crole-arn\u003e\n\tcnspec scan aws ec2 instance-connect \u003cuser@host\u003e\n\tcnspec scan aws ec2 instance-connect \u003cuser@host\u003e --identity-file \u003cpath\u003e\n\tcnspec scan aws ec2 ebs \u003csnapshot-id\u003e\n\tcnspec scan aws --filters regions=ap-south-1,us-east-1\n\nNotes:\n  If you set the AWS_PROFILE environment variable, you can omit the profile flag.\n\tTo learn about setting up your AWS credentials, read https://mondoo.com/docs/cnspec/cloud/aws.\n",
+      "max_args": 4,
+      "flags": [
+        {
+          "long": "endpoint-url",
+          "type": 3,
+          "desc": "Endpoint URL override for authentication with the API"
+        },
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter options, e.g., --filters regions=us-east-2,us-east-1 --filters ec2:instance-ids=i-093439483935 --filters s3:bucket-names=my-bucket --filters tag:Environment=production --filters tag:Team=platform --filters exclude:tag:Environment=dev"
+        },
+        {
+          "long": "no-setup",
+          "type": 3,
+          "desc": "Override option for EBS scanning that tells it to not create the snapshot or volume"
+        },
+        {
+          "long": "profile",
+          "type": 3,
+          "desc": "Profile to use when reading from ~/.aws/credentials"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "Region to use for authentication with the API (Note: This does not limit the discovery to the region.)"
+        },
+        {
+          "long": "role",
+          "type": 3,
+          "desc": "ARN of the role to use for authentication with the API"
+        },
+        {
+          "long": "scope",
+          "type": 3,
+          "desc": "Set the scope for the AWS WAFV2 to either CLOUDFRONT or REGIONAL"
+        }
+      ],
+      "discovery": [
+        "accounts",
+        "cloudfront-distributions",
+        "cloudtrail-trails",
+        "cloudwatch-loggroups",
+        "codebuild-projects",
+        "cognito-userpools",
+        "documentdb-clusters",
+        "dynamodb-global-tables",
+        "dynamodb-tables",
+        "ec2-instances-api",
+        "ec2-snapshots",
+        "ec2-volumes",
+        "ecr",
+        "ecr-image-api",
+        "ecr-repositories",
+        "ecs",
+        "ecs-containers-api",
+        "ecs-taskdefinitions",
+        "efs-filesystems",
+        "eks-clusters",
+        "elasticache-clusters",
+        "elb-loadbalancers",
+        "emr-clusters",
+        "es-domains",
+        "opensearch-domains",
+        "gateway-restapis",
+        "iam-groups",
+        "iam-users",
+        "instances",
+        "kms-keys",
+        "lambda-functions",
+        "memorydb-clusters",
+        "mq-brokers",
+        "msk-clusters",
+        "neptune-clusters",
+        "organization",
+        "rds-dbclusters",
+        "rds-dbinstances",
+        "redshift-clusters",
+        "resources",
+        "route53-hostedzones",
+        "s3-buckets",
+        "sagemaker-notebookinstances",
+        "sagemaker-processingjobs",
+        "sagemaker-trainingjobs",
+        "sagemaker-domains",
+        "sagemaker-models",
+        "secretsmanager-secrets",
+        "security-groups",
+        "ssm-instances",
+        "ssm-instances-api",
+        "transfer-servers",
+        "apigatewayv2-apis",
+        "athena-workgroups",
+        "appstream-fleets",
+        "batch-jobdefinitions",
+        "directoryservice-directories",
+        "documentdb-instances",
+        "sns-topics",
+        "sqs-queues",
+        "vpcs"
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "ec2"
+          ],
+          "func": "ParseCLI"
+        },
+        {
+          "index": 1,
+          "values": [
+            "instance-connect",
+            "ssm",
+            "ebs"
+          ],
+          "func": "handleAwsEc2Subcommands"
+        }
+      ]
+    },
+    {
+      "name": "azure",
+      "provider": "azure",
+      "use": "azure",
+      "short": "an Azure subscription",
+      "long": "Use the azure provider to query resources within Microsoft Azure, including storage, compute instances, snapshots, databases, and more.\n\nExamples run in your shell:\n  cnspec scan azure compute instance \u003cinstance-name\u003e --client-id \u003cyour-client-id\u003e --tenant-id \u003cyour-tenant-id\u003e --client-secret \u003cyour-client-secret-value\u003e\n  cnspec scan azure compute snapshot \u003csnapshot-name\u003e --client-id \u003cyour-client-id\u003e --tenant-id \u003cyour-tenant-id\u003e --client-secret \u003cyour-client-secret-value\u003e\n  cnspec shell azure \u003csubscription-name\u003e --client-id \u003cyour-client-id\u003e --tenant-id \u003cyour-tenant-id\u003e --client-secret \u003cyour-client-secret-value\u003e\n\nExamples run in the Azure CLI:\t\n  cnspec shell azure\n  cnspec scan azure --subscription \u003cspecific-subscription-id\u003e\n",
+      "max_args": 8,
+      "flags": [
+        {
+          "long": "auth-method",
+          "type": 3,
+          "desc": "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, workload-identity, managed-identity (default: try all, in that order)"
+        },
+        {
+          "long": "certificate-path",
+          "type": 3,
+          "desc": "Path (in PKCS #12/PFX or PEM format) to the authentication certificate"
+        },
+        {
+          "long": "certificate-secret",
+          "type": 3,
+          "desc": "Passphrase for the authentication certificate file"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Application (client) ID of the service principal"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Secret for application"
+        },
+        {
+          "long": "federated-token-file",
+          "type": 3,
+          "desc": "Path to a file containing an OIDC token to exchange via Azure workload identity federation"
+        },
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter options, e.g., --filters subscriptions=\u003cid1\u003e,\u003cid2\u003e --filters subscriptions-exclude=\u003cid3\u003e --filters tag:\u003ckey\u003e=\u003cvalue1\u003e,\u003cvalue2\u003e --filters exclude:tag:\u003ckey\u003e=\u003cvalue\u003e --filters propagate-subscription-tags=true --filters subscription-tag:\u003ckey\u003e=\u003cvalue\u003e"
+        },
+        {
+          "long": "subscription",
+          "type": 3,
+          "option": 1,
+          "desc": "ID of the Azure subscription to scan"
+        },
+        {
+          "long": "subscriptions",
+          "type": 3,
+          "desc": "Comma-separated list of Azure subscriptions to include"
+        },
+        {
+          "long": "subscriptions-exclude",
+          "type": 3,
+          "desc": "Comma-separated list of Azure subscriptions to exclude"
+        },
+        {
+          "long": "tenant-id",
+          "type": 3,
+          "desc": "Directory (tenant) ID of the service principal"
+        }
+      ],
+      "discovery": [
+        "subscriptions",
+        "instances",
+        "instances-api",
+        "sql-servers",
+        "postgres-servers",
+        "postgres-flexible-servers",
+        "mysql-servers",
+        "mysql-flexible-servers",
+        "aks-clusters",
+        "app-service-webapps",
+        "cache-redis-instances",
+        "batch-accounts",
+        "storage-accounts",
+        "storage-containers",
+        "keyvaults-vaults",
+        "keyvaults-managed-hsms",
+        "iot-hubs",
+        "security-groups",
+        "cosmosdb",
+        "virtual-networks",
+        "cognitiveservices-accounts"
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "compute"
+          ],
+          "func": "ParseCLI"
+        },
+        {
+          "index": 1,
+          "values": [
+            "instance",
+            "snapshot",
+            "disk"
+          ],
+          "func": "handleAzureComputeSubcommands"
+        }
+      ]
+    },
+    {
+      "name": "bicep",
+      "provider": "bicep",
+      "use": "bicep PATH",
+      "short": "a Bicep file, directory, or ARM template JSON",
+      "long": "Use the bicep provider to query Azure Bicep files and ARM templates, including resources, parameters, modules, and compiled output.\n\nExamples:\n  cnspec run bicep ./main.bicep -c \"bicep.files { resources { type apiVersion } }\"\n  cnspec shell bicep ./infra/\n",
+      "min_args": 1,
+      "max_args": 1
+    },
+    {
+      "name": "bigip",
+      "provider": "bigip",
+      "use": "bigip",
+      "short": "a remote F5 BIG-IP system",
+      "long": "Use the bigip provider to query resources on F5 BIG-IP devices.\n\nExamples:\n  cnspec shell bigip --hostname 192.168.1.245 --username admin --password secret\n  cnspec scan bigip --hostname bigip.example.com -u admin --ask-pass\n  cnspec shell bigip --hostname 10.0.0.1 -u admin -p secret --insecure\n  cnspec scan bigip --hostname 192.168.1.245 -u admin -p secret -f bigip-security-policy.mql.yaml\n\nNotes:\n  Use --insecure (-k) to skip TLS verification for devices with self-signed certificates.\n  The default port is 443 (iControl REST API). Use --port to specify a different port.\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the BIG-IP device"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "The password for authentication"
+        },
+        {
+          "long": "port",
+          "default": "443",
+          "type": 3,
+          "desc": "The port of the iControl REST API"
+        },
+        {
+          "long": "username",
+          "short": "u",
+          "default": "admin",
+          "type": 3,
+          "desc": "The username for authentication"
+        }
+      ]
+    },
+    {
+      "name": "bitwarden",
+      "provider": "bitwarden",
+      "use": "bitwarden",
+      "short": "a Bitwarden organization",
+      "long": "\nUse the bitwarden provider to query the organization governance settings of\na Bitwarden Teams or Enterprise organization: security policies, members,\ncollections, and groups. This provider reads organization governance only;\nit never reads vault item secrets.\n\nAuthentication uses an organization API key exchanged via OAuth2\nclient-credentials:\n\n  cnspec shell bitwarden --client-id organization.\u003cuuid\u003e --client-secret \u003csecret\u003e\n\nYou can also use the default environment variables 'BITWARDEN_CLIENT_ID' and 'BITWARDEN_CLIENT_SECRET' to provide\nyour credentials, and 'BITWARDEN_API_URL'/'BITWARDEN_IDENTITY_URL' to point at a self-hosted deployment.\n",
+      "flags": [
+        {
+          "long": "api-url",
+          "type": 3,
+          "desc": "Bitwarden Public API base URL, for self-hosted deployments"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Bitwarden organization client ID (e.g. organization.\u003cuuid\u003e)"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Bitwarden organization client secret"
+        },
+        {
+          "long": "identity-url",
+          "type": 3,
+          "desc": "Bitwarden identity token URL, for self-hosted deployments"
+        }
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "BITWARDEN_CLIENT_ID"
+          ],
+          "func": "NewBitwardenConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "cassandra",
+      "provider": "cassandra",
+      "use": "cassandra [host]",
+      "short": "an Apache Cassandra cluster",
+      "long": "Use the cassandra provider to query an Apache Cassandra cluster.\n\nThe provider connects over CQL and runs read-only queries against the system\nand system_auth keyspaces and the system_views.settings virtual table to\ninventory the cluster version, its security posture, and its roles, nodes, and\nkeyspaces, so you can audit the cluster's security posture.\n\nExamples:\n  cnspec shell cassandra localhost --user cassandra --ask-pass\n  cnspec scan cassandra db.contoso.com --user auditor --ask-pass --tls\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Cassandra hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "9042",
+          "type": 2,
+          "desc": "Cassandra CQL native transport port"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "Role name to authenticate as"
+        }
+      ]
+    },
+    {
+      "name": "checkpoint",
+      "provider": "checkpoint",
+      "use": "checkpoint",
+      "short": "a Check Point Security Management server",
+      "long": "Use the checkpoint provider to query resources on Check Point Security Management\nservers (the management plane behind SmartConsole) via the Management API.\n\nExamples:\n  cnspec shell checkpoint --hostname mgmt.example.com --api-key YOUR_API_KEY\n  cnspec scan  checkpoint --hostname 10.0.0.5 -u admin --ask-pass --insecure\n  cnspec scan  checkpoint --hostname mds.example.com --api-key KEY --domain Corporate\n\nNotes:\n  The provider opens a read-only Management API session.\n  Use --insecure (-k) to skip TLS verification for management servers with self-signed certificates.\n  The default port is 443. Use --port to specify a different port.\n  Use --api-key as an alternative to username/password authentication.\n  Use --domain to target a specific domain on a Multi-Domain Security Management server.\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "option": 8,
+          "desc": "API key for authentication (alternative to username/password)"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "domain",
+          "type": 3,
+          "desc": "The management domain to target (Multi-Domain Security Management)"
+        },
+        {
+          "long": "fingerprint",
+          "type": 3,
+          "desc": "Pin the management server's TLS certificate SHA-1 fingerprint"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the Check Point management server"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "The password for authentication"
+        },
+        {
+          "long": "port",
+          "default": "443",
+          "type": 3,
+          "desc": "The port of the Management API"
+        },
+        {
+          "long": "username",
+          "short": "u",
+          "type": 3,
+          "desc": "The username for authentication"
+        }
+      ],
+      "discovery": [
+        "gateways"
+      ]
+    },
+    {
+      "name": "ciscocatalyst",
+      "provider": "networkdevices",
+      "use": "ciscocatalyst hostname",
+      "short": "Cisco Catalyst Connection",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for SSH",
+          "config": "-"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "User name for the Cisco Catalyst Center"
+        }
+      ],
+      "discovery": [
+        "devices"
+      ]
+    },
+    {
+      "name": "claude",
+      "provider": "claude",
+      "use": "claude",
+      "short": "a Claude AI platform account",
+      "long": "Use the claude provider to query organization, workspace, API key, and service account\nconfiguration in a Claude AI platform account.\n\nExamples:\n  cnspec shell claude --token \u003cAPI-KEY\u003e\n  cnspec scan claude --admin-token \u003cADMIN-API-KEY\u003e --discover organization\n  cnspec scan claude --admin-token \u003cADMIN-API-KEY\u003e --discover workspaces\n\nNotes:\n  If you set the ANTHROPIC_API_KEY environment variable, you can omit the token flag.\n\n  Organization and workspace resources require an Admin API key. Supply it with\n  --admin-token or by setting the ANTHROPIC_ADMIN_API_KEY environment variable.\n",
+      "flags": [
+        {
+          "long": "admin-token",
+          "type": 3,
+          "desc": "Claude Admin API key for organization resources (or set ANTHROPIC_ADMIN_API_KEY env var)"
+        },
+        {
+          "long": "federation-rule-id",
+          "type": 3,
+          "desc": "Anthropic federation rule ID (fdrl_...) for WIF authentication"
+        },
+        {
+          "long": "identity-token-file",
+          "type": 3,
+          "desc": "Path to OIDC identity token file for Workload Identity Federation"
+        },
+        {
+          "long": "organization-id",
+          "type": 3,
+          "desc": "Anthropic organization ID for WIF authentication (or set ANTHROPIC_ORGANIZATION_ID env var)"
+        },
+        {
+          "long": "service-account-id",
+          "type": 3,
+          "desc": "Anthropic service account ID (svac_...) for WIF authentication"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Claude API key (or set ANTHROPIC_API_KEY env var)"
+        },
+        {
+          "long": "workspace-id",
+          "type": 3,
+          "desc": "Anthropic workspace ID (wrkspc_...) to scope WIF token to a specific workspace"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "organization",
+        "workspaces"
+      ],
+      "env": [
+        {
+          "flag": "admin-token",
+          "vars": [
+            "ANTHROPIC_ADMIN_API_KEY"
+          ],
+          "func": "NewClaudeConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "ANTHROPIC_API_KEY"
+          ],
+          "func": "NewClaudeConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "clickhouse",
+      "provider": "clickhouse",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "type": 3,
+          "desc": "Database to connect to (default \"default\")"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "ClickHouse hostname or IP address"
+        },
+        {
+          "long": "password",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "type": 2,
+          "desc": "ClickHouse native protocol port"
+        },
+        {
+          "long": "tls",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-insecure",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "User name to authenticate as (default \"default\")"
+        }
+      ],
+      "carried_forward": true
+    },
+    {
+      "name": "clickhousecloud",
+      "provider": "clickhousecloud",
+      "use": "clickhousecloud",
+      "short": "a ClickHouse Cloud organization",
+      "long": "Use the clickhousecloud provider to query the ClickHouse Cloud control-plane API.\n\nThe provider authenticates with an organization API key (key id + secret) and\ninventories the organization's services, their IP access lists and endpoints,\nAPI keys, and members, so you can audit the organization's security posture,\nfor example services reachable from any IP or API keys that never expire.\n\nExamples:\n  cnspec shell clickhousecloud --organization-id ORG_ID --api-key KEY_ID --ask-secret\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "ClickHouse Cloud API key id"
+        },
+        {
+          "long": "api-secret",
+          "type": 3,
+          "option": 8,
+          "desc": "ClickHouse Cloud API key secret",
+          "config": "-"
+        },
+        {
+          "long": "api-url",
+          "type": 3,
+          "desc": "Override the ClickHouse Cloud API base URL"
+        },
+        {
+          "long": "ask-secret",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the API key secret",
+          "config": "-"
+        },
+        {
+          "long": "organization-id",
+          "type": 3,
+          "desc": "ClickHouse Cloud organization ID"
+        }
+      ]
+    },
+    {
+      "name": "clickhousedb",
+      "provider": "clickhousedb",
+      "use": "clickhousedb [host]",
+      "short": "a ClickHouse server",
+      "long": "Use the clickhousedb provider to query a ClickHouse database server.\n\nThe provider connects over the ClickHouse native protocol and runs read-only\nqueries against the system tables (system.users, system.roles, system.grants,\nand related) to inventory the server version, its users, roles, grants, settings\nprofiles, quotas, and clusters, so you can audit the server's security posture.\n\nExamples:\n  cnspec shell clickhousedb db.contoso.com --user auditor --ask-pass\n  cnspec scan clickhousedb db.contoso.com --user auditor --ask-pass --tls\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "type": 3,
+          "desc": "Database to connect to (default \"default\")"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "ClickHouse hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "9000",
+          "type": 2,
+          "desc": "ClickHouse native protocol port"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "User name to authenticate as (default \"default\")"
+        }
+      ]
+    },
+    {
+      "name": "cloudflare",
+      "provider": "cloudflare",
+      "use": "cloudflare",
+      "short": "a Cloudflare account",
+      "long": "Use the cloudflare provider to query resources in your Cloudflare account, including zones, DNS records, and account settings.\n\nExamples:\n  cnspec shell cloudflare --token \u003caccess_token\u003e\n  cnspec scan cloudflare --token \u003caccess_token\u003e\n\nNotes:\n  If you set the CLOUDFLARE_TOKEN environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Cloudflare API token for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "zones",
+        "accounts"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "CLOUDFLARE_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "cloudformation",
+      "provider": "cloudformation",
+      "use": "cloudformation PATH",
+      "short": "an AWS CloudFormation template or AWS SAM template",
+      "long": "Use the cloudformation provider to query AWS CloudFormation templates or AWS SAM templates, including resources, parameters, outputs, and mappings.\n\nExamples:\n  cnspec shell cloudformation \u003cpath\u003e\n  cnspec scan cloudformation \u003cpath\u003e\n",
+      "min_args": 1,
+      "max_args": 1
+    },
+    {
+      "name": "container",
+      "provider": "os",
+      "use": "container",
+      "short": "a running container or container image",
+      "long": "Use the container provider to query running containers or container images.  \n\nExamples:\n  cnspec scan container ubuntu:latest\n  cnspec shell container ubuntu:latest\n",
+      "min_args": 1,
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "container-proxy",
+          "type": 3,
+          "desc": "HTTP proxy to use for container pulls"
+        },
+        {
+          "long": "disable-cache",
+          "default": "false",
+          "type": 1,
+          "desc": "Disable the in-memory cache for images. WARNING: This significantly slows scans."
+        },
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "sudo",
+          "default": "false",
+          "type": 1,
+          "desc": "Elevate privileges with sudo",
+          "config": "sudo.active"
+        }
+      ],
+      "discovery": [
+        "container",
+        "container-images"
+      ]
+    },
+    {
+      "name": "databricks",
+      "provider": "databricks",
+      "use": "databricks",
+      "short": "a Databricks account or workspace",
+      "long": "Use the databricks provider to query the security posture of a Databricks\naccount and its workspaces.\n\nConnecting to the account console (OAuth M2M service principal) discovers every\nworkspace as a child asset. You can also connect a single workspace directly\nwith a personal access token.\n\nExamples:\n  cnspec shell databricks --account-id \u003caccount-id\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n  cnspec shell databricks --host \u003cworkspace-url\u003e --token \u003cpat\u003e\n\nNotes:\n  Set DATABRICKS_ACCOUNT_ID, DATABRICKS_HOST, DATABRICKS_CLIENT_ID,\n  DATABRICKS_CLIENT_SECRET, or DATABRICKS_TOKEN to omit the matching flags.\n\n  For Azure- or GCP-hosted Databricks, override --host with the account console\n  host (accounts.azuredatabricks.net or accounts.gcp.databricks.com).\n",
+      "flags": [
+        {
+          "long": "account-id",
+          "type": 3,
+          "desc": "Databricks account id (connects to the account console and discovers workspaces)"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "OAuth M2M service principal client id"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "OAuth M2M service principal client secret"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Databricks host (account console host, or a workspace URL for a direct connect)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Personal access token for a direct workspace connect"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "workspaces"
+      ],
+      "env": [
+        {
+          "flag": "account-id",
+          "vars": [
+            "DATABRICKS_ACCOUNT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "client-id",
+          "vars": [
+            "DATABRICKS_CLIENT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "DATABRICKS_CLIENT_SECRET"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "host",
+          "vars": [
+            "DATABRICKS_HOST"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "DATABRICKS_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "datadog",
+      "provider": "datadog",
+      "use": "datadog",
+      "short": "a Datadog account",
+      "long": "Use the datadog provider to query resources in a Datadog account.\n\nExamples:\n  mql shell datadog --api-key \u003ckey\u003e --app-key \u003ckey\u003e\n  mql shell datadog\n\nNotes:\n  Set DD_API_KEY and DD_APP_KEY environment variables to avoid passing keys on the command line.\n  Set DD_SITE for non-US regions (e.g., datadoghq.eu).\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "Datadog API key (env: DD_API_KEY)"
+        },
+        {
+          "long": "app-key",
+          "type": 3,
+          "desc": "Datadog application key (env: DD_APP_KEY)"
+        },
+        {
+          "long": "site",
+          "type": 3,
+          "desc": "Datadog site (env: DD_SITE, e.g., datadoghq.eu, us3.datadoghq.com)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "api-key",
+          "vars": [
+            "DD_API_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "app-key",
+          "vars": [
+            "DD_APP_KEY"
+          ],
+          "func": "NewDatadogConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "site",
+          "vars": [
+            "DD_SITE"
+          ],
+          "func": "NewDatadogConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "db2",
+      "provider": "db2",
+      "use": "db2 [host]",
+      "short": "an IBM Db2 database",
+      "long": "Use the db2 provider to query an IBM Db2 (LUW) database.\n\nThe provider connects over the Db2 protocol and runs read-only queries against\nthe system catalog (SYSCAT, SYSIBMADM) to inventory the database service level,\nits configuration parameters, and its authorities, roles, and audit policies, so\nyou can audit the database against the CIS IBM Db2 benchmark.\n\nExamples:\n  cnspec shell db2 db.contoso.com --database TESTDB --user auditor --ask-pass\n  cnspec scan db2 db.contoso.com --database PRODDB --user auditor --ask-pass --tls\n",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "type": 3,
+          "desc": "Database name to connect to (for example TESTDB)"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Db2 hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "50000",
+          "type": 2,
+          "desc": "Db2 connection port"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User name to authenticate as"
+        }
+      ]
+    },
+    {
+      "name": "depsdev",
+      "provider": "depsdev",
+      "use": "depsdev [path-to-go.mod]",
+      "short": "deps.dev dependency analysis",
+      "long": "Use the depsdev provider to query Go module dependency information from the deps.dev API.\n\nPoint it at a go.mod file to check all direct dependencies:\n\n  mql shell depsdev ./go.mod\n\nOr use it without arguments and query individual packages:\n\n  mql shell depsdev\n  \u003e depsdev.package(\"github.com/rs/zerolog\") { latestVersion latestPublished }\n",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "path",
+          "type": 3,
+          "desc": "Path to a go.mod file"
+        }
+      ]
+    },
+    {
+      "name": "device",
+      "provider": "os",
+      "use": "device",
+      "short": "a block device target",
+      "long": "Use the device provider to query block devices. \n\nExamples:\n  cnspec scan device --lun \u003cLOGICAL-UNIT-NUMBER\u003e\n  cnspec shell device --device-name \u003cNAME-OF-LINUX-DEVICE\u003e\n",
+      "flags": [
+        {
+          "long": "device-name",
+          "type": 3,
+          "option": 3,
+          "desc": "The target device, e.g., /dev/sda. Supported only for Linux scanning. Do not use together with --lun or --serial-number"
+        },
+        {
+          "long": "device-names",
+          "type": 4,
+          "option": 1,
+          "desc": "The target devices, e.g., /dev/sda. Supported only for Linux scanning. Do not use together with --lun or --serial-number"
+        },
+        {
+          "long": "include-mounted",
+          "type": 1,
+          "option": 1,
+          "desc": "Include mounted block devices in the scan"
+        },
+        {
+          "long": "keep-mounted",
+          "type": 1,
+          "option": 1,
+          "desc": "Keep mounted block devices mounted after the scan"
+        },
+        {
+          "long": "lun",
+          "type": 3,
+          "option": 1,
+          "desc": "The logical unit number of the block device. Do not use with --device-name or --serial-number"
+        },
+        {
+          "long": "mount-all-partitions",
+          "type": 1,
+          "option": 1,
+          "desc": "Mount all partitions of the block device"
+        },
+        {
+          "long": "platform-ids",
+          "type": 4,
+          "option": 1,
+          "desc": "List of platform IDs to inject to the asset"
+        },
+        {
+          "long": "serial-number",
+          "type": 3,
+          "option": 1,
+          "desc": "The serial number of the block device. Supported only for Windows scanning. Do not use together with --device-name or --lun"
+        },
+        {
+          "long": "skip-attempt-expand-partitions",
+          "type": 1,
+          "option": 1,
+          "desc": "Skip attempt on trying to discover the fstab file on the device"
+        }
+      ]
+    },
+    {
+      "name": "digitalocean",
+      "provider": "digitalocean",
+      "use": "digitalocean",
+      "short": "a DigitalOcean account",
+      "long": "Use the digitalocean provider to query resources in a DigitalOcean account.\n\nExamples:\n  cnspec shell digitalocean --token \u003capi-token\u003e\n  cnspec shell digitalocean\n  cnspec scan digitalocean --discover all --filters tags=production\n\nNotes:\n  If you set the DIGITALOCEAN_TOKEN environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter discovered assets, e.g., --filters regions=nyc1,sfo3 --filters exclude:regions=ams3 --filters tags=production,web --filters exclude:tags=temporary"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "DigitalOcean personal access token (env: DIGITALOCEAN_TOKEN)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "databases",
+        "kubernetes",
+        "loadbalancers",
+        "firewalls",
+        "spaces-buckets",
+        "gradientai-agents"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "DIGITALOCEAN_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "docker",
+      "provider": "os",
+      "use": "docker",
+      "short": "a running Docker container, Docker image, or Dockerfile",
+      "long": "Use the docker provider to query running Docker containers or container images in public or private container registries using their registry name. Or scan a Dockerfile by specifying its path. \n\nExamples:\n  cnspec scan docker \u003cDOCKER-CONTAINER-ID\u003e\n  cnspec scan docker file \u003cFILEPATH\u003e\n  cnspec scan docker ubuntu:latest\n  cnspec scan docker elastic/elasticsearch:7.2.0\n  cnspec scan docker gcr.io/google-containers/ubuntu:22.04\n  cnspec scan docker registry.access.redhat.com/ubi8/ubi\n",
+      "min_args": 1,
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "container-proxy",
+          "type": 3,
+          "desc": "HTTP proxy to use for container pulls"
+        },
+        {
+          "long": "disable-cache",
+          "default": "false",
+          "type": 1,
+          "desc": "Disable the in-memory cache for images. WARNING: This significantly slows scans."
+        },
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "sudo",
+          "default": "false",
+          "type": 1,
+          "desc": "Elevate privileges with sudo.",
+          "config": "sudo.active"
+        }
+      ],
+      "discovery": [
+        "container",
+        "container-images"
+      ]
+    },
+    {
+      "name": "dropbox",
+      "provider": "dropbox",
+      "use": "dropbox",
+      "short": "a Dropbox Business team",
+      "long": "\nUse the dropbox provider to query the members, groups, linked devices, and\nlinked third-party apps of a Dropbox Business team.\n\nAuthentication uses a Dropbox Business team access token, issued to a\nDropbox Business App with team-level (not per-user) scoped access:\n\n  cnspec shell dropbox --token \u003cteam-scoped-access-token\u003e\n\nYou can also use the default environment variable 'DROPBOX_TEAM_TOKEN' to provide the\ntoken.\n",
+      "flags": [
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Dropbox Business team access token"
+        }
+      ]
+    },
+    {
+      "name": "elasticsearch",
+      "provider": "elasticsearch",
+      "use": "elasticsearch [host]",
+      "short": "an Elasticsearch cluster",
+      "long": "Use the elasticsearch provider to query an Elasticsearch cluster.\n\nThe provider connects to the cluster's REST API and runs read-only requests to\ninventory the cluster version and health, its security posture, and its users,\nroles, role mappings, and API keys, so you can audit the cluster's security\nposture.\n\nExamples:\n  cnspec shell elasticsearch localhost --user elastic --ask-pass\n  cnspec scan elasticsearch es.contoso.com --api-key API_KEY\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "option": 8,
+          "desc": "API key to authenticate with (base64 of id:api_key)",
+          "config": "-"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Elasticsearch hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "9200",
+          "type": 2,
+          "desc": "Elasticsearch REST API port"
+        },
+        {
+          "long": "scheme",
+          "default": "https",
+          "type": 3,
+          "desc": "Connection scheme: http or https"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User name for basic authentication"
+        }
+      ]
+    },
+    {
+      "name": "equinix",
+      "provider": "equinix",
+      "min_args": 2,
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "The Equinix API token for authenticating the user"
+        }
+      ],
+      "carried_forward": true
+    },
+    {
+      "name": "filesystem",
+      "provider": "os",
+      "use": "filesystem PATH [flags]",
+      "short": "a mounted file system target",
+      "long": "Use the filesystem provider to query mounted file systems. \n\nExamples:\n  cnspec scan filesystem \u003cMOUNT-PATH-TO-FILE-SYSTEM\u003e\n  cnspec shell fs \u003cMOUNT-PATH-TO-FILE-SYSTEM\u003e\n",
+      "aliases": [
+        "fs"
+      ],
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "path",
+          "type": 3,
+          "option": 2,
+          "desc": "Path to a local file or directory for the connection to use"
+        }
+      ]
+    },
+    {
+      "name": "fortios",
+      "provider": "fortios",
+      "use": "fortios",
+      "short": "a remote FortiOS system",
+      "flags": [
+        {
+          "long": "enable-forti-sdk-logs",
+          "default": "false",
+          "type": 1,
+          "desc": "Enable logging from the FortiOS SDK (useful for debugging connection issues)",
+          "config": "-"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the FortiOS device"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "token",
+          "short": "t",
+          "type": 3,
+          "desc": "The REST API token for authentication"
+        }
+      ]
+    },
+    {
+      "name": "gcp",
+      "provider": "gcp",
+      "use": "gcp",
+      "short": "a Google Cloud project or folder",
+      "long": "Use the gcp provider to query resources within Google Cloud Platform (GCP), including databases, services, instances, containers, and more.\n\nExamples without logging into and configuring GCP:\n  cnspec shell gcp org \u003cORGANIZATION-ID\u003e --credentials-path \u003cPATH-TO-YOUR-SERVICE-ACCT\u003e\n  cnspec scan gcp project \u003cPROJECT-ID\u003e --credentials-path \u003cPATH-TO-YOUR-SERVICE-ACCT\u003e\n\nNote:\n  If you log into GCP and configure the project you want to query or scan, you can omit credentials. To learn how, read https://mondoo.com/docs/cnspec/cloud/gcp.\n\nExamples with the GCP project configured:\n  cnspec scan gcp folder \u003cFOLDER-ID\u003e\n  cnspec shell gcp project\n\nExamples for a single Compute Engine instance or snapshot:\n  cnspec scan gcp instance \u003cINSTANCE-NAME\u003e --project-id \u003cPROJECT-ID\u003e --zone \u003cZONE\u003e\n  cnspec scan gcp snapshot \u003cSNAPSHOT-NAME\u003e --project-id \u003cPROJECT-ID\u003e\n\nExample for Google Container Registry:\n  cnspec scan gcp gcr \u003cPROJECT-ID\u003e\n",
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "create-snapshot",
+          "default": "false",
+          "type": 1,
+          "desc": "[gcp snapshot, gcp instance] create a new snapshot instead of using the latest available snapshot (only used for instance)"
+        },
+        {
+          "long": "credentials-path",
+          "type": 3,
+          "desc": "The path to the service account credentials to access the APIs with"
+        },
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter discovered resources, e.g., --filters storage:bucket-names=my-bucket --filters storage:exclude:bucket-names=noisy-bucket --filters propagate-project-labels=true"
+        },
+        {
+          "long": "project-id",
+          "type": 3,
+          "desc": "[gcp snapshot, gcp instance] specify the GCP project ID where the target instance is located"
+        },
+        {
+          "long": "repository",
+          "type": 3,
+          "desc": "[gcp gcr] specify the GCR repository to scan"
+        },
+        {
+          "long": "zone",
+          "type": 3,
+          "desc": "[gcp snapshot, gcp instance] specify the GCP zone where the target instance is located"
+        }
+      ],
+      "discovery": [
+        "organization",
+        "folders",
+        "instances",
+        "projects",
+        "compute-images",
+        "compute-networks",
+        "compute-subnetworks",
+        "compute-firewalls",
+        "gke-clusters",
+        "storage-buckets",
+        "bigquery-datasets",
+        "cloud-sql-mysql",
+        "cloud-sql-postgresql",
+        "cloud-sql-sqlserver",
+        "cloud-dns-zones",
+        "cloud-kms-keyrings",
+        "memorystore-redis",
+        "memorystore-rediscluster",
+        "secretmanager-secrets",
+        "pubsub-topics",
+        "pubsub-subscriptions",
+        "pubsub-snapshots",
+        "cloudrun-services",
+        "cloudrun-jobs",
+        "cloud-functions",
+        "dataproc-clusters",
+        "logging-buckets",
+        "apikeys",
+        "iam-service-accounts",
+        "alloydb-clusters",
+        "spanner-instances",
+        "firestore-databases",
+        "bigtable-instances",
+        "vertexai-endpoints",
+        "vertexai-pipelinejobs",
+        "vertexai-notebookruntimetemplates",
+        "modelarmor-templates",
+        "datastream-connectionprofiles"
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "org",
+            "organization",
+            "project",
+            "folder",
+            "gcr",
+            "snapshot",
+            "instance"
+          ],
+          "func": "ParseCLI"
+        }
+      ]
+    },
+    {
+      "name": "github",
+      "provider": "github",
+      "use": "github",
+      "short": "a GitHub organization or repository",
+      "long": "Use the github provider to query resources within GitHub organizations and repositories.\n\nAvailable commands:\n  org                       GitHub organization\n  repo                      GitHub repo\n  user                      GitHub user\n\nExamples:\n  cnspec scan github org \u003cORG_NAME\u003e --discover organization\n  cnspec scan github org \u003cORG_NAME\u003e --repos \"\u003cREPO1\u003e,\u003cREPO2\u003e\"\n  cnspec scan github repo \u003cORG_NAME\u003e/\u003cREPO_NAME\u003e\n  cnspec scan github user \u003cUSERNAME\u003e\n  cnspec shell github org \u003cORG_NAME\u003e\n  cnspec shell github repo \u003cORG_NAME\u003e/\u003cREPO_NAME\u003e\n  cnspec shell github org \u003cYOUR-GITHUB-ORG\u003e --app-id \u003cYOUR-GITHUB-APP-ID\u003e --app-installation-id \u003cYOUR-GITHUB-APP-INSTALL-ID\u003e --app-private-key \u003cPATH-TO-PEM-FILE\u003e\n\nNotes:\n  Mondoo needs a personal access token to scan a GitHub organization, public repo, or private repo. The token's level of access determines how much information Mondoo can retrieve. Supply your personal access token to Mondoo by setting the GITHUB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/github.\n\n\tIf you have very large GitHub organizations, consider giving Mondoo access using custom GitHub app credentials. To learn how, read https://mondoo.com/docs/cnspec/saas/gh-app. Provide the app's private key as a file path with --app-private-key, as inline PEM content with --app-private-key-content, or by setting the GITHUB_APP_PRIVATE_KEY environment variable.\n\n\tIf you have a GitHub Enterprise Server account, you must provide the URL for the account using the --enterprise-url flag.\n",
+      "min_args": 2,
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "app-id",
+          "type": 3,
+          "desc": "GitHub App ID"
+        },
+        {
+          "long": "app-installation-id",
+          "type": 3,
+          "desc": "GitHub App installation ID"
+        },
+        {
+          "long": "app-private-key",
+          "type": 3,
+          "desc": "GitHub App private key file path"
+        },
+        {
+          "long": "app-private-key-content",
+          "type": 3,
+          "desc": "GitHub App private key PEM content (alternative to --app-private-key; also settable via GITHUB_APP_PRIVATE_KEY)"
+        },
+        {
+          "long": "enterprise-url",
+          "type": 3,
+          "desc": "GitHub Enterprise Server URL"
+        },
+        {
+          "long": "repos",
+          "type": 3,
+          "desc": "Only include repositories matching these names"
+        },
+        {
+          "long": "repos-exclude",
+          "type": 3,
+          "desc": "Filter out repositories matching these names"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "GitHub personal access token"
+        }
+      ],
+      "discovery": [
+        "repos",
+        "users",
+        "organization",
+        "terraform",
+        "k8s-manifests",
+        "cloudformation",
+        "dockerfiles",
+        "bicep",
+        "helm",
+        "kustomize"
+      ],
+      "env": [
+        {
+          "flag": "app-private-key-content",
+          "vars": [
+            "GITHUB_APP_PRIVATE_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "GITHUB_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "org",
+            "user",
+            "repo"
+          ],
+          "func": "ParseCLI"
+        }
+      ]
+    },
+    {
+      "name": "gitlab",
+      "provider": "gitlab",
+      "use": "gitlab",
+      "short": "a GitLab group or project",
+      "long": "Use the gitlab provider to query resources within GitLab groups and projects.\n\nAvailable commands:\n  group                       GitLab group\n  project                     GitLab project\n\nExamples:\n  cnspec scan gitlab --group \u003cGROUP_NAME\u003e --token \u003cYOUR_TOKEN\u003e\n  cnspec scan gitlab --discover projects --token \u003cYOUR_TOKEN\u003e\n  cnspec scan gitlab --group \u003cGROUP_NAME\u003e --project \u003cPROJECT_NAME\u003e --token \u003cYOUR_TOKEN\u003e\n  cnspec scan gitlab --group \u003cGROUP_NAME\u003e --discover projects --token \u003cYOUR_TOKEN\u003e\n  cnspec scan gitlab --discover terraform --token \u003cYOUR_TOKEN\u003e\n  cnspec shell gitlab --group \u003cGROUP_NAME\u003e --token \u003cYOUR_TOKEN\u003e\n  cnspec shell gitlab --group \u003cGROUP_NAME\u003e --project \u003cPROJECT_NAME\u003e --token \u003cYOUR_TOKEN\u003e\n\nNotes:\n  Mondoo needs a personal access token to scan a GitLab group or project. The token's level of access determines how much information Mondoo can retrieve. Instead of providing a token with every command, you can supply your personal access token to Mondoo by setting the GITLAB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/gitlab.\n",
+      "flags": [
+        {
+          "long": "group",
+          "type": 3,
+          "option": 4,
+          "desc": "GitLab group to scan"
+        },
+        {
+          "long": "project",
+          "type": 3,
+          "desc": "GitLab project to scan"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "GitLab personal access token"
+        },
+        {
+          "long": "url",
+          "type": 3,
+          "desc": "Custom GitLab base URL (https://example.com/)"
+        }
+      ],
+      "discovery": [
+        "groups",
+        "projects",
+        "terraform",
+        "k8s-manifests",
+        "cloudformation",
+        "dockerfiles",
+        "bicep",
+        "helm",
+        "kustomize"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "GITLAB_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "google-workspace",
+      "provider": "google-workspace",
+      "use": "google-workspace [--credentials-path \u003ccredentials-path\u003e] [--customer-id \u003ccustomer-id\u003e] [--impersonated-user-email \u003cimpersonated-user-email\u003e]",
+      "short": "a Google Workspace account",
+      "long": "Use the google-workspace provider to query resources in a Google Workspace domain.\n\nExamples:\n  cnspec shell google-workspace --customer-id \u003ccustomer-id\u003e\n  cnspec shell google-workspace --credentials-path \u003ccredentials-path\u003e --customer-id \u003ccustomer-id\u003e\n  cnspec scan google-workspace --credentials-path \u003ccredentials-path\u003e --customer-id \u003ccustomer-id\u003e\n\nNote:\n\nIf you set the GOOGLE_APPLICATION_CREDENTIALS environment variable, you don't need to provide the --credentials-path flag.\n",
+      "aliases": [
+        "googleworkspace"
+      ],
+      "flags": [
+        {
+          "long": "credentials-path",
+          "type": 3,
+          "option": 4,
+          "desc": "Path to the service account credentials file (typically a JSON file) with which to access the APIs"
+        },
+        {
+          "long": "customer-id",
+          "type": 3,
+          "option": 4,
+          "desc": "Unique ID of the Google Workspace customer account"
+        },
+        {
+          "long": "impersonated-user-email",
+          "type": 3,
+          "desc": "Email address of the user to impersonate in the session (This is useful when the user executing the command does not have the necessary permissions, but can impersonate a user who does.)"
+        }
+      ]
+    },
+    {
+      "name": "grafana",
+      "provider": "grafana",
+      "use": "grafana",
+      "short": "a Grafana organization",
+      "long": "Use the grafana provider to query resources in a Grafana organization.\n\nExamples:\n  cnspec shell grafana --url https://myorg.grafana.net --token \u003capi-token\u003e\n  cnspec scan grafana --url https://myorg.grafana.net --token \u003capi-token\u003e\n\nNotes:\n  If you set the GRAFANA_TOKEN environment variable, you can omit the token flag.\n  If you set the GRAFANA_URL environment variable, you can omit the url flag.\n",
+      "flags": [
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Grafana service account token"
+        },
+        {
+          "long": "url",
+          "type": 3,
+          "desc": "Grafana instance URL (e.g., https://myorg.grafana.net)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "GRAFANA_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "url",
+          "vars": [
+            "GRAFANA_URL"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "hcp",
+      "provider": "hcp",
+      "use": "hcp",
+      "short": "a HashiCorp Cloud Platform organization",
+      "long": "Use the hcp provider to query the security posture of a HashiCorp Cloud\nPlatform (HCP) organization and the products provisioned beneath it.\n\nConnecting to an organization discovers every project and, within each\nproject, the Vault, Consul, and Boundary clusters, the Packer registry, and\nthe Waypoint applications as child assets. Scope the connection to a single\nproject with --project-id.\n\nAuthenticate with an HCP service principal (client id and client secret).\n\nExamples:\n  cnspec shell hcp --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n  cnspec shell hcp --org-id \u003corg-id\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n  cnspec shell hcp --project-id \u003cproject-id\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n\nNotes:\n  Set HCP_CLIENT_ID, HCP_CLIENT_SECRET, HCP_ORGANIZATION_ID, or\n  HCP_PROJECT_ID to omit the matching flags.\n",
+      "flags": [
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "HCP service principal client id"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "HCP service principal client secret"
+        },
+        {
+          "long": "org-id",
+          "type": 3,
+          "desc": "HCP organization id (defaults to the service principal's organization)"
+        },
+        {
+          "long": "project-id",
+          "type": 3,
+          "desc": "HCP project id for a single-project connect"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "projects",
+        "vault-clusters",
+        "consul-clusters",
+        "boundary-clusters",
+        "packer-registries",
+        "waypoint-applications"
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "HCP_CLIENT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "HCP_CLIENT_SECRET"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "org-id",
+          "vars": [
+            "HCP_ORGANIZATION_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "project-id",
+          "vars": [
+            "HCP_PROJECT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "helm",
+      "provider": "helm",
+      "use": "helm PATH",
+      "short": "a Helm chart directory or .tgz archive",
+      "long": "Use the helm provider to query Helm charts, including chart metadata, templates, values, and rendered Kubernetes resources.\n\nExamples:\n  cnspec run helm ./my-chart -c \"helm.charts { name version }\"\n  cnspec shell helm ./my-chart\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "api-versions",
+          "short": "a",
+          "type": 4,
+          "desc": "Kubernetes API versions for .Capabilities.APIVersions.Has during rendering (repeatable)"
+        },
+        {
+          "long": "is-upgrade",
+          "default": "false",
+          "type": 1,
+          "desc": "Render with .Release.IsUpgrade set instead of .Release.IsInstall"
+        },
+        {
+          "long": "kube-version",
+          "type": 3,
+          "desc": "Target Kubernetes version for .Capabilities.KubeVersion during rendering"
+        },
+        {
+          "long": "namespace",
+          "short": "n",
+          "type": 3,
+          "desc": "Release namespace used during rendering (defaults to \"default\")"
+        },
+        {
+          "long": "password",
+          "type": 3,
+          "option": 8,
+          "desc": "Password for the chart repository or OCI registry"
+        },
+        {
+          "long": "release-name",
+          "type": 3,
+          "desc": "Release name used during rendering (defaults to the chart name)"
+        },
+        {
+          "long": "repo",
+          "type": 3,
+          "desc": "Chart repository URL used to locate a chart referenced by name"
+        },
+        {
+          "long": "repository-cache",
+          "type": 3,
+          "desc": "Path to the Helm repository cache directory"
+        },
+        {
+          "long": "repository-config",
+          "type": 3,
+          "desc": "Path to the Helm repositories.yaml configuration"
+        },
+        {
+          "long": "set",
+          "type": 4,
+          "desc": "Override values on the command line (repeatable key=value, like helm --set)"
+        },
+        {
+          "long": "set-file",
+          "type": 4,
+          "desc": "Set a value from a file's contents (repeatable key=path, like helm --set-file)"
+        },
+        {
+          "long": "set-json",
+          "type": 4,
+          "desc": "Override values with JSON on the command line (repeatable key=json, like helm --set-json)"
+        },
+        {
+          "long": "set-string",
+          "type": 4,
+          "desc": "Override string values on the command line (repeatable key=value, like helm --set-string)"
+        },
+        {
+          "long": "username",
+          "type": 3,
+          "desc": "Username for the chart repository or OCI registry"
+        },
+        {
+          "long": "values",
+          "type": 4,
+          "desc": "Values files to merge into the chart's values before rendering (repeatable, like helm --values)"
+        },
+        {
+          "long": "version",
+          "type": 3,
+          "desc": "Chart version to pull when fetching a remote chart"
+        }
+      ]
+    },
+    {
+      "name": "hetzner",
+      "provider": "hetzner",
+      "use": "hetzner",
+      "short": "a Hetzner Cloud project",
+      "long": "\nUse the hetzner provider to query servers, volumes, networks, load balancers,\nand other resources in a Hetzner Cloud project.\n\nAuthenticate with a Hetzner Cloud API token:\n\n  cnspec shell hetzner --token \u003capi-token\u003e\n\nYou can also pass the token via the HCLOUD_TOKEN environment variable.\n",
+      "flags": [
+        {
+          "long": "endpoint",
+          "type": 3,
+          "desc": "Override the Hetzner Cloud API endpoint (env: HCLOUD_ENDPOINT)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Hetzner Cloud API token (env: HCLOUD_TOKEN)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "firewalls",
+        "loadbalancers"
+      ],
+      "env": [
+        {
+          "flag": "endpoint",
+          "vars": [
+            "HCLOUD_ENDPOINT"
+          ],
+          "func": "GetEndpoint",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "HCLOUD_TOKEN"
+          ],
+          "func": "GetToken",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "host",
+      "provider": "network",
+      "use": "host HOST",
+      "short": "a remote HTTP or HTTPS host",
+      "long": "Use the host provider to query remote HTTP or HTTPS hosts. \n\nExamples:\n  cnspec shell host \u003cYOUR-DOMAIN-OR-IP\u003e\n  cnspec scan host \u003cYOUR-DOMAIN-OR-IP\u003e\n\nNote:\n  If you don't provide a protocol, Mondoo assumes HTTPS.\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "follow-redirects",
+          "type": 1,
+          "desc": "Follow HTTP redirects"
+        },
+        {
+          "long": "insecure",
+          "type": 1,
+          "desc": "Disable TLS/SSL verification"
+        }
+      ]
+    },
+    {
+      "name": "huggingface",
+      "provider": "huggingface",
+      "use": "huggingface",
+      "short": "Hugging Face",
+      "long": "Use the huggingface provider to query models, datasets, and spaces on Hugging Face.\n\nExamples:\n  cnspec shell huggingface --token \u003cAPI-TOKEN\u003e\n  cnspec shell huggingface --namespace openai --namespace-type org\n  cnspec scan huggingface --namespace \u003cUSERNAME\u003e --namespace-type user\n\nNotes:\n  If you set the HF_TOKEN environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "namespace",
+          "type": 3,
+          "desc": "Target a specific user or organization namespace (e.g. openai)"
+        },
+        {
+          "long": "namespace-type",
+          "default": "user",
+          "type": 3,
+          "desc": "Type of the namespace: user or org"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Hugging Face API token (or set HF_TOKEN env var)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "HF_TOKEN"
+          ],
+          "func": "NewHuggingfaceConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "ipinfo",
+      "provider": "ipinfo",
+      "use": "ipinfo",
+      "short": "Query ipinfo.io for IP address information",
+      "long": "Use the ipinfo provider to query IP address information from ipinfo.io, including the IP address, hostname, and whether the IP address is a bogon.\n\nExamples:\n  cnspec shell ipinfo\n  cnspec run ipinfo -c \"ipinfo(ip('8.8.8.8')){*}\"\n  cnspec run ipinfo -c \"ipinfo(){*}\"  # Query your public IP\"\n  cnspec run -c \"network.interfaces.map(ips.map(_.ip)).flat.map(ipinfo(_){*})\"\n\nNotes:\n  - Pass an IP address to query information about that specific IP: ipinfo(ip(\"1.1.1.1\"))\n  - Pass no arguments (empty IP) to query your machine's public IP: ipinfo()\n  - The bogon field indicates whether the returned IP is a private, link-local, or otherwise non-routable address. When bogon is true, the returned IP is the same as the requested IP.\n  - Set IPINFO_TOKEN environment variable to use the authenticated ipinfo.io API.\n"
+    },
+    {
+      "name": "ipmi",
+      "provider": "ipmi",
+      "use": "ipmi USER@HOST",
+      "short": "an IPMI interface",
+      "long": "Use the ipmi provider to query resources using the Intelligent Platform Management Interface (IPMI).\n\nIPMI provides management and monitoring capabilities independently of the host system's CPU,\nfirmware (BIOS or UEFI), and operating system.\n\nExamples:\n  cnspec shell ipmi \u003cuser@host\u003e\n\tcnspec scan ipmi \u003cuser@host\u003e\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for IPMI connection",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "iru",
+      "provider": "iru",
+      "use": "iru",
+      "short": "an Iru tenant",
+      "long": "Use the Iru provider to query an Iru (formerly Kandji) tenant.\n\nTo access the Iru API, you need your tenant subdomain and a bearer token\nissued in the Iru admin console. The subdomain is the first label of your\ntenant API host: pass \"mondoo\" for a tenant served at\nhttps://mondoo.api.kandji.io. The token's per-endpoint permission flags\ndetermine which sub-resources will return data.\n\nExamples:\n  mql shell iru --subdomain mondoo --token \u003capi-token\u003e\n  cnspec scan iru --subdomain mondoo --token \u003capi-token\u003e\n",
+      "flags": [
+        {
+          "long": "subdomain",
+          "type": 3,
+          "desc": "Iru tenant subdomain (e.g. mondoo for https://mondoo.api.kandji.io)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "option": 8,
+          "desc": "Iru API bearer token",
+          "config": "-"
+        }
+      ],
+      "env": [
+        {
+          "flag": "subdomain",
+          "vars": [
+            "IRU_SUBDOMAIN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "IRU_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "jamf",
+      "provider": "jamf",
+      "use": "jamf",
+      "short": "a Jamf Pro account",
+      "long": "Use the Jamf provider to query a Jamf Pro instance.\n\nTo access the Jamf Pro API, you need your instance domain and API credentials.\n\nExamples:\n  mql shell jamf --client-id \u003cyour-client-id\u003e --client-secret \u003cyour-client-secret\u003e --instance-domain https://yourdomain.jamfcloud.com\n  cnspec scan jamf --client-id \u003cyour-client-id\u003e --client-secret \u003cyour-client-secret\u003e --instance-domain https://yourdomain.jamfcloud.com\n",
+      "flags": [
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Jamf Pro API client ID"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "option": 8,
+          "desc": "Jamf Pro API client secret",
+          "config": "-"
+        },
+        {
+          "long": "instance-domain",
+          "type": 3,
+          "desc": "Jamf Pro domain (e.g., https://yourdomain.jamfcloud.com)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "JAMF_CLIENT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "JAMF_CLIENT_SECRET"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "instance-domain",
+          "vars": [
+            "JAMF_INSTANCE_DOMAIN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "jumpcloud",
+      "provider": "jumpcloud",
+      "use": "jumpcloud",
+      "short": "a JumpCloud organization",
+      "long": "Use the jumpcloud provider to query the users, systems, groups, applications,\nand policies of a JumpCloud organization.\n\nAuthenticate with a JumpCloud API key. Multi-tenant (MSP) administrators also\npass the organization id the key should act on.\n\nExamples:\n  cnspec shell jumpcloud --api-key \u003capi-key\u003e\n  cnspec scan jumpcloud --api-key \u003capi-key\u003e --org-id \u003corg-id\u003e\n\nThe API key can also be supplied through the JUMPCLOUD_API_KEY environment\nvariable, and the organization id through JUMPCLOUD_ORG_ID.\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "JumpCloud API key"
+        },
+        {
+          "long": "org-id",
+          "type": 3,
+          "desc": "JumpCloud organization id (required for multi-tenant API keys)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "api-key",
+          "vars": [
+            "JUMPCLOUD_API_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "org-id",
+          "vars": [
+            "JUMPCLOUD_ORG_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "junos",
+      "provider": "junos",
+      "use": "junos",
+      "short": "a remote Junos OS device",
+      "long": "Use the junos provider to query resources on Juniper Networks Junos OS devices.\n\nExamples:\n  cnspec shell junos --hostname 192.168.1.1 --username admin --password secret\n  cnspec scan junos --hostname router.example.com -u admin --ask-pass\n  cnspec shell junos --hostname 10.0.0.1 -u admin -p secret --port 830\n  cnspec shell junos --hostname 10.0.0.1 -u admin -i ~/.ssh/id_rsa\n  cnspec scan junos --hostname 192.168.1.1 -u admin -p secret -f junos-security-policy.mql.yaml\n\nNotes:\n  The provider connects via NETCONF over SSH (default port 830).\n  Ensure NETCONF is enabled on the target device: \n\tconfigure\n\tset system services netconf ssh\n\tcommit\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the Junos OS device"
+        },
+        {
+          "long": "identity-file",
+          "short": "i",
+          "type": 3,
+          "desc": "The path to an SSH private key for authentication"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "The password for authentication"
+        },
+        {
+          "long": "port",
+          "default": "830",
+          "type": 3,
+          "desc": "The NETCONF SSH port"
+        },
+        {
+          "long": "username",
+          "short": "u",
+          "default": "admin",
+          "type": 3,
+          "desc": "The username for authentication"
+        }
+      ]
+    },
+    {
+      "name": "k8s",
+      "provider": "k8s",
+      "use": "k8s (optional MANIFEST path)",
+      "short": "a Kubernetes cluster or local manifest file(s)",
+      "long": "Use the k8s provider to query Kubernetes resources, including clusters, pods, services, containers, manifests, and more.\n\nRequirement:\n  To query or scan a Kubernetes cluster, you must install kubectl on your workstation. To learn how, read https://kubernetes.io/docs/tasks/tools/. \n\nExamples:\n  cnspec shell k8s\n  cnspec scan k8s\n  cnspec scan k8s \u003cMANIFEST-FILE\u003e\n",
+      "aliases": [
+        "kubernetes"
+      ],
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "container-proxy",
+          "type": 3,
+          "desc": "HTTP proxy to use for container pulls"
+        },
+        {
+          "long": "context",
+          "type": 3,
+          "desc": "Target a specific Kubernetes context from your kubeconfig"
+        },
+        {
+          "long": "images",
+          "type": 3,
+          "desc": "Only include container images matching the given image references during discovery (comma-separated, glob supported)"
+        },
+        {
+          "long": "images-exclude",
+          "type": 3,
+          "desc": "Filter out container images matching the given image references during discovery (comma-separated, glob supported)"
+        },
+        {
+          "long": "kubelogin",
+          "default": "false",
+          "type": 1,
+          "desc": "Authenticate against a remote Azure AD enabled Kubernetes cluster using an Azure identity."
+        },
+        {
+          "long": "namespace-label-selector",
+          "type": 3,
+          "desc": "Only include Kubernetes namespaces matching the label selector, along with all objects discovered within those namespaces"
+        },
+        {
+          "long": "namespaces",
+          "type": 3,
+          "desc": "Only include Kubernetes objects in the matching namespaces"
+        },
+        {
+          "long": "namespaces-exclude",
+          "type": 3,
+          "desc": "Filter out Kubernetes objects in the matching namespaces"
+        },
+        {
+          "long": "object-label-selector",
+          "type": 3,
+          "desc": "Only include Kubernetes objects matching the label selector; for container image discovery this matches the pod that references the image"
+        }
+      ],
+      "discovery": [
+        "admissionreviews",
+        "clusters",
+        "container-images",
+        "cronjobs",
+        "daemonsets",
+        "deployments",
+        "ingresses",
+        "jobs",
+        "namespaces",
+        "pods",
+        "replicasets",
+        "services",
+        "statefulsets"
+      ]
+    },
+    {
+      "name": "keycloak",
+      "provider": "keycloak",
+      "use": "keycloak",
+      "short": "a Keycloak server",
+      "long": "Use the keycloak provider to query the realms, clients, roles, groups, users, identity providers and authentication flows of a Keycloak server.\n\nThere are two ways to authenticate. An admin user signs in with the password\ngrant against the admin-cli client, which is the quickest way to try the\nprovider. A service account on a confidential client uses the client credentials\ngrant and holds only the roles it was granted, so it can be limited to the view\nroles of one realm.\n\nA service account needs the realm-management view roles (view-realm, view-users,\nview-clients, view-identity-providers and view-authorization) on every realm it\nreads. Reading every realm of a server needs the view-realm role of the\nmaster realm's realm-management client instead.\n\nExamples:\n  mql shell keycloak --url https://keycloak.example.com --username admin --password \u003cpassword\u003e\n  mql shell keycloak --url https://keycloak.example.com --realm production --client-id mondoo-scanner --client-secret \u003csecret\u003e\n  mql scan keycloak --url https://keycloak.example.com --username admin --password \u003cpassword\u003e --discover realms\n\nNotes:\n  KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET,\n  KEYCLOAK_USERNAME and KEYCLOAK_PASSWORD supply the same values as the flags.\n  A server installed under a context path keeps that path in the URL, for\n  example https://keycloak.example.com/auth.\n",
+      "flags": [
+        {
+          "long": "auth-realm",
+          "type": 3,
+          "desc": "Realm the token is requested from (defaults to master for a user, or the scanned realm for a service account)"
+        },
+        {
+          "long": "ca-cert",
+          "type": 3,
+          "desc": "Certificate authority to trust for the server certificate, either the PEM itself or a path to it"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Client the token is requested for (defaults to admin-cli for a user)"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Secret of a confidential client, which selects service account authentication"
+        },
+        {
+          "long": "password",
+          "type": 3,
+          "desc": "Password of the admin user"
+        },
+        {
+          "long": "realm",
+          "type": 3,
+          "desc": "Scope the scan to a single realm instead of every realm the credentials can read"
+        },
+        {
+          "long": "url",
+          "type": 3,
+          "desc": "Base URL of the Keycloak server, for example https://keycloak.example.com"
+        },
+        {
+          "long": "username",
+          "type": 3,
+          "desc": "Admin user to authenticate as, which selects password authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "realms"
+      ],
+      "env": [
+        {
+          "flag": "auth-realm",
+          "vars": [
+            "KEYCLOAK_AUTH_REALM"
+          ],
+          "func": "NewKeycloakConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "ca-cert",
+          "vars": [
+            "KEYCLOAK_CA_CERT"
+          ],
+          "func": "CACertificate",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "client-id",
+          "vars": [
+            "KEYCLOAK_CLIENT_ID"
+          ],
+          "func": "NewKeycloakConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "KEYCLOAK_CLIENT_SECRET"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "password",
+          "vars": [
+            "KEYCLOAK_PASSWORD"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "url",
+          "vars": [
+            "KEYCLOAK_URL"
+          ],
+          "func": "NewKeycloakConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "username",
+          "vars": [
+            "KEYCLOAK_USERNAME"
+          ],
+          "func": "NewKeycloakConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "kustomize",
+      "provider": "kustomize",
+      "use": "kustomize PATH",
+      "short": "a Kustomize overlay directory",
+      "long": "Use the kustomize provider to query Kustomize overlays, including patches, generators, image overrides, and rendered Kubernetes resources.\n\nExamples:\n  mql run kustomize ./overlays/production -c \"kustomize.kustomizations { path namespace }\"\n  mql shell kustomize ./overlays/production\n",
+      "min_args": 1,
+      "max_args": 1
+    },
+    {
+      "name": "local",
+      "provider": "os",
+      "use": "local",
+      "short": "your local system",
+      "long": "Use the local provider to query your local system. This is the default provider. There's no need to specify local in a command.  \n\nExamples:\n  cnspec shell\n  cnspec scan\n  cnspec scan -o json \u003e FILENAME.json\n",
+      "flags": [
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "sudo",
+          "default": "false",
+          "type": 1,
+          "desc": "Elevate privileges with sudo",
+          "config": "sudo.active"
+        }
+      ],
+      "discovery": [
+        "container",
+        "container-images",
+        "mcp-servers"
+      ]
+    },
+    {
+      "name": "mcp",
+      "provider": "ai",
+      "use": "mcp \u003chttp|https|stdio\u003e \u003ctarget\u003e",
+      "short": "a Model Context Protocol (MCP) server",
+      "long": "Connect to a Model Context Protocol (MCP) server.\n\nTakes two arguments: the transport (http, https, or stdio) and the target.\n\nstdio: the target is a command. The server is started for you and stopped when the\nsession ends, so it does not need to be running beforehand. Pass the whole command\nas one quoted argument. The command runs with a minimal environment (PATH, HOME,\nand similar) — your shell's other variables, including cloud credentials and\ntokens, are NOT passed through. Give the server anything it needs, including\nsecrets, explicitly with --env.\n\nhttp/https: the target is the server URL. Authenticate with --token or the\nMCP_TOKEN environment variable.\n\nExamples:\n  cnspec shell mcp http http://localhost:8080/mcp\n  cnspec shell mcp https https://api.example.com/mcp --token \"$MY_TOKEN\"\n  cnspec shell mcp stdio \"npx mcp-remote http://localhost:8080/mcp\"\n  cnspec shell mcp stdio \"npx -y @modelcontextprotocol/server-github\" --env GITHUB_TOKEN=ghp_...\n",
+      "min_args": 2,
+      "flags": [
+        {
+          "long": "cwd",
+          "type": 3,
+          "desc": "Working directory for a stdio server (defaults to the current directory)"
+        },
+        {
+          "long": "env",
+          "type": 4,
+          "desc": "Environment variable KEY=VALUE to pass to a stdio server (repeatable)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Bearer token for authenticating to an HTTP(S) MCP server (or set MCP_TOKEN)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "MCP_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ],
+      "gaps": [
+        {
+          "kind": "no-positional-vocabulary",
+          "detail": "takes 2 arguments but no literal comparison against them was found, so the words it accepts are documented only in its help text"
+        }
+      ]
+    },
+    {
+      "name": "mikrotik",
+      "provider": "mikrotik",
+      "use": "mikrotik user@host [flags]",
+      "short": "a MikroTik RouterOS device",
+      "long": "Use the mikrotik provider to query MikroTik RouterOS devices through the\nRouterOS API.\n\nExamples:\n  cnspec scan mikrotik admin@192.168.88.1 --password 'secret'\n  cnspec scan mikrotik admin@192.168.88.1 --tls --ask-pass\n  cnspec shell mikrotik admin@router.example.com --port 8728 --password 'secret'\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (used with --tls)",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "desc": "Password for the RouterOS user"
+        },
+        {
+          "long": "port",
+          "type": 3,
+          "desc": "RouterOS API port (default 8728, or 8729 with --tls)"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect using the RouterOS API-SSL service",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "mistral",
+      "provider": "mistral",
+      "use": "mistral",
+      "short": "a Mistral AI workspace",
+      "long": "Use the mistral provider to query models, fine-tuning jobs, uploaded\nfiles, and batch inference jobs in a Mistral AI workspace.\n\nImportant: Mistral AI API keys are scoped to a single workspace. To scan\nall workspaces in an organization, add each workspace as a separate asset\nwith its own API key.\n\nExamples:\n  mql shell mistral --token \u003capi-key\u003e\n  mql shell mistral --token \u003capi-key\u003e --workspace my-workspace\n  mql shell mistral   # uses MISTRAL_API_KEY or MISTRAL_KEY env var\n\nNotes:\n  The provider queries the Mistral AI REST API at https://api.mistral.ai/v1.\n  An API key is required; generate one at https://console.mistral.ai/api-keys.\n",
+      "flags": [
+        {
+          "long": "base-url",
+          "type": 3,
+          "desc": "API base URL (default: https://api.mistral.ai)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Mistral AI API key (or set MISTRAL_API_KEY env var)"
+        },
+        {
+          "long": "workspace",
+          "type": 3,
+          "desc": "Workspace name for asset identification (API keys are workspace-scoped)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "MISTRAL_API_KEY",
+            "MISTRAL_KEY"
+          ],
+          "func": "NewMistralConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "mock",
+      "provider": "mock",
+      "use": "mock",
+      "short": "a recording file without an active connection"
+    },
+    {
+      "name": "mondoo",
+      "provider": "mondoo",
+      "use": "mondoo",
+      "short": "Mondoo Platform",
+      "long": "Use the mondoo provider to query resources in Mondoo Platform.\n\nTo query Mondoo Platform from a workstation, the workstation must be registered with Mondoo Platform. To learn how to register a workstation, read https://mondoo.com/docs/cnspec/install/registration. \n\nExamples:\n  cnspec shell mondoo\n\tcnspec scan mondoo\n",
+      "max_args": 4
+    },
+    {
+      "name": "mongo",
+      "provider": "mongo",
+      "use": "mongo [host]",
+      "short": "a self-hosted MongoDB server",
+      "long": "Use the mongo provider to query a self-hosted MongoDB server.\n\nThe provider connects to a MongoDB server and runs read-only admin commands\n(buildInfo, getCmdLineOpts, getParameter, usersInfo, rolesInfo) to inventory\nthe server's configuration, users, roles, and databases so you can audit its\nsecurity posture (the CIS MongoDB benchmark).\n\nFor MongoDB Atlas (the managed service), use the mongodbatlas provider instead.\n\nExamples:\n  cnspec shell mongo db.contoso.com --user admin --ask-pass\n  cnspec scan mongo mongodb://admin@db.contoso.com:27017 --ask-pass\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "auth-db",
+          "default": "admin",
+          "type": 3,
+          "desc": "Authentication database (default admin)"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "MongoDB hostname or IP address (or a mongodb:// connection string)"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "27017",
+          "type": 2,
+          "desc": "MongoDB TCP port"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate validation"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User to authenticate as"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "instance",
+        "databases",
+        "none"
+      ]
+    },
+    {
+      "name": "mongodbatlas",
+      "provider": "mongodbatlas",
+      "use": "mongodbatlas",
+      "short": "a MongoDB Atlas organization or project",
+      "long": "Use the mongodbatlas provider to query the security posture of a MongoDB Atlas\norganization and its projects.\n\nConnecting to an organization discovers every project as a child asset. You can\nalso scope the connection to a single project with --project-id.\n\nAuthenticate with a programmatic API key (public/private) or a service account\n(client id/secret).\n\nExamples:\n  cnspec shell mongodbatlas --org-id \u003corg-id\u003e --public-key \u003cpublic\u003e --private-key \u003cprivate\u003e\n  cnspec shell mongodbatlas --project-id \u003cproject-id\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n\nNotes:\n  Set MONGODB_ATLAS_ORG_ID, MONGODB_ATLAS_PUBLIC_KEY, MONGODB_ATLAS_PRIVATE_KEY,\n  MONGODB_ATLAS_CLIENT_ID, or MONGODB_ATLAS_CLIENT_SECRET to omit the matching\n  flags.\n",
+      "flags": [
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Service account OAuth client id"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Service account OAuth client secret"
+        },
+        {
+          "long": "org-id",
+          "type": 3,
+          "desc": "MongoDB Atlas organization id (connects to the org and discovers projects)"
+        },
+        {
+          "long": "private-key",
+          "type": 3,
+          "desc": "Programmatic API key private key"
+        },
+        {
+          "long": "project-id",
+          "type": 3,
+          "desc": "MongoDB Atlas project id for a single-project connect"
+        },
+        {
+          "long": "public-key",
+          "type": 3,
+          "desc": "Programmatic API key public key"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "projects"
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "MONGODB_ATLAS_CLIENT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "MONGODB_ATLAS_CLIENT_SECRET"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "org-id",
+          "vars": [
+            "MONGODB_ATLAS_ORG_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "private-key",
+          "vars": [
+            "MONGODB_ATLAS_PRIVATE_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "project-id",
+          "vars": [
+            "MONGODB_ATLAS_PROJECT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "public-key",
+          "vars": [
+            "MONGODB_ATLAS_PUBLIC_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "ms365",
+      "provider": "ms365",
+      "use": "ms365",
+      "short": "a Microsoft 365 tenant",
+      "long": "Use the ms365 provider to query resources within Microsoft 365, including organizations, users, roles, SharePoint sites, and more.\n\nExamples:\n  cnspec shell ms365 --certificate-path \u003cPATH-TO-YOUR-PEM\u003e --tenant-id \u003cYOUR-TENANT-ID\u003e --client-id \u003cYOUR-CLIENT-ID\u003e\n  cnspec scan ms365 --certificate-path \u003cPATH-TO-YOUR-PEM\u003e --tenant-id \u003cYOUR-TENANT-ID\u003e --client-id \u003cYOUR-CLIENT-ID\u003e\n\nNotes:\n  If you give cnspec access through the Microsoft 365 API, you can omit the certificate-path, tenant-id, and client-id flags. To learn how, read https://mondoo.com/docs/cnspec/saas/m365#give-cnspec-access.\n",
+      "aliases": [
+        "m365"
+      ],
+      "max_args": 5,
+      "flags": [
+        {
+          "long": "auth-method",
+          "type": 3,
+          "desc": "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, workload-identity, managed-identity (default: try all, in that order)"
+        },
+        {
+          "long": "certificate-path",
+          "type": 3,
+          "desc": "Path (in PKCS #12/PFX or PEM format) to the authentication certificate"
+        },
+        {
+          "long": "certificate-secret",
+          "type": 3,
+          "desc": "Passphrase for the authentication certificate file"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Application (client) ID of the service principal"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Secret for the application"
+        },
+        {
+          "long": "organization",
+          "type": 3,
+          "desc": "Organization to scan"
+        },
+        {
+          "long": "sharepoint-url",
+          "type": 3,
+          "desc": "Sharepoint URL to scan"
+        },
+        {
+          "long": "tenant-id",
+          "type": 3,
+          "desc": "Directory (tenant) ID of the service principal"
+        }
+      ]
+    },
+    {
+      "name": "mssql",
+      "provider": "mssql",
+      "use": "mssql [host]",
+      "short": "a Microsoft SQL Server instance",
+      "long": "Use the mssql provider to query a Microsoft SQL Server instance.\n\nThe provider connects to a SQL Server instance over TDS and runs read-only\ncatalog queries (sys.* and msdb.*) to inventory server principals, databases,\npermissions, credentials, linked servers, audit settings, and encryption keys.\n\nAuthentication supports SQL logins, Windows (NTLM) integrated auth, and\nMicrosoft Entra ID (Azure AD) access tokens. By default the provider discovers\nevery online database on the instance as its own asset.\n\nExamples:\n  cnspec shell mssql sql.contoso.com --user sa --ask-pass\n  cnspec scan mssql sql.contoso.com --instance SQL2022 --auth windows --user 'CONTOSO\\audit' --ask-pass\n  cnspec scan mssql sql.contoso.com --auth azure --user audit@contoso.com --token \u003caccess-token\u003e\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "auth",
+          "default": "sql",
+          "type": 3,
+          "desc": "Authentication mode: sql, windows, kerberos, or azure",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "type": 3,
+          "desc": "Scope the connection to a single database"
+        },
+        {
+          "long": "encrypt",
+          "default": "mandatory",
+          "type": 3,
+          "desc": "TDS encryption mode: strict, mandatory, optional, or disable"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "SQL Server hostname or IP address"
+        },
+        {
+          "long": "instance",
+          "type": 3,
+          "desc": "Named instance (resolved via SQL Browser when the port is unknown)"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "1433",
+          "type": 2,
+          "desc": "SQL Server TCP port"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "option": 8,
+          "desc": "Access token for Microsoft Entra ID (Azure AD) authentication",
+          "config": "-"
+        },
+        {
+          "long": "trust-server-certificate",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate validation for the server"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "Login name (SQL login, DOMAIN\\user, or user principal name)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "instance",
+        "databases",
+        "none"
+      ]
+    },
+    {
+      "name": "mysqldb",
+      "provider": "mysqldb",
+      "use": "mysqldb [host]",
+      "short": "a MySQL or MariaDB server",
+      "long": "Use the mysqldb provider to query a MySQL, MariaDB, or Percona server.\n\nThe provider connects to the server and runs read-only queries against\ninformation_schema, performance_schema, and the system catalogs to inventory\nusers, roles, privileges, schemas, routines, plugins, components, and\nconfiguration variables.\n\nBy default the provider discovers every schema on the server as its own asset.\n\nExamples:\n  cnspec shell mysqldb db.contoso.com --user root --ask-pass\n  cnspec scan mysqldb db.contoso.com --tls-mode true --tls-ca ca.pem\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "type": 3,
+          "desc": "Default schema to connect to (optional)"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "MySQL/MariaDB hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "3306",
+          "type": 2,
+          "desc": "MySQL/MariaDB TCP port"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-cert",
+          "type": 3,
+          "desc": "Path to the client certificate for TLS client authentication"
+        },
+        {
+          "long": "tls-key",
+          "type": 3,
+          "desc": "Path to the client private key for TLS client authentication"
+        },
+        {
+          "long": "tls-mode",
+          "default": "preferred",
+          "type": 3,
+          "desc": "TLS mode: false, skip-verify, preferred, or true"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User name to authenticate as"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "instance",
+        "databases",
+        "none"
+      ]
+    },
+    {
+      "name": "nd-ssh",
+      "provider": "networkdevices",
+      "use": "nd-ssh user@host",
+      "short": "a remote network device via SSH",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-enable-password",
+          "default": "false",
+          "type": 1,
+          "option": 24,
+          "desc": "Prompt for enable password",
+          "config": "-"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "enable-password",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the password, required for privileged exec commands on the network device.",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for SSH",
+          "config": "-"
+        },
+        {
+          "long": "private-key-passphrase",
+          "type": 3,
+          "desc": "Passphrase for the private key file",
+          "config": "-"
+        },
+        {
+          "long": "private-key-path",
+          "type": 3,
+          "desc": "Path to the private key file for SSH",
+          "config": "-"
+        },
+        {
+          "long": "store-commands",
+          "type": 1,
+          "desc": "Indicates whether to store all commands that have been ran on the networkdevices in a file. This flag is usually used to collect information for debugging purposes. Note that all commands output is stored.",
+          "config": "-"
+        },
+        {
+          "long": "system-transport-args",
+          "type": 4,
+          "desc": "A list of arguments to pass to the system open command, e.g. -oHostKeyAlgorithms=+ssh-dss",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "neon",
+      "provider": "neon",
+      "use": "neon",
+      "short": "a Neon organization or account",
+      "long": "Use the neon provider to query the configuration and security posture of your Neon organizations, projects, and branches.\n\nThe token is a Neon API key, created under Account settings \u003e API keys. A\npersonal key reaches the projects your account owns; an organization key\nreaches that organization's projects and its member roster.\n\nExamples:\n  cnspec shell neon --token \u003capi_key\u003e\n  cnspec scan neon --token \u003capi_key\u003e\n  cnspec scan neon --token \u003capi_key\u003e --organization \u003corg_id\u003e\n\nNotes:\n  If you set the NEON_API_KEY environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "organization",
+          "type": 3,
+          "desc": "Scope the scan to a single Neon organization (ID)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Neon API key for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "organizations",
+        "projects"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "NEON_API_KEY",
+            "NEON_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "netlify",
+      "provider": "netlify",
+      "use": "netlify",
+      "short": "a Netlify account",
+      "long": "Use the netlify provider to query the configuration and security posture of your Netlify accounts and sites.\n\nThe token is a Netlify personal access token, created under User settings \u003e\nApplications \u003e Personal access tokens. The token inherits your account roles,\nso a token issued by a member rather than an owner sees a narrower resource\ntree.\n\nExamples:\n  cnspec shell netlify --token \u003caccess_token\u003e\n  cnspec scan netlify --token \u003caccess_token\u003e\n  cnspec scan netlify --token \u003caccess_token\u003e --account \u003caccount_slug\u003e\n\nNotes:\n  If you set the NETLIFY_AUTH_TOKEN environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "account",
+          "type": 3,
+          "desc": "Scope the scan to a single Netlify account (slug or ID)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Netlify personal access token for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "accounts",
+        "sites"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "NETLIFY_AUTH_TOKEN",
+            "NETLIFY_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "networkdiscovery",
+      "provider": "networkdiscovery",
+      "use": "networkdiscovery DOMAIN_NAME",
+      "short": "Discover subdomains for a given domain.",
+      "long": "Use the networkdiscovery provider to discover subdomains for a given FQDN.\nThis provider is often used implicitly via the host provider, but can be invoked directly for discovery.\n\nExample:\n  cnspec scan networkdiscovery mondoohq.com --discover subdomains\n",
+      "min_args": 1,
+      "max_args": 1,
+      "discovery": [
+        "subdomains",
+        "all",
+        "auto"
+      ]
+    },
+    {
+      "name": "nextdns",
+      "provider": "nextdns",
+      "use": "nextdns",
+      "short": "a NextDNS account",
+      "long": "Use the nextdns provider to query resources in your NextDNS account, including profiles and their security, privacy, and parental-control configuration.\n\nExamples:\n  cnspec shell nextdns --api-key \u003capi_key\u003e\n  cnspec scan nextdns --api-key \u003capi_key\u003e\n\nNotes:\n  If you set the NEXTDNS_API_KEY environment variable, you can omit the api-key flag.\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "NextDNS API key for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "accounts",
+        "profiles"
+      ],
+      "env": [
+        {
+          "flag": "api-key",
+          "vars": [
+            "NEXTDNS_API_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "nmap",
+      "provider": "nmap",
+      "use": "nmap",
+      "short": "a Nmap network scanner",
+      "long": "Use the nmap provider to query network information using the Nmap network scanner, including open ports, services, and host information.\n\nRequirement:\n  Nmap must be installed on your system. To learn how, read https://nmap.org/download.html.\n\nAvailable sub-commands:\n  host \u003cTARGET\u003e             Scan a single host by IP address or hostname\n  domain \u003cTARGET\u003e           Scan a domain and the hosts behind it\n\nExamples:\n  cnspec shell nmap host 192.168.1.1\n  cnspec shell nmap domain example.com\n  cnspec shell nmap --networks 10.0.0.0/8,192.168.0.0/16\n  cnspec shell nmap --networks \"192.168.1.0/24\" --discover hosts\n  cnspec scan nmap host 192.168.1.1\n  cnspec scan nmap domain example.com\n  cnspec shell nmap host 192.168.1.1 --ports 22,80,443\n",
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "networks",
+          "type": 4,
+          "desc": "Comma-separated list of networks to scan (e.g., 10.0.0.0/8,192.168.0.0/16)"
+        },
+        {
+          "long": "ports",
+          "type": 3,
+          "desc": "Ports to scan (e.g., 22,80,443 or 1-1024)"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "hosts"
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "host",
+            "domain"
+          ],
+          "func": "ParseCLI"
+        }
+      ]
+    },
+    {
+      "name": "nutanix",
+      "provider": "nutanix",
+      "use": "nutanix --endpoint ENDPOINT [flags]",
+      "short": "a Nutanix Prism Central instance",
+      "long": "Use the nutanix provider to query Nutanix clusters, hosts, and virtual\nmachines through a Prism Central instance.\n\nAuthenticate with either basic auth (username and password) or an IAM API key.\n\nExamples:\n  cnspec scan nutanix --endpoint pc.example.com --user admin --ask-pass\n  cnspec scan nutanix --endpoint pc.example.com --user admin --password PASSWORD --insecure\n  cnspec scan nutanix --endpoint pc.example.com --api-key API_KEY\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "option": 8,
+          "desc": "IAM API key for service-account authentication",
+          "config": "-"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "endpoint",
+          "type": 3,
+          "option": 4,
+          "desc": "Prism Central host: IP address or FQDN"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Password for basic authentication",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "9440",
+          "type": 2,
+          "desc": "Prism Central API port"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "Username for basic authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "clusters",
+        "nodes"
+      ]
+    },
+    {
+      "name": "oci",
+      "provider": "oci",
+      "use": "oci",
+      "short": "an Oracle Cloud Infrastructure tenancy",
+      "long": "Use the oci provider to query resources in an Oracle Cloud Infrastructure tenancy, including compute instances, networks, storage, and identity resources.\n\nExamples:\n  cnspec shell oci --tenancy \u003ctenancy_ocid\u003e --user \u003cuser_ocid\u003e --region \u003cregion\u003e --key-path \u003cpath_to_private_key\u003e --fingerprint \u003ckey_fingerprint\u003e\n  cnspec scan oci --tenancy \u003ctenancy_ocid\u003e --user \u003cuser_ocid\u003e --region \u003cregion\u003e --key-path \u003cpath_to_private_key\u003e --fingerprint \u003ckey_fingerprint\u003e\n  cnspec shell oci --profile MYPROFILE\n  cnspec shell oci --config-file /path/to/config --profile MYPROFILE\n  cnspec scan oci --auth-method instance-principal\n  cnspec scan oci --auth-method workload-identity\n",
+      "flags": [
+        {
+          "long": "auth-method",
+          "type": 3,
+          "desc": "Authentication method: api-key (default), instance-principal, resource-principal, workload-identity, or security-token"
+        },
+        {
+          "long": "config-file",
+          "type": 3,
+          "desc": "Path to OCI config file (default: ~/.oci/config)"
+        },
+        {
+          "long": "filters",
+          "type": 5,
+          "desc": "Filter options, e.g., --filters regions=us-ashburn-1,us-phoenix-1 --filters compartments=production --filters exclude:compartments=sandbox --filters tag:env=prod --filters tag:Operations.CostCenter=42 --filters exclude:tag:env=dev"
+        },
+        {
+          "long": "fingerprint",
+          "type": 3,
+          "desc": "The fingerprint of the private key"
+        },
+        {
+          "long": "key-path",
+          "type": 3,
+          "desc": "Path to the private key file for API key authentication"
+        },
+        {
+          "long": "key-secret",
+          "type": 3,
+          "desc": "Passphrase for the private key file, if encrypted"
+        },
+        {
+          "long": "profile",
+          "type": 3,
+          "desc": "OCI config profile name (e.g., DEFAULT)"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "The OCI region to connect to (e.g., us-ashburn-1)"
+        },
+        {
+          "long": "tenancy",
+          "type": 3,
+          "desc": "The tenancy's OCID"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "The user's OCID"
+        }
+      ],
+      "discovery": [
+        "tenancy",
+        "network-securitylists",
+        "identity-users",
+        "identity-policies",
+        "objectstorage-buckets",
+        "apigateway-deployments",
+        "loadbalancer-loadbalancers",
+        "redis-clusters",
+        "vault-secrets",
+        "oke-clusters",
+        "generativeai-endpoints"
+      ]
+    },
+    {
+      "name": "okta",
+      "provider": "okta",
+      "use": "okta",
+      "short": "an Okta organization",
+      "long": "Use the okta provider to query resources in an Okta organization.\n\nTo query an Okta organization, you need the organization's domain and credentials to access that domain. To learn how, read https://mondoo.com/docs/cnspec/identity/okta.\n\nThere are two ways to authenticate. An API token is the simplest, but it inherits the privileges of the admin who created it. A service application authenticates with a private key JWT and holds only the scopes it was granted, so it can be limited to read-only access.\n\nExamples:\n  cnspec shell okta -organization \u003cokta-domain\u003e -token \u003capi-token\u003e\n\tcnspec scan okta -organization \u003cokta-domain\u003e -token \u003capi-token\u003e\n\tcnspec scan okta -organization \u003cokta-domain\u003e -client-id \u003cclient-id\u003e -private-key \u003cpem-or-path\u003e -private-key-id \u003ckey-id\u003e -scopes okta.users.read,okta.groups.read\n",
+      "flags": [
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Client ID of the Okta service app to authenticate as"
+        },
+        {
+          "long": "organization",
+          "type": 3,
+          "desc": "The domain of the Okta organization to scan"
+        },
+        {
+          "long": "private-key",
+          "type": 3,
+          "desc": "Private key of the Okta service app, either the PEM itself or a path to it"
+        },
+        {
+          "long": "private-key-id",
+          "type": 3,
+          "desc": "ID of the public key registered with the Okta service app"
+        },
+        {
+          "long": "scopes",
+          "type": 3,
+          "desc": "Okta API scopes to request for the service app, separated by commas"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Access token for the Okta organization"
+        }
+      ],
+      "env": [
+        {
+          "flag": "client-id",
+          "vars": [
+            "OKTA_API_CLIENT_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "organization",
+          "vars": [
+            "OKTA_ORG_NAME",
+            "OKTA_BASE_URL"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true,
+          "composed": true
+        },
+        {
+          "flag": "private-key",
+          "vars": [
+            "OKTA_API_PRIVATE_KEY"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "private-key-id",
+          "vars": [
+            "OKTA_API_PRIVATE_KEY_ID"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "scopes",
+          "vars": [
+            "OKTA_API_SCOPES"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "OKTA_API_TOKEN",
+            "OKTA_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "ollama",
+      "provider": "ollama",
+      "use": "ollama",
+      "short": "an Ollama instance",
+      "long": "Use the ollama provider to query the models and configuration of an Ollama instance.\n\nExamples:\n  cnspec shell ollama\n  cnspec shell ollama --host http://\u003cHOST\u003e:11434\n  cnspec scan ollama --token \u003cAPI-TOKEN\u003e\n\nNotes:\n  Without the host flag, Ollama is queried at http://localhost:11434. You can also set\n  the OLLAMA_HOST environment variable. Use the token flag, or OLLAMA_API_TOKEN, to\n  authenticate against a cloud-hosted Ollama instance.\n",
+      "flags": [
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Ollama host address (or set OLLAMA_HOST env var, default: http://localhost:11434)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Ollama API token for cloud authentication (or set OLLAMA_API_TOKEN env var)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "host",
+          "vars": [
+            "OLLAMA_HOST"
+          ],
+          "func": "NewOllamaConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "OLLAMA_API_TOKEN"
+          ],
+          "func": "NewOllamaConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "opcua",
+      "provider": "opcua",
+      "use": "opcua [--endpoint \u003cendpoint\u003e]",
+      "short": "an OPC UA device",
+      "long": "Use the opcua provider to query resources on an Open Platform Communications Unified Architecture (OPC UA) server or device. OPC UA is a protocol for machine-to-machine communication in industrial automation.\n\nExamples:\n  cnspec shell opcua --endpoint opc.tcp://\u003chost\u003e:\u003cport\u003e\n  cnspec scan opcua --endpoint opc.tcp://\u003chost\u003e:\u003cport\u003e\n",
+      "flags": [
+        {
+          "long": "endpoint",
+          "type": 3,
+          "option": 4,
+          "desc": "OPC UA endpoint URL of the OPC UA server in the format opc.tcp://\u003chost\u003e:\u003cport\u003e"
+        }
+      ]
+    },
+    {
+      "name": "openai",
+      "provider": "openai",
+      "use": "openai",
+      "short": "an OpenAI account",
+      "long": "Use the openai provider to query project, organization, and API key configuration\nin an OpenAI account.\n\nExamples:\n  cnspec shell openai --token \u003cAPI-KEY\u003e\n  cnspec scan openai --token \u003cADMIN-API-KEY\u003e --organization \u003cORG-ID\u003e\n  cnspec scan openai --project \u003cPROJECT-ID\u003e\n\nNotes:\n  If you set the OPENAI_API_KEY environment variable, you can omit the token flag. Both\n  project keys (sk-proj-...) and admin keys (sk-admin-...) are accepted and detected\n  automatically; organization resources require an admin key.\n",
+      "flags": [
+        {
+          "long": "base-url",
+          "type": 3,
+          "desc": "OpenAI API base URL for custom endpoints (or set OPENAI_BASE_URL env var)"
+        },
+        {
+          "long": "organization",
+          "type": 3,
+          "desc": "OpenAI organization ID (or set OPENAI_ORG_ID env var)"
+        },
+        {
+          "long": "project",
+          "type": 3,
+          "desc": "OpenAI project ID (or set OPENAI_PROJECT_ID env var)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "OpenAI API key — project key (sk-proj-...) or admin key (sk-admin-...), auto-detected"
+        }
+      ],
+      "env": [
+        {
+          "flag": "base-url",
+          "vars": [
+            "OPENAI_BASE_URL"
+          ],
+          "func": "NewOpenaiConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "organization",
+          "vars": [
+            "OPENAI_ORG_ID"
+          ],
+          "func": "NewOpenaiConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "project",
+          "vars": [
+            "OPENAI_PROJECT_ID"
+          ],
+          "func": "NewOpenaiConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "OPENAI_API_KEY"
+          ],
+          "func": "NewOpenaiConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "opensearch",
+      "provider": "opensearch",
+      "use": "opensearch [host]",
+      "short": "an OpenSearch cluster",
+      "long": "Use the opensearch provider to query an OpenSearch cluster.\n\nThe provider connects to the cluster's REST API and runs read-only requests to\ninventory the cluster version and health, its security posture, and its\ninternal users, roles, and role mappings, so you can audit the cluster's\nsecurity posture.\n\nExamples:\n  cnspec shell opensearch localhost --user admin --ask-pass --tls-insecure\n  cnspec scan opensearch os.contoso.com --user auditor --ask-pass --tls-ca ca.pem\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "OpenSearch hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "9200",
+          "type": 2,
+          "desc": "OpenSearch REST API port"
+        },
+        {
+          "long": "scheme",
+          "default": "https",
+          "type": 3,
+          "desc": "Connection scheme: http or https"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (for the default self-signed demo certificate)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User name for basic authentication"
+        }
+      ]
+    },
+    {
+      "name": "openstack",
+      "provider": "openstack",
+      "use": "openstack",
+      "short": "an OpenStack project",
+      "long": "\nUse the openstack provider to query Keystone, Nova, and Neutron resources\nin an OpenStack project.\n\nAuthentication options (in priority order):\n  1. CLI flags (--auth-url, --username, --password, --project-name, ...)\n  2. --cloud \u003cname\u003e to select a clouds.yaml entry\n  3. OS_* environment variables\n\nApplication credentials are also supported via --application-credential-id\nand --application-credential-secret.\n\nExamples:\n  cnspec shell openstack --cloud \u003cCLOUDS-YAML-ENTRY\u003e\n  cnspec scan openstack --auth-url \u003cKEYSTONE-URL\u003e --username \u003cUSERNAME\u003e --password \u003cPASSWORD\u003e --project-name \u003cPROJECT-NAME\u003e\n  cnspec scan openstack --auth-url \u003cKEYSTONE-URL\u003e --application-credential-id \u003cID\u003e --application-credential-secret \u003cSECRET\u003e\n  cnspec scan openstack --cloud \u003cCLOUDS-YAML-ENTRY\u003e --discover security-groups\n",
+      "flags": [
+        {
+          "long": "application-credential-id",
+          "type": 3,
+          "desc": "application credential ID (env: OS_APPLICATION_CREDENTIAL_ID)"
+        },
+        {
+          "long": "application-credential-name",
+          "type": 3,
+          "desc": "application credential name (env: OS_APPLICATION_CREDENTIAL_NAME)"
+        },
+        {
+          "long": "application-credential-secret",
+          "type": 3,
+          "desc": "application credential secret (env: OS_APPLICATION_CREDENTIAL_SECRET)"
+        },
+        {
+          "long": "auth-url",
+          "type": 3,
+          "desc": "Keystone auth URL (env: OS_AUTH_URL)"
+        },
+        {
+          "long": "cloud",
+          "type": 3,
+          "desc": "clouds.yaml entry to use"
+        },
+        {
+          "long": "insecure",
+          "type": 1,
+          "desc": "skip TLS certificate verification"
+        },
+        {
+          "long": "password",
+          "type": 3,
+          "desc": "password (env: OS_PASSWORD)"
+        },
+        {
+          "long": "project-domain-id",
+          "type": 3,
+          "desc": "project domain ID (env: OS_PROJECT_DOMAIN_ID)"
+        },
+        {
+          "long": "project-domain-name",
+          "type": 3,
+          "desc": "project domain name (env: OS_PROJECT_DOMAIN_NAME)"
+        },
+        {
+          "long": "project-id",
+          "type": 3,
+          "desc": "project ID (env: OS_PROJECT_ID)"
+        },
+        {
+          "long": "project-name",
+          "type": 3,
+          "desc": "project name (env: OS_PROJECT_NAME)"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "region (env: OS_REGION_NAME)"
+        },
+        {
+          "long": "user-domain-id",
+          "type": 3,
+          "desc": "user domain ID (env: OS_USER_DOMAIN_ID)"
+        },
+        {
+          "long": "user-domain-name",
+          "type": 3,
+          "desc": "user domain name (env: OS_USER_DOMAIN_NAME)"
+        },
+        {
+          "long": "username",
+          "type": 3,
+          "desc": "username (env: OS_USERNAME)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "security-groups"
+      ]
+    },
+    {
+      "name": "oracledb",
+      "provider": "oracledb",
+      "use": "oracledb [host]",
+      "short": "an Oracle Database",
+      "long": "Use the oracledb provider to query an Oracle Database.\n\nThe provider connects over the Oracle Net protocol and runs read-only queries\nagainst the V$ views and the DBA_* data dictionary to inventory the database\nversion, its initialization parameters, and its users, roles, and profiles, so\nyou can audit the database against the CIS Oracle Database benchmark.\n\nExamples:\n  cnspec shell oracledb db.contoso.com --service FREEPDB1 --user auditor --ask-pass\n  cnspec scan oracledb db.contoso.com --service ORCLPDB1 --user auditor --ask-pass --tls\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Oracle Database hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "1521",
+          "type": 2,
+          "desc": "Oracle Net listener port"
+        },
+        {
+          "long": "service",
+          "type": 3,
+          "desc": "Service name to connect to (for example FREEPDB1)"
+        },
+        {
+          "long": "sid",
+          "type": 3,
+          "desc": "System identifier (SID) to connect to, as an alternative to --service"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS (TCPS)"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "User name to authenticate as"
+        }
+      ]
+    },
+    {
+      "name": "panos",
+      "provider": "panos",
+      "use": "panos",
+      "short": "a remote PAN-OS system",
+      "long": "Use the panos provider to query resources on Palo Alto Networks PAN-OS devices.\n\nExamples:\n  cnspec shell panos --hostname 192.168.1.1 --username admin --password secret\n  cnspec scan panos --hostname firewall.example.com -u admin --ask-pass\n  cnspec shell panos --hostname 10.0.0.1 -u admin -p secret --insecure\n  cnspec scan panos --hostname 192.168.1.1 -u admin -p secret -f panos-security-policy.mql.yaml\n\nNotes:\n  Use --insecure (-k) to skip TLS verification for devices with self-signed certificates.\n  For production environments, configure a trusted certificate on your PAN-OS device.\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the PAN-OS device"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "The password for authentication"
+        },
+        {
+          "long": "username",
+          "short": "u",
+          "default": "admin",
+          "type": 3,
+          "desc": "The username for authentication"
+        }
+      ]
+    },
+    {
+      "name": "portainer",
+      "provider": "portainer",
+      "use": "portainer HOST",
+      "short": "a Portainer instance",
+      "long": "Use the portainer provider to audit the control-plane security posture of a\nPortainer instance: authentication settings, the container-security flags that\ngovern what regular users may do, user and team RBAC, and the environments\n(endpoints) Portainer manages.\n\nThe instance address is a positional argument. It may be a bare host, host:port,\nor a full URL; https is assumed when no scheme is given.\n\nExamples:\n  cnspec scan portainer https://portainer.example.com --access-token ptr_xxx\n  cnspec shell portainer portainer.example.com:9443 --access-token ptr_xxx\n\nUse --insecure (-k) to skip TLS verification for instances with self-signed\ncertificates.\n\nThe address and access token can also be supplied through environment variables:\n\n  PORTAINER_ADDRESS, PORTAINER_ACCESS_TOKEN\n",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "access-token",
+          "type": 3,
+          "desc": "Portainer access token, format ptr_xxx (env: PORTAINER_ACCESS_TOKEN)"
+        },
+        {
+          "long": "address",
+          "type": 3,
+          "desc": "Portainer instance address, e.g. https://portainer.example.com (env: PORTAINER_ADDRESS)"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "environments",
+        "docker",
+        "kubernetes",
+        "edge"
+      ],
+      "env": [
+        {
+          "flag": "address",
+          "vars": [
+            "PORTAINER_ADDRESS"
+          ],
+          "func": "NewPortainerConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "postgresdb",
+      "provider": "postgresdb",
+      "use": "postgresdb [host]",
+      "short": "a PostgreSQL server",
+      "long": "Use the postgresdb provider to query a PostgreSQL server.\n\nThe provider connects to a PostgreSQL server and runs read-only catalog\nqueries (pg_catalog and information_schema) to inventory roles, databases,\nschemas, privileges, settings, host-based authentication rules, extensions,\nforeign servers, and replication configuration.\n\nBy default the provider discovers every connectable database on the server as\nits own asset.\n\nExamples:\n  cnspec shell postgresdb db.contoso.com --user postgres --ask-pass\n  cnspec scan postgresdb db.contoso.com --database appdb --sslmode verify-full --sslrootcert ca.pem\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "default": "postgres",
+          "type": 3,
+          "desc": "Database to connect to for the initial (server) connection"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "PostgreSQL hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "5432",
+          "type": 2,
+          "desc": "PostgreSQL TCP port"
+        },
+        {
+          "long": "sslcert",
+          "type": 3,
+          "desc": "Path to the client certificate for TLS client authentication"
+        },
+        {
+          "long": "sslkey",
+          "type": 3,
+          "desc": "Path to the client private key for TLS client authentication"
+        },
+        {
+          "long": "sslmode",
+          "default": "prefer",
+          "type": 3,
+          "desc": "TLS mode: disable, allow, prefer, require, verify-ca, or verify-full"
+        },
+        {
+          "long": "sslrootcert",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "Role name to authenticate as"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "instance",
+        "databases",
+        "none"
+      ]
+    },
+    {
+      "name": "proxmox",
+      "provider": "proxmox",
+      "use": "proxmox --host HOST --token TOKEN [flags]",
+      "short": "a Proxmox VE hypervisor",
+      "long": "Use the proxmox provider to query and scan Proxmox VE clusters.\n\nExamples:\n  cnspec scan proxmox --host https://192.168.1.10:8006 --token 'PVEAPIToken=user@realm!id=secret'\n  cnspec scan proxmox --host https://pve.example.com:8006 --token 'PVEAPIToken=user@realm!id=secret' --insecure\n",
+      "flags": [
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Proxmox VE host URL (e.g. https://192.168.1.10:8006)"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "token",
+          "short": "t",
+          "type": 3,
+          "desc": "Proxmox API token (format: PVEAPIToken=user@realm!tokenid=secret)"
+        }
+      ]
+    },
+    {
+      "name": "recording",
+      "provider": "recording",
+      "use": "recording [flags]",
+      "short": "read recording file from disk",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "recording-path",
+          "type": 3,
+          "desc": "path to the recording file"
+        }
+      ]
+    },
+    {
+      "name": "redfish",
+      "provider": "redfish",
+      "use": "redfish USER@HOST",
+      "short": "a Redfish management controller (BMC)",
+      "long": "Use the redfish provider to query a server's baseboard management controller (BMC)\nover the DMTF Redfish REST API, including HPE iLO and Dell iDRAC.\n\nRedfish provides out-of-band management and inventory independently of the host\nsystem's CPU, firmware (BIOS or UEFI), and operating system.\n\nExamples:\n  cnspec shell redfish \u003cuser@host\u003e --ask-pass\n  cnspec scan redfish \u003cuser@host\u003e --password \u003cpassword\u003e --insecure\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Do not verify the controller's TLS certificate (BMCs ship self-signed certificates by default)",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for the Redfish controller",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "redisdb",
+      "provider": "redisdb",
+      "use": "redisdb [host]",
+      "short": "a Redis or Valkey server",
+      "long": "Use the redisdb provider to query a Redis or Valkey server.\n\nThe provider connects to the server and runs read-only commands (INFO,\nCONFIG GET, and the ACL commands) to inventory the server's version and mode,\nits network and authentication posture, its access-control users, and its\ndurability configuration, so you can audit the server's security posture.\n\nExamples:\n  cnspec shell redisdb localhost --ask-pass\n  cnspec scan redisdb redis.contoso.com --user auditor --ask-pass --tls\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "database",
+          "default": "0",
+          "type": 2,
+          "desc": "Logical database index to select"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Redis/Valkey hostname or IP address"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "port",
+          "default": "6379",
+          "type": 2,
+          "desc": "Redis/Valkey TCP port"
+        },
+        {
+          "long": "tls",
+          "default": "false",
+          "type": 1,
+          "desc": "Connect over TLS"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        },
+        {
+          "long": "user",
+          "short": "u",
+          "type": 3,
+          "desc": "ACL user name to authenticate as (Redis 6+); omit for legacy password auth"
+        }
+      ]
+    },
+    {
+      "name": "sbom",
+      "provider": "sbom",
+      "use": "sbom [flags]",
+      "short": "read SBOM file on disk",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "format",
+          "type": 3,
+          "desc": "Format of the sbom file (default is auto-detect)."
+        }
+      ]
+    },
+    {
+      "name": "shodan",
+      "provider": "shodan",
+      "use": "shodan",
+      "short": "a Shodan account",
+      "long": "Use the shodan provider to query domain and IP security information in the Shodan search engine.\n\nAvailable sub-commands:\n  host \u003cTARGET\u003e             Query a single host by IP address or hostname\n  domain \u003cTARGET\u003e           Query a domain and the hosts Shodan associates with it\n\nExamples:\n  cnspec shell shodan --token \u003capi-token\u003e\n  cnspec shell shodan host example.com\n  cnspec shell shodan domain example.com\n  cnspec shell shodan --networks \u003cip-range\u003e --discover hosts\n  cnspec scan shodan --token \u003capi-token\u003e\n  cnspec scan shodan host 192.168.1.1\n  cnspec scan shodan domain example.com\n\nNotes:\n  If you set the SHODAN_TOKEN environment variable, you can omit the token flag.\n",
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "networks",
+          "type": 4,
+          "desc": "Comma-separated list of IP ranges to query (e.g., 10.0.0.0/8,192.168.0.0/16)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Shodan API token"
+        }
+      ],
+      "discovery": [
+        "hosts"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "SHODAN_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ],
+      "positional": [
+        {
+          "index": 0,
+          "values": [
+            "host",
+            "domain"
+          ],
+          "func": "ParseCLI"
+        }
+      ]
+    },
+    {
+      "name": "slack",
+      "provider": "slack",
+      "use": "slack",
+      "short": "a Slack team",
+      "long": "Use the slack provider to query resources in a Slack team.\n\nExamples:\n  cnspec shell slack --token \u003capi-token\u003e\n  cnspec scan slack --team-id \u003cteam-id\u003e --token \u003capi-token\u003e\n",
+      "flags": [
+        {
+          "long": "team-id",
+          "type": 3,
+          "desc": "Team ID (required if the token is an org token)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Slack API token (To learn more, read https://mondoo.com/docs/cnspec/saas/slack)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "SLACK_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "snowflake",
+      "provider": "snowflake",
+      "use": "snowflake",
+      "short": "a Snowflake account",
+      "long": "Use the snowflake provider to query a Snowflake account.\n\nTo access a Snowflake account, you must first authenticate with Snowflake. The recommended method is a programmatic access token (PAT), which replaces password sign-ins that Snowflake is phasing out. Generate a PAT for your user in Snowsight and pass it with --token. Key-pair authentication (--identity-file) is also supported; to learn how, read https://docs.snowflake.com/en/user-guide/key-pair-auth.\n\nOnce you successfully authenticate, you can scan or query the Snowflake account.\n\nExample:\n  cnspec shell snowflake --account \u003caccount id\u003e --region \u003cregion\u003e --user \u003cyour id\u003e --role \u003cthe role you use\u003e --token \u003cyour PAT\u003e\n  cnspec scan snowflake --account \u003caccount id\u003e --region \u003cregion\u003e --user \u003cyour id\u003e --role \u003cthe role you use\u003e --token \u003cyour PAT\u003e\n",
+      "flags": [
+        {
+          "long": "account",
+          "type": 3,
+          "desc": "Snowflake account ID"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the connection password",
+          "config": "-"
+        },
+        {
+          "long": "identity-file",
+          "short": "i",
+          "type": 3,
+          "desc": "Select a file from which to read the identity (private key) for public key authentication"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "Snowflake region"
+        },
+        {
+          "long": "role",
+          "type": 3,
+          "desc": "The role you use to access Snowflake"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the programmatic access token (PAT)",
+          "config": "-"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "desc": "Snowflake user name"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "databases",
+        "none"
+      ]
+    },
+    {
+      "name": "ssh",
+      "provider": "os",
+      "use": "ssh user@host",
+      "short": "a remote system via SSH",
+      "long": "Use the ssh provider to query remote systems using SSH.  \n\nExamples:\n  cnspec scan ssh USER@IP-ADDRESS --ask-pass\n  cnspec shell ssh USER@IP-ADDRESS --ask-pass\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "identity-file",
+          "short": "i",
+          "type": 3,
+          "desc": "Select a file from which to read the identity (private key) for public key authentication"
+        },
+        {
+          "long": "insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Disable SSH hostkey verification"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for SSH",
+          "config": "-"
+        },
+        {
+          "long": "sudo",
+          "default": "false",
+          "type": 1,
+          "desc": "Elevate privileges with sudo"
+        }
+      ]
+    },
+    {
+      "name": "stackit",
+      "provider": "stackit",
+      "use": "stackit",
+      "short": "a STACKIT project",
+      "long": "\nUse the stackit provider to query servers, networks, Kubernetes clusters,\nmanaged databases, object storage, and other STACKIT cloud resources scoped\nto a single project.\n\nAuthenticate with a STACKIT service account key file:\n\n  cnspec shell stackit --project-id \u003cuuid\u003e --service-account-key-path /path/to/sa-key.json\n\nYou can also pass credentials via STACKIT environment variables\n(STACKIT_PROJECT_ID, STACKIT_SERVICE_ACCOUNT_KEY_PATH, STACKIT_SERVICE_ACCOUNT_KEY, STACKIT_SERVICE_ACCOUNT_TOKEN).\n",
+      "flags": [
+        {
+          "long": "endpoint",
+          "type": 3,
+          "desc": "Override the STACKIT API endpoint (env: STACKIT_ENDPOINT)"
+        },
+        {
+          "long": "private-key",
+          "type": 3,
+          "desc": "STACKIT service account RSA private key (env: STACKIT_PRIVATE_KEY)"
+        },
+        {
+          "long": "private-key-path",
+          "type": 3,
+          "desc": "Path to a STACKIT service account RSA private key (env: STACKIT_PRIVATE_KEY_PATH)"
+        },
+        {
+          "long": "project-id",
+          "type": 3,
+          "desc": "STACKIT project ID (env: STACKIT_PROJECT_ID)"
+        },
+        {
+          "long": "region",
+          "type": 3,
+          "desc": "STACKIT region (env: STACKIT_REGION, default: eu01)"
+        },
+        {
+          "long": "service-account-key",
+          "type": 3,
+          "desc": "STACKIT service account key JSON (env: STACKIT_SERVICE_ACCOUNT_KEY)"
+        },
+        {
+          "long": "service-account-key-path",
+          "type": 3,
+          "desc": "Path to a STACKIT service account key JSON (env: STACKIT_SERVICE_ACCOUNT_KEY_PATH)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "STACKIT service account token (env: STACKIT_SERVICE_ACCOUNT_TOKEN)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "servers",
+        "ske-clusters",
+        "object-storage-buckets",
+        "postgres-flex-instances",
+        "mongodb-flex-instances",
+        "sqlserver-flex-instances",
+        "opensearch-instances",
+        "mariadb-instances",
+        "redis-instances",
+        "rabbitmq-instances",
+        "logme-instances",
+        "secrets-manager-instances"
+      ],
+      "env": [
+        {
+          "flag": "endpoint",
+          "vars": [
+            "STACKIT_ENDPOINT"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "private-key",
+          "vars": [
+            "STACKIT_PRIVATE_KEY"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "private-key-path",
+          "vars": [
+            "STACKIT_PRIVATE_KEY_PATH"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "project-id",
+          "vars": [
+            "STACKIT_PROJECT_ID"
+          ],
+          "func": "NewStackitConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "region",
+          "vars": [
+            "STACKIT_REGION"
+          ],
+          "func": "NewStackitConnection",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "service-account-key",
+          "vars": [
+            "STACKIT_SERVICE_ACCOUNT_KEY"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "service-account-key-path",
+          "vars": [
+            "STACKIT_SERVICE_ACCOUNT_KEY_PATH"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "STACKIT_SERVICE_ACCOUNT_TOKEN"
+          ],
+          "func": "buildAuthOptions",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "tailscale",
+      "provider": "tailscale",
+      "use": "tailscale",
+      "short": "a Tailscale network",
+      "long": "\nUse the tailscale provider to query devices, DNS nameservers, and more information about a Tailscale network,\nknown as a tailnet.\n\nTo authenticate using an API access token:\n\n  cnspec shell tailscale --token \u003caccess-token\u003e\n\nTo authenticate using an OAuth client:\n\n  cnspec shell tailscale --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n\nYou can also use the default environment variables 'TAILSCALE_OAUTH_CLIENT_ID', 'TAILSCALE_OAUTH_CLIENT_SECRET',\nand 'TAILSCALE_TAILNET' to provide your credentials.\n\nIf you are using an API access token instead of an OAuth client, use the 'TAILSCALE_API_KEY' variable instead.\n",
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "base-url",
+          "type": 3,
+          "desc": "Base URL for the Tailscale API"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Tailscale OAuth client ID for authentication"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Tailscale OAuth client secret for authentication"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Tailscale API access token for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "devices",
+        "users"
+      ],
+      "env": [
+        {
+          "flag": "base-url",
+          "vars": [
+            "TAILSCALE_BASE_URL"
+          ],
+          "func": "GetBaseURL",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "client-id",
+          "vars": [
+            "TAILSCALE_OAUTH_CLIENT_ID"
+          ],
+          "func": "GetToken",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "client-secret",
+          "vars": [
+            "TAILSCALE_OAUTH_CLIENT_SECRET"
+          ],
+          "func": "GetClientSecret",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "token",
+          "vars": [
+            "TAILSCALE_API_KEY"
+          ],
+          "func": "GetToken",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "terraform",
+      "provider": "terraform",
+      "use": "terraform PATH",
+      "short": "Terraform HCL configurations, plan files, and state files",
+      "long": "Use the terraform provider to query Terraform HCL, plan, or state files as well as directories of files.\n\nAvailable commands:\n  plan                       Terraform plan file\n  state                      Terraform state file\n\nExamples:\n  cnspec shell terraform \u003cPATH-TO-HCL-DIRECTORY\u003e\n  cnspec scan terraform \u003cPATH-TO-HCL-FILE\u003e\n  cnspec scan terraform plan \u003cPATH-TO-PLAN-JSON\u003e\n  cnspec scan terraform state \u003cPATH-TO-STATE-JSON\u003e\n",
+      "min_args": 1,
+      "max_args": 2,
+      "flags": [
+        {
+          "long": "ignore-dot-terraform",
+          "default": "false",
+          "type": 1,
+          "desc": "Exclude the .terraform directory (contains cached provider plugins and modules)",
+          "config": "ignore_dot_terraform"
+        }
+      ]
+    },
+    {
+      "name": "together",
+      "provider": "together",
+      "use": "together",
+      "short": "a Together AI account",
+      "long": "Use the together provider to query models, fine-tuning jobs, dedicated\nendpoint deployments, and uploaded files in a Together AI account.\n\nExamples:\n  mql shell together --token \u003capi-key\u003e\n  mql shell together   # uses TOGETHER_API_KEY env var\n\nNotes:\n  The provider queries the Together AI REST API at https://api.together.ai/v1.\n  An API key is required; generate one at https://api.together.ai/settings/api-keys.\n",
+      "flags": [
+        {
+          "long": "base-url",
+          "type": 3,
+          "desc": "API base URL (default: https://api.together.ai/v1)"
+        },
+        {
+          "long": "project",
+          "type": 3,
+          "desc": "Together AI project ID (e.g. proj_...)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Together AI API key (or set TOGETHER_API_KEY env var)"
+        }
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "TOGETHER_API_KEY"
+          ],
+          "func": "NewTogetherConnection",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "unifi",
+      "provider": "unifi",
+      "use": "unifi",
+      "short": "a remote Ubiquiti UniFi controller",
+      "long": "Use the unifi provider to query resources on Ubiquiti UniFi controllers.\n\nExamples:\n  cnspec shell unifi --hostname 192.168.1.1 --username admin --password secret\n  cnspec scan unifi --hostname unifi.example.com -u admin --ask-pass\n  cnspec shell unifi --hostname 10.0.0.1 --api-key YOUR_API_KEY --insecure\n  cnspec scan unifi --hostname 192.168.1.1 -u admin -p secret --site mysite\n\nNotes:\n  Use --insecure (-k) to skip TLS verification for controllers with self-signed certificates.\n  The default port is 443. Use --port to specify a different port.\n  The default site is \"default\". Use --site to specify a different site.\n  You can use --api-key as an alternative to username/password authentication.\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "option": 8,
+          "desc": "API key for authentication (alternative to username/password)"
+        },
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "hostname",
+          "type": 3,
+          "desc": "The hostname or IP address of the UniFi controller"
+        },
+        {
+          "long": "insecure",
+          "short": "k",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "The password for authentication"
+        },
+        {
+          "long": "port",
+          "default": "443",
+          "type": 3,
+          "desc": "The port of the UniFi controller API"
+        },
+        {
+          "long": "site",
+          "default": "default",
+          "type": 3,
+          "desc": "The UniFi site name"
+        },
+        {
+          "long": "username",
+          "short": "u",
+          "type": 3,
+          "desc": "The username for authentication"
+        }
+      ]
+    },
+    {
+      "name": "upstream",
+      "provider": "mock",
+      "use": "upstream",
+      "short": "use upstream asset data",
+      "is_hidden": true,
+      "flags": [
+        {
+          "long": "asset",
+          "type": 3,
+          "desc": "the upstream asset MRN to connect with"
+        }
+      ]
+    },
+    {
+      "name": "vagrant",
+      "provider": "os",
+      "use": "vagrant host",
+      "short": "a Vagrant host",
+      "long": "Use the vagrant provider to query Vagrant virtual machines.  \n\nExamples:\n  cnspec scan vagrant HOST\n  cnspec shell vagrant HOST\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "sudo",
+          "default": "false",
+          "type": 1,
+          "desc": "Elevate privileges with sudo"
+        }
+      ]
+    },
+    {
+      "name": "vcd",
+      "provider": "vcd",
+      "use": "vcd [--user \u003cuser\u003e] [--host \u003chost\u003e] [--organization \u003corganization\u003e] [--ask-pass] [--password \u003cpassword\u003e]",
+      "short": "a VMware Cloud Director installation",
+      "long": "Use the vcd provider to query resources in a VMware Cloud Director environment. The VMware Cloud Director platform facilitates the operation and management of virtual resources within a multi-tenant cloud environment.\n\n\t\t\tExamples:\n\t\t\t  cnspec shell vcd --user \u003cUSER-NAME\u003e --host \u003cHOST-NAME\u003e --ask-pass\n\t\t\t\tcnspec scan vcd --user \u003cUSER-NAME\u003e --host \u003cHOST-NAME\u003e --password \u003cPASSWORD\u003e\n",
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "option": 4,
+          "desc": "VMware Cloud Director hostname (e.g., vcd.example.com)"
+        },
+        {
+          "long": "organization",
+          "type": 3,
+          "desc": "VMware Cloud Director organization name to connect to"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        },
+        {
+          "long": "user",
+          "type": 3,
+          "option": 4,
+          "desc": "VMware Cloud Director username for authentication"
+        }
+      ]
+    },
+    {
+      "name": "vercel",
+      "provider": "vercel",
+      "use": "vercel",
+      "short": "a Vercel account",
+      "long": "Use the vercel provider to query configuration and security posture of your Vercel teams and projects.\n\nExamples:\n  cnspec shell vercel --token \u003caccess_token\u003e\n  cnspec scan vercel --token \u003caccess_token\u003e\n  cnspec scan vercel --token \u003caccess_token\u003e --team \u003cteam_slug_or_id\u003e\n\nNotes:\n  If you set the VERCEL_TOKEN environment variable, you can omit the token flag.\n",
+      "flags": [
+        {
+          "long": "team",
+          "type": 3,
+          "desc": "Scope discovery to a single Vercel team (slug or ID)"
+        },
+        {
+          "long": "token",
+          "type": 3,
+          "desc": "Vercel API token for authentication"
+        }
+      ],
+      "discovery": [
+        "all",
+        "auto",
+        "teams",
+        "projects"
+      ],
+      "env": [
+        {
+          "flag": "token",
+          "vars": [
+            "VERCEL_TOKEN",
+            "VERCEL_API_TOKEN"
+          ],
+          "func": "ParseCLI",
+          "via": "parse-cli",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "vllm",
+      "provider": "vllm",
+      "use": "vllm ENDPOINT",
+      "short": "a vLLM inference server",
+      "long": "Use the vllm provider to assess the externally observable HTTP posture of a vLLM inference server.\n\nExamples:\n  mql shell vllm http://localhost:8000\n  mql shell vllm https://vllm.example.com --api-key \u003ctoken\u003e\n\nNotes:\n  The provider probes remote HTTP routes only. Host-local flags, environment\n  variables, LoRA resolver state, media allowlists, and internode network\n  controls are outside this connector's observable scope.\n\nSecurity:\n  Only scan vLLM endpoints you are authorized to assess. The connector sends\n  HTTP requests to the supplied URL, so templating that URL from untrusted data\n  can create server-side request forgery risk. Explicit API-key credentials\n  override VLLM_API_KEY from the environment.\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "desc": "Bearer token for authenticated comparison probes"
+        },
+        {
+          "long": "insecure",
+          "type": 1,
+          "desc": "Disable TLS certificate verification"
+        },
+        {
+          "long": "timeout",
+          "default": "10",
+          "type": 2,
+          "desc": "HTTP request timeout in seconds"
+        }
+      ],
+      "env": [
+        {
+          "flag": "api-key",
+          "vars": [
+            "VLLM_API_KEY"
+          ],
+          "func": "apiKeyFromConfig",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    },
+    {
+      "name": "vsphere",
+      "provider": "vsphere",
+      "use": "vsphere user@host",
+      "short": "a VMware vSphere installation",
+      "long": "Use the vsphere provider to query VMware vSphere installations. \n\nExamples:\n  cnspec scan vsphere \u003cUSER\u003e@\u003cHOST\u003e --askpass\n\tcnspec shell vsphere \u003cUSER\u003e@\u003cHOST\u003e --password \u003cYOUR-PASSWORD\u003e\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password",
+          "config": "-"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password",
+          "config": "-"
+        }
+      ],
+      "discovery": [
+        "api",
+        "instances",
+        "host-machines"
+      ]
+    },
+    {
+      "name": "weaviate",
+      "provider": "weaviate",
+      "use": "weaviate [host]",
+      "short": "a Weaviate vector database",
+      "long": "Use the weaviate provider to query a Weaviate vector database server.\n\nThe provider connects to the server's REST API and runs read-only requests to\ninventory the server's version and modules, collections, role-based access\ncontrol roles and permissions, users, and cluster nodes, so you can audit the\nserver's security posture.\n\nBy default the provider discovers every collection on the server as its own\nasset.\n\nExamples:\n  cnspec shell weaviate localhost --api-key API_KEY\n  cnspec scan weaviate my-instance.example.com --scheme https --api-key API_KEY\n",
+      "flags": [
+        {
+          "long": "api-key",
+          "type": 3,
+          "option": 8,
+          "desc": "API key to authenticate with",
+          "config": "-"
+        },
+        {
+          "long": "ask-api-key",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for the API key",
+          "config": "-"
+        },
+        {
+          "long": "host",
+          "type": 3,
+          "desc": "Weaviate hostname or IP address"
+        },
+        {
+          "long": "port",
+          "default": "8080",
+          "type": 2,
+          "desc": "Weaviate REST API port"
+        },
+        {
+          "long": "scheme",
+          "default": "http",
+          "type": 3,
+          "desc": "Connection scheme: http or https"
+        },
+        {
+          "long": "tls-ca",
+          "type": 3,
+          "desc": "Path to the trusted CA certificate for TLS verification"
+        },
+        {
+          "long": "tls-insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Skip TLS certificate verification (testing only)"
+        }
+      ],
+      "discovery": [
+        "auto",
+        "all",
+        "instance",
+        "collections",
+        "none"
+      ]
+    },
+    {
+      "name": "winrm",
+      "provider": "os",
+      "use": "winrm user@host",
+      "short": "a remote system via WinRM",
+      "long": "Use the winrm provider to query remote systems using WinRM.  \n\nExamples:\n  cnspec scan winrm USER@HOST --ask-pass\n  cnspec shell winrm USER@HOST --ask-pass\n",
+      "min_args": 1,
+      "max_args": 1,
+      "flags": [
+        {
+          "long": "ask-pass",
+          "default": "false",
+          "type": 1,
+          "desc": "Prompt for connection password"
+        },
+        {
+          "long": "id-detector",
+          "type": 3,
+          "option": 1,
+          "desc": "User override for platform ID detection mechanism"
+        },
+        {
+          "long": "insecure",
+          "default": "false",
+          "type": 1,
+          "desc": "Disable TLS/SSL checks"
+        },
+        {
+          "long": "password",
+          "short": "p",
+          "default": "false",
+          "type": 3,
+          "option": 8,
+          "desc": "Set the connection password for SSH",
+          "config": "-"
+        }
+      ]
+    },
+    {
+      "name": "zoom",
+      "provider": "zoom",
+      "use": "zoom",
+      "short": "a Zoom account",
+      "long": "\nUse the zoom provider to query the account-level security posture of a Zoom\naccount: meeting-security defaults, cloud-recording encryption, single\nsign-on, users, roles, and groups.\n\nAuthentication uses Server-to-Server OAuth (an account ID plus a\nServer-to-Server OAuth app's client ID and client secret):\n\n  mql shell zoom --account-id \u003cid\u003e --client-id \u003cid\u003e --client-secret \u003csecret\u003e\n\nYou can also use the default environment variables 'ZOOM_ACCOUNT_ID', 'ZOOM_CLIENT_ID',\nand 'ZOOM_CLIENT_SECRET' to provide your credentials.\n",
+      "flags": [
+        {
+          "long": "account-id",
+          "type": 3,
+          "desc": "Zoom account ID"
+        },
+        {
+          "long": "client-id",
+          "type": 3,
+          "desc": "Zoom Server-to-Server OAuth app client ID"
+        },
+        {
+          "long": "client-secret",
+          "type": 3,
+          "desc": "Zoom Server-to-Server OAuth app client secret"
+        }
+      ],
+      "env": [
+        {
+          "flag": "account-id",
+          "vars": [
+            "ZOOM_ACCOUNT_ID"
+          ],
+          "func": "GetAccountID",
+          "via": "connection",
+          "declared": true
+        },
+        {
+          "flag": "client-id",
+          "vars": [
+            "ZOOM_CLIENT_ID"
+          ],
+          "func": "GetClientID",
+          "via": "connection",
+          "declared": true
+        }
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "provider": "activedirectory",
+      "kind": "unbound-env",
+      "detail": "ParseCLI reads USERDOMAIN but its value never meets a flag",
+      "where": "mql:providers/activedirectory/provider/provider.go:33"
+    },
+    {
+      "provider": "ai",
+      "connector": "mcp",
+      "kind": "no-positional-vocabulary",
+      "detail": "takes 2 arguments but no literal comparison against them was found, so the words it accepts are documented only in its help text"
+    },
+    {
+      "provider": "alicloud",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads ALIBABA_CLOUD_SECURITY_TOKEN; ALICLOUD_SECURITY_TOKEN, which no declared flag accounts for"
+    },
+    {
+      "provider": "anthropic",
+      "connector": "anthropic",
+      "kind": "carried-forward",
+      "detail": "not found in the source that was read; its metadata is the previously recorded one and nothing here re-derived it"
+    },
+    {
+      "provider": "auth0",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads AUTH0_CLIENT_SECRET, which no declared flag accounts for"
+    },
+    {
+      "provider": "azure",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads AZURE_FEDERATED_TOKEN_FILE (option \"azure-federated-token-file\"), which no declared flag accounts for"
+    },
+    {
+      "provider": "bitwarden",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads BITWARDEN_CLIENT_SECRET; BITWARDEN_API_URL; BITWARDEN_IDENTITY_URL, which no declared flag accounts for"
+    },
+    {
+      "provider": "claude",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads ANTHROPIC_AUTH_TOKEN; ANTHROPIC_PROFILE; ANTHROPIC_FEDERATION_RULE_ID, which no declared flag accounts for"
+    },
+    {
+      "provider": "clickhouse",
+      "connector": "clickhouse",
+      "kind": "carried-forward",
+      "detail": "not found in the source that was read; its metadata is the previously recorded one and nothing here re-derived it"
+    },
+    {
+      "provider": "digitalocean",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads DIGITALOCEAN_SPACES_KEY; DIGITALOCEAN_SPACES_SECRET; DIGITALOCEAN_SPACES_REGION, which no declared flag accounts for"
+    },
+    {
+      "provider": "dropbox",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads DROPBOX_TEAM_TOKEN, which no declared flag accounts for"
+    },
+    {
+      "provider": "equinix",
+      "kind": "provider-source-absent",
+      "detail": "the directory holds a built provider but no config package, so nothing about it could be read",
+      "where": "mql:providers/equinix"
+    },
+    {
+      "provider": "equinix",
+      "connector": "equinix",
+      "kind": "carried-forward",
+      "detail": "not found in the source that was read; its metadata is the previously recorded one and nothing here re-derived it"
+    },
+    {
+      "provider": "gcp",
+      "kind": "dynamic-getenv",
+      "detail": "readEnvs calls os.Getenv with a value the syntax does not name",
+      "where": "mql:providers/gcp/provider/provider.go:51"
+    },
+    {
+      "provider": "google-workspace",
+      "kind": "dynamic-getenv",
+      "detail": "readEnvs calls os.Getenv with a value the syntax does not name",
+      "where": "mql:providers/google-workspace/provider/provider.go:38"
+    },
+    {
+      "provider": "ipinfo",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads IPINFO_TOKEN, which no declared flag accounts for"
+    },
+    {
+      "provider": "k8s",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads KUBECONFIG; DEBUG, which no declared flag accounts for"
+    },
+    {
+      "provider": "mistral",
+      "kind": "alternative-branches",
+      "detail": "ParseCLI: \"token\" is declared by two arms of one if/else chain, one holding flag \"token\" and the other MISTRAL_API_KEY, MISTRAL_KEY; nothing but the shared name says they are the same credential"
+    },
+    {
+      "provider": "networkdevices",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads DEBUG, which no declared flag accounts for"
+    },
+    {
+      "provider": "os",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads DOCKER_CONTEXT; SSH_AUTH_SOCK; MONDOO_SSH_SCP; WINRM_DISABLE_HTTPS, which no declared flag accounts for"
+    },
+    {
+      "provider": "os",
+      "kind": "positional-ambiguous",
+      "detail": "one ParseCLI serves 6 connectors that take positional arguments, so argument 0: file cannot be attributed to one of them"
+    },
+    {
+      "provider": "portainer",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads PORTAINER_ACCESS_TOKEN, which no declared flag accounts for"
+    },
+    {
+      "provider": "secrets",
+      "kind": "provider-source-absent",
+      "detail": "the directory holds a built provider but no config package, so nothing about it could be read",
+      "where": "mql:providers/secrets"
+    },
+    {
+      "provider": "tailscale",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads TAILSCALE_TAILNET (option \"tailnet\"), which no declared flag accounts for"
+    },
+    {
+      "provider": "together",
+      "kind": "alternative-branches",
+      "detail": "ParseCLI: \"token\" is declared by two arms of one if/else chain, one holding flag \"token\" and the other TOGETHER_API_KEY; nothing but the shared name says they are the same credential"
+    },
+    {
+      "provider": "vllm",
+      "kind": "alternative-branches",
+      "detail": "ParseCLI: \"apiKey\" is declared by two arms of one if/else chain, one holding flag \"api-key\" and the other VLLM_API_KEY; nothing but the shared name says they are the same credential"
+    },
+    {
+      "provider": "zoom",
+      "kind": "env-outside-parsecli",
+      "detail": "the connection package reads ZOOM_CLIENT_SECRET, which no declared flag accounts for"
+    }
+  ]
+}

--- a/internal/connectors/connectors_test.go
+++ b/internal/connectors/connectors_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connectors
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/cnspec/internal/connectorgen"
+)
+
+// TestArtifactParses is what an embedded JSON buys instead of generated Go
+// source: the compile-time guarantee that the data is well formed, moved to a
+// test that runs in CI where no provider is installed.
+func TestArtifactParses(t *testing.T) {
+	art, err := Load()
+	if err != nil {
+		t.Fatalf("the embedded artifact does not parse: %v", err)
+	}
+	if art.Schema != connectorgen.SchemaVersion {
+		t.Errorf("artifact schema %d, generator writes %d -- regenerate it with `make connectors/generate MQL=<path>`",
+			art.Schema, connectorgen.SchemaVersion)
+	}
+	if len(art.Connectors) < 50 {
+		t.Fatalf("only %d connectors recorded; the artifact looks truncated", len(art.Connectors))
+	}
+	for _, c := range art.Connectors {
+		if c.Name == "" || c.Provider == "" {
+			t.Errorf("connector with no name or provider: %+v", c)
+		}
+	}
+	t.Logf("%d connectors, %d with a positional vocabulary, %d with env routes",
+		len(art.Connectors), countWith(art.Connectors, func(c Connector) bool { return len(c.Positional) > 0 }),
+		countWith(art.Connectors, func(c Connector) bool { return len(c.Env) > 0 }))
+}
+
+func countWith(cs []Connector, pred func(Connector) bool) int {
+	n := 0
+	for _, c := range cs {
+		if pred(c) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestProjectionIsFaithful is the contract between this package and the
+// generator that writes the file it embeds.
+//
+// The types here are a projection: they carry what a consumer reads and drop
+// the provenance the generator records for its own report. A projection is only
+// safe while everyone knows which fields it drops, so this asserts exactly
+// that -- it fails when the generator grows a connector field this package does
+// not carry and has not been told to ignore.
+//
+// The failure is deliberately not "add the field". It is "decide": a new
+// generator field is either something production should read, in which case it
+// belongs on Connector above, or something only the report wants, in which case
+// it belongs in the ignore list beside a reason.
+func TestProjectionIsFaithful(t *testing.T) {
+	// Fields the generator records that a consumer deliberately does not read.
+	ignored := map[string]string{
+		"IsHidden": "the catalog decides what to offer from the installed provider set, not from a recording",
+		"Maturity": "not consumed by any form; the launcher shows what a provider declares at runtime",
+		"Gaps":     "a report of what the extraction could not determine, for a human, not an input to a form",
+	}
+
+	gen := reflect.TypeOf(connectorgen.Connector{})
+	proj := reflect.TypeOf(Connector{})
+	have := map[string]reflect.StructField{}
+	for i := 0; i < proj.NumField(); i++ {
+		have[proj.Field(i).Name] = proj.Field(i)
+	}
+
+	var missing []string
+	for i := 0; i < gen.NumField(); i++ {
+		f := gen.Field(i)
+		if _, skip := ignored[f.Name]; skip {
+			continue
+		}
+		got, ok := have[f.Name]
+		if !ok {
+			missing = append(missing, f.Name)
+			continue
+		}
+		if tagName(got.Tag.Get("json")) != tagName(f.Tag.Get("json")) {
+			t.Errorf("%s: json tag %q here, %q in the generator -- the projection would silently read nothing",
+				f.Name, got.Tag.Get("json"), f.Tag.Get("json"))
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("connectorgen.Connector has fields this projection neither carries nor ignores: %v.\n"+
+			"Either add them to connectors.Connector, or list them in `ignored` above with the reason a form does not need them.",
+			missing)
+	}
+}
+
+func tagName(tag string) string {
+	name, _, _ := strings.Cut(tag, ",")
+	return name
+}
+
+// TestRawIsTheParsedFile guards the one way Raw() and the typed accessors can
+// disagree: a caller reading the bytes and a caller reading the projection have
+// to be looking at the same connectors.
+func TestRawIsTheParsedFile(t *testing.T) {
+	var direct struct {
+		Connectors []struct {
+			Name string `json:"name"`
+		} `json:"connectors"`
+	}
+	if err := json.Unmarshal(Raw(), &direct); err != nil {
+		t.Fatal(err)
+	}
+	if len(direct.Connectors) != len(All()) {
+		t.Fatalf("Raw() holds %d connectors, All() returns %d", len(direct.Connectors), len(All()))
+	}
+	for i, c := range direct.Connectors {
+		if All()[i].Name != c.Name {
+			t.Fatalf("connector %d: Raw() says %q, All() says %q", i, c.Name, All()[i].Name)
+		}
+	}
+}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1592,7 +1592,23 @@ func mustCompile(code string) *llx.CodeBundle {
 }
 
 func createProgressBar(disableProgressBar bool) (progress.MultiProgress, error) {
-	if isatty.IsTerminal(os.Stdout.Fd()) && !disableProgressBar && !strings.EqualFold(logger.GetLevel(), "debug") && !strings.EqualFold(logger.GetLevel(), "trace") {
+	if disableProgressBar {
+		return progress.NoopMultiProgress{}, nil
+	}
+
+	// An explicit progress-stream target wins over terminal detection. A parent
+	// process that asked for machine-readable progress must get it even when it
+	// handed the child a pty, and unlike the TODO list the stream has its own
+	// destination, so debug/trace logging cannot corrupt it.
+	if target := os.Getenv(progress.StreamEnvVar); target != "" {
+		stream, err := progress.NewStream(target)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to set up %s", progress.StreamEnvVar)
+		}
+		return stream, nil
+	}
+
+	if isatty.IsTerminal(os.Stdout.Fd()) && !strings.EqualFold(logger.GetLevel(), "debug") && !strings.EqualFold(logger.GetLevel(), "trace") {
 		return progress.NewTodoList(progress.WithScore())
 	}
 	return progress.NoopMultiProgress{}, nil

--- a/policy/scan/progress_test.go
+++ b/policy/scan/progress_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/progress"
+)
+
+// Go test binaries run with stdout on a pipe, so these cover the non-TTY side
+// of createProgressBar: the noop today, and the NDJSON stream when a parent
+// process asks for one.
+
+func TestCreateProgressBarPipedWithoutStreamIsNoop(t *testing.T) {
+	t.Setenv(progress.StreamEnvVar, "")
+
+	mp, err := createProgressBar(false)
+	require.NoError(t, err)
+	assert.IsType(t, progress.NoopMultiProgress{}, mp)
+}
+
+func TestCreateProgressBarStream(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "progress.ndjson")
+	t.Setenv(progress.StreamEnvVar, path)
+
+	mp, err := createProgressBar(false)
+	require.NoError(t, err)
+	require.NotNil(t, mp)
+	assert.NotEqual(t, progress.NoopMultiProgress{}, mp)
+
+	require.NoError(t, mp.Open())
+	mp.AddTask("id-1", nil)
+	mp.Completed("id-1")
+	mp.Close()
+	mp.Close() // the scanner closes explicitly and again from a defer
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		var e progress.StreamEvent
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &e), "unparseable line: %q", line)
+		names = append(names, e.Event)
+	}
+	assert.Equal(t, []string{
+		progress.EventScanStart,
+		progress.EventAssetAdded,
+		progress.EventAssetDone,
+		progress.EventScanDone,
+	}, names)
+}
+
+// An explicitly disabled progress bar stays disabled — headless callers such as
+// `cnspec serve` pass DisableProgressBar and must not start writing a stream
+// just because one is configured in the environment.
+func TestCreateProgressBarDisabledWinsOverStream(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "progress.ndjson")
+	t.Setenv(progress.StreamEnvVar, path)
+
+	mp, err := createProgressBar(true)
+	require.NoError(t, err)
+	assert.IsType(t, progress.NoopMultiProgress{}, mp)
+	assert.NoFileExists(t, path)
+}
+
+func TestCreateProgressBarStreamTargetFails(t *testing.T) {
+	t.Setenv(progress.StreamEnvVar, filepath.Join(t.TempDir(), "no-such-dir", "progress.ndjson"))
+
+	_, err := createProgressBar(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), progress.StreamEnvVar)
+}

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -29,7 +29,7 @@ Flags:
       --inventory-format-ansible      Set the inventory format to Ansible
       --inventory-format-domainlist   Set the inventory format to domain list
   -j, --json                          Run the query and return the object in a JSON structure
-  -o, --output string                 Set the output format: compact, csv, full, hdf, json, json-v1, json-v2, junit, ocsf-json, ocsf-parquet, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "compact")
+  -o, --output string                 Set the output format: compact, csv, full, hdf, json, json-full, json-v1, json-v2, junit, ocsf-json, ocsf-parquet, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "compact")
       --output-target string          Set the output target for the asset report: an AWS SQS topic URL, a local file, or a local directory (with -o hdf, one OHDF file per asset; with the OCSF formats, one file per event class)
       --parallelism int               Set the number of assets to scan in parallel. Defaults to a per-provider value capped by the CPUs available on this machine. Use 1 for sequential
       --platform-id string            Select a specific target asset by providing its platform ID

--- a/test/cli/testdata/cnspec_vuln.ct
+++ b/test/cli/testdata/cnspec_vuln.ct
@@ -12,7 +12,7 @@ Flags:
       --inventory-ansible       Set the inventory format to Ansible
       --inventory-domainlist    Set the inventory format to domain list
       --inventory-file string   Set the path to the inventory file
-  -o, --output string           Set the output format: compact, csv, full, hdf, json, json-v1, json-v2, junit, ocsf-json, ocsf-parquet, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
+  -o, --output string           Set the output format: compact, csv, full, hdf, json, json-full, json-v1, json-v2, junit, ocsf-json, ocsf-parquet, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
       --platform-id string      Select a specific target asset by providing its platform ID
 
 Global Flags:

--- a/typos.toml
+++ b/typos.toml
@@ -11,6 +11,10 @@ extend-exclude = [
   "cnquery/",
   # Test fixtures and captured command output
   "**/testdata/**",
+  # Generated from provider source: vendor prose we do not author (HPE iLO,
+  # Dell iDRAC, ...). It lived under testdata/ until it became embedded
+  # production data, which is how it started reaching this check.
+  "internal/connectors/connectors.json",
   "**/validation/scans/fixtures/**",
   "content/validation/data/**",
   # Dependency manifests (module paths / hashes, not prose)


### PR DESCRIPTION
## What this is

`cnspec ui` — a two-pane terminal launcher. Connectors on the left, a form for
the selected one on the right, an explicit Scan button. It assembles a command
line and re-executes this same binary, so what it launches goes through the
identical startup path as a typed command (provider auto-install, flag parsing,
discovery), and the launcher is still there afterwards to run the next thing.

The command is **hidden** and this PR is a **draft**: it covers a small share of
the catalog so far. See "Not done yet" below.

## Design decisions worth reviewing

**The catalog is a union, not a list.** The compiled-in provider list is the
floor — it is all cnspec can name offline. The installed set wins, because it is
the only thing carrying the flag and discovery metadata forms are built from;
whole categories, every database provider among them, exist only there. Keyed on
provider `Name`, not the ID `ListActive` returns, which is a full import path.

**Forms are curated per connector**, behind a seam shaped like the SDK type that
should eventually supply them (`providerFormSpec`). Fields stay hidden until the
choice above makes them relevant: picking a live cluster asks for a cluster,
picking a manifest asks for a path, and neither screen shows the other's
questions.

**Credentials never reach the command line.** They go to the OS keychain and are
referenced by id; where that fails the launcher warns and falls back to a 0600
inventory in a private directory, removed after the run. A connector whose
secret cannot be delivered safely by either route is refused rather than quietly
downgraded. The secret classifier is name-based on purpose — `FlagOption_Password`
is set only on the database family and os/ssh, while a sweep found 60
secret-carrying flags across 45 providers with `Option=0`.

**Value pickers are declared, not special-cased.** A `Source` states its cost
(deciding whether it runs on selection or on open), what it says while it runs,
what its failure means in one actionable sentence, and which fields parameterise
it. A table test holds every source to that contract, so the next one cannot
rediscover the bugs the last one taught — a picker that shows nothing when it
means "cannot reach", a cache key that made a complete answer invisible, a live
list left attached to the wrong selector.

Nine sources today: aws profiles, kube contexts and namespaces, ssh hosts, gcp
projects and zones, docker containers and images.

**One escape hatch worth knowing about:** k8s `--context` is inert — it is parsed
into options and never reaches the client config (`connection.go:61` passes
`""`), so it only renames the asset. Emitting it would scan the wrong cluster
while looking correct. The launcher materialises a kubeconfig with the
`current-context` rewritten and sets `KUBECONFIG` instead.

## Testing

112 tests, 73.5% statement coverage, race-clean, cross-compiles for Windows.
The two `go vet` warnings under `apps/cnspec/cmd/` (`framework.go`,
`policy.go`) are pre-existing on `main` and untouched here.

## Not done yet

Three classes of discovery remain, and they are why this is a draft:

- the unexploited local credential files (oci and alicloud are the same ini
  format aws already reads; `~/.azure/azureProfile.json` lists every
  subscription `az` has seen)
- the ~7 providers with a single ambient token and *nothing to enumerate*, which
  want a credential-state widget rather than a picker
- generic post-connection discovery, one implementation over `cnspec discover`
  for the 15 connectors that can actually consume the result

## Known issues, filed against myself

Found in a review of this branch and not yet fixed:

1. The keychain write is synchronous inside `Update` with no timeout, so a
   locked macOS keychain can freeze the UI behind an OS auth dialog.
2. Inventory cleanup is tied to one message; a panic or `SIGKILL` leaks the
   fallback credential file into `/tmp`.
3. Cancelling a picker does not kill the subprocess (timeouts bound it).
4. The subprocess test double drops the env, so the `KUBECONFIG` path above is
   untested in exactly its critical dimension.
5. `home(".config", "gcloud")` is wrong on Windows (`%APPDATA%\gcloud`), so gcp
   discovery silently finds nothing there.
