### PR TITLE
🐛 filters: decide asset-filter matches from the final score, not the first passing one

### DIFF
--- a/policy/executor/graph.go
+++ b/policy/executor/graph.go
@@ -122,7 +122,7 @@ func ExecuteFilterQueries(ctx context.Context, runtime llx.Runtime, queries []*p
 		queryMap[codeBundle.CodeV2.Id] = m
 	}
 
-	passingFilterQueries := map[string]struct{}{}
+	tracker := newFilterScoreTracker()
 	collector := &internal.FuncCollector{
 		SinkScoreFunc: func(scores []*policy.Score) {
 			for _, s := range scores {
@@ -134,9 +134,7 @@ func ExecuteFilterQueries(ctx context.Context, runtime llx.Runtime, queries []*p
 					Int("dataCompletion", int(s.DataCompletion)).
 					Int("value", int(s.Value)).
 					Msg("filter query score received")
-				if s.ScoreCompletion == 100 && s.Value == 100 {
-					passingFilterQueries[s.QrId] = struct{}{}
-				}
+				tracker.record(s)
 			}
 		},
 	}
@@ -157,6 +155,10 @@ func ExecuteFilterQueries(ctx context.Context, runtime llx.Runtime, queries []*p
 
 	ge.Debug(ctx, "filter-queries")
 
+	// Decided only now that execution has finished, so every provisional score
+	// has had the chance to be corrected. See filterScoreTracker.
+	passingFilterQueries := tracker.passing()
+
 	filteredQueries := []*policy.Mquery{}
 	for id, query := range queryMap {
 		if _, ok := passingFilterQueries[id]; ok {
@@ -165,6 +167,65 @@ func ExecuteFilterQueries(ctx context.Context, runtime llx.Runtime, queries []*p
 	}
 
 	return filteredQueries, errors
+}
+
+// filterScoreTracker records the scores the graph emits for filter queries and
+// decides which filters matched once execution has finished.
+//
+// The graph emits a score for a reporting query on EVERY round in which all of
+// that query's entrypoints are resolved, and those intermediate scores are
+// provisional. Datapoint checksums are content-addressed and shared across
+// queries, so another query can resolve one of this query's entrypoints before
+// this query executes it itself — with a short-circuit nil for a branch it
+// never evaluated, or with a broadcast placeholder for a query that could not
+// run at all. ReportingQueryNodeData.score() skips nil-valued entrypoints
+// rather than failing them, so a multi-statement filter can transiently score
+// 100 on just the subset that happened to resolve.
+//
+// Concretely: the Debian 8 and Debian 9 policy filters are identical apart from
+// their version line —
+//
+//	asset.platform == "debian"
+//	asset.version == /^8\./
+//	asset.kind != "container-image"
+//
+// On a Debian 11 host, statements 1 and 3 are resolved TRUE by the Debian
+// 9/10/11 filters, which compile to the same checksums. If the version
+// statement is nil for a single round, the Debian 8 filter scores 100 and the
+// host is told to run the whole Debian 8 policy. ScoreCompletion is 100 on
+// every round, so a provisional score is indistinguishable from a final one at
+// this layer.
+//
+// resultUpgrades() repairs the datapoint and the node recalculates to the real
+// score, so the LAST score emitted for a query is the authoritative one.
+// Latching the first passing score threw that correction away and made the
+// filter set depend on the order results happened to arrive in.
+type filterScoreTracker struct {
+	last map[string]*policy.Score
+}
+
+func newFilterScoreTracker() *filterScoreTracker {
+	return &filterScoreTracker{last: map[string]*policy.Score{}}
+}
+
+// record keeps the most recent score seen for a query, replacing any earlier
+// provisional one.
+func (t *filterScoreTracker) record(s *policy.Score) {
+	if s == nil {
+		return
+	}
+	t.last[s.QrId] = s
+}
+
+// passing returns the queries whose FINAL score means the filter matched.
+func (t *filterScoreTracker) passing() map[string]struct{} {
+	res := make(map[string]struct{}, len(t.last))
+	for id, s := range t.last {
+		if s.ScoreCompletion == 100 && s.Value == 100 {
+			res[id] = struct{}{}
+		}
+	}
+	return res
 }
 
 func ExecuteQuery(runtime llx.Runtime, codeBundle *llx.CodeBundle, props map[string]*llx.Primitive, features mql.Features) (*policy.Score, map[string]*llx.RawResult, error) {

--- a/policy/executor/graph_test.go
+++ b/policy/executor/graph_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func filterScore(qrID string, value uint32) *policy.Score {
+	return &policy.Score{
+		QrId:            qrID,
+		Type:            policy.ScoreType_Result,
+		Value:           value,
+		ScoreCompletion: 100,
+	}
+}
+
+// The graph emits a score every round a query's entrypoints are all resolved,
+// and a provisional round can score 100 on a filter that does not actually
+// match (a shared entrypoint checksum resolved by another query as a
+// short-circuit nil, which score() skips instead of failing). Only the final
+// score may decide whether the filter matched.
+func TestFilterScoreTracker_ProvisionalPassIsRevised(t *testing.T) {
+	// The Debian 8 filter on a Debian 11 host: `asset.platform == "debian"`
+	// and `asset.kind != "container-image"` resolve TRUE from the Debian 9/10
+	// filters (identical statements, identical checksums) while
+	// `asset.version == /^8\./` is still nil, so the query provisionally
+	// scores 100. Once its own execution reports the version statement as
+	// false, the node recalculates to 0.
+	tracker := newFilterScoreTracker()
+	tracker.record(filterScore("debian8-filter", 100))
+	tracker.record(filterScore("debian8-filter", 0))
+
+	assert.NotContains(t, tracker.passing(), "debian8-filter",
+		"a provisional 100 that was revised to 0 must not count as a match")
+}
+
+func TestFilterScoreTracker_Passing(t *testing.T) {
+	t.Run("a single passing score matches", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		tracker.record(filterScore("debian11-filter", 100))
+		assert.Contains(t, tracker.passing(), "debian11-filter")
+	})
+
+	t.Run("a provisional failure upgraded to a pass matches", func(t *testing.T) {
+		// The mirror of the case above: a placeholder from a query that could
+		// not run poisons a shared checksum first, and the query's own
+		// execution then reports the real, passing result.
+		tracker := newFilterScoreTracker()
+		tracker.record(filterScore("debian11-filter", 0))
+		tracker.record(filterScore("debian11-filter", 100))
+		assert.Contains(t, tracker.passing(), "debian11-filter")
+	})
+
+	t.Run("a failing score does not match", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		tracker.record(filterScore("debian8-filter", 0))
+		assert.Empty(t, tracker.passing())
+	})
+
+	t.Run("an incomplete score does not match", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		s := filterScore("debian8-filter", 100)
+		s.ScoreCompletion = 50
+		tracker.record(s)
+		assert.Empty(t, tracker.passing())
+	})
+
+	t.Run("an errored score does not match", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		tracker.record(&policy.Score{
+			QrId:            "debian8-filter",
+			Type:            policy.ScoreType_Error,
+			Value:           0,
+			ScoreCompletion: 100,
+		})
+		assert.Empty(t, tracker.passing())
+	})
+
+	t.Run("queries are tracked independently", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		tracker.record(filterScore("debian8-filter", 100))
+		tracker.record(filterScore("debian11-filter", 100))
+		tracker.record(filterScore("debian8-filter", 0))
+
+		passing := tracker.passing()
+		assert.NotContains(t, passing, "debian8-filter")
+		assert.Contains(t, passing, "debian11-filter")
+	})
+
+	t.Run("nil scores are ignored", func(t *testing.T) {
+		tracker := newFilterScoreTracker()
+		tracker.record(nil)
+		assert.Empty(t, tracker.passing())
+	})
+}

