### PR TITLE
⚡ scan assets in parallel by default, using the provider's declared value

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -84,7 +84,7 @@ func init() {
 	_ = scanCmd.Flags().MarkDeprecated("score-threshold", "Please use --risk-threshold instead")
 	_ = scanCmd.Flags().Int("risk-threshold", reporter.DEFAULT_RISK_THRESHOLD, "Set the risk threshold. Exit with status 1 if any risk meets or exceeds this value")
 	_ = scanCmd.Flags().String("output-target", "", "Set the output target for the asset report. Currently only supports AWS SQS topic URLs and local files")
-	_ = scanCmd.Flags().Int("parallelism", 1, "Set the number of assets to scan in parallel. A value of 0 or 1 means sequential")
+	_ = scanCmd.Flags().Int("parallelism", 0, "Set the number of assets to scan in parallel. Defaults to a per-provider value capped by the CPUs available on this machine. Use 1 for sequential")
 	_ = scanCmd.Flags().String("output-scan-db", "", "Save each asset's scan database (SQLite) to this directory in addition to uploading. Used to capture seeds for the cnspec loadtest tool")
 	_ = scanCmd.Flags().MarkHidden("output-scan-db")
 	_ = scanCmd.Flags().Bool("collect-support-bundle", false, "Collect a support bundle (debug logs, asset bundle, inventory, resolved policy, report, provider versions) for sharing with Mondoo support. By default writes to a timestamped directory in the current working dir; override with --support-bundle-dir.")

--- a/apps/cnspec/cmd/scan_test.go
+++ b/apps/cnspec/cmd/scan_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
 
@@ -122,4 +123,15 @@ func TestApplyAutoDiscoveredInventory_OnlyFirstMatchingAssetIsMergedIntoTarget(t
 		"only the first matching inventory asset's id_detector should be lifted")
 	assert.Equal(t, []*inventory.Asset{target}, inv.Spec.Assets,
 		"second-local and all other inventory assets should be discarded")
+}
+
+// TestParallelismFlagDefaultsToAuto pins the contract behind the flag's zero
+// value: unset means "let the scanner derive a default from the providers behind
+// the root assets", not "scan sequentially". Restoring the old default of 1 would
+// silently turn every scan sequential again without failing anything else.
+func TestParallelismFlagDefaultsToAuto(t *testing.T) {
+	flag := scanCmd.Flags().Lookup("parallelism")
+	require.NotNil(t, flag, "--parallelism flag should be registered")
+	assert.Equal(t, "0", flag.DefValue,
+		"an unset --parallelism must reach the scanner as 0 so it resolves a provider default")
 }

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260819000633-f705b63814ae
-	go.mondoo.com/mql v0.0.0-20260820124214-e54d04484d4a
+	go.mondoo.com/mql v0.0.0-20260820153852-05e74586f59d
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1082,8 +1082,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260819000633-f705b63814ae h1:MW6SvczrQXXWibSOCuSlhaDtalmxlN1XN9YVizBaF0E=
 go.mondoo.com/mondoo-go v0.0.0-20260819000633-f705b63814ae/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260820124214-e54d04484d4a h1:z9DuSwgsQtMmrvIQ0InBsa1nGqy79DUp0CKY3eQYuQw=
