### PR TITLE
🐛 give every asset its own copy of the policy bundle

### DIFF
--- a/policy/scan/bundle_isolation_test.go
+++ b/policy/scan/bundle_isolation_test.go
@@ -1,0 +1,140 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scan
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/v13/internal/datalakes/inmemory"
+	"go.mondoo.com/cnspec/v13/policy"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
+	"google.golang.org/protobuf/proto"
+)
+
+func sharedTestBundle() *policy.Bundle {
+	return &policy.Bundle{
+		Policies: []*policy.Policy{{
+			Uid:     "test-policy",
+			Name:    "Test Policy",
+			Version: "1.0.0",
+			Groups: []*policy.PolicyGroup{{
+				Filters: &policy.Filters{Items: map[string]*policy.Mquery{
+					"//local/filter": {Mql: "true"},
+				}},
+				Checks: []*policy.Mquery{
+					{Uid: "check-name", Title: "asset has a name", Mql: "asset.name != ''"},
+					{Uid: "check-platform", Title: "asset has a platform", Mql: "asset.platform != ''"},
+				},
+			}},
+		}},
+	}
+}
+
+func newTestAssetScanner(t *testing.T, bundle *policy.Bundle, assetMrn string) *localAssetScanner {
+	t.Helper()
+	runtime := testutils.Local()
+	_, services, err := inmemory.NewServices(runtime)
+	require.NoError(t, err)
+
+	return &localAssetScanner{
+		services: services,
+		Runtime:  runtime,
+		job: &AssetJob{
+			Ctx:            context.Background(),
+			Asset:          &inventory.Asset{Mrn: assetMrn, Name: "test-asset"},
+			Bundle:         bundle,
+			UpstreamConfig: &upstream.UpstreamConfig{Incognito: true},
+		},
+	}
+}
+
+func TestPrepareAssetLeavesTheJobBundleUntouched(t *testing.T) {
+	bundle := sharedTestBundle()
+	before, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+
+	scanner := newTestAssetScanner(t, bundle, "//assets/test-1")
+	require.NoError(t, scanner.prepareAsset())
+
+	after, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+	assert.Equal(t, before, after,
+		"prepareAsset must compile a copy: the job's bundle is shared by every asset in the scan")
+}
+
+// TestConcurrentPrepareAssetOnOneBundle is the regression test for the crash
+// that parallel scanning used to produce: several assets sharing one job bundle
+// each compiled it in place, which raced on the queries' MRNs and checksums and
+// killed the process outright with a concurrent map write in ComputedFilters.
+// Run under -race, this fails without the per-asset copy.
+func TestConcurrentPrepareAssetOnOneBundle(t *testing.T) {
+	bundle := sharedTestBundle()
+	before, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+
+	const assets = 8
+	scanners := make([]*localAssetScanner, assets)
+	for i := range scanners {
+		scanners[i] = newTestAssetScanner(t, bundle, "//assets/test-"+strconv.Itoa(i))
+	}
+
+	errs := make([]error, assets)
+	var wg sync.WaitGroup
+	for i := range scanners {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = scanners[i].prepareAsset()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "asset %d", i)
+	}
+
+	after, err := proto.Marshal(bundle)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "concurrent asset preparation must not touch the shared bundle")
+}
+
+// TestPrepareAssetMapsPropsFromTheCopy guards the one value prepareAsset reads
+// back out of the compiled bundle. Property MRNs are filled in during
+// compilation, so they have to be read from the asset's copy; reading them from
+// the job's (now untouched) bundle would silently drop every override.
+func TestPrepareAssetMapsPropsFromTheCopy(t *testing.T) {
+	bundle := sharedTestBundle()
+	bundle.Policies[0].Props = []*policy.Property{{
+		Uid: "homeDir",
+		Mql: "return '/home'",
+	}}
+
+	scanner := newTestAssetScanner(t, bundle, "//assets/test-props")
+	scanner.job.Props = map[string]string{"homeDir": "return '/root'"}
+
+	require.NoError(t, scanner.prepareAsset())
+
+	compiled := bundle.CloneVT()
+	_, err := compiled.CompileExt(context.Background(), policy.BundleCompileConf{
+		CompilerConfig: scanner.services.NewCompilerConfig(),
+		Library:        scanner.services.DataLake,
+		RemoveFailing:  true,
+	})
+	require.NoError(t, err)
+
+	req, err := scanner.mapPropOverrides(compiled)
+	require.NoError(t, err)
+	require.Len(t, req.Props, 1, "the override must match the property the bundle exposes")
+	assert.Equal(t, "return '/root'", req.Props[0].Mql)
+	require.Len(t, req.Props[0].For, 1)
+	assert.Contains(t, req.Props[0].For[0].Mrn, "homeDir",
+		"the override must resolve to the property MRN written during compilation")
+}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1210,10 +1210,25 @@ func (s *localAssetScanner) prepareAsset() error {
 		return errors.New("no bundle provided to run")
 	}
 