--- a/policy/executor/internal/nodes_multientrypoint_test.go
+++ b/policy/executor/internal/nodes_multientrypoint_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// A multi-statement asset filter compiles to one query with one entrypoint per
+// statement, and score() combines the statements with a logical and: the query
+// scores 100 only if every entrypoint is true. But score() SKIPS nil-valued
+// entrypoints instead of failing them, so while a statement is still nil the
+// query is scored on the subset that did resolve — and it reports
+// ScoreCompletion 100 while doing so.
+//
+// This is reachable because datapoint checksums are content-addressed and
+// shared across queries: an entrypoint of this query can be resolved by a
+// different query that short-circuited the same statement, before this query
+// has executed it. The Debian 8 and Debian 9 policy filters are identical apart
+// from their version line, so `asset.platform == "debian"` and
+// `asset.kind != "container-image"` arrive from a sibling filter while
+// `asset.version == /^8\./` is still outstanding.
+//
+// Consumers of these scores must therefore wait for execution to finish rather
+// than latch the first passing score they see (see filterScoreTracker in
+// policy/executor/graph.go).
+func TestReportingQueryNode_NilEntrypointScoresProvisionally(t *testing.T) {
+	nodeData := &ReportingQueryNodeData{
+		queryID: "debian8-filter",
+		results: map[string]*DataResult{
+			"platform-cs": {checksum: "platform-cs"},
+			"version-cs":  {checksum: "version-cs"},
+			"kind-cs":     {checksum: "kind-cs"},
+		},
+	}
+	nodeData.initialize()
+
+	// The sibling Debian 9/10/11 filters compile these two statements to the
+	// same checksums and report them first.
+	nodeData.consume(NodeID("platform-cs"), &envelope{res: realBoolRes("platform-cs", true)})
+	nodeData.consume(NodeID("kind-cs"), &envelope{res: realBoolRes("kind-cs", true)})
+
+	// Nothing is scored yet: the version statement is still outstanding.
+	assert.Nil(t, nodeData.score(), "no score before every entrypoint is resolved")
+
+	// A nil lands on the shared version checksum — a branch some other query
+	// short-circuited and never evaluated.
+	nodeData.consume(NodeID("version-cs"), &envelope{res: executedNilRes("version-cs")})
+
+	s := nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Result, s.Type)
+	assert.Equal(t, uint32(100), s.Value,
+		"the nil entrypoint is skipped, so the filter provisionally passes on the other two statements")
+	assert.Equal(t, uint32(100), s.ScoreCompletion,
+		"the provisional score is indistinguishable from a final one by completion alone")
+
+	// This query then executes the version statement itself. A real result
+	// upgrades the nil and the node recalculates to the truth: no match.
+	nodeData.consume(NodeID("version-cs"), &envelope{res: realBoolRes("version-cs", false)})
+	nodeData.invalidated = true
+
+	s = nodeData.score()
+	require.NotNil(t, s)
+	assert.Equal(t, policy.ScoreType_Result, s.Type)
+	assert.Equal(t, uint32(0), s.Value,
+		"the executed result must override the short-circuit nil")
+}
+
+// Deciding a filter from its final score is only sound if the correction
+// actually reaches the reporting query: the datapoint node has already
+// forwarded the nil once, and it must forward the upgrade too rather than treat
+// itself as done. Without this the reporting query would keep the nil forever
+// and its last score would still be the provisional one.
+func TestDatapointNode_NilUpgradeIsForwardedAgain(t *testing.T) {
+	nodeData := &DatapointNodeData{}
+	nodeData.initialize()
+
+	nodeData.consume("", &envelope{res: executedNilRes("version-cs")})
+	require.NotNil(t, nodeData.recalculate(), "the short-circuit nil is forwarded downstream")
+	require.Nil(t, nodeData.recalculate(), "nothing new to forward")
+
+	nodeData.consume("", &envelope{res: realBoolRes("version-cs", false)})
+	out := nodeData.recalculate()
+	require.NotNil(t, out, "the upgrade must be forwarded so consumers can re-score")
+	require.NotNil(t, out.res)
+	assert.Equal(t, false, out.res.Data.Value)
+}


