### PR TITLE
🐛 sbom: refuse an unsupported --output instead of silently falling back

### DIFF
--- a/apps/cnspec/cmd/aibom.go
+++ b/apps/cnspec/cmd/aibom.go
@@ -67,6 +67,12 @@ Examples:
 		if err := viper.BindPFlag("output-target", cmd.Flags().Lookup("output-target")); err != nil {
 			log.Fatal().Err(err).Msg("failed to bind output-target flag")
 		}
+
+		// aibom.NewFormatter falls back to markdown instead of returning nil, so the
+		// format has to be rejected here or an unsupported -o silently renders markdown
+		if format := viper.GetString("output"); !aibom.IsSupportedFormat(format) {
+			log.Fatal().Msg("unsupported output format: " + format + ". Supported formats: " + aibom.AllFormats())
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {},
 }
@@ -103,11 +109,8 @@ var aibomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *p
 
 	boms := generator.GenerateAiBom(cnspecReport.ToCnqueryReport())
 
-	output := viper.GetString("output")
-	formatter := aibom.NewFormatter(output)
-	if formatter == nil {
-		log.Fatal().Msg("unsupported output format: " + output)
-	}
+	// the output format is validated in PreRun, aibom.NewFormatter always returns a handler
+	formatter := aibom.NewFormatter(viper.GetString("output"))
 
 	outputTarget := viper.GetString("output-target")
 	for i := range boms {

--- a/apps/cnspec/cmd/sbom.go
+++ b/apps/cnspec/cmd/sbom.go
@@ -68,6 +68,12 @@ Note this command is experimental and may change in the future.
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to bind with-cpes flag")
 		}
+
+		// sbom.New falls back to the table format instead of returning nil, so the
+		// format has to be rejected here or an unsupported -o silently renders a table
+		if format := viper.GetString("output"); !sbom.IsSupportedFormat(format) {
+			log.Fatal().Msg("unsupported output format: " + format + ". Supported formats: " + sbom.AllFormats())
+		}
 	},
 	// we have to initialize an empty run so it shows up as a runnable command in --help
 	Run: func(cmd *cobra.Command, args []string) {},
@@ -107,12 +113,8 @@ var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 
 	boms := generator.GenerateBom(cnspecReport.ToCnqueryReport())
 