+	// Every asset gets its own copy of the bundle. The job's bundle is one
+	// pointer shared by all assets, and the work below writes to it: CompileExt
+	// fills in MRNs and checksums on the policies and queries it walks, its
+	// RemoveFailing option deletes the queries that would not compile ("we do
+	// this to the original bundle, because the intent is to clean it up with
+	// this option"), and SetBundleMap goes on to replace ComputedFilters on
+	// every policy it stores. Sharing the bundle across concurrently scanning
+	// assets crashes the process outright with a concurrent map write.
+	//
+	// Cloning also keeps assets independent when they run one after another:
+	// the compiler schema is process-global and grows as providers load lazily,
+	// so a pruned bundle would otherwise carry an early asset's idea of what
+	// compiles into every asset that follows it.
+	bundle := s.job.Bundle.CloneVT()
+
 	// Ensure any required providers declared in the bundle are installed
 	// before we try to compile it. This handles bundles with Require metadata.
-	if s.job.Bundle.HasRequirements() {
-		if err := s.job.Bundle.EnsureRequirements(true); err != nil {
+	if bundle.HasRequirements() {
+		if err := bundle.EnsureRequirements(true); err != nil {
 			log.Warn().Err(err).Msg("failed to ensure some policy requirements, continuing with available providers")
 		}
 	}
@@ -1222,7 +1237,7 @@ func (s *localAssetScanner) prepareAsset() error {
 	// The upstream bundle may contain queries for all providers in the space,
 	// but we only need the ones relevant to this asset's platform.
 	conf := s.services.NewCompilerConfig()
-	bundleMap, err := s.job.Bundle.CompileExt(s.job.Ctx, policy.BundleCompileConf{
+	bundleMap, err := bundle.CompileExt(s.job.Ctx, policy.BundleCompileConf{
 		CompilerConfig: conf,
 		Library:        s.services.DataLake,
 		RemoveFailing:  true,
@@ -1234,11 +1249,11 @@ func (s *localAssetScanner) prepareAsset() error {
 		return err
 	}
 
-	policyMrns := filterPolicyMrns(s.job.Bundle, s.job.PolicyFilters)
+	policyMrns := filterPolicyMrns(bundle, s.job.PolicyFilters)
 
-	frameworkMrns := make([]string, len(s.job.Bundle.Frameworks))
-	for i := range s.job.Bundle.Frameworks {
-		frameworkMrns[i] = s.job.Bundle.Frameworks[i].Mrn
+	frameworkMrns := make([]string, len(bundle.Frameworks))
+	for i := range bundle.Frameworks {
+		frameworkMrns[i] = bundle.Frameworks[i].Mrn
 	}
 
 	var resolver policy.PolicyResolver = s.services
@@ -1253,7 +1268,7 @@ func (s *localAssetScanner) prepareAsset() error {
 	}
 
 	if len(s.job.Props) != 0 {
-		propsReq, err := s.mapPropOverrides()
+		propsReq, err := s.mapPropOverrides(bundle)
 		if err != nil {
 			return fmt.Errorf("failed to map property overrides: %w", err)
 		}
@@ -1266,9 +1281,12 @@ func (s *localAssetScanner) prepareAsset() error {
 	return nil
 }
 
-func (s *localAssetScanner) mapPropOverrides() (*policy.PropsReq, error) {
+// mapPropOverrides reads the property MRNs off the compiled bundle, so it takes
+// the asset's own copy rather than the job's shared one: the MRNs it needs are
+// written during compilation, which no longer touches the shared bundle.
+func (s *localAssetScanner) mapPropOverrides(bundle *policy.Bundle) (*policy.PropsReq, error) {
 	exposedProps := make(map[string][]string, len(s.job.Props))
-	for _, pol := range s.job.Bundle.Policies {
+	for _, pol := range bundle.Policies {
 		for _, prop := range pol.Props {
 			propUid, err := policy.GetPropName(prop.Mrn)
 			if err != nil {


### PR DESCRIPTION
The job's bundle is one pointer shared by every asset in a scan, and prepareAsset writes to it: CompileExt fills in MRNs and checksums on the policies and queries it walks, RemoveFailing deletes the queries that would not compile, and SetBundleMap replaces ComputedFilters on every policy it stores.

With more than one asset in flight this killed the process. Reproduced on a manifest with 20 Deployments: 565 data races under -race, and 3 of 5 plain runs died with "fatal error: concurrent map writes" in ComputedFilters, scoring zero assets. The two that survived scored 19 and 21 of 22, leaking half-written state as "failed to get checksums for dependent policy".

Compiling a per-asset copy also keeps assets independent when they run in sequence: the compiler schema is process-global and grows as providers load lazily, so a destructively pruned bundle carried an early asset's idea of what compiles into every asset after it.

After the fix the same scan reports 0 races and scores 22/22 on every run, with identical results sequentially and in parallel.