### PR DESCRIPTION
## The report

A customer's Debian 11 host **sometimes** — not every time — executed checks from the Debian 8 and Debian 9 policies. Confirmed by CS.

The filters themselves are strict and cannot match a Debian 11 host, and the server can only ever *narrow* what a client reports as matching. The fault is on the client, in how `ExecuteFilterQueries` reads the scores the graph gives it.

## Root cause

The graph emits a score for a reporting query on **every round** in which all of that query's entrypoints are resolved, and those intermediate scores are **provisional**. Datapoint checksums are content-addressed and shared across queries, so one query's entrypoint can be resolved by a *different* query first — as a short-circuit nil for a branch that query never evaluated, or as a broadcast placeholder for a query that could not run at all. That cross-query poisoning is exactly what `resultUpgrades()` and `TestReportingQueryNode_PoisonedSharedChecksumRecovers` already exist for.

`ReportingQueryNodeData.score()` **skips** nil-valued entrypoints rather than failing them, so while a statement is nil the query is scored on the subset that did resolve.

The Debian 8 and Debian 9 policy filters are byte-identical apart from their version line:

```
asset.platform == "debian"
asset.version  == /^8\./          # /^9\./ for the Debian 9 policy
asset.kind != "container-image"
```

That is one query with three entrypoints. On a Debian 11 host, statements 1 and 3 are resolved `TRUE` by the sibling Debian 9/10/11 filters — same statements, same checksums — so if the version statement is nil for a single round, the Debian 8 filter scores **100, ScoreCompletion 100**, which is indistinguishable from a final score at this layer.