-go.mondoo.com/mql v0.0.0-20260820124214-e54d04484d4a/go.mod h1:OtIXfPOF8IA2HtsDNME5PtyEpNm4Kp3f2O+Lt1+1/ac=
+go.mondoo.com/mql v0.0.0-20260820153852-05e74586f59d h1:jdCLiv2w+GNxDyCHunES7DyC60vshnc5pXtCcvhOe1k=
+go.mondoo.com/mql v0.0.0-20260820153852-05e74586f59d/go.mod h1:OtIXfPOF8IA2HtsDNME5PtyEpNm4Kp3f2O+Lt1+1/ac=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/cnspec_policy.pb.go
+++ b/policy/cnspec_policy.pb.go
@@ -8933,8 +8933,14 @@ func (x *GetScanParametersReq) GetScopeMrn() string {
 type ScanParameters struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	EnabledFeatures []string               `protobuf:"bytes,1,rep,name=enabled_features,json=enabledFeatures,proto3" json:"enabled_features,omitempty"` // mql feature names enabled by server
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Hard ceiling on how many assets a client may scan concurrently in this
+	// scope. It overrules everything the client would otherwise pick, including
+	// an explicit --parallelism, so a scope under load can throttle the scans
+	// pointed at it without any client-side change. Zero (or unset) means the
+	// server sets no limit and the client decides on its own.
+	MaxParallelism int32 `protobuf:"varint,2,opt,name=max_parallelism,json=maxParallelism,proto3" json:"max_parallelism,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ScanParameters) Reset() {
@@ -8972,6 +8978,13 @@ func (x *ScanParameters) GetEnabledFeatures() []string {
 		return x.EnabledFeatures
 	}
 	return nil
+}
+
+func (x *ScanParameters) GetMaxParallelism() int32 {
+	if x != nil {
+		return x.MaxParallelism
+	}
+	return 0
 }
 
 type PurgeAssetsRequest struct {
@@ -10338,9 +10351,10 @@ const file_cnspec_policy_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12H\n" +
 	"\x05value\x18\x02 \x01(\v22.cnspec.policy.v1.SynchronizeAssetsRespAssetDetailR\x05value:\x028\x01\"3\n" +
 	"\x14GetScanParametersReq\x12\x1b\n" +
-	"\tscope_mrn\x18\x01 \x01(\tR\bscopeMrn\";\n" +
+	"\tscope_mrn\x18\x01 \x01(\tR\bscopeMrn\"d\n" +
 	"\x0eScanParameters\x12)\n" +
-	"\x10enabled_features\x18\x01 \x03(\tR\x0fenabledFeatures\"\x97\x03\n" +
+	"\x10enabled_features\x18\x01 \x03(\tR\x0fenabledFeatures\x12'\n" +
+	"\x0fmax_parallelism\x18\x02 \x01(\x05R\x0emaxParallelism\"\x97\x03\n" +
 	"\x12PurgeAssetsRequest\x12\x1a\n" +
 	"\bspaceMrn\x18\x01 \x01(\tR\bspaceMrn\x12\x1d\n" +
 	"\n" +

--- a/policy/cnspec_policy.proto
+++ b/policy/cnspec_policy.proto
@@ -1434,6 +1434,13 @@ message GetScanParametersReq {
 
 message ScanParameters {
   repeated string enabled_features = 1;  // mql feature names enabled by server
+
+  // Hard ceiling on how many assets a client may scan concurrently in this
+  // scope. It overrules everything the client would otherwise pick, including
+  // an explicit --parallelism, so a scope under load can throttle the scans
+  // pointed at it without any client-side change. Zero (or unset) means the
+  // server sets no limit and the client decides on its own.
+  int32 max_parallelism = 2;
 }
 
 message PurgeAssetsRequest {

--- a/policy/cnspec_policy_vtproto.pb.go
+++ b/policy/cnspec_policy_vtproto.pb.go
@@ -2940,6 +2940,7 @@ func (m *ScanParameters) CloneVT() *ScanParameters {
 		return (*ScanParameters)(nil)
 	}
 	r := new(ScanParameters)
+	r.MaxParallelism = m.MaxParallelism
 	if rhs := m.EnabledFeatures; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -11334,6 +11335,11 @@ func (m *ScanParameters) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.MaxParallelism != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxParallelism))
+		i--
+		dAtA[i] = 0x10
+	}
 	if len(m.EnabledFeatures) > 0 {
 		for iNdEx := len(m.EnabledFeatures) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.EnabledFeatures[iNdEx])
@@ -15278,6 +15284,9 @@ func (m *ScanParameters) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.MaxParallelism != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxParallelism))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -38963,6 +38972,25 @@ func (m *ScanParameters) UnmarshalVT(dAtA []byte) error {
 			}
 			m.EnabledFeatures = append(m.EnabledFeatures, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxParallelism", wireType)
+			}
+			m.MaxParallelism = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxParallelism |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -494,13 +494,23 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	// is safe
 	defer multiprogress.Close()
 
-	parallelism := int(job.Parallelism)
-	if parallelism < 1 {
-		parallelism = 1
+	// Children are connected one branch at a time further down, so everything
+	// Connected() reports right now is a root -- the set the default parallelism
+	// is derived from. A job that carries an explicit parallelism keeps it; the
+	// roots are only consulted when it does not.
+	connectedRoots := explorer.Connected()
+	rootAssets := make([]*inventory.Asset, 0, len(connectedRoots))
+	for _, root := range connectedRoots {
+		rootAssets = append(rootAssets, root.Asset)
 	}
+	parallelism := providers.ResolveParallelism(int(job.Parallelism), rootAssets)
 
 	maxConn := getMaxConnections()
-	log.Info().Int("max_connections", maxConn).Int("parallelism", parallelism).Msg("scan pipeline configuration")
+	log.Info().
+		Int("max_connections", maxConn).
+		Int("parallelism", parallelism).
+		Bool("parallelism_explicit", job.Parallelism > 0).
+		Msg("scan pipeline configuration")
 	connSem := make(chan struct{}, maxConn)
 	var scannedAssets atomic.Int64
 

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -377,7 +377,8 @@ func withServerFeatures(ctx context.Context, featureNames []string) context.Cont
 // resolveServerScanParameters fetches server-controlled scan parameters and
 // layers any server-activated features onto ctx. It returns the enriched ctx
 // plus the resolved remote services and space MRN, which the scan pipeline
-// reuses.
+// reuses, and the parameters themselves for the settings the pipeline reads
+// directly (e.g. MaxParallelism).
 //
 // This MUST run before asset discovery. Connection-level features (e.g.
 // TerraformResolveVars, read at provider Connect time) only take effect if they
@@ -385,33 +386,64 @@ func withServerFeatures(ctx context.Context, featureNames []string) context.Cont
 // the root asset. Fetching scan parameters after discovery — as this code used
 // to — left those features inactive on the root connection. For incognito or
 // credential-less scans it is a no-op that returns ctx unchanged with nil
-// services.
-func (s *LocalScanner) resolveServerScanParameters(ctx context.Context, upstreamConfig *upstream.UpstreamConfig) (context.Context, *policy.Services, string, error) {
+// services and nil parameters.
+func (s *LocalScanner) resolveServerScanParameters(ctx context.Context, upstreamConfig *upstream.UpstreamConfig) (context.Context, *policy.Services, string, *policy.ScanParameters, error) {
 	if upstreamConfig == nil || upstreamConfig.ApiEndpoint == "" || upstreamConfig.Incognito {
-		return ctx, nil, "", nil
+		return ctx, nil, "", nil, nil
 	}
 
 	client, err := upstreamConfig.InitClient(ctx)
 	if err != nil {
-		return ctx, nil, "", err
+		return ctx, nil, "", nil, err
 	}
 	spaceMrn := client.SpaceMrn
 
 	services, err := policy.NewRemoteServices(client.ApiEndpoint, client.Plugins, client.HttpClient)
 	if err != nil {
-		return ctx, nil, "", err
+		return ctx, nil, "", nil, err
 	}
 
 	resp, err := services.GetScanParameters(ctx, &policy.GetScanParametersReq{ScopeMrn: spaceMrn})
 	if err != nil {
 		// A failed scan-parameters call must not abort the scan; proceed without
-		// server-activated features.
+		// server-activated features. Note that this also means we proceed without
+		// the server's parallelism ceiling: it is a throttle for a scope under
+		// load, not a safety control, and failing the scan over an unreachable
+		// settings endpoint would be worse than scanning at the local default.
 		log.Warn().Err(err).Msg("could not get server scan parameters")
-		return ctx, services, spaceMrn, nil
+		return ctx, services, spaceMrn, nil, nil
 	}
 
 	ctx = withServerFeatures(ctx, resp.GetEnabledFeatures())
-	return ctx, services, spaceMrn, nil
+	return ctx, services, spaceMrn, resp, nil
+}
+
+// resolveScanParallelism decides how many assets this scan may run at once.
+// The provider defaults (or the user's explicit --parallelism) are resolved
+// first, then the server's ceiling is applied on top -- in that order, so the
+// server outranks an explicit request rather than merely competing with it.
+func resolveScanParallelism(requested int, roots []*inventory.Asset, serverMax int) int {
+	parallelism := providers.ResolveParallelism(requested, roots)
+
+	limited := clampToServerMax(parallelism, serverMax)
+	if limited != parallelism {
+		log.Info().
+			Int("requested", parallelism).
+			Int("server_max", serverMax).
+			Msg("scan parallelism limited by the server")
+	}
+	return limited
+}
+
+// clampToServerMax applies the server's ceiling on scan parallelism. The server
+// gets the last word — above the provider's declared default and above an
+// explicit --parallelism — so a scope under load can throttle every scan pointed
+// at it without touching the clients. A max of zero means the server set none.
+func clampToServerMax(parallelism, serverMax int) int {
+	if serverMax <= 0 || parallelism <= serverMax {
+		return parallelism
+	}
+	return serverMax
 }
 
 func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *upstream.UpstreamConfig) (*ScanResult, error) {
@@ -449,7 +481,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	// Fetch server-controlled scan parameters and layer any server-activated
 	// features onto ctx BEFORE discovery, so connection-level features (e.g.
 	// TerraformResolveVars) are present when discovery connects the root asset.
-	ctx, services, spaceMrn, err := s.resolveServerScanParameters(ctx, upstream)
+	ctx, services, spaceMrn, scanParams, err := s.resolveServerScanParameters(ctx, upstream)
 	if err != nil {
 		return nil, err
 	}
@@ -503,13 +535,15 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	for _, root := range connectedRoots {
 		rootAssets = append(rootAssets, root.Asset)
 	}
-	parallelism := providers.ResolveParallelism(int(job.Parallelism), rootAssets)
+	serverMax := int(scanParams.GetMaxParallelism())
+	parallelism := resolveScanParallelism(int(job.Parallelism), rootAssets, serverMax)
 
 	maxConn := getMaxConnections()
 	log.Info().
 		Int("max_connections", maxConn).
 		Int("parallelism", parallelism).
 		Bool("parallelism_explicit", job.Parallelism > 0).
+		Int("server_max_parallelism", serverMax).
 		Msg("scan pipeline configuration")
 	connSem := make(chan struct{}, maxConn)
 	var scannedAssets atomic.Int64

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -109,15 +109,16 @@ func TestResolveServerScanParameters_NoUpstream(t *testing.T) {
 	base := mql.SetFeatures(context.Background(), mql.DefaultFeatures)
 
 	t.Run("nil upstream", func(t *testing.T) {
-		ctx, services, spaceMrn, err := s.resolveServerScanParameters(base, nil)
+		ctx, services, spaceMrn, params, err := s.resolveServerScanParameters(base, nil)
 		require.NoError(t, err)
 		require.Equal(t, base, ctx)
 		require.Nil(t, services)
 		require.Empty(t, spaceMrn)
+		require.Nil(t, params)
 	})
 
 	t.Run("incognito upstream", func(t *testing.T) {
-		ctx, services, spaceMrn, err := s.resolveServerScanParameters(base, &upstream.UpstreamConfig{
+		ctx, services, spaceMrn, params, err := s.resolveServerScanParameters(base, &upstream.UpstreamConfig{
 			ApiEndpoint: "https://example.com",
 			Incognito:   true,
 		})
@@ -125,6 +126,7 @@ func TestResolveServerScanParameters_NoUpstream(t *testing.T) {
 		require.Equal(t, base, ctx)
 		require.Nil(t, services)
 		require.Empty(t, spaceMrn)
+		require.Nil(t, params)
 	})
 }
 
@@ -715,5 +717,62 @@ func TestNewLocalScannerWithOptions(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, 9999, rt.AutoUpdate.RefreshInterval)
 		assert.False(t, rt.AutoUpdate.Enabled, "should not be modified if a custom runtime is provided")
+	})
+}
+
+// TestClampToServerMax covers the one rule the server ceiling has to obey: it
+// is a maximum, never a minimum, and it outranks whatever the client picked --
+// including a parallelism the user asked for explicitly.
+func TestClampToServerMax(t *testing.T) {
+	tests := []struct {
+		name        string
+		parallelism int
+		serverMax   int
+		expected    int
+	}{
+		{name: "no server limit set", parallelism: 8, serverMax: 0, expected: 8},
+		{name: "negative server limit is ignored", parallelism: 8, serverMax: -1, expected: 8},
+		{name: "server limit above the client value", parallelism: 4, serverMax: 16, expected: 4},
+		{name: "server limit equal to the client value", parallelism: 6, serverMax: 6, expected: 6},
+		{name: "server limit cuts the client value down", parallelism: 8, serverMax: 2, expected: 2},
+		{name: "server can force sequential", parallelism: 8, serverMax: 1, expected: 1},
+		{name: "server never raises a sequential scan", parallelism: 1, serverMax: 16, expected: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, clampToServerMax(tc.parallelism, tc.serverMax))
+		})
+	}
+}
+
+// TestScanParametersMaxParallelismDefaultsToUnset pins the wire behavior the
+// clamp depends on: a server that says nothing about parallelism must read back
+// as zero, which clampToServerMax treats as "no limit" rather than "sequential".
+func TestScanParametersMaxParallelismDefaultsToUnset(t *testing.T) {
+	var nilParams *policy.ScanParameters
+	assert.Equal(t, int32(0), nilParams.GetMaxParallelism(), "a nil response must not throttle the scan")
+
+	empty := &policy.ScanParameters{EnabledFeatures: []string{"some-feature"}}
+	assert.Equal(t, int32(0), empty.GetMaxParallelism())
+	assert.Equal(t, 8, clampToServerMax(8, int(empty.GetMaxParallelism())))
+}
+
+// TestResolveScanParallelismServerOutranksTheClient pins the ordering the
+// server ceiling depends on: it is applied after the client has made its
+// choice, so it cuts down an explicit --parallelism rather than losing to it.
+func TestResolveScanParallelismServerOutranksTheClient(t *testing.T) {
+	t.Run("explicit request with no server limit", func(t *testing.T) {
+		assert.Equal(t, 20, resolveScanParallelism(20, nil, 0))
+	})
+
+	t.Run("server limit cuts an explicit request down", func(t *testing.T) {
+		assert.Equal(t, 2, resolveScanParallelism(20, nil, 2),
+			"an explicit --parallelism must not escape the server ceiling")
+	})
+
+	t.Run("server limit never raises the resolved value", func(t *testing.T) {
+		// No roots means no provider opted in, which resolves to sequential.
+		assert.Equal(t, 1, resolveScanParallelism(0, nil, 16))
 	})
 }

--- a/policy/scan/scan.pb.go
+++ b/policy/scan/scan.pb.go
@@ -176,7 +176,9 @@ type Job struct {
 	// Vault configuration + credentials query
 	// Report type configuration
 	ReportType ReportType `protobuf:"varint,22,opt,name=report_type,json=reportType,proto3,enum=cnspec.policy.scan.ReportType" json:"report_type,omitempty"`
-	// Number of assets to scan in parallel. A value of 0 or 1 means sequential.
+	// Number of assets to scan in parallel. Zero (or unset) lets the scanner pick
+	// a default from the providers behind the root assets, capped by the CPUs
+	// available on the machine. Use 1 for sequential.
 	Parallelism   int32 `protobuf:"varint,24,opt,name=parallelism,proto3" json:"parallelism,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/policy/scan/scan.proto
+++ b/policy/scan/scan.proto
@@ -51,7 +51,9 @@ message Job {
 	// Report type configuration
   ReportType report_type = 22;
 
-  // Number of assets to scan in parallel. A value of 0 or 1 means sequential.
+  // Number of assets to scan in parallel. Zero (or unset) lets the scanner pick
+  // a default from the providers behind the root assets, capped by the CPUs
+  // available on the machine. Use 1 for sequential.
   int32 parallelism = 24;
 }
 

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -31,7 +31,7 @@ Flags:
   -j, --json                          Run the query and return the object in a JSON structure
   -o, --output string                 Set the output format: compact, csv, full, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "compact")
       --output-target string          Set the output target for the asset report. Currently only supports AWS SQS topic URLs and local files
-      --parallelism int               Set the number of assets to scan in parallel. A value of 0 or 1 means sequential (default 1)
+      --parallelism int               Set the number of assets to scan in parallel. Defaults to a per-provider value capped by the CPUs available on this machine. Use 1 for sequential
       --platform-id string            Select a specific target asset by providing its platform ID
       --policy strings                Specify policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY
   -f, --policy-bundle strings         Set the path to a policy file. Supports local paths, s3:// URIs, and http(s):// URLs


### PR DESCRIPTION
--parallelism now defaults to 0, meaning "ask the providers". The scanner resolves it through providers.ResolveParallelism: the smallest value declared by the providers behind the root assets, capped at half the machine's available CPUs. An explicit --parallelism (or MONDOO_PARALLELISM) still wins and is not capped, and 1 is still sequential.

Providers that have not opted in resolve to 1, so this is a no-op for every provider that has not declared a value, and for a mixed inventory where any root belongs to one that has not.

Measured on a 6-host inventory running a TLS check: 10.87s sequential vs 5.71s at the resolved default of 6, with byte-identical output.

The scan pipeline log line gained parallelism_explicit so it is visible whether the number came from the operator or from the provider.

Requires an mql release containing providers.ResolveParallelism.