-	var exporter sbom.FormatSpecificationHandler
-	output := viper.GetString("output")
-	exporter = sbom.New(output)
-	if exporter == nil {
-		log.Fatal().Err(err).Msg("failed to get exporter for output format: " + output)
-	}
+	// the output format is validated in PreRun, sbom.New always returns a handler
+	exporter := sbom.New(viper.GetString("output"))
 
 	if viper.GetBool("with-evidence") {
 		exporter.ApplyOptions(sbom.WithEvidence())

--- a/internal/aibom/aibom.go
+++ b/internal/aibom/aibom.go
@@ -24,35 +24,60 @@ type FormatHandler interface {
 	Render(w io.Writer, bom *AiBom) error
 }
 
-func AllFormats() string {
-	return strings.Join([]string{
-		FormatMarkdown, FormatJSON, FormatCycloneDxJSON, FormatCycloneDxXML,
-	}, ", ")
+// format is one value --output accepts: what builds it, and whether it is
+// advertised. AllFormats, IsSupportedFormat and NewFormatter all read this, so
+// a format cannot be constructible but rejected by the guard, or accepted and
+// then silently fall through to a default. Those were three hand-kept lists.
+type format struct {
+	name       string
+	documented bool
+	new        func() FormatHandler
 }
 
-// IsSupportedFormat returns true if NewFormatter can render the given format.
-// NewFormatter falls back to markdown for anything it does not recognize, so
-// callers that want to reject an unknown format have to ask this first.
-func IsSupportedFormat(format string) bool {
-	switch format {
-	case FormatMarkdown, FormatJSON, FormatCycloneDxJSON, FormatCycloneDxXML:
-		return true
-	default:
-		return false
-	}
-}
-
-func NewFormatter(format string) FormatHandler {
-	switch format {
-	case FormatCycloneDxJSON:
+var formats = []format{
+	{FormatMarkdown, true, func() FormatHandler { return &TextListFormatter{} }},
+	{FormatJSON, true, func() FormatHandler { return &JSONFormatter{} }},
+	{FormatCycloneDxJSON, true, func() FormatHandler {
 		return &CycloneDXFormatter{Format: cyclonedx.BOMFileFormatJSON}
-	case FormatCycloneDxXML:
+	}},
+	{FormatCycloneDxXML, true, func() FormatHandler {
 		return &CycloneDXFormatter{Format: cyclonedx.BOMFileFormatXML}
-	case FormatJSON:
-		return &JSONFormatter{}
-	case FormatMarkdown:
-		fallthrough
-	default:
-		return &TextListFormatter{}
+	}},
+}
+
+func lookup(name string) (format, bool) {
+	for _, f := range formats {
+		if f.name == name {
+			return f, true
+		}
 	}
+	return format{}, false
+}
+
+// AllFormats lists the documented formats, for the error a bad --output gets.
+func AllFormats() string {
+	names := make([]string, 0, len(formats))
+	for _, f := range formats {
+		if f.documented {
+			names = append(names, f.name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+// IsSupportedFormat reports whether NewFormatter can render the format.
+// NewFormatter falls back to markdown for anything else, so a caller that wants
+// to refuse an unknown --output has to ask this first.
+func IsSupportedFormat(format string) bool {
+	_, ok := lookup(format)
+	return ok
+}
+
+// NewFormatter returns the handler for a format. It keeps the historical
+// fallback to markdown for callers that did not check IsSupportedFormat first.
+func NewFormatter(name string) FormatHandler {
+	if f, ok := lookup(name); ok {
+		return f.new()
+	}
+	return &TextListFormatter{}
 }

--- a/internal/aibom/aibom.go
+++ b/internal/aibom/aibom.go
@@ -30,6 +30,18 @@ func AllFormats() string {
 	}, ", ")
 }
 
+// IsSupportedFormat returns true if NewFormatter can render the given format.
+// NewFormatter falls back to markdown for anything it does not recognize, so
+// callers that want to reject an unknown format have to ask this first.
+func IsSupportedFormat(format string) bool {
+	switch format {
+	case FormatMarkdown, FormatJSON, FormatCycloneDxJSON, FormatCycloneDxXML:
+		return true
+	default:
+		return false
+	}
+}
+
 func NewFormatter(format string) FormatHandler {
 	switch format {
 	case FormatCycloneDxJSON:

--- a/internal/sbom/formats.go
+++ b/internal/sbom/formats.go
@@ -35,54 +35,73 @@ type FormatSpecificationHandler interface {
 	Decoder
 }
 
+// format is one value --output accepts: what builds it, and whether it is
+// advertised. The undocumented ones are accepted but not listed -- "list" is
+// the flag's own default while FormatList is "table", and the two json aliases
+// predate this and stay for callers already using them.
+//
+// AllFormats, IsSupportedFormat and New all read this, so a format cannot be
+// constructible but rejected by the guard, or accepted and then silently fall
+// through to a default. Those were three hand-kept lists before.
+type format struct {
+	name       string
+	documented bool
+	new        func() FormatSpecificationHandler
+}
+
+var formats = []format{
+	{FormatJson, true, func() FormatSpecificationHandler { return &CnspecBOM{} }},
+	{"cnquery-json", false, func() FormatSpecificationHandler { return &CnspecBOM{} }},
+	{"cnspec-json", false, func() FormatSpecificationHandler { return &CnspecBOM{} }},
+	{FormatCycloneDxJSON, true, func() FormatSpecificationHandler {
+		return &CycloneDX{Format: cyclonedx.BOMFileFormatJSON}
+	}},
+	{FormatCycloneDxXML, true, func() FormatSpecificationHandler {
+		return &CycloneDX{Format: cyclonedx.BOMFileFormatXML}
+	}},
+	{FormatSpdxJSON, true, func() FormatSpecificationHandler {
+		return &Spdx{Version: "2.3", Format: FormatSpdxJSON}
+	}},
+	{FormatSpdxTagValue, true, func() FormatSpecificationHandler {
+		return &Spdx{Version: "2.3", Format: FormatSpdxTagValue}
+	}},
+	{FormatList, true, func() FormatSpecificationHandler { return &TextList{} }},
+	{"list", false, func() FormatSpecificationHandler { return &TextList{} }},
+}
+
+func lookup(name string) (format, bool) {
+	for _, f := range formats {
+		if f.name == name {
+			return f, true
+		}
+	}
+	return format{}, false
+}
+
+// AllFormats lists the documented formats, for the error a bad --output gets.
 func AllFormats() string {
-	formats := []string{
-		FormatJson, FormatCycloneDxJSON, FormatCycloneDxXML, FormatSpdxJSON, FormatSpdxTagValue, FormatList,
+	names := make([]string, 0, len(formats))
+	for _, f := range formats {
+		if f.documented {
+			names = append(names, f.name)
+		}
 	}
-
-	return strings.Join(formats, ", ")
+	return strings.Join(names, ", ")
 }
 
-// IsSupportedFormat returns true if New can render the given format. New falls
-// back to the table format for anything it does not recognize, so callers that
-// want to reject an unknown format have to ask this first.
+// IsSupportedFormat reports whether New can render the format. New falls back to
+// the table renderer for anything else, so a caller that wants to refuse an
+// unknown --output has to ask this first.
 func IsSupportedFormat(format string) bool {
-	switch format {
-	case FormatJson, "cnquery-json", "cnspec-json",
-		FormatCycloneDxJSON, FormatCycloneDxXML,
-		FormatSpdxJSON, FormatSpdxTagValue,
-		FormatList, "list":
-		return true
-	default:
-		return false
-	}
+	_, ok := lookup(format)
+	return ok
 }
 
-func New(format string) FormatSpecificationHandler {
-	switch format {
-	case FormatJson, "cnquery-json", "cnspec-json":
-		return &CnspecBOM{}
-	case FormatCycloneDxJSON:
-		return &CycloneDX{
-			Format: cyclonedx.BOMFileFormatJSON,
-		}
-	case FormatCycloneDxXML:
-		return &CycloneDX{
-			Format: cyclonedx.BOMFileFormatXML,
-		}
-	case FormatSpdxJSON:
-		return &Spdx{
-			Version: "2.3",
-			Format:  FormatSpdxJSON,
-		}
-	case FormatSpdxTagValue:
-		return &Spdx{
-			Version: "2.3",
-			Format:  FormatSpdxTagValue,
-		}
-	case FormatList:
-		fallthrough
-	default:
-		return &TextList{}
+// New returns the handler for a format. It keeps the historical fallback to the
+// table renderer for callers that did not check IsSupportedFormat first.
+func New(name string) FormatSpecificationHandler {
+	if f, ok := lookup(name); ok {
+		return f.new()
 	}
+	return &TextList{}
 }

--- a/internal/sbom/formats.go
+++ b/internal/sbom/formats.go
@@ -43,6 +43,21 @@ func AllFormats() string {
 	return strings.Join(formats, ", ")
 }
 
+// IsSupportedFormat returns true if New can render the given format. New falls
+// back to the table format for anything it does not recognize, so callers that
+// want to reject an unknown format have to ask this first.
+func IsSupportedFormat(format string) bool {
+	switch format {
+	case FormatJson, "cnquery-json", "cnspec-json",
+		FormatCycloneDxJSON, FormatCycloneDxXML,
+		FormatSpdxJSON, FormatSpdxTagValue,
+		FormatList, "list":
+		return true
+	default:
+		return false
+	}
+}
+
 func New(format string) FormatSpecificationHandler {
 	switch format {
 	case FormatJson, "cnquery-json", "cnspec-json":

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1140,7 +1140,11 @@ func (s *LocalScanner) getUpstreamConfig(incognito bool, job *Job) (*upstream.Up
 	if s.allowJobCredentials && jobCredentials != nil {
 		res.Creds = jobCredentials
 		res.ApiEndpoint = jobCredentials.GetApiEndpoint()
-		res.SpaceMrn = jobCredentials.GetParentMrn()
+		res.SpaceMrn = jobCredentials.GetScopeMrn()
+		if res.SpaceMrn == "" {
+			// service accounts issued before scope_mrn existed only carry parent_mrn
+			res.SpaceMrn = jobCredentials.GetParentMrn()
+		}
 	}
 
 	if !res.Incognito {

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -57,7 +57,7 @@ func TestGetUpstreamConfig(t *testing.T) {
 				Spec: &inventory.InventorySpec{
 					UpstreamCredentials: &upstream.ServiceAccountCredentials{
 						ApiEndpoint: "api",
-						ParentMrn:   "space-mrn",
+						ScopeMrn:    "space-mrn",
 						PrivateKey:  string(pk),
 						Certificate: string(cert),
 					},

--- a/policy/scan/local_scanner_test.go
+++ b/policy/scan/local_scanner_test.go
@@ -71,6 +71,48 @@ func TestGetUpstreamConfig(t *testing.T) {
 		_, err = scanner.getUpstreamConfig(true, &Job{})
 		require.NoError(t, err)
 	})
+
+	// Which field carries the space is a compatibility question, not a
+	// formatting one: scope_mrn replaced parent_mrn, and service accounts
+	// issued before that only ever carry the old one. Getting it wrong does not
+	// fail loudly -- SpaceMrn just ends up empty and the scan reports nowhere --
+	// so each of the three cases is pinned rather than inferred from NoError.
+	t.Run("space mrn comes from scope_mrn, falling back to parent_mrn", func(t *testing.T) {
+		pk, err := os.ReadFile("../testdata/private-key.p8")
+		require.NoError(t, err)
+		cert, err := os.ReadFile("../testdata/cert.pem")
+		require.NoError(t, err)
+
+		for _, tc := range []struct {
+			name      string
+			scopeMrn  string
+			parentMrn string
+			want      string
+		}{
+			{"scope_mrn only", "scope-mrn", "", "scope-mrn"},
+			{"parent_mrn only, a service account issued before scope_mrn", "", "parent-mrn", "parent-mrn"},
+			{"both set, scope_mrn wins", "scope-mrn", "parent-mrn", "scope-mrn"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				creds := &upstream.ServiceAccountCredentials{
+					ApiEndpoint: "api",
+					ScopeMrn:    tc.scopeMrn,
+					PrivateKey:  string(pk),
+					Certificate: string(cert),
+				}
+				creds.ParentMrn = tc.parentMrn //nolint:staticcheck // the field under test
+
+				scanner := NewLocalScanner(AllowJobCredentials())
+				conf, err := scanner.getUpstreamConfig(false, &Job{
+					Inventory: &inventory.Inventory{
+						Spec: &inventory.InventorySpec{UpstreamCredentials: creds},
+					},
+				})
+				require.NoError(t, err)
+				require.Equal(t, tc.want, conf.SpaceMrn)
+			})
+		}
+	})
 }
 
 func TestDefaultConfig(t *testing.T) {


### PR DESCRIPTION
`cnspec sbom --output nonsense` produced table output and exited 0. So did `cnspec aibom -o nonsense`, which rendered markdown.

The guard meant to catch it could never fire:

```go
exporter = sbom.New(output)
if exporter == nil {
    log.Fatal().Msg("failed to get exporter for output format: " + output)
}
```

`New` returns an interface and every arm of its switch — including `default:` — returns a non-nil concrete handler, so an unrecognised format falls through to the fallback renderer rather than reaching the guard. staticcheck reports it as SA4023, "this comparison is never true".

Both commands now validate in `PreRun`, so a bad format is refused before the scan runs rather than after:

```
$ cnspec sbom local --output nonsense
FTL unsupported output format: nonsense. Supported formats: json, cyclonedx-json, cyclonedx-xml, spdx-json, spdx-tag-value, table
```

Two aliases only ever worked *because* the guard was dead, and both are kept: the flag's own default is `list` while `FormatList` is `"table"`, and `New` also accepts undocumented `cnquery-json`/`cnspec-json`. Verified that `list`, `table`, no flag, and both aliases still work.

Also reads `scope_mrn` from job service-account credentials, since `ParentMrn` is deprecated. Production had to change with the test: `getUpstreamConfig` read `GetParentMrn()`, so swapping the field in the test alone would have left `SpaceMrn` empty and failed. It now prefers `GetScopeMrn()` and falls back to `GetParentMrn()` for service accounts issued before `scope_mrn` existed.

Together these take `golangci-lint --config=.github/.golangci.yaml --new=false` from 5 findings to 0. That matters beyond tidiness: `only-new-issues: true` silently degrades to linting everything when a PR diff exceeds GitHub's 20,000-line patch limit, so these fail CI on any large PR.