The real result then upgrades the nil and the node recalculates to 0. But `ExecuteFilterQueries` had already latched the pass:

```go
if s.ScoreCompletion == 100 && s.Value == 100 {
    passingFilterQueries[s.QrId] = struct{}{}   // never removed
}
```

So the client reported the Debian 8 filter as matching, and the server resolved the entire Debian 8 policy onto the asset. Whether the provisional round happens before the real value lands is a scheduling race — hence "sometimes, not every time".

## The fix

Keep the **last** score per query and decide which filters matched after `Execute()` returns — the state the upgrade machinery already exists to produce.

## Blast radius

The change is **strictly narrowing**. A query passed before if *any* score was 100/100; it passes now if its *last* score is 100/100. So the only sequences whose outcome changes are exactly the buggy ones — a pass that was later revised away. The opposite order (a poisoned checksum scoring 0 before the real result arrives and scores 100) was already handled correctly by the old latch and still passes; there is no second class of bug being fixed here.

Narrowing is safe because a datapoint can only ever move *toward* real data: `resultUpgrades()` lets an executed result replace a placeholder or a short-circuit nil, and never the reverse. So the last score a query emits is computed from fully-resolved values, and a filter that genuinely matches cannot be dropped by this change.

`ExecuteFilterQueries` has one caller (`localAssetScanner.FilterQueries`), so the change is confined to the scan filter phase. `SinkScore` runs on the `Execute()` goroutine, so no new concurrency is introduced — the tracker replaces a plain map with a plain map.

## Tests

Both of these pass against the **unmodified** production code — they pin behaviour the fix depends on rather than behaviour the fix introduces:

- `TestReportingQueryNode_NilEntrypointScoresProvisionally` — the three-entrypoint Debian-8-shaped query really does emit `Result/100, ScoreCompletion 100` while its version entrypoint is nil, then `Result/0` once the executed result upgrades it. The provisional 100 is real, not hypothetical.
- `TestDatapointNode_NilUpgradeIsForwardedAgain` — a datapoint node that has already forwarded a nil forwards the upgrade too. This is load-bearing: if the node treated itself as done after the first emit, the correction would never reach the reporting query, its last score would still be the provisional one, and this fix would be inert.

Plus `TestFilterScoreTracker_*` for the decision logic itself: provisional-pass-then-fail does not match, provisional-fail-then-pass does, and incomplete/errored scores never match.

I did not attempt a deterministic end-to-end reproduction of the round ordering — that is a scheduling race across a real runtime. The tests cover each link in the chain and the wiring between them is three lines.

## Verifying against a live host

`ExecuteFilterQueries` already logs every score it receives, so an affected host proves the bug on the spot:

```
cnspec scan --log-level debug ... 2>&1 | grep "filter query score received"
```

The same `qrId` appearing with `value=100` and then `value=0` is the latch firing.

## Not fixed here

`ReportingQueryNodeData.score()` skipping nil entrypoints is arguably wrong for a multi-entrypoint query — a null statement is not a satisfied statement. I left it alone deliberately: the `allSkipped` → `ScoreType_Skip` path depends on that behaviour, and fixing the latch is sufficient for this bug and much lower risk. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhbHMJRr3rakWSPUBcPTi9
