### PR TITLE
✨ reporter: add the ohdf/hdf (inspec exec-json) output format to scan

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -83,7 +83,7 @@ func init() {
 	_ = scanCmd.Flags().Int("score-threshold", 0, "If any score falls below the threshold, exit 1")
 	_ = scanCmd.Flags().MarkDeprecated("score-threshold", "Please use --risk-threshold instead")
 	_ = scanCmd.Flags().Int("risk-threshold", reporter.DEFAULT_RISK_THRESHOLD, "Set the risk threshold. Exit with status 1 if any risk meets or exceeds this value")
-	_ = scanCmd.Flags().String("output-target", "", "Set the output target for the asset report. Currently only supports AWS SQS topic URLs and local files")
+	_ = scanCmd.Flags().String("output-target", "", "Set the output target for the asset report: a local file, an AWS SQS topic URL, or - with -o hdf - a directory to write one OHDF file per asset into")
 	_ = scanCmd.Flags().Int("parallelism", 0, "Set the number of assets to scan in parallel. Defaults to a per-provider value capped by the CPUs available on this machine. Use 1 for sequential")
 	_ = scanCmd.Flags().String("output-scan-db", "", "Save each asset's scan database (SQLite) to this directory in addition to uploading. Used to capture seeds for the cnspec loadtest tool")
 	_ = scanCmd.Flags().MarkHidden("output-scan-db")

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/cli/reporter/hdf"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql"
 	"go.mondoo.com/mql/cli/printer"
@@ -165,6 +166,9 @@ func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollectio
 	case FormatSarif:
 		writer := iox.IOWriter{Writer: r.out}
 		return ConvertToSarif(data, &writer)
+	case FormatHDF:
+		writer := iox.IOWriter{Writer: r.out}
+		return hdf.Convert(data, &writer)
 	// case FormatCSV:
 	// 	res, err = data.ToCsv()
 	default:
@@ -194,6 +198,8 @@ func (r *Reporter) PrintVulns(data *mvd.VulnReport, target string) error {
 		return errors.New("'junit' is not supported for vuln reports, please use one of the other formats")
 	case FormatSarif:
 		return errors.New("'sarif' is not supported for vuln reports, please use one of the other formats")
+	case FormatHDF:
+		return errors.New("'hdf' is not supported for vuln reports, please use one of the other formats")
 	case FormatCSV:
 		writer := iox.IOWriter{Writer: r.out}
 		return VulnReportToCSV(data, &writer)

--- a/cli/reporter/file_handler.go
+++ b/cli/reporter/file_handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec/cli/reporter/hdf"
 	"go.mondoo.com/cnspec/policy"
 )
 
@@ -33,5 +34,22 @@ func (h *localFileHandler) WriteReport(ctx context.Context, report *policy.Repor
 		return err
 	}
 	log.Info().Str("file", trimmedFile).Msg("wrote report to file")
+	return nil
+}
+
+// hdfDirHandler writes one OHDF document per scanned asset into a directory. It is
+// selected when --output-target names a directory and the format is hdf, because an
+// OHDF document describes a single target: consumers resolve a document down to one
+// root profile, so several assets in one file would lose all but the first.
+type hdfDirHandler struct {
+	dir string
+}
+
+func (h *hdfDirHandler) WriteReport(ctx context.Context, report *policy.ReportCollection) error {
+	files, err := hdf.ConvertToDir(report, h.dir)
+	if err != nil {
+		return err
+	}
+	log.Info().Str("dir", h.dir).Int("files", len(files)).Msg("wrote OHDF reports to directory")
 	return nil
 }

--- a/cli/reporter/hdf/bench_test.go
+++ b/cli/reporter/hdf/bench_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hdf
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/utils/iox"
+)
+
+// benchCollection grows the recorded ubuntu scan to the requested number of assets
+// by cloning its report onto extra MRNs, so the per-asset paths have a fleet to
+// work on without a 2.4 MB fixture per asset.
+func benchCollection(b testing.TB, assets int) *policy.ReportCollection {
+	b.Helper()
+	raw, err := os.ReadFile("../testdata/report-ubuntu.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	var r policy.ReportCollection
+	if err := json.Unmarshal(raw, &r); err != nil {
+		b.Fatal(err)
+	}
+	var srcMrn string
+	for k := range r.Assets {
+		srcMrn = k
+	}
+	src, srcRep, srcRes := r.Assets[srcMrn], r.Reports[srcMrn], r.ResolvedPolicies[srcMrn]
+	for i := 0; i < assets-1; i++ {
+		m := fmt.Sprintf("%s-%d", srcMrn, i)
+		r.Assets[m] = &inventory.Asset{Name: fmt.Sprintf("host-%d", i), Platform: src.Platform}
+		r.Reports[m] = srcRep
+		r.ResolvedPolicies[m] = srcRes
+	}
+	return &r
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+func BenchmarkConvertToHDF(b *testing.B) {
+	// The multi-asset path logs a warning per call; it would dominate the output.
+	restore := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	b.Cleanup(func() { zerolog.SetGlobalLevel(restore) })
+
+	for _, n := range []int{1, 200} {
+		r := benchCollection(b, n)
+		b.Run(fmt.Sprintf("assets=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			w := iox.IOWriter{Writer: discard{}}
+			for i := 0; i < b.N; i++ {
+				if err := Convert(r, &w); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkConvertToHDFDir(b *testing.B) {
+	r := benchCollection(b, 200)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		dir := b.TempDir()
+		if _, err := ConvertToDir(r, dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHDFDocuments(b *testing.B) {
+	r := benchCollection(b, 200)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := hdfDocuments(r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cli/reporter/hdf/doc.go
+++ b/cli/reporter/hdf/doc.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package hdf converts a cnspec scan into the OASIS Heimdall Data Format
+// (OHDF, formerly HDF).
+//
+// OHDF is the normalized security result schema of the MITRE Security Automation
+// Framework, and the same schema InSpec emits as `exec-json`, so everything that
+// reads InSpec results - Heimdall, the SAF CLI, the SAF threshold gates - reads a
+// cnspec scan unchanged.
+//
+// A document describes exactly one asset, because that is all its consumers can
+// read: Heimdall and the SAF CLI resolve a document down to a single root profile
+// and tally only that one, so findings parked in a second profile are dropped
+// without a word. A scan of several assets is written as a file each.
+//
+//	platform      the asset the document covers
+//	profiles[0]   its only profile: controls = the asset's checks and advisories,
+//	              groups = the policies they came from
+//	control       a check: id, title, desc, impact, refs, tags, MQL, results
+//	result        the outcome of that check on that asset
+//	passthrough   asset metadata and scores that OHDF itself has no place for
+//
+// The check documentation (description, audit steps, remediation, references,
+// compliance mappings) comes from the same helpers the JUnit and SARIF reporters
+// use, so all three surface identical content.
+//
+// It is a package of its own so that the format and the CLI plumbing can move
+// independently: cli/reporter decides that `-o hdf` was asked for and where the
+// bytes go, and everything about what those bytes say lives here. The dependency
+// runs one way - cli/reporter imports hdf, never the reverse - which is why the
+// check documentation both of them read comes from cli/reporter/reportdoc rather
+// than from cli/reporter itself.
+package hdf

--- a/cli/reporter/hdf/hdf.go
+++ b/cli/reporter/hdf/hdf.go
@@ -1,0 +1,1165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hdf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnspec"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/cli/printer"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
+	"go.mondoo.com/mql/utils/iox"
+)
+
+const (
+	hdfToolName          = "cnspec"
+	hdfAssetErrorID      = "asset-error"
+	hdfVulnPackageID     = "vulnerable-package"
+	hdfVulnGroupID       = "cnspec-vulnerabilities"
+	hdfProfileStatus     = "loaded"
+	hdfNistTagKey        = "compliance/nist-sp-800-53-rev5"
+	hdfNistTagPrefix     = "nist-sp-800-53-rev5-"
+	hdfNistUnmappedTag   = "UM-1"
+	hdfSourceLocationRef = "cnspec"
+)
+
+// OHDF result statuses. Heimdall derives the control's overall status from these
+// together with the impact - see hdfControlImpact.
+const (
+	hdfStatusPassed  = "passed"
+	hdfStatusFailed  = "failed"
+	hdfStatusSkipped = "skipped"
+	hdfStatusError   = "error"
+)
+
+// hdfMinImpact is the impact floor for a check that carries no severity. Two values
+// below it would lose the finding: an impact of exactly 0 means "Not Applicable" in
+// Heimdall, which has to stay reserved for checks the scan deliberately excluded,
+// and anything under 0.1 lands in the "none" severity band, which the SAF CLI's
+// summary buckets have no counter for - an unrated check that errored would drop out
+// of the tally entirely. 0.1 is the lowest impact the toolchain actually counts.
+const hdfMinImpact = 0.1
+
+// hdfTimeNow is the clock used for result timestamps. It is a variable so tests can
+// pin it and compare rendered documents byte for byte.
+var hdfTimeNow = time.Now
+
+type hdfReport struct {
+	Platform    hdfPlatform     `json:"platform"`
+	Version     string          `json:"version"`
+	Statistics  hdfStatistics   `json:"statistics"`
+	Profiles    []*hdfProfile   `json:"profiles"`
+	Passthrough *hdfPassthrough `json:"passthrough,omitempty"`
+}
+
+type hdfPlatform struct {
+	Name     string `json:"name"`
+	Release  string `json:"release"`
+	TargetID string `json:"target_id"`
+}
+
+type hdfStatistics struct {
+	Duration *float64 `json:"duration"`
+}
+
+type hdfProfile struct {
+	Name           string              `json:"name"`
+	Title          *string             `json:"title"`
+	Version        *string             `json:"version"`
+	Maintainer     *string             `json:"maintainer"`
+	Summary        *string             `json:"summary"`
+	License        *string             `json:"license"`
+	Copyright      *string             `json:"copyright"`
+	CopyrightEmail *string             `json:"copyright_email"`
+	Supports       []map[string]string `json:"supports"`
+	Attributes     []any               `json:"attributes"`
+	Depends        []any               `json:"depends"`
+	Groups         []*hdfGroup         `json:"groups"`
+	Sha256         string              `json:"sha256"`
+	Status         string              `json:"status"`
+	Controls       []*hdfControl       `json:"controls"`
+}
+
+type hdfGroup struct {
+	ID       string   `json:"id"`
+	Title    *string  `json:"title"`
+	Controls []string `json:"controls"`
+}
+
+type hdfControl struct {
+	ID             string            `json:"id"`
+	Title          *string           `json:"title"`
+	Desc           *string           `json:"desc"`
+	Descriptions   []hdfDescription  `json:"descriptions"`
+	Impact         float64           `json:"impact"`
+	Refs           []hdfRef          `json:"refs"`
+	Tags           map[string]any    `json:"tags"`
+	Code           string            `json:"code"`
+	SourceLocation hdfSourceLocation `json:"source_location"`
+	Results        []hdfResult       `json:"results"`
+}
+
+type hdfDescription struct {
+	Label string `json:"label"`
+	Data  string `json:"data"`
+}
+
+type hdfRef struct {
+	Ref string `json:"ref,omitempty"`
+	URL string `json:"url,omitempty"`
+}
+
+type hdfSourceLocation struct {
+	Ref  string `json:"ref"`
+	Line int    `json:"line"`
+}
+
+type hdfResult struct {
+	Status      string   `json:"status"`
+	CodeDesc    string   `json:"code_desc"`
+	Message     string   `json:"message,omitempty"`
+	SkipMessage string   `json:"skip_message,omitempty"`
+	Resource    string   `json:"resource,omitempty"`
+	RunTime     *float64 `json:"run_time,omitempty"`
+	StartTime   string   `json:"start_time"`
+}
+
+type hdfPassthrough struct {
+	AuxiliaryData []hdfAuxiliaryData `json:"auxiliary_data"`
+}
+
+type hdfAuxiliaryData struct {
+	Name string `json:"name"`
+	Data any    `json:"data"`
+}
+
+// hdfAssetContext carries everything the converter needs about the asset whose
+// profile is currently being built.
+type hdfAssetContext struct {
+	assetMrn     string
+	asset        *inventory.Asset
+	platformKeys map[string]bool
+	policyTitles map[string][]string
+	startTime    string
+}
+
+// hdfDocument is one rendered OHDF document together with the asset it covers, so
+// callers that write a file per asset can name the file after it.
+type hdfDocument struct {
+	assetMrn string
+	name     string
+	report   *hdfReport
+}
+
+// Convert converts a ReportCollection into OHDF (Heimdall Data Format) and
+// writes it to a single stream.
+//
+// A scan of one asset - the usual case in CI - produces exactly one document. A
+// scan that covered several cannot: an OHDF document describes a single target, and
+// Heimdall and the SAF CLI tally only the first profile in a document, so folding
+// several assets into one would silently drop every finding but the first asset's.
+// Those are written as a JSON array of documents instead, and the caller is pointed
+// at ConvertToDir, which writes each one to its own file.
+func Convert(r *policy.ReportCollection, out iox.OutputHelper) error {
+	conv, err := newHDFConverter(r)
+	if err != nil {
+		return err
+	}
+
+	switch len(conv.assetMrns) {
+	case 0:
+		return writeHDFValue(hdfEmptyReport(), out)
+	case 1:
+		return writeHDFValue(conv.document(conv.assetMrns[0]).report, out)
+	}
+
+	log.Warn().Int("assets", len(conv.assetMrns)).
+		Msg("an OHDF document describes a single asset, so this scan is written as a JSON array of documents. " +
+			"Pass a directory to --output-target to get one OHDF file per asset instead")
+
+	// Rendered and written one at a time: a scan of a large fleet would otherwise
+	// hold every converted document in memory at once, on top of the report
+	// collection it was built from.
+	if err := out.WriteString("["); err != nil {
+		return err
+	}
+	for i, assetMrn := range conv.assetMrns {
+		if i > 0 {
+			if err := out.WriteString(","); err != nil {
+				return err
+			}
+		}
+		data, err := json.Marshal(conv.document(assetMrn).report)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(data); err != nil {
+			return err
+		}
+	}
+	return out.WriteString("]\n")
+}
+
+// ConvertToDir writes one OHDF document per scanned asset into dir, named after
+// the asset. This is the form the MITRE tooling expects for a multi-target scan.
+func ConvertToDir(r *policy.ReportCollection, dir string) ([]string, error) {
+	conv, err := newHDFConverter(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+
+	// Asset names are free-form, so two of them can sanitize to the same filename.
+	used := map[string]int{}
+	written := make([]string, 0, len(conv.assetMrns))
+	var errs []error
+	for _, assetMrn := range conv.assetMrns {
+		// Built inside the loop so only one document is live at a time.
+		doc := conv.document(assetMrn)
+		path := filepath.Join(dir, hdfUniqueName(hdfFileBase(doc), used)+".hdf.json")
+		if err := writeHDFFile(doc.report, path); err != nil {
+			// Keep going: one asset the filesystem rejects should not cost the
+			// report of every asset after it. The errors are returned together.
+			errs = append(errs, fmt.Errorf("write report for %q: %w", doc.name, err))
+			continue
+		}
+		written = append(written, path)
+	}
+	return written, errors.Join(errs...)
+}
+
+// writeHDFFile renders one document to its own file.
+func writeHDFFile(report *hdfReport, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	writer := iox.IOWriter{Writer: f}
+	if err := writeHDFValue(report, &writer); err != nil {
+		f.Close() //nolint:errcheck // the write error is the one worth reporting
+		return err
+	}
+	return f.Close()
+}
+
+// hdfConverter holds the state every document of a scan shares - the query index,
+// the policy titles, the asset order - so it is derived once rather than per asset.
+type hdfConverter struct {
+	r            *policy.ReportCollection
+	bundle       *policy.PolicyBundleMap
+	queries      map[string]*policy.Mquery
+	policyTitles map[string][]string
+	assetMrns    []string
+}
+
+func newHDFConverter(r *policy.ReportCollection) (*hdfConverter, error) {
+	if r == nil {
+		return &hdfConverter{}, nil
+	}
+	if r.Bundle == nil {
+		return nil, fmt.Errorf("no policy bundle found")
+	}
+
+	bundle := r.Bundle.ToMap()
+	return &hdfConverter{
+		r:            r,
+		bundle:       bundle,
+		queries:      reportdoc.QueryMap(bundle),
+		policyTitles: reportdoc.PolicyTitlesByQuery(bundle),
+		assetMrns:    slices.Sorted(maps.Keys(r.Assets)),
+	}, nil
+}
+
+// document renders the OHDF document for one asset.
+func (c *hdfConverter) document(assetMrn string) *hdfDocument {
+	assetObj := c.r.Assets[assetMrn]
+	if assetObj == nil {
+		assetObj = &inventory.Asset{Name: assetMrn}
+	}
+
+	ctx := &hdfAssetContext{
+		assetMrn:     assetMrn,
+		asset:        assetObj,
+		platformKeys: reportdoc.PlatformRemediationKeys(assetObj.Platform),
+		policyTitles: c.policyTitles,
+		startTime:    hdfStartTime(c.r.Reports[assetMrn]),
+	}
+
+	report := hdfEmptyReport()
+	report.Platform = hdfPlatformFor(assetObj, assetMrn)
+	report.Statistics = hdfStatisticsFor(c.r.Reports[assetMrn])
+	report.Profiles = []*hdfProfile{hdfAssetProfile(c.r, ctx, c.bundle, c.queries)}
+	report.Passthrough = hdfPassthroughFor(c.r, ctx)
+
+	return &hdfDocument{
+		assetMrn: assetMrn,
+		name:     hdfProfileName(assetObj, assetMrn),
+		report:   report,
+	}
+}
+
+// hdfDocuments renders every document of a scan at once. Only the tests use it; the
+// writers render one at a time so a large fleet does not have to fit in memory.
+func hdfDocuments(r *policy.ReportCollection) ([]*hdfDocument, error) {
+	conv, err := newHDFConverter(r)
+	if err != nil {
+		return nil, err
+	}
+
+	docs := make([]*hdfDocument, 0, len(conv.assetMrns))
+	for _, assetMrn := range conv.assetMrns {
+		docs = append(docs, conv.document(assetMrn))
+	}
+	return docs, nil
+}
+
+// hdfEmptyReport is a well-formed OHDF document with no findings in it.
+func hdfEmptyReport() *hdfReport {
+	return &hdfReport{
+		Platform: hdfPlatform{Name: hdfToolName, Release: cnspec.GetVersion()},
+		Version:  cnspec.GetVersion(),
+		Profiles: []*hdfProfile{},
+	}
+}
+
+// hdfMaxFileBase caps the stem of a written filename. Asset names are free-form and
+// routinely long - a full ARN, an image reference with a digest, a namespaced
+// Kubernetes object - while most filesystems stop at 255 bytes for one path element.
+// The cap leaves room for the ".hdf.json" suffix and the "-N" a collision adds.
+const hdfMaxFileBase = 200
+
+// hdfFileBase turns an asset into a filename stem. Asset names carry spaces, slashes
+// and colons (an image reference, a cloud resource id), none of which belong in a
+// path, and an asset with no usable name at all falls back to its MRN digest.
+func hdfFileBase(doc *hdfDocument) string {
+	var b strings.Builder
+	for _, r := range doc.name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+
+	name := strings.Trim(b.String(), "-.")
+	if name == "" {
+		return "asset-" + hdfSha256(doc.assetMrn)[:12]
+	}
+
+	// Truncating alone would collide two assets that share a long prefix - think a
+	// registry path where only the trailing digest differs - so the MRN digest goes
+	// on the end to keep them apart.
+	if len(name) > hdfMaxFileBase {
+		digest := hdfSha256(doc.assetMrn)[:12]
+		name = strings.Trim(name[:hdfMaxFileBase-len(digest)-1], "-.") + "-" + digest
+	}
+	return name
+}
+
+// hdfUniqueName suffixes a name that has already been used, so no document
+// overwrites another.
+func hdfUniqueName(name string, used map[string]int) string {
+	used[name]++
+	if n := used[name]; n > 1 {
+		return name + "-" + strconv.Itoa(n)
+	}
+	return name
+}
+
+// hdfPlatformFor describes the target of a document: the asset it covers.
+func hdfPlatformFor(assetObj *inventory.Asset, assetMrn string) hdfPlatform {
+	res := hdfPlatform{Name: hdfToolName, Release: cnspec.GetVersion()}
+	if assetObj.Platform != nil && assetObj.Platform.Name != "" {
+		res.Name = assetObj.Platform.Name
+		res.Release = assetObj.Platform.Version
+	}
+	res.TargetID = hdfTargetID(assetObj, assetMrn)
+	return res
+}
+
+// hdfTargetID identifies the asset. The platform id is the stable, tool-independent
+// handle; the asset MRN is the fallback for assets that have none.
+func hdfTargetID(assetObj *inventory.Asset, assetMrn string) string {
+	if len(assetObj.PlatformIds) > 0 && assetObj.PlatformIds[0] != "" {
+		return assetObj.PlatformIds[0]
+	}
+	return assetMrn
+}
+
+// hdfStatisticsFor reports how long the asset took to scan, when its report carries
+// the timestamps to derive it from. It stays null otherwise - OHDF consumers treat a
+// missing duration as "not reported", but would read a 0 as an instant scan.
+func hdfStatisticsFor(report *policy.Report) hdfStatistics {
+	if report == nil || report.Created <= 0 || report.Modified <= report.Created {
+		return hdfStatistics{}
+	}
+	duration := float64(report.Modified - report.Created)
+	return hdfStatistics{Duration: &duration}
+}
+
+// hdfStartTime is the time the checks of an asset ran, formatted the way OHDF
+// expects. It falls back to the current time for reports that carry no timestamp
+// (local scans do not set one).
+func hdfStartTime(report *policy.Report) string {
+	if report != nil && report.Created > 0 {
+		return time.Unix(report.Created, 0).UTC().Format(time.RFC3339)
+	}
+	return hdfTimeNow().UTC().Format(time.RFC3339)
+}
+
+// hdfAssetProfile builds the one profile of an asset's document: its check results,
+// its scan error if it had one, and its vulnerability findings.
+//
+// It has to be a single profile. Heimdall and the SAF CLI resolve a document down to
+// one root profile and tally only that one, so anything in a second, unlinked
+// profile is dropped without a word - a vulnerability finding parked in its own
+// profile never reaches the summary. Grouping keeps the two kinds distinguishable.
+func hdfAssetProfile(r *policy.ReportCollection, ctx *hdfAssetContext, bundle *policy.PolicyBundleMap, queries map[string]*policy.Mquery) *hdfProfile {
+	profile := hdfNewProfile(hdfProfileName(ctx.asset, ctx.assetMrn))
+	profile.Title = strPtr("cnspec policy scan of " + hdfAssetLabel(ctx.asset, ctx.assetMrn))
+	profile.Summary = strPtr(hdfAssetSummary(ctx.asset))
+	profile.Supports = hdfSupports(ctx.asset.Platform)
+
+	// controlIDs maps a check MRN to the control it produced, so the policy groups
+	// below can reference only the checks that actually reported for this asset.
+	controlIDs := map[string]string{}
+
+	report := r.Reports[ctx.assetMrn]
+	resolved := r.ResolvedPolicies[ctx.assetMrn]
+	if report != nil && resolved != nil && resolved.CollectorJob != nil {
+		for _, id := range slices.Sorted(maps.Keys(report.Scores)) {
+			if _, ok := resolved.CollectorJob.ReportingQueries[id]; !ok {
+				continue
+			}
+			query, ok := queries[id]
+			if !ok {
+				continue
+			}
+
+			control := hdfCheckControl(ctx, resolved, report, query, report.Scores[id])
+			profile.Controls = append(profile.Controls, control)
+			if query.Mrn != "" {
+				controlIDs[query.Mrn] = control.ID
+			}
+		}
+	}
+
+	if errMsg, ok := r.Errors[ctx.assetMrn]; ok {
+		profile.Controls = append(profile.Controls, hdfAssetErrorControl(ctx, errMsg))
+	}
+
+	profile.Groups = hdfPolicyGroups(bundle, controlIDs)
+
+	if vulnControls := hdfVulnControls(r.VulnReports[ctx.assetMrn], ctx); len(vulnControls) > 0 {
+		ids := make([]string, 0, len(vulnControls))
+		for _, control := range vulnControls {
+			ids = append(ids, control.ID)
+		}
+		sort.Strings(ids)
+		profile.Controls = append(profile.Controls, vulnControls...)
+		profile.Groups = append(profile.Groups, &hdfGroup{
+			ID:       hdfVulnGroupID,
+			Title:    strPtr("Vulnerabilities"),
+			Controls: ids,
+		})
+	}
+
+	profile.Sha256 = hdfProfileChecksum(resolved, ctx.assetMrn, profile.Controls)
+	return profile
+}
+
+// hdfCheckControl turns a check and its score into an OHDF control.
+func hdfCheckControl(ctx *hdfAssetContext, resolved *policy.ResolvedPolicy, report *policy.Report, query *policy.Mquery, score *policy.Score) *hdfControl {
+	control := &hdfControl{
+		ID:             reportdoc.QueryRuleID(query),
+		Impact:         hdfControlImpact(query, score),
+		Descriptions:   []hdfDescription{},
+		Refs:           hdfRefs(reportdoc.QueryRefs(query)),
+		Code:           reportdoc.QueryMql(query),
+		SourceLocation: hdfSourceLocation{Ref: hdfSourceLocationRef, Line: 1},
+	}
+
+	if query.Title != "" {
+		control.Title = strPtr(query.Title)
+	}
+	if desc := strings.TrimSpace(reportdoc.QueryDescription(query)); desc != "" {
+		control.Desc = strPtr(desc)
+	}
+	if audit := reportdoc.QueryAudit(query); audit != "" {
+		control.Descriptions = append(control.Descriptions, hdfDescription{Label: "check", Data: audit})
+	}
+	if rem := reportdoc.QueryRemediation(query, ctx.platformKeys); rem != "" {
+		control.Descriptions = append(control.Descriptions, hdfDescription{Label: "fix", Data: rem})
+	}
+
+	control.Tags = hdfCheckTags(ctx, query, control.Impact)
+	control.Results = hdfCheckResults(ctx, resolved, report, query, score)
+	return control
+}
+
+// hdfControlImpact maps a check's cnspec impact (0-100) onto the OHDF 0.0-1.0
+// scale. The severity bands line up exactly - cnspec calls 70 HIGH and Heimdall
+// calls 0.7 high - so the conversion is a straight division.
+//
+// Two values are special: an impact of 0 renders as "Not Applicable" in Heimdall,
+// which is the right reading for a check the scan deliberately excluded and the
+// wrong one for every other check, so those are floored at hdfMinImpact.
+func hdfControlImpact(query *policy.Mquery, score *policy.Score) float64 {
+	if score != nil {
+		switch score.Type {
+		case policy.ScoreType_Skip, policy.ScoreType_OutOfScope, policy.ScoreType_Disabled:
+			return 0
+		}
+	}
+
+	risk := hdfControlRisk(query, score)
+	if risk >= 100 {
+		return 1
+	}
+	if risk <= 0 {
+		return hdfMinImpact
+	}
+	return float64(risk) / 100
+}
+
+// hdfControlRisk is the cnspec risk (0-100) a control is reported at: its configured
+// impact, or - for a check that has none - what its score implies. The fallback is
+// limited to scored results on purpose: an errored or skipped check carries a score
+// value of 0, and reading that as risk 100 would report every one of them as
+// critical.
+func hdfControlRisk(query *policy.Mquery, score *policy.Score) int32 {
+	if risk, ok := reportdoc.QueryImpact(query); ok {
+		return risk
+	}
+	if score != nil && score.Type == policy.ScoreType_Result {
+		return reportdoc.ScoreRisk(score)
+	}
+	return 0
+}
+
+// hdfCheckTags carries the check's metadata. `nist` and `severity` are the keys
+// Heimdall reads for its compliance and severity views; the rest is cnspec context
+// that would otherwise be lost.
+func hdfCheckTags(ctx *hdfAssetContext, query *policy.Mquery, impact float64) map[string]any {
+	tags := map[string]any{
+		"nist":     hdfNistTags(query),
+		"severity": hdfSeverityLabel(impact),
+		"asset":    ctx.asset.Name,
+	}
+	if ctx.assetMrn != "" {
+		tags["assetMrn"] = ctx.assetMrn
+	}
+	if query.Mrn != "" {
+		tags["queryMrn"] = query.Mrn
+	}
+	if mql := strings.TrimSpace(reportdoc.QueryMql(query)); mql != "" {
+		tags["mql"] = mql
+	}
+	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
+		tags["policies"] = titles
+	}
+	for key, value := range reportdoc.QueryComplianceTags(query) {
+		tags[key] = value
+	}
+	return tags
+}
+
+// hdfSeverityLabel is the severity band an impact falls into, using the thresholds
+// Heimdall and the SAF CLI apply. It is derived from the impact rather than from the
+// cnspec risk so the two can never disagree: the SAF summary buckets a finding by
+// this tag, and a control tagged "none" is dropped from the tally no matter what its
+// impact says.
+func hdfSeverityLabel(impact float64) string {
+	switch {
+	case impact >= 0.9:
+		return "critical"
+	case impact >= 0.7:
+		return "high"
+	case impact >= 0.4:
+		return "medium"
+	case impact >= 0.1:
+		return "low"
+	default:
+		return "none"
+	}
+}
+
+var hdfNistControlRe = regexp.MustCompile(`^([a-z]{2})-(\d+)(?:-(\d+))?$`)
+
+// hdfNistTags renders a check's NIST SP 800-53 mapping the way Heimdall's
+// compliance views expect it: "nist-sp-800-53-rev5-si-7" becomes "SI-7", and a
+// control enhancement like "ac-2-1" becomes "AC-2 (1)". Checks with no mapping get
+// MITRE's "UM-1" marker for unmapped controls, so they still appear in the views.
+func hdfNistTags(query *policy.Mquery) []string {
+	raw := reportdoc.QueryComplianceTags(query)[hdfNistTagKey]
+	match := hdfNistControlRe.FindStringSubmatch(strings.TrimPrefix(raw, hdfNistTagPrefix))
+	if match == nil {
+		return []string{hdfNistUnmappedTag}
+	}
+
+	control := strings.ToUpper(match[1]) + "-" + match[2]
+	if match[3] != "" {
+		control += " (" + match[3] + ")"
+	}
+	return []string{control}
+}
+
+// hdfCheckResults renders the outcome of a check. A check that failed on resources
+// carrying source context (Terraform and friends) reports one result per failing
+// resource so consumers can point at the offending file; everything else reports a
+// single result.
+func hdfCheckResults(ctx *hdfAssetContext, resolved *policy.ResolvedPolicy, report *policy.Report, query *policy.Mquery, score *policy.Score) []hdfResult {
+	status := hdfStatus(score)
+
+	codeDesc := strings.TrimSpace(reportdoc.QueryMql(query))
+	if codeDesc == "" {
+		codeDesc = query.Title
+	}
+	if codeDesc == "" {
+		codeDesc = reportdoc.QueryRuleID(query)
+	}
+
+	base := hdfResult{
+		Status:    status,
+		CodeDesc:  codeDesc,
+		StartTime: ctx.startTime,
+	}
+
+	switch status {
+	case hdfStatusSkipped:
+		base.SkipMessage = hdfSkipMessage(score)
+	case hdfStatusError:
+		base.Message = score.MessageLine()
+	}
+
+	// A passing check has nothing to explain and no failing resource to point at,
+	// so the assessment is never read for one. Building and rendering it anyway
+	// costs the majority of the work in a healthy scan.
+	if status == hdfStatusPassed {
+		return []hdfResult{base}
+	}
+
+	var assessment *llx.Assessment
+	var codeBundle *llx.CodeBundle
+	if report != nil && resolved != nil && resolved.ExecutionJob != nil {
+		if codeBundle = resolved.GetCodeBundle(query); codeBundle != nil {
+			assessment = policy.Query2Assessment(codeBundle, report)
+		}
+	}
+
+	var detail string
+	if assessment != nil && codeBundle != nil {
+		detail = strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(codeBundle, assessment))
+	}
+
+	var locations []llx.SourceContext
+	if assessment != nil && codeBundle != nil {
+		for _, sc := range codeBundle.FailingResourceContexts(assessment) {
+			if sc.Path != "" {
+				locations = append(locations, sc)
+			}
+		}
+	}
+
+	if len(locations) == 0 {
+		if status == hdfStatusFailed && detail != "" {
+			base.Message = detail
+		}
+		if base.Message == "" && status != hdfStatusPassed {
+			base.Message = score.MessageLine()
+		}
+		return []hdfResult{base}
+	}
+
+	// The assessment covers all failing resources at once, so repeating it on every
+	// location would grow the report quadratically. It travels with the result only
+	// when there is a single location to attribute it to.
+	res := make([]hdfResult, 0, len(locations))
+	for i := range locations {
+		loc := hdfLocationLabel(locations[i])
+		cur := base
+		cur.CodeDesc = codeDesc + " @ " + loc
+		cur.Resource = locations[i].Path
+		if len(locations) == 1 {
+			cur.Message = detail
+		} else {
+			cur.Message = loc
+		}
+		res = append(res, cur)
+	}
+	return res
+}
+
+// hdfLocationLabel renders a source context as "path:line".
+func hdfLocationLabel(ctx llx.SourceContext) string {
+	if startLine, _, _, _, _, ok := ctx.Range.Bounds(); ok && startLine >= 1 {
+		return ctx.Path + ":" + strconv.FormatInt(int64(startLine), 10)
+	}
+	return ctx.Path
+}
+
+// hdfStatus maps a cnspec score onto an OHDF result status. Everything that is
+// neither a result nor an error - skipped, out of scope, disabled, unscored,
+// unknown - reports as skipped; hdfControlImpact then decides whether Heimdall
+// renders it as "Not Applicable" or "Not Reviewed".
+func hdfStatus(score *policy.Score) string {
+	if score == nil {
+		return hdfStatusSkipped
+	}
+
+	switch score.Type {
+	case policy.ScoreType_Result:
+		if score.Value == 100 {
+			return hdfStatusPassed
+		}
+		return hdfStatusFailed
+	case policy.ScoreType_Error:
+		return hdfStatusError
+	default:
+		return hdfStatusSkipped
+	}
+}
+
+// hdfSkipMessage explains why a check did not run. OHDF has no way to say "skipped
+// for no stated reason", so there is always a line: the score's own message when it
+// has one, and what kind of score it was when it does not.
+//
+// The nil case comes first because Score.TypeLabel dereferences without checking.
+func hdfSkipMessage(score *policy.Score) string {
+	if score == nil {
+		return "no score reported"
+	}
+	if msg := score.MessageLine(); msg != "" {
+		return msg
+	}
+	return "check " + score.TypeLabel()
+}
+
+// hdfAssetErrorControl reports an asset that could not be scanned at all. Without
+// it the asset would show up as a profile with no controls and read as "nothing to
+// check" rather than "nothing was checked".
+func hdfAssetErrorControl(ctx *hdfAssetContext, errMsg string) *hdfControl {
+	return &hdfControl{
+		ID:           hdfAssetErrorID,
+		Title:        strPtr("Asset scan error"),
+		Desc:         strPtr("cnspec could not complete the scan of this asset. No policy results are available for it."),
+		Impact:       1,
+		Descriptions: []hdfDescription{},
+		Refs:         []hdfRef{},
+		Tags: map[string]any{
+			"nist":     []string{hdfNistUnmappedTag},
+			"severity": "critical",
+			"asset":    ctx.asset.Name,
+		},
+		SourceLocation: hdfSourceLocation{Ref: hdfSourceLocationRef, Line: 1},
+		Results: []hdfResult{{
+			Status:    hdfStatusError,
+			CodeDesc:  "cnspec scan " + hdfAssetLabel(ctx.asset, ctx.assetMrn),
+			Message:   errMsg,
+			StartTime: ctx.startTime,
+		}},
+	}
+}
+
+// hdfPolicyGroups maps the policies of the bundle onto OHDF control groups, so a
+// consumer can still see which policy a control came from even though the profile
+// is the asset. Policies with no reporting check on this asset are left out.
+func hdfPolicyGroups(bundle *policy.PolicyBundleMap, controlIDs map[string]string) []*hdfGroup {
+	res := []*hdfGroup{}
+	if bundle == nil || len(controlIDs) == 0 {
+		return res
+	}
+
+	for _, mrn := range slices.Sorted(maps.Keys(bundle.Policies)) {
+		p := bundle.Policies[mrn]
+		if p == nil {
+			continue
+		}
+
+		var ids []string
+		seen := map[string]bool{}
+		for _, group := range p.Groups {
+			if group == nil {
+				continue
+			}
+			for _, check := range group.Checks {
+				if check == nil {
+					continue
+				}
+				id, ok := controlIDs[check.Mrn]
+				if !ok || seen[id] {
+					continue
+				}
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		sort.Strings(ids)
+
+		group := &hdfGroup{ID: mrn, Controls: ids}
+		if p.Name != "" {
+			group.Title = strPtr(p.Name)
+		}
+		res = append(res, group)
+	}
+	return res
+}
+
+// hdfVulnControls turns an asset's vulnerability findings into controls: one per
+// advisory, plus one catch-all for affected packages that no advisory in the report
+// accounts for. They join the asset's own profile rather than forming one of their
+// own - see hdfAssetProfile.
+func hdfVulnControls(vulnReport *mvd.VulnReport, ctx *hdfAssetContext) []*hdfControl {
+	if vulnReport == nil {
+		return nil
+	}
+
+	affected := map[string]*mvd.Package{}
+	byName := map[string]*mvd.Package{}
+	for _, pkg := range vulnReport.Packages {
+		if pkg == nil || !pkg.Affected {
+			continue
+		}
+		affected[reportdoc.VulnPackageKey(pkg)] = pkg
+		byName[pkg.Name] = pkg
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	advisories := make([]*mvd.Advisory, 0, len(vulnReport.Advisories))
+	for _, advisory := range vulnReport.Advisories {
+		if advisory != nil && advisory.ID != "" {
+			advisories = append(advisories, advisory)
+		}
+	}
+	sort.Slice(advisories, func(i, j int) bool { return advisories[i].ID < advisories[j].ID })
+
+	var res []*hdfControl
+	covered := map[string]bool{}
+	for _, advisory := range advisories {
+		pkgs := reportdoc.AdvisoryPackages(advisory, affected, byName)
+		if len(pkgs) == 0 {
+			continue
+		}
+		for _, pkg := range pkgs {
+			covered[reportdoc.VulnPackageKey(pkg)] = true
+		}
+		res = append(res, hdfAdvisoryControl(ctx, advisory, pkgs))
+	}
+
+	var remaining []string
+	for key := range affected {
+		if !covered[key] {
+			remaining = append(remaining, key)
+		}
+	}
+	if len(remaining) > 0 {
+		sort.Strings(remaining)
+		pkgs := make([]*mvd.Package, 0, len(remaining))
+		for _, key := range remaining {
+			pkgs = append(pkgs, affected[key])
+		}
+		res = append(res, hdfAdvisoryControl(ctx, nil, pkgs))
+	}
+	return res
+}
+
+// hdfAdvisoryControl reports one advisory and the packages of this asset it
+// affects. With no advisory it reports the packages on their own, which is what
+// happens when the report knows a package is vulnerable but carries no advisory
+// covering it.
+func hdfAdvisoryControl(ctx *hdfAssetContext, advisory *mvd.Advisory, pkgs []*mvd.Package) *hdfControl {
+	id := hdfVulnPackageID
+	title := "Vulnerable package"
+	desc := "An installed package is affected by known vulnerabilities. Update it to a fixed version."
+	var score int32
+	refs := []hdfRef{}
+
+	if advisory != nil {
+		id = advisory.ID
+		title = advisory.Title
+		if title == "" {
+			title = advisory.ID
+		}
+		desc = strings.TrimSpace(advisory.Description)
+		score = advisory.Score
+		for _, ref := range advisory.Refs {
+			if ref != nil && ref.Url != "" {
+				refs = append(refs, hdfRef{Ref: ref.Title, URL: ref.Url})
+			}
+		}
+	}
+
+	tags := map[string]any{
+		// SI-2 (flaw remediation) and RA-5 (vulnerability monitoring) are the NIST
+		// controls MITRE's converters map vulnerability findings onto.
+		"nist":  []string{"SI-2", "RA-5"},
+		"asset": ctx.asset.Name,
+	}
+	if advisory != nil {
+		tags["advisory"] = advisory.ID
+		if cves := reportdoc.AdvisoryCves(advisory); len(cves) > 0 {
+			ids := make([]string, 0, len(cves))
+			for _, cve := range cves {
+				ids = append(ids, cve.ID)
+				if cve.Url != "" {
+					refs = append(refs, hdfRef{Ref: cve.ID, URL: cve.Url})
+				}
+			}
+			tags["cves"] = ids
+		}
+		if advisory.Published != "" {
+			tags["published"] = advisory.Published
+		}
+		if advisory.Modified != "" {
+			tags["modified"] = advisory.Modified
+		}
+	}
+
+	control := &hdfControl{
+		ID:             id,
+		Title:          strPtr(title),
+		Descriptions:   []hdfDescription{},
+		Refs:           refs,
+		Tags:           tags,
+		SourceLocation: hdfSourceLocation{Ref: hdfSourceLocationRef, Line: 1},
+		Results:        make([]hdfResult, 0, len(pkgs)),
+	}
+	if desc != "" {
+		control.Desc = strPtr(desc)
+	}
+
+	// An advisory without its own score falls back to the worst score of the
+	// packages it affects, so the finding never reads as harmless by omission.
+	worst := score
+	for _, pkg := range pkgs {
+		if pkg.Score > worst {
+			worst = pkg.Score
+		}
+	}
+	control.Impact = hdfVulnImpact(worst)
+	control.Tags["severity"] = hdfSeverityLabel(control.Impact)
+
+	for _, pkg := range pkgs {
+		control.Results = append(control.Results, hdfResult{
+			Status:    hdfStatusFailed,
+			CodeDesc:  pkg.Name + " " + pkg.Version,
+			Message:   hdfVulnMessage(advisory, pkg),
+			Resource:  pkg.Name,
+			StartTime: ctx.startTime,
+		})
+	}
+	return control
+}
+
+// hdfVulnImpact maps an advisory or package score (0-100) onto the OHDF scale.
+func hdfVulnImpact(score int32) float64 {
+	if score >= 100 {
+		return 1
+	}
+	if score <= 0 {
+		return hdfMinImpact
+	}
+	return float64(score) / 100
+}
+
+// hdfVulnMessage explains what is wrong with an installed package and what to do
+// about it.
+func hdfVulnMessage(advisory *mvd.Advisory, pkg *mvd.Package) string {
+	msg := pkg.Name + " " + pkg.Version + " has known vulnerabilities"
+	if advisory != nil {
+		title := advisory.Title
+		if title == "" {
+			title = advisory.ID
+		}
+		msg = pkg.Name + " " + pkg.Version + " is affected by " + advisory.ID + " (" + title + ")"
+	}
+	if pkg.Available != "" {
+		return msg + ". Update to " + pkg.Available + "."
+	}
+	return msg + ". No fixed version is available yet."
+}
+
+// hdfPassthroughFor carries the cnspec context that OHDF itself has no field for:
+// the asset's identity, platform detail and overall score.
+func hdfPassthroughFor(r *policy.ReportCollection, ctx *hdfAssetContext) *hdfPassthrough {
+	asset := map[string]any{"mrn": ctx.assetMrn, "name": ctx.asset.Name}
+	if platformName := reportdoc.PlatformName(ctx.asset); platformName != "" {
+		asset["platform"] = platformName
+	}
+	if ctx.asset.Platform != nil {
+		if ctx.asset.Platform.Version != "" {
+			asset["platformVersion"] = ctx.asset.Platform.Version
+		}
+		if ctx.asset.Platform.Arch != "" {
+			asset["arch"] = ctx.asset.Platform.Arch
+		}
+	}
+	if len(ctx.asset.PlatformIds) > 0 {
+		asset["platformIds"] = ctx.asset.PlatformIds
+	}
+	if report := r.Reports[ctx.assetMrn]; report != nil && report.Score != nil {
+		asset["score"] = report.Score.Value
+		asset["grade"] = report.Score.Rating().Letter()
+	}
+	if errMsg, ok := r.Errors[ctx.assetMrn]; ok {
+		asset["error"] = errMsg
+	}
+
+	return &hdfPassthrough{
+		AuxiliaryData: []hdfAuxiliaryData{{
+			Name: hdfToolName,
+			Data: map[string]any{
+				"version": cnspec.GetVersion(),
+				"asset":   asset,
+			},
+		}},
+	}
+}
+
+// hdfNewProfile creates a profile with the OHDF-required fields filled in.
+func hdfNewProfile(name string) *hdfProfile {
+	return &hdfProfile{
+		Name:       name,
+		Version:    strPtr(cnspec.GetVersion()),
+		Maintainer: strPtr("Mondoo, Inc"),
+		Supports:   []map[string]string{},
+		Attributes: []any{},
+		Depends:    []any{},
+		Groups:     []*hdfGroup{},
+		Status:     hdfProfileStatus,
+		Controls:   []*hdfControl{},
+	}
+}
+
+// hdfProfileName names the profile after the asset it covers.
+func hdfProfileName(assetObj *inventory.Asset, assetMrn string) string {
+	if assetObj.Name != "" {
+		return assetObj.Name
+	}
+	return assetMrn
+}
+
+// hdfAssetLabel names an asset for human-readable text, qualified by its platform
+// when it has one.
+func hdfAssetLabel(assetObj *inventory.Asset, assetMrn string) string {
+	name := hdfProfileName(assetObj, assetMrn)
+	if platformName := reportdoc.PlatformName(assetObj); platformName != "" {
+		return name + " (" + platformName + ")"
+	}
+	return name
+}
+
+// hdfAssetSummary describes the scanned platform.
+func hdfAssetSummary(assetObj *inventory.Asset) string {
+	platformName := reportdoc.PlatformName(assetObj)
+	if platformName == "" {
+		return "Checks reported by cnspec for this asset"
+	}
+	if assetObj.Platform != nil && assetObj.Platform.Version != "" {
+		return platformName + " " + assetObj.Platform.Version
+	}
+	return platformName
+}
+
+// hdfSupports declares the platform the profile applies to, using the keys InSpec
+// profiles use for the same purpose.
+func hdfSupports(platform *inventory.Platform) []map[string]string {
+	res := []map[string]string{}
+	if platform == nil || platform.Name == "" {
+		return res
+	}
+
+	entry := map[string]string{"platform-name": platform.Name}
+	if platform.Version != "" {
+		entry["release"] = platform.Version
+	}
+	return append(res, entry)
+}
+
+// hdfProfileChecksum identifies a profile. OHDF requires a sha256 on every profile,
+// and consumers treat two profiles carrying the same one as the same profile.
+//
+// The profile here is the asset, so the asset has to be in the hash. The resolved
+// policy's graph checksum alone is not enough: every asset in a fleet scanned
+// against the same policies resolves to the same graph, which would hand a hundred
+// documents with a hundred different control sets one shared identity. Pairing it
+// with the asset keeps the checksum stable across re-scans - which is the property
+// a profile checksum is supposed to have - without merging the fleet.
+//
+// Hashing the control ids is the fallback for a scan that carries no graph
+// checksum, e.g. an asset that failed before it resolved anything.
+func hdfProfileChecksum(resolved *policy.ResolvedPolicy, key string, controls []*hdfControl) string {
+	if resolved != nil && resolved.GraphExecutionChecksum != "" {
+		return hdfSha256(key, resolved.GraphExecutionChecksum)
+	}
+
+	parts := make([]string, 0, len(controls)+1)
+	parts = append(parts, key)
+	for _, control := range controls {
+		parts = append(parts, control.ID)
+	}
+	return hdfSha256(parts...)
+}
+
+// strPtr is the pointer OHDF's optional string fields are declared as: the schema
+// distinguishes a field that is absent from one that is present and empty.
+func strPtr(s string) *string {
+	return &s
+}
+
+func hdfSha256(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// hdfRefs maps a check's references onto the OHDF ref shape.
+func hdfRefs(refs []*policy.MqueryRef) []hdfRef {
+	res := make([]hdfRef, 0, len(refs))
+	for _, ref := range refs {
+		res = append(res, hdfRef{Ref: ref.Title, URL: ref.Url})
+	}
+	return res
+}
+
+// writeHDFValue emits one JSON document. The output is compact, like the SARIF and
+// json-v2 reporters: indenting it costs a second full pass over the buffer and a
+// second copy of it, on a document nothing reads by eye. `jq .` renders it.
+func writeHDFValue(value any, out iox.OutputHelper) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write(data); err != nil {
+		return err
+	}
+	return out.WriteString("\n")
+}

--- a/cli/reporter/hdf/hdf_test.go
+++ b/cli/reporter/hdf/hdf_test.go
@@ -1,0 +1,532 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hdf
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reporter/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/utils/iox"
+)
+
+// pinHDFClock freezes the timestamp the converter stamps on results that have no
+// report time of their own, so a rendered document is comparable across runs.
+func pinHDFClock(t *testing.T) {
+	t.Helper()
+	original := hdfTimeNow
+	hdfTimeNow = func() time.Time { return time.Date(2026, 8, 22, 10, 30, 0, 0, time.UTC) }
+	t.Cleanup(func() { hdfTimeNow = original })
+}
+
+// toHDFBytes runs the converter and returns the raw document.
+func toHDFBytes(t *testing.T, r *policy.ReportCollection) []byte {
+	t.Helper()
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	require.NoError(t, Convert(r, &writer))
+	return buf.Bytes()
+}
+
+// toHDF runs the converter and parses the result back into the OHDF types.
+func toHDF(t *testing.T, r *policy.ReportCollection) *hdfReport {
+	t.Helper()
+	var report hdfReport
+	require.NoError(t, json.Unmarshal(toHDFBytes(t, r), &report))
+	return &report
+}
+
+func findHDFProfile(report *hdfReport, name string) *hdfProfile {
+	for _, profile := range report.Profiles {
+		if profile.Name == name {
+			return profile
+		}
+	}
+	return nil
+}
+
+func findHDFControl(profile *hdfProfile, id string) *hdfControl {
+	if profile == nil {
+		return nil
+	}
+	for _, control := range profile.Controls {
+		if control.ID == id {
+			return control
+		}
+	}
+	return nil
+}
+
+func TestHDFConverter(t *testing.T) {
+	pinHDFClock(t)
+	report := toHDF(t, reportfixture.Sample())
+
+	// A single-asset scan reports that asset as the platform.
+	assert.Equal(t, "ubuntu", report.Platform.Name)
+	assert.Equal(t, "22.04", report.Platform.Release)
+	assert.Equal(t, "//platformid.api.mondoo.app/hostname/X1", report.Platform.TargetID)
+	assert.NotEmpty(t, report.Version)
+
+	// One profile, named after the asset, holding its checks and its vulnerabilities.
+	require.Len(t, report.Profiles, 1)
+	checks := findHDFProfile(report, "X1")
+	require.NotNil(t, checks, "expected a profile named after the asset")
+
+	// The profile carries the fields OHDF requires.
+	for _, profile := range report.Profiles {
+		assert.NotEmpty(t, profile.Name)
+		assert.NotEmpty(t, profile.Sha256, "profile %q needs a checksum", profile.Name)
+		assert.NotNil(t, profile.Supports)
+		assert.NotNil(t, profile.Attributes)
+		assert.NotNil(t, profile.Groups)
+		assert.NotNil(t, profile.Controls)
+	}
+
+	assert.Equal(t, []map[string]string{{"platform-name": "ubuntu", "release": "22.04"}}, checks.Supports)
+
+	// three checks plus the vulnerability finding
+	require.Len(t, checks.Controls, 4)
+	for _, control := range checks.Controls {
+		assert.NotEmpty(t, control.ID)
+		require.Len(t, control.Results, 1, "control %q", control.ID)
+		assert.Equal(t, "2026-08-22T10:30:00Z", control.Results[0].StartTime)
+	}
+}
+
+// TestHDFStatusMapping pins the score type to result status mapping, including the
+// impact of 0 that makes Heimdall render a check as "Not Applicable".
+func TestHDFStatusMapping(t *testing.T) {
+	pinHDFClock(t)
+	report := toHDF(t, reportfixture.Sample())
+	checks := findHDFProfile(report, "X1")
+	require.NotNil(t, checks)
+
+	passed := findHDFControl(checks, "mondoo-linux-security-snmp-server-is-not-enabled")
+	require.NotNil(t, passed)
+	assert.Equal(t, hdfStatusPassed, passed.Results[0].Status)
+	assert.Greater(t, passed.Impact, 0.0, "a passing check must not read as Not Applicable")
+
+	errored := findHDFControl(checks, "mondoo-kubernetes-security-kubelet-event-record-qps")
+	require.NotNil(t, errored)
+	assert.Equal(t, hdfStatusError, errored.Results[0].Status)
+
+	skipped := findHDFControl(checks, "mondoo-kubernetes-security-secure-scheduler_conf")
+	require.NotNil(t, skipped)
+	assert.Equal(t, hdfStatusSkipped, skipped.Results[0].Status)
+	assert.Equal(t, 0.0, skipped.Impact, "a skipped check is Not Applicable in Heimdall")
+	assert.NotEmpty(t, skipped.Results[0].SkipMessage)
+}
+
+func TestHDFStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		score *policy.Score
+		want  string
+	}{
+		{"nil score", nil, hdfStatusSkipped},
+		{"passed", &policy.Score{Type: policy.ScoreType_Result, Value: 100}, hdfStatusPassed},
+		{"failed", &policy.Score{Type: policy.ScoreType_Result, Value: 40}, hdfStatusFailed},
+		{"error", &policy.Score{Type: policy.ScoreType_Error}, hdfStatusError},
+		{"skip", &policy.Score{Type: policy.ScoreType_Skip}, hdfStatusSkipped},
+		{"unscored", &policy.Score{Type: policy.ScoreType_Unscored}, hdfStatusSkipped},
+		{"out of scope", &policy.Score{Type: policy.ScoreType_OutOfScope}, hdfStatusSkipped},
+		{"disabled", &policy.Score{Type: policy.ScoreType_Disabled}, hdfStatusSkipped},
+		{"unknown", &policy.Score{Type: policy.ScoreType_Unknown}, hdfStatusSkipped},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, hdfStatus(test.score))
+		})
+	}
+}
+
+// TestHDFSkipMessage pins all three outcomes, the nil score included: OHDF wants a
+// skip_message on every skipped result, and a check reaches this with no score at
+// all when it was resolved but never reported on.
+func TestHDFSkipMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		score *policy.Score
+		want  string
+	}{
+		{"no score at all", nil, "no score reported"},
+		{
+			"the score explains itself",
+			&policy.Score{Type: policy.ScoreType_Skip, Message: "excluded by\nthe policy filter"},
+			"excluded by the policy filter",
+		},
+		{
+			"no message, so the score type is the reason",
+			&policy.Score{Type: policy.ScoreType_OutOfScope},
+			"check out of scope",
+		},
+		{
+			"a blank message is not a reason",
+			&policy.Score{Type: policy.ScoreType_Unscored, Message: "   "},
+			"check unscored",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, hdfSkipMessage(test.score))
+		})
+	}
+}
+
+// TestHDFControlImpact checks that the cnspec severity bands survive the trip onto
+// the OHDF 0.0-1.0 scale: cnspec calls impact 70 HIGH and Heimdall calls 0.7 high,
+// so a converted value has to land in the same bucket it started in.
+func TestHDFControlImpact(t *testing.T) {
+	impactQuery := func(impact int32) *policy.Mquery {
+		return &policy.Mquery{Impact: &policy.Impact{Value: &policy.ImpactValue{Value: impact}}}
+	}
+	result := func(value uint32) *policy.Score {
+		return &policy.Score{Type: policy.ScoreType_Result, Value: value}
+	}
+
+	tests := []struct {
+		name  string
+		query *policy.Mquery
+		score *policy.Score
+		want  float64
+	}{
+		{"critical", impactQuery(100), result(0), 1},
+		{"critical band", impactQuery(90), result(0), 0.9},
+		{"high band", impactQuery(70), result(0), 0.7},
+		{"medium band", impactQuery(40), result(0), 0.4},
+		{"low band", impactQuery(10), result(0), 0.1},
+		{"no severity is floored, never Not Applicable", impactQuery(0), result(0), hdfMinImpact},
+		{"unset impact falls back to the score", &policy.Mquery{}, result(20), 0.8},
+		{"unset impact on a passing check is floored", &policy.Mquery{}, result(100), hdfMinImpact},
+		{
+			"an errored check with no severity is not reported as critical",
+			&policy.Mquery{},
+			&policy.Score{Type: policy.ScoreType_Error},
+			hdfMinImpact,
+		},
+		{
+			"skipped is Not Applicable",
+			impactQuery(90),
+			&policy.Score{Type: policy.ScoreType_Skip},
+			0,
+		},
+		{
+			"disabled is Not Applicable",
+			impactQuery(90),
+			&policy.Score{Type: policy.ScoreType_Disabled},
+			0,
+		},
+		{
+			"unscored keeps its severity so it reads as Not Reviewed",
+			impactQuery(90),
+			&policy.Score{Type: policy.ScoreType_Unscored},
+			0.9,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.InDelta(t, test.want, hdfControlImpact(test.query, test.score), 1e-9)
+		})
+	}
+}
+
+// TestHDFSeverityLabel pins the bands Heimdall and the SAF CLI bucket findings by.
+func TestHDFSeverityLabel(t *testing.T) {
+	tests := []struct {
+		impact float64
+		want   string
+	}{
+		{1, "critical"},
+		{0.9, "critical"},
+		{0.89, "high"},
+		{0.7, "high"},
+		{0.69, "medium"},
+		{0.4, "medium"},
+		{0.39, "low"},
+		{0.1, "low"},
+		{0.09, "none"},
+		{0, "none"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, hdfSeverityLabel(test.impact), "impact %v", test.impact)
+	}
+}
+
+// TestHDFUnratedCheckStaysCounted guards the finding that a check with no configured
+// severity must not fall into the "none" band. The SAF CLI's summary buckets a
+// finding by its severity tag and has no counter for "none", so an unrated check
+// that errored would vanish from the tally - the scan would look cleaner than it is.
+func TestHDFUnratedCheckStaysCounted(t *testing.T) {
+	pinHDFClock(t)
+
+	r := reportfixture.Sample()
+	for _, query := range r.Bundle.Queries {
+		query.Impact = nil
+	}
+	r.Reports[reportfixture.AssetMrn].Scores["057itYF8s30="] = &policy.Score{Type: policy.ScoreType_Error}
+
+	report := toHDF(t, r)
+	control := findHDFControl(findHDFProfile(report, "X1"), "mondoo-kubernetes-security-kubelet-event-record-qps")
+	require.NotNil(t, control)
+
+	assert.Equal(t, hdfStatusError, control.Results[0].Status)
+	assert.GreaterOrEqual(t, control.Impact, hdfMinImpact)
+	assert.NotEqual(t, "none", control.Tags["severity"],
+		"an unrated finding tagged \"none\" is dropped from the SAF summary")
+}
+
+// TestHDFNistTags pins the transform that makes cnspec's compliance mapping legible
+// to Heimdall's NIST 800-53 views.
+func TestHDFNistTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+		want []string
+	}{
+		{"no tags at all", nil, []string{hdfNistUnmappedTag}},
+		{
+			"mapped control",
+			map[string]string{hdfNistTagKey: "nist-sp-800-53-rev5-si-7"},
+			[]string{"SI-7"},
+		},
+		{
+			"control enhancement",
+			map[string]string{hdfNistTagKey: "nist-sp-800-53-rev5-ac-2-1"},
+			[]string{"AC-2 (1)"},
+		},
+		{
+			"multi-digit control",
+			map[string]string{hdfNistTagKey: "nist-sp-800-53-rev5-cm-14"},
+			[]string{"CM-14"},
+		},
+		{
+			"explicitly unmapped",
+			map[string]string{hdfNistTagKey: "false"},
+			[]string{hdfNistUnmappedTag},
+		},
+		{
+			"other frameworks do not leak in",
+			map[string]string{"compliance/iso-27001-2022": "iso-27001-2022-a-8-8"},
+			[]string{hdfNistUnmappedTag},
+		},
+		{
+			"unrecognized shape",
+			map[string]string{hdfNistTagKey: "nist-sp-800-53-rev5-whatever"},
+			[]string{hdfNistUnmappedTag},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, hdfNistTags(&policy.Mquery{Tags: test.tags}))
+		})
+	}
+}
+
+// TestHDFCheckTags verifies that the compliance mappings and cnspec context ride
+// along on every control.
+func TestHDFCheckTags(t *testing.T) {
+	pinHDFClock(t)
+
+	r := reportfixture.Sample()
+	r.Bundle.Queries[0].Tags = map[string]string{
+		hdfNistTagKey:               "nist-sp-800-53-rev5-si-7",
+		"compliance/iso-27001-2022": "iso-27001-2022-a-8-8",
+		"compliance/hipaa":          "false",
+	}
+	r.Bundle.Queries[0].Impact = &policy.Impact{Value: &policy.ImpactValue{Value: 80}}
+
+	report := toHDF(t, r)
+	control := findHDFControl(findHDFProfile(report, "X1"), "mondoo-linux-security-snmp-server-is-not-enabled")
+	require.NotNil(t, control)
+
+	assert.Equal(t, []any{"SI-7"}, control.Tags["nist"])
+	assert.Equal(t, "high", control.Tags["severity"])
+	assert.Equal(t, "iso-27001-2022-a-8-8", control.Tags["compliance/iso-27001-2022"])
+	assert.NotContains(t, control.Tags, "compliance/hipaa", "mappings turned off must be dropped")
+	assert.Equal(t, "X1", control.Tags["asset"])
+	assert.Equal(t, r.Bundle.Queries[0].Mrn, control.Tags["queryMrn"])
+}
+
+// TestHDFPolicyGroups checks that the policy a control came from survives, even
+// though the profile is the asset rather than the policy.
+func TestHDFPolicyGroups(t *testing.T) {
+	pinHDFClock(t)
+
+	r := reportfixture.Sample()
+	r.Bundle.Policies = []*policy.Policy{{
+		Mrn:  "//policy.api.mondoo.app/policies/mondoo-linux-security",
+		Name: "Linux Security by Mondoo",
+		Groups: []*policy.PolicyGroup{{
+			Checks: []*policy.Mquery{
+				{Mrn: r.Bundle.Queries[0].Mrn},
+				// a check of the policy that did not report for this asset
+				{Mrn: "//policy.api.mondoo.app/queries/not-in-this-scan"},
+			},
+		}},
+	}}
+
+	report := toHDF(t, r)
+	checks := findHDFProfile(report, "X1")
+	require.NotNil(t, checks)
+
+	var policyGroup *hdfGroup
+	for _, group := range checks.Groups {
+		if group.ID == "//policy.api.mondoo.app/policies/mondoo-linux-security" {
+			policyGroup = group
+		}
+	}
+	require.NotNil(t, policyGroup, "expected a group for the policy")
+	require.NotNil(t, policyGroup.Title)
+	assert.Equal(t, "Linux Security by Mondoo", *policyGroup.Title)
+	assert.Equal(t, []string{"mondoo-linux-security-snmp-server-is-not-enabled"}, policyGroup.Controls)
+
+	// The policy is attributed on the control itself as well.
+	control := findHDFControl(checks, "mondoo-linux-security-snmp-server-is-not-enabled")
+	require.NotNil(t, control)
+	assert.Equal(t, []any{"Linux Security by Mondoo"}, control.Tags["policies"])
+}
+
+// TestHDFVulnerabilities checks the advisory findings that ride in the asset's
+// profile.
+func TestHDFVulnerabilities(t *testing.T) {
+	pinHDFClock(t)
+	report := toHDF(t, reportfixture.Sample())
+
+	// The sample report has an affected package but no advisory covering it, so it
+	// lands in the catch-all control.
+	control := findHDFControl(findHDFProfile(report, "X1"), hdfVulnPackageID)
+	require.NotNil(t, control)
+	assert.Equal(t, 1.0, control.Impact)
+	assert.Equal(t, "critical", control.Tags["severity"])
+	assert.Equal(t, []any{"SI-2", "RA-5"}, control.Tags["nist"])
+
+	require.Len(t, control.Results, 1)
+	assert.Equal(t, hdfStatusFailed, control.Results[0].Status)
+	assert.Equal(t, "libssl1.1 1.1.1f-3ubuntu2.19", control.Results[0].CodeDesc)
+	assert.Contains(t, control.Results[0].Message, "Update to 1.1.1f-3ubuntu2.20.")
+}
+
+// TestHDFAssetError makes sure an asset that could not be scanned reports as a
+// failure rather than as an empty, apparently clean profile.
+func TestHDFAssetError(t *testing.T) {
+	pinHDFClock(t)
+
+	r := reportfixture.Sample()
+	r.Errors = map[string]string{reportfixture.AssetMrn: "could not connect to asset"}
+
+	report := toHDF(t, r)
+	control := findHDFControl(findHDFProfile(report, "X1"), hdfAssetErrorID)
+	require.NotNil(t, control, "expected an asset-error control")
+	assert.Equal(t, 1.0, control.Impact)
+	require.Len(t, control.Results, 1)
+	assert.Equal(t, hdfStatusError, control.Results[0].Status)
+	assert.Equal(t, "could not connect to asset", control.Results[0].Message)
+
+	// The failure is also visible in the passthrough data.
+	require.NotNil(t, report.Passthrough)
+	require.Len(t, report.Passthrough.AuxiliaryData, 1)
+}
+
+// TestHDFDuplicateAssetNames covers assets that share a display name - several
+// containers of one image. They must still come out as separate documents; the
+// filenames they are written to are covered by TestHDFDirWritesOneFilePerAsset.
+func TestHDFDuplicateAssetNames(t *testing.T) {
+	pinHDFClock(t)
+
+	r := multiAssetReportCollection(t)
+	r.Assets[reportfixture.AssetMrn+"-two"].Name = "X1"
+
+	docs, err := hdfDocuments(r)
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	assert.NotEqual(t, docs[0].assetMrn, docs[1].assetMrn)
+
+	// Each document names its own target rather than a shared placeholder.
+	assert.Equal(t, "ubuntu", docs[0].report.Platform.Name)
+	assert.Equal(t, "debian", docs[1].report.Platform.Name)
+}
+
+// TestHDFDeterministic guards against map iteration leaking into the output: two
+// conversions of the same report must be byte-identical, or every re-scan looks
+// like a change to whatever consumes the document.
+func TestHDFDeterministic(t *testing.T) {
+	pinHDFClock(t)
+
+	r := reportfixture.Sample()
+	first := toHDFBytes(t, r)
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, string(first), string(toHDFBytes(t, r)))
+	}
+}
+
+func TestHDFEmptyReport(t *testing.T) {
+	pinHDFClock(t)
+
+	report := toHDF(t, nil)
+	assert.Equal(t, hdfToolName, report.Platform.Name)
+	assert.Empty(t, report.Profiles)
+	assert.Nil(t, report.Statistics.Duration)
+}
+
+func TestHDFMissingBundle(t *testing.T) {
+	buf := bytes.Buffer{}
+	writer := iox.IOWriter{Writer: &buf}
+	err := Convert(&policy.ReportCollection{}, &writer)
+	assert.ErrorContains(t, err, "no policy bundle found")
+}
+
+// TestHDFUbuntuReport runs the converter over a full recorded scan and checks the
+// shape of the document rather than individual values.
+func TestHDFUbuntuReport(t *testing.T) {
+	pinHDFClock(t)
+
+	raw, err := os.ReadFile("../testdata/report-ubuntu.json")
+	require.NoError(t, err)
+
+	var r policy.ReportCollection
+	require.NoError(t, json.Unmarshal(raw, &r))
+
+	report := toHDF(t, &r)
+	require.NotEmpty(t, report.Profiles)
+
+	var controls int
+	for _, profile := range report.Profiles {
+		assert.NotEmpty(t, profile.Sha256)
+		for _, control := range profile.Controls {
+			controls++
+			assert.NotEmpty(t, control.ID)
+			assert.GreaterOrEqual(t, control.Impact, 0.0)
+			assert.LessOrEqual(t, control.Impact, 1.0)
+			assert.NotEmpty(t, control.Tags["nist"], "control %q needs a NIST tag", control.ID)
+			// The severity tag is what the SAF CLI buckets by, so it has to agree
+			// with the impact rather than being derived separately.
+			assert.Equal(t, hdfSeverityLabel(control.Impact), control.Tags["severity"],
+				"control %q: severity tag and impact disagree", control.ID)
+			require.NotEmpty(t, control.Results, "control %q needs a result", control.ID)
+			if control.Impact > 0 {
+				assert.NotEqual(t, "none", control.Tags["severity"],
+					"control %q would drop out of the SAF summary", control.ID)
+			}
+			for _, result := range control.Results {
+				assert.Contains(t,
+					[]string{hdfStatusPassed, hdfStatusFailed, hdfStatusSkipped, hdfStatusError},
+					result.Status)
+				assert.NotEmpty(t, result.CodeDesc)
+				assert.NotEmpty(t, result.StartTime)
+			}
+		}
+	}
+	assert.NotZero(t, controls, "expected the recorded scan to produce controls")
+}

--- a/cli/reporter/hdf/schema_test.go
+++ b/cli/reporter/hdf/schema_test.go
@@ -1,0 +1,337 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hdf
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+	"go.mondoo.com/cnspec/cli/reporter/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// The OHDF/exec-json schema, checked in from
+// https://github.com/mitre/heimdall2/blob/master/libs/inspecjs/schemas/exec-json.json
+// so conformance is proven on every run rather than by hand. Refresh it when MITRE
+// revises the schema; a failure here means our document stopped being readable by
+// Heimdall and the SAF CLI.
+const ohdfSchemaFile = "./testdata/ohdf-exec-json-schema.json"
+
+func ohdfSchema(t *testing.T) *gojsonschema.Schema {
+	t.Helper()
+	abs, err := filepath.Abs(ohdfSchemaFile)
+	require.NoError(t, err)
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader("file://" + abs))
+	require.NoError(t, err, "could not load the OHDF schema")
+	return schema
+}
+
+// assertValidOHDF fails with the schema's own messages, which name the offending
+// field, so a break points straight at the mapping that caused it.
+func assertValidOHDF(t *testing.T, schema *gojsonschema.Schema, doc []byte, label string) {
+	t.Helper()
+
+	res, err := schema.Validate(gojsonschema.NewBytesLoader(doc))
+	require.NoError(t, err, "%s: could not validate", label)
+	if res.Valid() {
+		return
+	}
+
+	var b strings.Builder
+	for _, e := range res.Errors() {
+		b.WriteString("\n  " + e.String())
+	}
+	t.Errorf("%s does not conform to the OHDF schema:%s", label, b.String())
+}
+
+// TestHDFConformsToSchema validates what the converter actually emits against the
+// published OHDF schema, for the report shapes that exercise different parts of the
+// mapping.
+func TestHDFConformsToSchema(t *testing.T) {
+	pinHDFClock(t)
+	schema := ohdfSchema(t)
+
+	errored := reportfixture.Sample()
+	errored.Errors = map[string]string{reportfixture.AssetMrn: "could not connect to asset"}
+
+	noVulns := reportfixture.Sample()
+	noVulns.VulnReports = nil
+
+	tests := []struct {
+		name   string
+		report *policy.ReportCollection
+	}{
+		{"empty scan", nil},
+		{"checks and vulnerabilities", reportfixture.Sample()},
+		{"checks only", noVulns},
+		{"asset error", errored},
+		{"recorded ubuntu scan", loadReportCollection(t, "../testdata/report-ubuntu.json")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertValidOHDF(t, schema, toHDFBytes(t, test.report), test.name)
+		})
+	}
+}
+
+// TestHDFDirConformsToSchema covers the multi-asset path: every file written into
+// the directory has to be a valid OHDF document in its own right.
+func TestHDFDirConformsToSchema(t *testing.T) {
+	pinHDFClock(t)
+	schema := ohdfSchema(t)
+
+	dir := t.TempDir()
+	files, err := ConvertToDir(multiAssetReportCollection(t), dir)
+	require.NoError(t, err)
+	require.Len(t, files, 2, "expected one file per asset")
+
+	for _, path := range files {
+		doc, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assertValidOHDF(t, schema, doc, filepath.Base(path))
+	}
+}
+
+// TestHDFSingleProfilePerDocument is the invariant behind the file-per-asset split.
+// Heimdall and the SAF CLI resolve a document down to one root profile and tally
+// only that one, so a second, unlinked profile is dropped without an error - the
+// scan reads cleaner than it is. Every document must carry exactly one profile.
+func TestHDFSingleProfilePerDocument(t *testing.T) {
+	pinHDFClock(t)
+
+	docs, err := hdfDocuments(multiAssetReportCollection(t))
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+
+	for _, doc := range docs {
+		assert.Len(t, doc.report.Profiles, 1,
+			"asset %q: findings outside the first profile are dropped by OHDF consumers", doc.name)
+	}
+
+	// The vulnerability findings ride in that one profile rather than a second one.
+	report := toHDF(t, reportfixture.Sample())
+	require.Len(t, report.Profiles, 1)
+	assert.NotNil(t, findHDFControl(report.Profiles[0], hdfVulnPackageID),
+		"vulnerability controls must live in the asset's profile")
+
+	// They stay distinguishable through their own control group.
+	var vulnGroup *hdfGroup
+	for _, group := range report.Profiles[0].Groups {
+		if group.ID == hdfVulnGroupID {
+			vulnGroup = group
+		}
+	}
+	require.NotNil(t, vulnGroup, "expected a vulnerabilities group")
+	assert.Contains(t, vulnGroup.Controls, hdfVulnPackageID)
+}
+
+// TestHDFProfileChecksumIsPerAsset is the regression for a fleet scan collapsing in
+// Heimdall. Every asset scanned against the same policies resolves to the same
+// execution graph, and the checksum used to be that graph alone - so a hundred
+// documents, each with its own asset, its own controls and its own results, all
+// claimed to be the same profile.
+func TestHDFProfileChecksumIsPerAsset(t *testing.T) {
+	pinHDFClock(t)
+
+	r := multiAssetReportCollection(t)
+	// what a real scan carries and the hand-built fixture does not: one resolved
+	// policy shared by every asset it was scanned against
+	for _, resolved := range r.ResolvedPolicies {
+		resolved.GraphExecutionChecksum = "6+kRFHvaz8A="
+	}
+
+	docs, err := hdfDocuments(r)
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	assert.NotEqual(t, docs[0].report.Profiles[0].Sha256, docs[1].report.Profiles[0].Sha256,
+		"two assets scanned against one policy must not share a profile identity")
+
+	// It still has to be stable: a profile checksum identifies the profile, not the
+	// run, so re-scanning an asset must not look like a new profile because a check
+	// changed its verdict.
+	rerun := multiAssetReportCollectionWith(t, "6+kRFHvaz8A=")
+	rerun.Reports[reportfixture.AssetMrn].Scores["+u6doYoYG5E="] =
+		&policy.Score{Type: policy.ScoreType_Result, Value: 0}
+
+	again, err := hdfDocuments(rerun)
+	require.NoError(t, err)
+	assert.Equal(t, docs[0].report.Profiles[0].Sha256, again[0].report.Profiles[0].Sha256)
+}
+
+// TestHDFDirWritesOneFilePerAsset covers the naming: asset names carry characters
+// that do not belong in a path, and two assets can share one.
+func TestHDFDirWritesOneFilePerAsset(t *testing.T) {
+	pinHDFClock(t)
+
+	r := multiAssetReportCollection(t)
+	r.Assets[reportfixture.AssetMrn].Name = "docker.io/library/nginx:1.25"
+	r.Assets[reportfixture.AssetMrn+"-two"].Name = "docker.io/library/nginx:1.25"
+
+	dir := t.TempDir()
+	files, err := ConvertToDir(r, dir)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(files))
+	for _, path := range files {
+		names = append(names, filepath.Base(path))
+	}
+	assert.Equal(t, []string{
+		"docker.io-library-nginx-1.25.hdf.json",
+		"docker.io-library-nginx-1.25-2.hdf.json",
+	}, names, "colliding asset names must not overwrite each other")
+}
+
+// TestHDFFileBase covers the filename stem. Asset names are attacker-adjacent input
+// in the sense that they come from whatever was scanned - a container image
+// reference, a cloud resource ARN, a Kubernetes object - so a path separator must
+// never survive into a filename, and a long one must not blow the filesystem's limit.
+func TestHDFFileBase(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "web-02", "web-02"},
+		{"image reference", "docker.io/library/nginx:1.25", "docker.io-library-nginx-1.25"},
+		{"arn", "arn:aws:ec2:us-east-1:1:instance/i-0abc", "arn-aws-ec2-us-east-1-1-instance-i-0abc"},
+		{"traversal", "../../etc/passwd", "etc-passwd"},
+		{"absolute path", "/etc/shadow", "etc-shadow"},
+		{"windows traversal", `..\..\windows\system32`, "windows-system32"},
+		{"newlines", "name\nwith\nnewlines", "name-with-newlines"},
+		{"non-ascii", "héllo wörld", "h-llo-w-rld"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := hdfFileBase(&hdfDocument{name: test.in, assetMrn: "//mrn/" + test.in})
+			assert.Equal(t, test.want, got)
+			assert.NotContains(t, got, "/")
+			assert.NotContains(t, got, `\`)
+		})
+	}
+
+	// Names that sanitize away entirely fall back to the MRN digest rather than to
+	// something the filesystem would reject.
+	for _, in := range []string{"", ".", "..", "....", "-", "\x00"} {
+		got := hdfFileBase(&hdfDocument{name: in, assetMrn: "//mrn/x"})
+		assert.Equal(t, "asset-"+hdfSha256("//mrn/x")[:12], got, "input %q", in)
+	}
+
+	// A long name is capped, and two that share a prefix stay distinct.
+	longA := hdfFileBase(&hdfDocument{name: strings.Repeat("x", 300) + "-a", assetMrn: "//mrn/a"})
+	longB := hdfFileBase(&hdfDocument{name: strings.Repeat("x", 300) + "-b", assetMrn: "//mrn/b"})
+	assert.LessOrEqual(t, len(longA), hdfMaxFileBase)
+	assert.NotEqual(t, longA, longB, "truncated names must not collide")
+}
+
+// TestHDFDirLongAssetName is the regression: a name past the filesystem's limit used
+// to fail the write and abandon every asset after it, so one long name cost the
+// whole export.
+func TestHDFDirLongAssetName(t *testing.T) {
+	pinHDFClock(t)
+
+	r := multiAssetReportCollection(t)
+	r.Assets[reportfixture.AssetMrn].Name = strings.Repeat("x", 300)
+
+	dir := t.TempDir()
+	files, err := ConvertToDir(r, dir)
+	require.NoError(t, err)
+	assert.Len(t, files, 2, "both assets must be written")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+// TestHDFDirReportsFailuresWithoutAbandoningTheRest covers the other half: when one
+// asset genuinely cannot be written, the remaining assets still are, and the failure
+// is reported rather than swallowed.
+func TestHDFDirReportsFailuresWithoutAbandoningTheRest(t *testing.T) {
+	pinHDFClock(t)
+
+	dir := t.TempDir()
+	// Occupy the path the first asset would write to, so os.Create fails on it.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "X1.hdf.json"), 0o755))
+
+	files, err := ConvertToDir(multiAssetReportCollection(t), dir)
+	require.Error(t, err, "the unwritable asset must be reported")
+	assert.Contains(t, err.Error(), "X1")
+
+	require.Len(t, files, 1, "the other asset must still be written")
+	assert.Equal(t, "web-02.hdf.json", filepath.Base(files[0]))
+}
+
+// TestHDFMultiAssetStream documents what a multi-asset scan looks like on stdout:
+// an array of documents, since one OHDF document cannot describe several targets.
+func TestHDFMultiAssetStream(t *testing.T) {
+	pinHDFClock(t)
+
+	var reports []*hdfReport
+	require.NoError(t, json.Unmarshal(toHDFBytes(t, multiAssetReportCollection(t)), &reports))
+	require.Len(t, reports, 2)
+
+	for _, report := range reports {
+		assert.Len(t, report.Profiles, 1)
+	}
+	// Each document names its own target rather than a shared placeholder.
+	assert.NotEqual(t, reports[0].Platform.TargetID, reports[1].Platform.TargetID)
+}
+
+func loadReportCollection(t *testing.T, path string) *policy.ReportCollection {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var r policy.ReportCollection
+	require.NoError(t, json.Unmarshal(raw, &r))
+	return &r
+}
+
+// multiAssetReportCollection clones the sample scan onto a second asset running a
+// different platform, so the multi-asset paths have something to work on.
+func multiAssetReportCollection(t *testing.T) *policy.ReportCollection {
+	t.Helper()
+
+	r := reportfixture.Sample()
+	secondMrn := reportfixture.AssetMrn + "-two"
+	r.Assets[secondMrn] = &inventory.Asset{
+		Name:        "web-02",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/web-02"},
+		Platform:    &inventory.Platform{Name: "debian", Version: "12", Arch: "amd64"},
+	}
+	r.ResolvedPolicies[secondMrn] = r.ResolvedPolicies[reportfixture.AssetMrn]
+
+	scores := map[string]*policy.Score{}
+	for id := range r.Reports[reportfixture.AssetMrn].Scores {
+		scores[id] = &policy.Score{Type: policy.ScoreType_Result, Value: 100}
+	}
+	r.Reports[secondMrn] = &policy.Report{
+		ScoringMrn: secondMrn,
+		EntityMrn:  secondMrn,
+		Scores:     scores,
+		Score:      &policy.Score{Value: 100, ScoreCompletion: 100, DataCompletion: 100},
+	}
+	return r
+}
+
+// multiAssetReportCollectionWith is multiAssetReportCollection with the graph
+// checksum a real scan would carry.
+func multiAssetReportCollectionWith(t *testing.T, graphChecksum string) *policy.ReportCollection {
+	t.Helper()
+
+	r := multiAssetReportCollection(t)
+	for _, resolved := range r.ResolvedPolicies {
+		resolved.GraphExecutionChecksum = graphChecksum
+	}
+	return r
+}

--- a/cli/reporter/hdf/testdata/ohdf-exec-json-schema.json
+++ b/cli/reporter/hdf/testdata/ohdf-exec-json-schema.json
@@ -1,0 +1,832 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "platform",
+    "profiles",
+    "statistics",
+    "version"
+  ],
+  "properties": {
+    "platform": {
+      "$ref": "#/definitions/Platform",
+      "description": "Information on the platform the run from the tool that generated the findings was from.  Example: the name of the operating system."
+    },
+    "profiles": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Exec_JSON_Profile"
+      },
+      "description": "Information on the run(s) from the tool that generated the findings.  Example: the findings."
+    },
+    "statistics": {
+      "$ref": "#/definitions/Statistics",
+      "description": "Statistics for the run(s) from the tool that generated the findings.  Example: the runtime duration."
+    },
+    "version": {
+      "type": "string",
+      "description": "Version number of the tool that generated the findings.  Example: '4.18.108' is a version of Chef InSpec."
+    }
+  },
+  "description": "The top level value containing all of the results.",
+  "title": "Exec JSON Output",
+  "definitions": {
+    "Control_Description": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "label",
+        "data"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The type of description.  Examples: 'fix' or 'check'."
+        },
+        "data": {
+          "type": "string",
+          "description": "The text of the description."
+        }
+      },
+      "description": "A description for a control.",
+      "title": "Control Description"
+    },
+    "Control_Group": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "id",
+        "controls"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The unique identifier for the group.  Example: the relative path to the file specifying the controls."
+        },
+        "title": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The title of the group - should be human readable."
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of controls as specified by their ids in this group.  Example: 'V-75443'."
+        }
+      },
+      "description": "Descriptions for controls in a group, such as the list of all the controls.",
+      "title": "Control Group"
+    },
+    "Control_Result": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "code_desc",
+        "start_time"
+      ],
+      "properties": {
+        "status": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Control_Result_Status",
+              "description": "The status of this test within the control.  Example: 'failed'."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "code_desc": {
+          "type": "string",
+          "description": "A description of this test.  Example: 'limits.conf * is expected to include ['hard', 'maxlogins', '10']."
+        },
+        "run_time": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "The execution time in seconds for the test."
+        },
+        "start_time": {
+          "type": "string",
+          "description": "The time at which the test started."
+        },
+        "resource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The resource used in the test.  Example: in Inspec, you can use the 'File' resource."
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "An explanation of the test status - usually only provided when the test fails."
+        },
+        "skip_message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "An explanation of the test status if the status was 'skipped."
+        },
+        "exception": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The type of exception if an exception was thrown."
+        },
+        "resource_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The unique identifier of the resource."
+        },
+        "backtrace": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The stacktrace/backtrace of the exception if one occurred."
+        }
+      },
+      "description": "A test within a control and its results and findings such as how long it took to run.",
+      "title": "Control Result"
+    },
+    "Control_Result_Status": {
+      "type": "string",
+      "enum": [
+        "passed",
+        "failed",
+        "skipped",
+        "error"
+      ],
+      "description": "The status of a control.  Should be one of 'passed', 'failed', 'skipped', or 'error'.",
+      "title": "Control Result Status"
+    },
+    "Dependency": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The name/assigned alias."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The address of the dependency."
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The branch name for a git repo."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The relative path if the dependency is locally available."
+        },
+        "status_message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The reason for the status if it is 'failed' or 'skipped'."
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The status.  Should be: 'loaded', 'failed', or 'skipped'."
+        },
+        "git": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The location of the git repo.  Example: 'https://github.com/mitre/canonical-ubuntu-18.04-lts-stig-baseline.git'."
+        },
+        "supermarket": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The 'user/profilename' attribute for a Supermarket server."
+        },
+        "compliance": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The 'user/profilename' attribute for an Automate server."
+        }
+      },
+      "description": "A dependency for a profile.  Can include relative paths or urls for where to find the dependency.",
+      "title": "Dependency"
+    },
+    "Exec_JSON_Control": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "id",
+        "impact",
+        "refs",
+        "tags",
+        "source_location",
+        "results"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The id."
+        },
+        "title": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The title - is nullable."
+        },
+        "desc": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The description for the overarching control."
+        },
+        "descriptions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Control_Description"
+          },
+          "description": "A set of additional descriptions.  Example: the 'fix' text."
+        },
+        "impact": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "The impactfulness or severity."
+        },
+        "refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          },
+          "description": "The set of references to external documents."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "A set of tags - usually metadata."
+        },
+        "code": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The raw source code of the control. Note that if this is an overlay control, it does not include the underlying source code."
+        },
+        "source_location": {
+          "$ref": "#/definitions/Source_Location",
+          "description": "The explicit location of the control within the source code."
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Control_Result"
+          },
+          "description": "\n             The set of all tests within the control and their results and findings.  Example:\n             For Chef Inspec, if in the control's code we had the following:\n               describe sshd_config do\n                 its('Port') { should cmp 22 }\n               end\n             The findings from this block would be appended to the results, as well as those of any other blocks within the control.\n          "
+        },
+        "waiver_data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Waiver_Data"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "attestation_data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Attestation_Data"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "description": "Describes a control and any findings it has.",
+      "title": "Exec JSON Control"
+    },
+    "Exec_JSON_Profile": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "sha256",
+        "supports",
+        "attributes",
+        "groups",
+        "controls"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name - must be unique."
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The title - should be human readable."
+        },
+        "maintainer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The maintainer(s)."
+        },
+        "copyright": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The copyright holder(s)."
+        },
+        "copyright_email": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The email address or other contact information of the copyright holder(s)."
+        },
+        "depends": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "The set of dependencies this profile depends on.  Example: an overlay profile is dependent on another profile."
+        },
+        "parent_profile": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The name of the parent profile if the profile is a dependency of another."
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The copyright license.  Example: the full text or the name, such as 'Apache License, Version 2.0'."
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The summary.  Example: the Security Technical Implementation Guide (STIG) header."
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The version of the profile."
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Supported_Platform"
+          },
+          "description": "The set of supported platform targets."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The description - should be more detailed than the summary."
+        },
+        "inspec_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The version of Inspec."
+        },
+        "sha256": {
+          "type": "string",
+          "description": "The checksum of the profile."
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The status.  Example: loaded."
+        },
+        "status_message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The reason for the status.  Example: why it was skipped or failed to load."
+        },
+        "skip_message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The reason for skipping if it was skipped."
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Exec_JSON_Control"
+          },
+          "description": "The set of controls including any findings."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Control_Group"
+          },
+          "description": "A set of descriptions for the control groups.  Example: the ids of the controls."
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "An input or attribute used in the run."
+          },
+          "description": "The input(s) or attribute(s) used in the run."
+        }
+      },
+      "description": "Information on the set of controls assessed.  Example: it can include the name of the Inspec profile and any findings.",
+      "title": "Exec JSON Profile"
+    },
+    "Platform": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "release"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the platform this was run on."
+        },
+        "release": {
+          "type": "string",
+          "description": "The version of the platform this was run on."
+        },
+        "target_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The id of the target.  Example: the name and version of the operating system were not sufficient to identify the platform so a release identifier can additionally be provided like '21H2' for the release version of MS Windows 10."
+        }
+      },
+      "description": "Platform information such as its name.",
+      "title": "Platform"
+    },
+    "Reference": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "ref"
+          ],
+          "properties": {
+            "ref": {
+              "type": "string"
+            }
+          },
+          "description": "A human readable/meaningful reference.  Example: a book title."
+        },
+        {
+          "type": "object",
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "url": {
+              "type": "string"
+            }
+          },
+          "description": "A url pointing at the reference."
+        },
+        {
+          "type": "object",
+          "required": [
+            "uri"
+          ],
+          "properties": {
+            "uri": {
+              "type": "string"
+            }
+          },
+          "description": "A uri pointing at the reference."
+        },
+        {
+          "type": "object",
+          "required": [
+            "ref"
+          ],
+          "properties": {
+            "ref": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "description": ""
+        }
+      ],
+      "description": "A reference to an external document.",
+      "title": "Reference"
+    },
+    "Source_Location": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to the file that this control originates from."
+        },
+        "line": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "The line on which this control is located."
+        }
+      },
+      "required": [],
+      "description": "The explicit location of the control.",
+      "title": "Source Location"
+    },
+    "Statistic_Block": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "total"
+      ],
+      "properties": {
+        "total": {
+          "type": "number",
+          "description": "The total.  Example: the total number of controls in a given category for a run."
+        }
+      },
+      "description": "Statistics for a given item, such as the total.",
+      "title": "Statistic Block"
+    },
+    "Statistic_Hash": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "passed": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Statistic_Block",
+              "description": "Statistics for the controls that passed."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "skipped": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Statistic_Block",
+              "description": "Statistics for the controls that were skipped."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failed": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Statistic_Block",
+              "description": "Statistics for the controls that failed."
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "description": "Statistics for the control results.",
+      "title": "Statistic Hash"
+    },
+    "Statistics": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "duration": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "How long (in seconds) this run by the tool was."
+        },
+        "controls": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Statistic_Hash",
+              "description": "Breakdowns of control statistics by result"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "description": "Statistics for the run(s) such as how long it took.",
+      "title": "Statistics"
+    },
+    "Supported_Platform": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "platform-family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The platform family.  Example: 'redhat'."
+        },
+        "platform-name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The platform name - can include wildcards.  Example: 'debian'."
+        },
+        "platform": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The location of the platform.  Can be: 'os', 'aws', 'azure', or 'gcp'."
+        },
+        "release": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The release of the platform.  Example: '20.04' for 'ubuntu'."
+        },
+        "os-family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Deprecated in favor of platform-family."
+        },
+        "os-name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Deprecated in favor of platform-name."
+        }
+      },
+      "description": "A supported platform target.  Example: the platform name being 'ubuntu'.",
+      "title": "Supported Platform"
+    },
+    "Waiver_Data": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "properties": {
+        "expiration_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "justification": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "skipped_due_to_waiver": {
+          "type": [
+            "boolean",
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "Attestation_Status": {
+      "type": "string",
+      "enum": [
+        "passed",
+        "failed"
+      ],
+      "description": "The attested status of the control",
+      "title": "Control Attestation Status"
+    },
+    "Attestation_Data": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "control_id",
+        "explanation",
+        "frequency",
+        "status",
+        "updated",
+        "updated_by"
+      ],
+      "properties": {
+        "control_id": {
+          "type": "string"
+        },
+        "explanation": {
+          "type": "string"
+        },
+        "frequency": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/Attestation_Status"
+        },
+        "updated": {
+          "type": "string"
+        },
+        "updated_by": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/cli/reporter/hdf_format_test.go
+++ b/cli/reporter/hdf_format_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reporter/internal/reportfixture"
+)
+
+// What the document says is the hdf package's business; these cover the wiring that
+// only exists here - that `-o hdf` reaches the converter at all, and which handler a
+// given --output-target picks.
+
+func TestHDFReporterFormat(t *testing.T) {
+	conf, err := ParseConfig("hdf")
+	require.NoError(t, err)
+	assert.Equal(t, FormatHDF, conf.format)
+
+	buf := bytes.Buffer{}
+	require.NoError(t, NewReporter(conf, false).WithOutput(&buf).
+		WriteReport(t.Context(), reportfixture.Sample()))
+
+	var report struct {
+		Profiles []json.RawMessage `json:"profiles"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
+	assert.NotEmpty(t, report.Profiles)
+}
+
+// TestOutputHandlerHDFDirectory covers the one output target whose handler depends
+// on the format: an OHDF document describes a single asset, so a directory target
+// means "a file per asset" rather than "a file called that".
+func TestOutputHandlerHDFDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name   string
+		format string
+		target string
+		want   OutputHandler
+	}{
+		{"hdf into an existing directory", "hdf", dir, &hdfDirHandler{}},
+		{"hdf into a path asking for one", "hdf", filepath.Join(dir, "out") + "/", &hdfDirHandler{}},
+		{"hdf into a file", "hdf", filepath.Join(dir, "report.json"), &localFileHandler{}},
+		{"another format into a directory", "json", dir, &localFileHandler{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rep, err := NewOutputHandler(HandlerConfig{Format: test.format, OutputTarget: test.target})
+			require.NoError(t, err)
+			require.IsType(t, test.want, rep)
+		})
+	}
+}

--- a/cli/reporter/internal/reportfixture/fixture.go
+++ b/cli/reporter/internal/reportfixture/fixture.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package reportfixture holds the hand-built scan the reporter tests convert.
+//
+// It is a package rather than a helper in one test file because the JUnit, SARIF
+// and OHDF reporters now live in separate packages and have to be compared on the
+// same scan: the point of the fixture is that one asset carries a passing, an
+// errored and a skipped check plus an affected package, so every reporter is shown
+// the same four outcomes and their treatment of them can be read side by side.
+package reportfixture
+
+import (
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
+)
+
+// AssetMrn is the single asset Sample reports on.
+const AssetMrn = "//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2"
+
+// Sample is a scan of one Ubuntu asset with a passed, an errored and a skipped
+// check, and one affected package that no advisory in the report covers.
+func Sample() *policy.ReportCollection {
+	return &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			AssetMrn: {
+				Name:        "X1",
+				PlatformIds: []string{"//platformid.api.mondoo.app/hostname/X1"},
+				State:       inventory.State_STATE_ONLINE,
+				Platform: &inventory.Platform{
+					Name:    "ubuntu",
+					Arch:    "amd64",
+					Kind:    "baremetal",
+					Version: "22.04",
+					Family:  []string{"debian", "linux", "unix", "os"},
+				},
+			},
+		},
+		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
+			AssetMrn: {
+				CollectorJob: &policy.CollectorJob{
+					ReportingQueries: map[string]*policy.StringArray{
+						"+u6doYoYG5E=": nil,
+						"057itYF8s30=": nil,
+						"GyJVAziB/tU=": nil,
+					},
+				},
+			},
+		},
+		Bundle: &policy.Bundle{
+			Policies: nil, // not needed for this test since junit does not sort by policy
+			Queries: []*policy.Mquery{
+				{
+					Mrn:    "//policy.api.mondoo.app/queries/mondoo-linux-security-snmp-server-is-not-enabled",
+					CodeId: "+u6doYoYG5E=",
+					Title:  "Ensure SNMP server is stopped and not enabled",
+				},
+				{
+					Mrn:    "//policy.api.mondoo.app/queries/mondoo-kubernetes-security-kubelet-event-record-qps",
+					CodeId: "057itYF8s30=",
+					Title:  "Configure kubelet to capture all event creation",
+				},
+				{
+					Mrn:    "//policy.api.mondoo.app/queries/mondoo-kubernetes-security-secure-scheduler_conf",
+					CodeId: "GyJVAziB/tU=",
+					Title:  "Set secure file permissions on the scheduler.conf file",
+				},
+			},
+		},
+		Reports: map[string]*policy.Report{
+			AssetMrn: {
+				ScoringMrn: AssetMrn,
+				EntityMrn:  AssetMrn,
+				Score: &policy.Score{
+					Value:           29,
+					ScoreCompletion: 100,
+					DataCompletion:  100,
+				},
+				// add passed, failed and skipped test
+				Scores: map[string]*policy.Score{
+					"+u6doYoYG5E=": {
+						Type:  2, // result
+						Value: 100,
+					},
+					"057itYF8s30=": {
+						Type:  4, // error
+						Value: 0,
+					},
+					"GyJVAziB/tU=": {
+						Type:  8, // skip
+						Value: 0,
+					},
+				},
+			},
+		},
+		VulnReports: map[string]*mvd.VulnReport{
+			AssetMrn: {
+				Packages: []*mvd.Package{
+					{
+						Name:      "libssl1.1",
+						Version:   "1.1.1f-3ubuntu2.19",
+						Affected:  true,
+						Score:     100,
+						Available: "1.1.1f-3ubuntu2.20",
+					},
+				},
+				Stats: &mvd.ReportStats{
+					Packages: &mvd.ReportStatsPackages{
+						Total:    1,
+						Critical: 1,
+						Affected: 1,
+					},
+				},
+			},
+		},
+	}
+}

--- a/cli/reporter/json.go
+++ b/cli/reporter/json.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"strconv"
 
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	cr "go.mondoo.com/mql/cli/reporter"
 	"go.mondoo.com/mql/llx"
@@ -52,7 +53,7 @@ func prepareAssetsForPrinting(assets map[string]*inventory.Asset) map[string]*as
 			Mrn:          a.Mrn,
 			Name:         a.Name,
 			Url:          a.Url,
-			PlatformName: getPlatformNameForAsset(a),
+			PlatformName: reportdoc.PlatformName(a),
 		}
 		printableAssets[k] = pAsset
 	}

--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/cli/printer"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
@@ -57,7 +58,7 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper, detailed b
 		}
 
 		bundle := r.Bundle.ToMap()
-		queries := reporterQueryMap(bundle)
+		queries := reportdoc.QueryMap(bundle)
 
 		// iterate over asset mrns
 		for assetMrn, assetObj := range r.Assets {
@@ -111,7 +112,7 @@ func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inv
 	// Data queries have no score and are not represented here. When detailed is set,
 	// failed/errored checks carry their meta information (description, query, assessment,
 	// remediation, references) in the failure body below.
-	platformKeys := platformRemediationKeys(assetObj.Platform)
+	platformKeys := reportdoc.PlatformRemediationKeys(assetObj.Platform)
 	for id, score := range report.Scores {
 		_, ok := resolved.CollectorJob.ReportingQueries[id]
 		if !ok {
@@ -260,13 +261,13 @@ func assetMvdTests(r *policy.ReportCollection, assetMrn string, assetObj *invent
 func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, query *policy.Mquery, score *policy.Score, platformKeys map[string]bool) string {
 	var b strings.Builder
 
-	if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+	if desc := strings.TrimSpace(reportdoc.QueryDescription(query)); desc != "" {
 		b.WriteString(desc)
 		b.WriteString("\n")
 	}
 
-	if mql := queryMql(query); mql != "" {
-		writeDetailSection(&b, "Query", mql)
+	if mql := reportdoc.QueryMql(query); mql != "" {
+		reportdoc.WriteDetailSection(&b, "Query", mql)
 	}
 
 	// The assessment (expected vs actual) is only available for assertion checks
@@ -279,10 +280,10 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 		if cb := resolved.GetCodeBundle(query); cb != nil {
 			if assessment := policy.Query2Assessment(cb, report); assessment != nil {
 				if text := strings.TrimSpace(printer.PlainNoColorPrinter.Assessment(cb, assessment)); text != "" {
-					writeDetailSection(&b, "Result", text)
+					reportdoc.WriteDetailSection(&b, "Result", text)
 				}
-				if locs := failingResourceLocations(cb, assessment); locs != "" {
-					writeDetailSection(&b, "Failing resources", locs)
+				if locs := reportdoc.FailingResourceLocations(cb, assessment); locs != "" {
+					reportdoc.WriteDetailSection(&b, "Failing resources", locs)
 				}
 			}
 		}
@@ -291,12 +292,12 @@ func detailedCheckBody(resolved *policy.ResolvedPolicy, report *policy.Report, q
 	// For errored checks the score message carries the failure reason.
 	if score != nil && score.Type == policy.ScoreType_Error {
 		if msg := score.MessageLine(); msg != "" {
-			writeDetailSection(&b, "Error", msg)
+			reportdoc.WriteDetailSection(&b, "Error", msg)
 		}
 	}
 
-	writeDetailSection(&b, "Remediation", queryRemediation(query, platformKeys))
-	writeDetailSection(&b, "References", queryReferences(query))
+	reportdoc.WriteDetailSection(&b, "Remediation", reportdoc.QueryRemediation(query, platformKeys))
+	reportdoc.WriteDetailSection(&b, "References", reportdoc.QueryReferences(query))
 
 	return strings.TrimSpace(b.String())
 }

--- a/cli/reporter/junit_test.go
+++ b/cli/reporter/junit_test.go
@@ -11,110 +11,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reporter/internal/reportfixture"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/mql/utils/iox"
 )
 
-func sampleReportCollection() *policy.ReportCollection {
-	return &policy.ReportCollection{
-		Assets: map[string]*inventory.Asset{
-			"//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2": {
-				Name:        "X1",
-				PlatformIds: []string{"//platformid.api.mondoo.app/hostname/X1"},
-				State:       inventory.State_STATE_ONLINE,
-				Platform: &inventory.Platform{
-					Name:    "ubuntu",
-					Arch:    "amd64",
-					Kind:    "baremetal",
-					Version: "22.04",
-					Family:  []string{"debian", "linux", "unix", "os"},
-				},
-			},
-		},
-		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
-			"//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2": {
-				CollectorJob: &policy.CollectorJob{
-					ReportingQueries: map[string]*policy.StringArray{
-						"+u6doYoYG5E=": nil,
-						"057itYF8s30=": nil,
-						"GyJVAziB/tU=": nil,
-					},
-				},
-			},
-		},
-		Bundle: &policy.Bundle{
-			Policies: nil, // not needed for this test since junit does not sort by policy
-			Queries: []*policy.Mquery{
-				{
-					Mrn:    "//policy.api.mondoo.app/queries/mondoo-linux-security-snmp-server-is-not-enabled",
-					CodeId: "+u6doYoYG5E=",
-					Title:  "Ensure SNMP server is stopped and not enabled",
-				},
-				{
-					Mrn:    "//policy.api.mondoo.app/queries/mondoo-kubernetes-security-kubelet-event-record-qps",
-					CodeId: "057itYF8s30=",
-					Title:  "Configure kubelet to capture all event creation",
-				},
-				{
-					Mrn:    "//policy.api.mondoo.app/queries/mondoo-kubernetes-security-secure-scheduler_conf",
-					CodeId: "GyJVAziB/tU=",
-					Title:  "Set secure file permissions on the scheduler.conf file",
-				},
-			},
-		},
-		Reports: map[string]*policy.Report{
-			"//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2": {
-				ScoringMrn: "//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2",
-				EntityMrn:  "//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2",
-				Score: &policy.Score{
-					Value:           29,
-					ScoreCompletion: 100,
-					DataCompletion:  100,
-				},
-				// add passed, failed and skipped test
-				Scores: map[string]*policy.Score{
-					"+u6doYoYG5E=": {
-						Type:  2, // result
-						Value: 100,
-					},
-					"057itYF8s30=": {
-						Type:  4, // error
-						Value: 0,
-					},
-					"GyJVAziB/tU=": {
-						Type:  8, // skip
-						Value: 0,
-					},
-				},
-			},
-		},
-		VulnReports: map[string]*mvd.VulnReport{
-			"//assets.api.mondoo.app/spaces/dazzling-golick-767384/assets/2DRZ1cCWFyTYCArycAXHwvn1oU2": {
-				Packages: []*mvd.Package{
-					{
-						Name:      "libssl1.1",
-						Version:   "1.1.1f-3ubuntu2.19",
-						Affected:  true,
-						Score:     100,
-						Available: "1.1.1f-3ubuntu2.20",
-					},
-				},
-				Stats: &mvd.ReportStats{
-					Packages: &mvd.ReportStatsPackages{
-						Total:    1,
-						Critical: 1,
-						Affected: 1,
-					},
-				},
-			},
-		},
-	}
-}
-
 func TestJunitConverter(t *testing.T) {
-	yr := sampleReportCollection()
+	yr := reportfixture.Sample()
 	buf := bytes.Buffer{}
 	writer := iox.IOWriter{Writer: &buf}
 	err := ConvertToJunit(yr, &writer, false)
@@ -262,23 +167,23 @@ func TestQueryRemediationPlatformFilter(t *testing.T) {
 	tf := &policy.TypedDoc{Id: "terraform", Desc: "terraform fix"}
 	def := &policy.TypedDoc{Id: "default", Desc: "generic fix"}
 
-	tfKeys := platformRemediationKeys(&inventory.Platform{Name: "terraform-hcl", Family: []string{"terraform"}})
+	tfKeys := reportdoc.PlatformRemediationKeys(&inventory.Platform{Name: "terraform-hcl", Family: []string{"terraform"}})
 
 	// family match ("terraform" via terraform-hcl) keeps only the terraform item
-	out := queryRemediation(mkQuery(console, tf), tfKeys)
+	out := reportdoc.QueryRemediation(mkQuery(console, tf), tfKeys)
 	assert.Contains(t, out, "[terraform] terraform fix")
 	assert.NotContains(t, out, "console fix")
 
 	// no platform-specific match -> fall back to all items (never drop remediation)
-	out = queryRemediation(mkQuery(console), tfKeys)
+	out = reportdoc.QueryRemediation(mkQuery(console), tfKeys)
 	assert.Contains(t, out, "[console] console fix")
 
 	// platform-agnostic "default" is kept and shown without a label
-	out = queryRemediation(mkQuery(def, console), tfKeys)
+	out = reportdoc.QueryRemediation(mkQuery(def, console), tfKeys)
 	assert.Contains(t, out, "generic fix")
 	assert.NotContains(t, out, "[default]")
 	assert.NotContains(t, out, "console fix")
 
 	// nil docs / nil remediation are safe
-	assert.Equal(t, "", queryRemediation(&policy.Mquery{}, tfKeys))
+	assert.Equal(t, "", reportdoc.QueryRemediation(&policy.Mquery{}, tfKeys))
 }

--- a/cli/reporter/output_handler.go
+++ b/cli/reporter/output_handler.go
@@ -6,6 +6,8 @@ package reporter
 import (
 	"bytes"
 	"context"
+	"os"
+	"strings"
 
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/utils/iox"
@@ -43,6 +45,11 @@ func NewOutputHandler(config HandlerConfig) (OutputHandler, error) {
 	typ := determineOutputType(config.OutputTarget)
 	switch typ {
 	case LOCAL_FILE:
+		// An OHDF document describes a single asset, so a multi-asset scan needs a
+		// file each. Pointing --output-target at a directory asks for exactly that.
+		if conf.format == FormatHDF && isDirTarget(config.OutputTarget) {
+			return &hdfDirHandler{dir: strings.TrimPrefix(config.OutputTarget, "file://")}, nil
+		}
 		return &localFileHandler{file: config.OutputTarget, conf: conf}, nil
 	case AWS_SQS:
 		return &awsSqsHandler{sqsQueueUrl: config.OutputTarget, format: conf.format}, nil
@@ -72,6 +79,20 @@ func determineOutputType(target string) OutputTarget {
 	}
 
 	return LOCAL_FILE
+}
+
+// isDirTarget reports whether an output target names a directory: one that already
+// exists, or a path written with a trailing separator to ask for one.
+func isDirTarget(target string) bool {
+	target = strings.TrimPrefix(target, "file://")
+	if target == "" {
+		return false
+	}
+	if strings.HasSuffix(target, "/") || strings.HasSuffix(target, string(os.PathSeparator)) {
+		return true
+	}
+	info, err := os.Stat(target)
+	return err == nil && info.IsDir()
 }
 
 func reportToYamlV1(report *policy.ReportCollection) ([]byte, error) {

--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/muesli/termenv"
 	"go.mondoo.com/cnspec/policy"
-	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
 
 type Format byte
@@ -147,6 +146,7 @@ const (
 	FormatJSONv2
 	FormatYAMLv2
 	FormatSarif
+	FormatHDF
 )
 
 // Formats that are supported by the reporter
@@ -166,6 +166,7 @@ var Formats = map[string]Format{
 	"junit":   FormatJUnit,
 	"csv":     FormatCSV,
 	"sarif":   FormatSarif,
+	"hdf":     FormatHDF,
 }
 
 func AllFormats() string {
@@ -203,16 +204,4 @@ func (r *Reporter) scoreColored(rating policy.ScoreRating, s string) string {
 		return termenv.String(s).Foreground(r.Colors.Critical).String()
 	}
 	return s
-}
-
-func getPlatformNameForAsset(asset *inventory.Asset) string {
-	platformName := ""
-	if asset.Platform != nil {
-		if asset.Platform.Title == "" {
-			platformName = asset.Platform.Name
-		} else {
-			platformName = asset.Platform.Title
-		}
-	}
-	return platformName
 }

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -18,6 +18,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/rs/zerolog/log"
 	cnspecComponents "go.mondoo.com/cnspec/cli/components"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
@@ -189,7 +190,7 @@ func (r *defaultReporter) printSummary(orderedAssets []assetMrnName) {
 		if val, ok := asset.Labels["mondoo.com/project-id"]; ok {
 			projectId = val
 		}
-		platformName := getPlatformNameForAsset(asset)
+		platformName := reportdoc.PlatformName(asset)
 		if platformName != "" {
 			assetsByPlatform[platformName] = append(assetsByPlatform[platformName], asset)
 		}
@@ -325,7 +326,7 @@ func (r *defaultReporter) printAssetSections(orderedAssets []assetMrnName) {
 			target = assetMrn
 		}
 
-		r.out(r.Printer.H2("Asset: (" + getPlatformNameForAsset(asset) + ") " + target))
+		r.out(r.Printer.H2("Asset: (" + reportdoc.PlatformName(asset) + ") " + target))
 		r.assetBodyPrinted = false
 
 		errorMsg, ok := r.data.Errors[assetMrn]

--- a/cli/reporter/reportdoc/asset.go
+++ b/cli/reporter/reportdoc/asset.go
@@ -1,0 +1,18 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportdoc
+
+import "go.mondoo.com/mql/providers-sdk/v1/inventory"
+
+func PlatformName(asset *inventory.Asset) string {
+	platformName := ""
+	if asset.Platform != nil {
+		if asset.Platform.Title == "" {
+			platformName = asset.Platform.Name
+		} else {
+			platformName = asset.Platform.Title
+		}
+	}
+	return platformName
+}

--- a/cli/reporter/reportdoc/doc.go
+++ b/cli/reporter/reportdoc/doc.go
@@ -1,0 +1,20 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package reportdoc reads the facts a report is written from out of a scan: what a
+// check documents about itself (description, MQL, audit steps, remediation,
+// references, compliance mappings), how severe its result was, which packages an
+// advisory affects, and what to call the asset it all ran against.
+//
+// It exists because every output format needs the same answers and has to give the
+// same ones. When the JUnit body, the SARIF rule help and the OHDF control each
+// derived remediation on their own, they disagreed on which variant applied to the
+// platform being scanned - a Terraform scan showed Kubernetes remediation in one
+// format and not in another.
+//
+// Nothing here knows about an output format. That is what lets the format packages
+// (cli/reporter and cli/reporter/hdf) depend on it without depending on each other:
+// the OHDF converter lives in its own package precisely because it needs these
+// helpers, and a shared package underneath both is what keeps that from being an
+// import cycle.
+package reportdoc

--- a/cli/reporter/reportdoc/query.go
+++ b/cli/reporter/reportdoc/query.go
@@ -1,33 +1,31 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-package reporter
+package reportdoc
 
 import (
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mrn"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/utils/stringx"
 )
 
-// Helpers that extract the human-readable documentation of a check (description,
-// MQL, audit steps, remediation, references, compliance mappings) and the severity
-// derived from its impact. They are shared by the JUnit and SARIF reporters so both
-// surface the same content.
-
-// reporterQueryMap indexes a bundle's queries the way the reporters look them up:
+// QueryMap indexes a bundle's queries the way the reporters look them up:
 // by code id, falling back to the MRN. Several queries can share a code id (e.g.
 // variants that compile to the same MQL), so the one with the lowest MRN wins.
 // policy.PolicyBundleMap.QueryMap picks an arbitrary one instead - it iterates a
 // map - which makes SARIF rule ids and JUnit test names flip between runs of the
 // same report.
-func reporterQueryMap(bundle *policy.PolicyBundleMap) map[string]*policy.Mquery {
+func QueryMap(bundle *policy.PolicyBundleMap) map[string]*policy.Mquery {
 	res := make(map[string]*policy.Mquery, len(bundle.Queries))
-	for _, key := range sortedKeys(bundle.Queries) {
+	for _, key := range slices.Sorted(maps.Keys(bundle.Queries)) {
 		query := bundle.Queries[key]
 		if query == nil {
 			continue
@@ -47,8 +45,8 @@ func reporterQueryMap(bundle *policy.PolicyBundleMap) map[string]*policy.Mquery 
 	return res
 }
 
-// queryDescription extracts a description from a query
-func queryDescription(query *policy.Mquery) string {
+// QueryDescription extracts a description from a query
+func QueryDescription(query *policy.Mquery) string {
 	if query.Docs != nil && query.Docs.Desc != "" {
 		return query.Docs.Desc
 	}
@@ -58,29 +56,29 @@ func queryDescription(query *policy.Mquery) string {
 	return ""
 }
 
-// queryMql returns the MQL source for a query, preferring the current field and
+// QueryMql returns the MQL source for a query, preferring the current field and
 // falling back to the deprecated one (which the compact reporter still reads).
-func queryMql(query *policy.Mquery) string {
+func QueryMql(query *policy.Mquery) string {
 	if query.Mql != "" {
 		return query.Mql
 	}
 	return query.Query
 }
 
-// queryAudit returns the manual audit instructions of a check, if it has any.
-func queryAudit(query *policy.Mquery) string {
+// QueryAudit returns the manual audit instructions of a check, if it has any.
+func QueryAudit(query *policy.Mquery) string {
 	if query.Docs == nil {
 		return ""
 	}
 	return strings.TrimSpace(query.Docs.Audit)
 }
 
-// platformRemediationKeys returns the set of remediation ids relevant to an
+// PlatformRemediationKeys returns the set of remediation ids relevant to an
 // asset's platform: the platform name, its family entries (e.g. "terraform" for
 // the "terraform-hcl" platform), and the platform-agnostic "default"/"" ids. It
 // is used to filter remediation down to the platform being scanned so a Terraform
 // scan shows Terraform remediation rather than every IaC/tool variant.
-func platformRemediationKeys(platform *inventory.Platform) map[string]bool {
+func PlatformRemediationKeys(platform *inventory.Platform) map[string]bool {
 	keys := map[string]bool{"": true, "default": true}
 	if platform != nil {
 		if platform.Name != "" {
@@ -95,10 +93,10 @@ func platformRemediationKeys(platform *inventory.Platform) map[string]bool {
 	return keys
 }
 
-// remediationItems returns the remediation entries of a query that apply to the
+// RemediationItems returns the remediation entries of a query that apply to the
 // asset's platform (name/family) or that are platform-agnostic. If none match, all
 // items are returned so remediation is never dropped entirely.
-func remediationItems(query *policy.Mquery, platformKeys map[string]bool) []*policy.TypedDoc {
+func RemediationItems(query *policy.Mquery, platformKeys map[string]bool) []*policy.TypedDoc {
 	if query.Docs == nil || query.Docs.Remediation == nil {
 		return nil
 	}
@@ -120,11 +118,11 @@ func remediationItems(query *policy.Mquery, platformKeys map[string]bool) []*pol
 	return matched
 }
 
-// queryRemediation renders the remediation for a query as plain text, labeling
+// QueryRemediation renders the remediation for a query as plain text, labeling
 // each item with its platform/tool id (e.g. "[terraform]") when present.
-func queryRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
+func QueryRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
 	var b strings.Builder
-	for _, item := range remediationItems(query, platformKeys) {
+	for _, item := range RemediationItems(query, platformKeys) {
 		if b.Len() > 0 {
 			b.WriteString("\n")
 		}
@@ -136,9 +134,9 @@ func queryRemediation(query *policy.Mquery, platformKeys map[string]bool) string
 	return b.String()
 }
 
-// queryRefs returns the references of a query. It prefers docs.refs (the canonical
+// QueryRefs returns the references of a query. It prefers docs.refs (the canonical
 // location) and falls back to the deprecated refs field.
-func queryRefs(query *policy.Mquery) []*policy.MqueryRef {
+func QueryRefs(query *policy.Mquery) []*policy.MqueryRef {
 	refs := query.Refs
 	if query.Docs != nil && len(query.Docs.Refs) > 0 {
 		refs = query.Docs.Refs
@@ -154,10 +152,10 @@ func queryRefs(query *policy.Mquery) []*policy.MqueryRef {
 	return res
 }
 
-// queryReferences renders a query's references as "Title: URL" lines.
-func queryReferences(query *policy.Mquery) string {
+// QueryReferences renders a query's references as "Title: URL" lines.
+func QueryReferences(query *policy.Mquery) string {
 	var b strings.Builder
-	for _, ref := range queryRefs(query) {
+	for _, ref := range QueryRefs(query) {
 		if b.Len() > 0 {
 			b.WriteString("\n")
 		}
@@ -169,10 +167,10 @@ func queryReferences(query *policy.Mquery) string {
 	return b.String()
 }
 
-// queryComplianceTags returns the compliance framework mappings of a check, keyed
+// QueryComplianceTags returns the compliance framework mappings of a check, keyed
 // by framework (e.g. "compliance/iso-27001-2022" -> "iso-27001-2022-a-8-24").
 // Entries that are explicitly turned off (value "false") are dropped.
-func queryComplianceTags(query *policy.Mquery) map[string]string {
+func QueryComplianceTags(query *policy.Mquery) map[string]string {
 	res := map[string]string{}
 	for k, v := range query.Tags {
 		if !strings.HasPrefix(k, "compliance/") || v == "" || v == "false" {
@@ -183,10 +181,10 @@ func queryComplianceTags(query *policy.Mquery) map[string]string {
 	return res
 }
 
-// failingResourceLocations lists the source locations (path:line) of the resources
+// FailingResourceLocations lists the source locations (path:line) of the resources
 // that caused a check to fail. It is populated for resources that carry source
 // context (e.g. Terraform/HCL) and empty for scalar checks.
-func failingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) string {
+func FailingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) string {
 	var b strings.Builder
 	for _, sc := range cb.FailingResourceContexts(assessment) {
 		if sc.Path == "" {
@@ -204,9 +202,9 @@ func failingResourceLocations(cb *llx.CodeBundle, assessment *llx.Assessment) st
 	return b.String()
 }
 
-// writeDetailSection appends an indented "Title:\n  body" section to b. It is the
+// WriteDetailSection appends an indented "Title:\n  body" section to b. It is the
 // plain-text section format used in JUnit failure bodies and SARIF rule help.
-func writeDetailSection(b *strings.Builder, title, body string) {
+func WriteDetailSection(b *strings.Builder, title, body string) {
 	body = strings.TrimSpace(body)
 	if body == "" {
 		return
@@ -220,9 +218,9 @@ func writeDetailSection(b *strings.Builder, title, body string) {
 	b.WriteString("\n")
 }
 
-// policyTitlesByQuery maps a check MRN to the titles of the policies that include
+// PolicyTitlesByQuery maps a check MRN to the titles of the policies that include
 // it, so a finding can be attributed to the policy it came from.
-func policyTitlesByQuery(bundle *policy.PolicyBundleMap) map[string][]string {
+func PolicyTitlesByQuery(bundle *policy.PolicyBundleMap) map[string][]string {
 	res := map[string][]string{}
 	if bundle == nil {
 		return res
@@ -261,55 +259,28 @@ func policyTitlesByQuery(bundle *policy.PolicyBundleMap) map[string][]string {
 	return res
 }
 
-// queryImpact returns the configured impact of a check (0-100, where 100 is the
+// QueryImpact returns the configured impact of a check (0-100, where 100 is the
 // most impactful) and whether it is set at all.
-func queryImpact(query *policy.Mquery) (int32, bool) {
+func QueryImpact(query *policy.Mquery) (int32, bool) {
 	if query == nil || query.Impact == nil || query.Impact.Value == nil {
 		return 0, false
 	}
 	return query.Impact.Value.Value, true
 }
 
-// riskSeverityLabel maps a cnspec risk value (0-100, the inverse of a score value)
-// to the severity label cnspec uses everywhere else. The bands mirror
-// policy.ScoreRatingsText:
-//
-//	90 .. 100 → CRITICAL
-//	70 ..  89 → HIGH
-//	40 ..  69 → MEDIUM
-//	 1 ..  39 → LOW
-//	        0 → NONE
-func riskSeverityLabel(risk int32) string {
-	switch {
-	case risk >= 90:
-		return policy.ScoreRatingTextCritical
-	case risk >= 70:
-		return policy.ScoreRatingTextHigh
-	case risk >= 40:
-		return policy.ScoreRatingTextMedium
-	case risk >= 1:
-		return policy.ScoreRatingTextLow
-	default:
-		return policy.ScoreRatingTextNone
+// QueryRuleID returns a stable, human-readable rule ID for a query.
+// It prefers the UID, then extracts the resource name from the MRN
+// (stripping prefixes like //local.cnspec.io/run/local-execution/queries/),
+// and falls back to the code ID.
+func QueryRuleID(query *policy.Mquery) string {
+	if query.Uid != "" {
+		return query.Uid
 	}
-}
-
-// riskSarifLevel maps a cnspec risk value to a SARIF level. The bands are the same
-// ones GitHub code scanning uses for security-severity (>= 7.0 error, >= 4.0
-// warning), which keeps level and security-severity consistent.
-func riskSarifLevel(risk int32) string {
-	switch {
-	case risk >= 70:
-		return "error"
-	case risk >= 40:
-		return "warning"
-	default:
-		return "note"
+	if query.Mrn != "" {
+		if name, err := mrn.GetResource(query.Mrn, policy.MRN_RESOURCE_QUERY); err == nil {
+			return name
+		}
+		return query.Mrn
 	}
-}
-
-// securitySeverity renders a cnspec risk value (0-100) as the 0.0-10.0 string that
-// GitHub code scanning reads from the "security-severity" rule property.
-func securitySeverity(risk int32) string {
-	return strconv.FormatFloat(float64(risk)/10, 'f', 1, 64)
+	return query.CodeId
 }

--- a/cli/reporter/reportdoc/severity.go
+++ b/cli/reporter/reportdoc/severity.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportdoc
+
+import "go.mondoo.com/cnspec/policy"
+
+// ScoreRisk is the inverse of a score value: 0 (no risk) to 100 (critical).
+func ScoreRisk(score *policy.Score) int32 {
+	if score == nil {
+		return 0
+	}
+	return 100 - int32(score.Value)
+}
+
+// RiskSeverityLabel maps a cnspec risk value (0-100, the inverse of a score value)
+// to the severity label cnspec uses everywhere else. The bands mirror
+// policy.ScoreRatingsText:
+//
+//	90 .. 100 → CRITICAL
+//	70 ..  89 → HIGH
+//	40 ..  69 → MEDIUM
+//	 1 ..  39 → LOW
+//	        0 → NONE
+func RiskSeverityLabel(risk int32) string {
+	switch {
+	case risk >= 90:
+		return policy.ScoreRatingTextCritical
+	case risk >= 70:
+		return policy.ScoreRatingTextHigh
+	case risk >= 40:
+		return policy.ScoreRatingTextMedium
+	case risk >= 1:
+		return policy.ScoreRatingTextLow
+	default:
+		return policy.ScoreRatingTextNone
+	}
+}

--- a/cli/reporter/reportdoc/vuln.go
+++ b/cli/reporter/reportdoc/vuln.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reportdoc
+
+import (
+	"sort"
+
+	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
+)
+
+func VulnPackageKey(pkg *mvd.Package) string {
+	return pkg.Name + "@" + pkg.Version
+}
+
+// AdvisoryPackages returns the packages of an advisory that the asset is actually
+// affected by, in deterministic order.
+func AdvisoryPackages(advisory *mvd.Advisory, affected, byName map[string]*mvd.Package) []*mvd.Package {
+	var res []*mvd.Package
+	seen := map[string]bool{}
+	for _, pkg := range advisory.Affected {
+		if pkg == nil {
+			continue
+		}
+		match, ok := affected[VulnPackageKey(pkg)]
+		if !ok {
+			// the advisory may carry a different version than the installed one
+			match, ok = byName[pkg.Name]
+			if !ok {
+				continue
+			}
+		}
+		key := VulnPackageKey(match)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		res = append(res, match)
+	}
+	sort.Slice(res, func(i, j int) bool { return VulnPackageKey(res[i]) < VulnPackageKey(res[j]) })
+	return res
+}
+
+// AdvisoryCves returns the CVEs of an advisory in deterministic order.
+func AdvisoryCves(advisory *mvd.Advisory) []*mvd.CVE {
+	res := make([]*mvd.CVE, 0, len(advisory.Cves))
+	for _, cve := range advisory.Cves {
+		if cve != nil && cve.ID != "" {
+			res = append(res, cve)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
+	return res
+}

--- a/cli/reporter/sarif.go
+++ b/cli/reporter/sarif.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"go.mondoo.com/cnspec"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/cli/printer"
 	"go.mondoo.com/mql/llx"
-	"go.mondoo.com/mql/mrn"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
 	"go.mondoo.com/mql/utils/iox"
@@ -81,8 +81,8 @@ func ConvertToSarif(r *policy.ReportCollection, out iox.OutputHelper) error {
 	}
 
 	bundle := r.Bundle.ToMap()
-	queries := reporterQueryMap(bundle)
-	policyTitles := policyTitlesByQuery(bundle)
+	queries := reportdoc.QueryMap(bundle)
+	policyTitles := reportdoc.PolicyTitlesByQuery(bundle)
 
 	// Create one run per asset (deterministic order via sorted keys)
 	assetMrns := sortedKeys(r.Assets)
@@ -92,7 +92,7 @@ func ConvertToSarif(r *policy.ReportCollection, out iox.OutputHelper) error {
 			assetMrn:     assetMrn,
 			asset:        assetObj,
 			logicalLoc:   assetLogicalLocation(assetObj),
-			platformKeys: platformRemediationKeys(assetObj.Platform),
+			platformKeys: reportdoc.PlatformRemediationKeys(assetObj.Platform),
 			policyTitles: policyTitles,
 		}
 		run := newAssetRun(r, ctx)
@@ -147,7 +147,7 @@ func newAssetRun(r *policy.ReportCollection, ctx *sarifRunContext) *sarif.Run {
 		props["assetMrn"] = ctx.assetMrn
 	}
 	if ctx.asset.Platform != nil {
-		if platformName := getPlatformNameForAsset(ctx.asset); platformName != "" {
+		if platformName := reportdoc.PlatformName(ctx.asset); platformName != "" {
 			props["platform"] = platformName
 		}
 		if ctx.asset.Platform.Version != "" {
@@ -256,7 +256,7 @@ func registerAssetRules(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRu
 // (query, audit steps, remediation, references, compliance mappings), severity
 // and the policies it belongs to.
 func registerCheckRule(run *sarif.Run, query *policy.Mquery, ctx *sarifRunContext) {
-	ruleID := queryRuleID(query)
+	ruleID := reportdoc.QueryRuleID(query)
 	rb := run.AddRule(ruleID)
 
 	title := query.Title
@@ -265,7 +265,7 @@ func registerCheckRule(run *sarif.Run, query *policy.Mquery, ctx *sarifRunContex
 	}
 	rb.WithName(title).WithDescription(title)
 
-	if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+	if desc := strings.TrimSpace(reportdoc.QueryDescription(query)); desc != "" {
 		rb.WithFullDescription(sarif.NewMultiformatMessageString(desc).WithMarkdown(desc))
 	}
 
@@ -273,14 +273,14 @@ func registerCheckRule(run *sarif.Run, query *policy.Mquery, ctx *sarifRunContex
 		rb.WithHelp(sarif.NewMultiformatMessageString(text).WithMarkdown(markdown))
 	}
 
-	if refs := queryRefs(query); len(refs) > 0 {
+	if refs := reportdoc.QueryRefs(query); len(refs) > 0 {
 		rb.WithHelpURI(refs[0].Url)
 	}
 
 	props := sarif.Properties{"tags": checkRuleTags(query, ctx)}
-	if impact, ok := queryImpact(query); ok {
+	if impact, ok := reportdoc.QueryImpact(query); ok {
 		props["impact"] = impact
-		props["severity"] = riskSeverityLabel(impact)
+		props["severity"] = reportdoc.RiskSeverityLabel(impact)
 		// GitHub code scanning reads the alert severity from this property.
 		props["security-severity"] = securitySeverity(impact)
 		rb.WithDefaultConfiguration(sarif.NewReportingConfiguration().WithLevel(riskSarifLevel(impact)))
@@ -288,16 +288,16 @@ func registerCheckRule(run *sarif.Run, query *policy.Mquery, ctx *sarifRunContex
 	if query.Mrn != "" {
 		props["queryMrn"] = query.Mrn
 	}
-	if mql := strings.TrimSpace(queryMql(query)); mql != "" {
+	if mql := strings.TrimSpace(reportdoc.QueryMql(query)); mql != "" {
 		props["mql"] = mql
 	}
 	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
 		props["policies"] = titles
 	}
-	if compliance := queryComplianceTags(query); len(compliance) > 0 {
+	if compliance := reportdoc.QueryComplianceTags(query); len(compliance) > 0 {
 		props["compliance"] = compliance
 	}
-	if rem := queryRemediation(query, ctx.platformKeys); rem != "" {
+	if rem := reportdoc.QueryRemediation(query, ctx.platformKeys); rem != "" {
 		props["remediation"] = rem
 	}
 	rb.WithProperties(props)
@@ -312,7 +312,7 @@ func checkRuleTags(query *policy.Mquery, ctx *sarifRunContext) []string {
 		tags = append(tags, "policy/"+title)
 	}
 	// the compliance tag keys are already namespaced, e.g. "compliance/iso-27001-2022"
-	return append(tags, sortedKeys(queryComplianceTags(query))...)
+	return append(tags, sortedKeys(reportdoc.QueryComplianceTags(query))...)
 }
 
 // checkHelp renders the static documentation of a check as plain text and as
@@ -321,45 +321,45 @@ func checkRuleTags(query *policy.Mquery, ctx *sarifRunContext) []string {
 func checkHelp(query *policy.Mquery, ctx *sarifRunContext) (string, string) {
 	var text, md strings.Builder
 
-	desc := strings.TrimSpace(queryDescription(query))
+	desc := strings.TrimSpace(reportdoc.QueryDescription(query))
 	if desc != "" {
 		text.WriteString(desc + "\n")
 		md.WriteString(desc + "\n")
 	}
 
-	if impact, ok := queryImpact(query); ok {
-		severity := riskSeverityLabel(impact) + " (impact " + strconv.Itoa(int(impact)) + ")"
-		writeDetailSection(&text, "Severity", severity)
+	if impact, ok := reportdoc.QueryImpact(query); ok {
+		severity := reportdoc.RiskSeverityLabel(impact) + " (impact " + strconv.Itoa(int(impact)) + ")"
+		reportdoc.WriteDetailSection(&text, "Severity", severity)
 		writeMarkdownSection(&md, "Severity", severity)
 	}
 
 	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
-		writeDetailSection(&text, "Policies", strings.Join(titles, "\n"))
+		reportdoc.WriteDetailSection(&text, "Policies", strings.Join(titles, "\n"))
 		writeMarkdownSection(&md, "Policies", markdownList(titles))
 	}
 
-	if mql := strings.TrimSpace(queryMql(query)); mql != "" {
-		writeDetailSection(&text, "Query", mql)
+	if mql := strings.TrimSpace(reportdoc.QueryMql(query)); mql != "" {
+		reportdoc.WriteDetailSection(&text, "Query", mql)
 		writeMarkdownSection(&md, "Query", markdownCode(mql))
 	}
 
-	if audit := queryAudit(query); audit != "" {
-		writeDetailSection(&text, "Audit", audit)
+	if audit := reportdoc.QueryAudit(query); audit != "" {
+		reportdoc.WriteDetailSection(&text, "Audit", audit)
 		writeMarkdownSection(&md, "Audit", audit)
 	}
 
-	writeDetailSection(&text, "Remediation", queryRemediation(query, ctx.platformKeys))
+	reportdoc.WriteDetailSection(&text, "Remediation", reportdoc.QueryRemediation(query, ctx.platformKeys))
 	writeMarkdownSection(&md, "Remediation", markdownRemediation(query, ctx.platformKeys))
 
-	writeDetailSection(&text, "References", queryReferences(query))
+	reportdoc.WriteDetailSection(&text, "References", reportdoc.QueryReferences(query))
 	writeMarkdownSection(&md, "References", markdownReferences(query))
 
-	if compliance := queryComplianceTags(query); len(compliance) > 0 {
+	if compliance := reportdoc.QueryComplianceTags(query); len(compliance) > 0 {
 		var lines []string
 		for _, framework := range sortedKeys(compliance) {
 			lines = append(lines, strings.TrimPrefix(framework, "compliance/")+": "+compliance[framework])
 		}
-		writeDetailSection(&text, "Compliance", strings.Join(lines, "\n"))
+		reportdoc.WriteDetailSection(&text, "Compliance", strings.Join(lines, "\n"))
 		writeMarkdownSection(&md, "Compliance", markdownList(lines))
 	}
 
@@ -411,7 +411,7 @@ func addAssetResults(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRunCo
 			continue
 		}
 
-		ruleID := queryRuleID(query)
+		ruleID := reportdoc.QueryRuleID(query)
 		level := scoreToSarifLevel(score)
 		kind := scoreToSarifKind(score)
 
@@ -498,14 +498,14 @@ func addAssetResults(run *sarif.Run, r *policy.ReportCollection, ctx *sarifRunCo
 func checkResultMessage(query *policy.Mquery, score *policy.Score, detail string) (string, string) {
 	title := query.Title
 	if title == "" {
-		title = queryRuleID(query)
+		title = reportdoc.QueryRuleID(query)
 	}
 
 	// "FAIL · CRITICAL · score 0/100 · <what the check reported>"
 	status := scoreStatusLabel(score)
 	var details string
 	if score != nil && score.Type == policy.ScoreType_Result {
-		details += " · " + riskSeverityLabel(scoreRisk(score)) + " · score " + strconv.Itoa(int(score.Value)) + "/100"
+		details += " · " + reportdoc.RiskSeverityLabel(reportdoc.ScoreRisk(score)) + " · score " + strconv.Itoa(int(score.Value)) + "/100"
 	}
 	if msg := score.MessageLine(); msg != "" {
 		details += " · " + msg
@@ -537,8 +537,8 @@ func checkResultProperties(query *policy.Mquery, score *policy.Score, ctx *sarif
 		props["completion"] = score.Completion()
 		if score.Type == policy.ScoreType_Result {
 			props["score"] = score.Value
-			props["risk"] = scoreRisk(score)
-			props["severity"] = riskSeverityLabel(scoreRisk(score))
+			props["risk"] = reportdoc.ScoreRisk(score)
+			props["severity"] = reportdoc.RiskSeverityLabel(reportdoc.ScoreRisk(score))
 		}
 	}
 	if titles := ctx.policyTitles[query.Mrn]; len(titles) > 0 {
@@ -554,7 +554,7 @@ func withRiskRank(result *sarif.Result, score *policy.Score) {
 	if score == nil || score.Type != policy.ScoreType_Result || score.Value == 100 {
 		return
 	}
-	result.WithRank(float32(scoreRisk(score)))
+	result.WithRank(float32(reportdoc.ScoreRisk(score)))
 }
 
 // addAssetVulnerabilities emits the asset's vulnerability findings: one result per
@@ -573,7 +573,7 @@ func addAssetVulnerabilities(run *sarif.Run, vulnReport *mvd.VulnReport, ctx *sa
 		if pkg == nil || !pkg.Affected {
 			continue
 		}
-		affected[vulnPackageKey(pkg)] = pkg
+		affected[reportdoc.VulnPackageKey(pkg)] = pkg
 		byName[pkg.Name] = pkg
 	}
 	if len(affected) == 0 {
@@ -591,14 +591,14 @@ func addAssetVulnerabilities(run *sarif.Run, vulnReport *mvd.VulnReport, ctx *sa
 	sort.Slice(advisories, func(i, j int) bool { return advisories[i].ID < advisories[j].ID })
 
 	for _, advisory := range advisories {
-		pkgs := advisoryPackages(advisory, affected, byName)
+		pkgs := reportdoc.AdvisoryPackages(advisory, affected, byName)
 		if len(pkgs) == 0 {
 			continue
 		}
 
 		registerAdvisoryRule(run, advisory)
 		for _, pkg := range pkgs {
-			covered[vulnPackageKey(pkg)] = true
+			covered[reportdoc.VulnPackageKey(pkg)] = true
 			run.AddResult(vulnResult(advisory.ID, advisory, pkg, ctx))
 		}
 	}
@@ -627,34 +627,6 @@ func addAssetVulnerabilities(run *sarif.Run, vulnReport *mvd.VulnReport, ctx *sa
 	}
 }
 
-// advisoryPackages returns the packages of an advisory that the asset is actually
-// affected by, in deterministic order.
-func advisoryPackages(advisory *mvd.Advisory, affected, byName map[string]*mvd.Package) []*mvd.Package {
-	var res []*mvd.Package
-	seen := map[string]bool{}
-	for _, pkg := range advisory.Affected {
-		if pkg == nil {
-			continue
-		}
-		match, ok := affected[vulnPackageKey(pkg)]
-		if !ok {
-			// the advisory may carry a different version than the installed one
-			match, ok = byName[pkg.Name]
-			if !ok {
-				continue
-			}
-		}
-		key := vulnPackageKey(match)
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		res = append(res, match)
-	}
-	sort.Slice(res, func(i, j int) bool { return vulnPackageKey(res[i]) < vulnPackageKey(res[j]) })
-	return res
-}
-
 // registerAdvisoryRule registers an advisory (e.g. USN-5825-1) as a SARIF rule,
 // carrying its description, CVEs and references.
 func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
@@ -674,11 +646,11 @@ func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
 		md.WriteString(desc + "\n")
 	}
 
-	severity := riskSeverityLabel(advisory.Score) + " (score " + securitySeverity(advisory.Score) + ")"
-	writeDetailSection(&text, "Severity", severity)
+	severity := reportdoc.RiskSeverityLabel(advisory.Score) + " (score " + securitySeverity(advisory.Score) + ")"
+	reportdoc.WriteDetailSection(&text, "Severity", severity)
 	writeMarkdownSection(&md, "Severity", severity)
 
-	cves := advisoryCves(advisory)
+	cves := reportdoc.AdvisoryCves(advisory)
 	if len(cves) > 0 {
 		var textLines, mdLines []string
 		for _, cve := range cves {
@@ -692,7 +664,7 @@ func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
 			}
 			mdLines = append(mdLines, line)
 		}
-		writeDetailSection(&text, "CVEs", strings.Join(textLines, "\n"))
+		reportdoc.WriteDetailSection(&text, "CVEs", strings.Join(textLines, "\n"))
 		writeMarkdownSection(&md, "CVEs", markdownList(mdLines))
 	}
 
@@ -708,7 +680,7 @@ func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
 		refLines = append(refLines, refTitle+": "+ref.Url)
 		refMdLines = append(refMdLines, "["+refTitle+"]("+ref.Url+")")
 	}
-	writeDetailSection(&text, "References", strings.Join(refLines, "\n"))
+	reportdoc.WriteDetailSection(&text, "References", strings.Join(refLines, "\n"))
 	writeMarkdownSection(&md, "References", markdownList(refMdLines))
 
 	if help := strings.TrimSpace(text.String()); help != "" {
@@ -723,7 +695,7 @@ func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
 	props := sarif.Properties{
 		"tags":              []string{"security", "cnspec", "vulnerability", "advisory"},
 		"security-severity": securitySeverity(advisory.Score),
-		"severity":          riskSeverityLabel(advisory.Score),
+		"severity":          reportdoc.RiskSeverityLabel(advisory.Score),
 		"advisory":          advisory.ID,
 	}
 	if len(cves) > 0 {
@@ -741,18 +713,6 @@ func registerAdvisoryRule(run *sarif.Run, advisory *mvd.Advisory) {
 	}
 	rb.WithProperties(props)
 	rb.WithDefaultConfiguration(sarif.NewReportingConfiguration().WithLevel(riskSarifLevel(advisory.Score)))
-}
-
-// advisoryCves returns the CVEs of an advisory in deterministic order.
-func advisoryCves(advisory *mvd.Advisory) []*mvd.CVE {
-	res := make([]*mvd.CVE, 0, len(advisory.Cves))
-	for _, cve := range advisory.Cves {
-		if cve != nil && cve.ID != "" {
-			res = append(res, cve)
-		}
-	}
-	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
-	return res
 }
 
 // vulnResult builds the finding for one affected package. When advisory is set the
@@ -778,8 +738,8 @@ func vulnResult(ruleID string, advisory *mvd.Advisory, pkg *mvd.Package, ctx *sa
 		text = pkg.Name + " " + pkg.Version + " is affected by " + advisory.ID + " (" + title + ")"
 		markdown = "**" + pkg.Name + "** " + pkg.Version + " is affected by **" + advisory.ID + "** — " + title
 	}
-	text += " · " + riskSeverityLabel(score) + " (score " + securitySeverity(score) + ") · " + update
-	markdown += "\n\n" + scoreIcon(score) + " **" + riskSeverityLabel(score) + "**" +
+	text += " · " + reportdoc.RiskSeverityLabel(score) + " (score " + securitySeverity(score) + ") · " + update
+	markdown += "\n\n" + scoreIcon(score) + " **" + reportdoc.RiskSeverityLabel(score) + "**" +
 		" · score " + securitySeverity(score) + " · " + update
 
 	logicalLocs := []*sarif.LogicalLocation{
@@ -792,7 +752,7 @@ func vulnResult(ruleID string, advisory *mvd.Advisory, pkg *mvd.Package, ctx *sa
 		"asset":             ctx.asset.Name,
 		"package":           pkg.Name,
 		"installedVersion":  pkg.Version,
-		"severity":          riskSeverityLabel(score),
+		"severity":          reportdoc.RiskSeverityLabel(score),
 		"security-severity": securitySeverity(score),
 		"status":            "fail",
 	}
@@ -823,15 +783,11 @@ func vulnResult(ruleID string, advisory *mvd.Advisory, pkg *mvd.Package, ctx *sa
 			sarif.NewLocation().WithLogicalLocations(logicalLocs),
 		}).
 		WithPartialFingerPrints(map[string]interface{}{
-			sarifFingerprintKey: sarifFingerprint(ruleID, ctx.assetMrn, vulnPackageKey(pkg)),
+			sarifFingerprintKey: sarifFingerprint(ruleID, ctx.assetMrn, reportdoc.VulnPackageKey(pkg)),
 		}).
 		WithRank(float32(score))
 	result.Properties = props
 	return result
-}
-
-func vulnPackageKey(pkg *mvd.Package) string {
-	return pkg.Name + "@" + pkg.Version
 }
 
 // assetLogicalLocation builds the SARIF logical location that identifies an asset.
@@ -840,7 +796,7 @@ func assetLogicalLocation(assetObj *inventory.Asset) *sarif.LogicalLocation {
 		WithName(assetObj.Name).
 		WithKind("asset")
 	if assetObj.Platform != nil {
-		platformName := getPlatformNameForAsset(assetObj)
+		platformName := reportdoc.PlatformName(assetObj)
 		if platformName != "" {
 			logicalLoc.WithFullyQualifiedName(assetObj.Name + " (" + platformName + ")")
 		}
@@ -889,14 +845,6 @@ func sarifFingerprint(parts ...string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// scoreRisk is the inverse of a score value: 0 (no risk) to 100 (critical).
-func scoreRisk(score *policy.Score) int32 {
-	if score == nil {
-		return 0
-	}
-	return 100 - int32(score.Value)
-}
-
 // scoreToSarifLevel maps a cnspec Score to a SARIF level using cnspec's
 // severity rating system:
 //
@@ -920,7 +868,7 @@ func scoreToSarifLevel(score *policy.Score) string {
 		if score.Value == 100 {
 			return "none" // pass
 		}
-		return riskSarifLevel(scoreRisk(score))
+		return riskSarifLevel(reportdoc.ScoreRisk(score))
 	default:
 		return "none"
 	}
@@ -999,23 +947,6 @@ func scoreIcon(risk int32) string {
 	return "ℹ️"
 }
 
-// queryRuleID returns a stable, human-readable rule ID for a query.
-// It prefers the UID, then extracts the resource name from the MRN
-// (stripping prefixes like //local.cnspec.io/run/local-execution/queries/),
-// and falls back to the code ID.
-func queryRuleID(query *policy.Mquery) string {
-	if query.Uid != "" {
-		return query.Uid
-	}
-	if query.Mrn != "" {
-		if name, err := mrn.GetResource(query.Mrn, policy.MRN_RESOURCE_QUERY); err == nil {
-			return name
-		}
-		return query.Mrn
-	}
-	return query.CodeId
-}
-
 // writeMarkdownSection appends a "**Title**\n\nbody" section to b.
 func writeMarkdownSection(b *strings.Builder, title, body string) {
 	body = strings.TrimSpace(body)
@@ -1055,7 +986,7 @@ func markdownCode(content string) string {
 // each variant introduced by its platform/tool id.
 func markdownRemediation(query *policy.Mquery, platformKeys map[string]bool) string {
 	var b strings.Builder
-	for _, item := range remediationItems(query, platformKeys) {
+	for _, item := range reportdoc.RemediationItems(query, platformKeys) {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
@@ -1069,7 +1000,7 @@ func markdownRemediation(query *policy.Mquery, platformKeys map[string]bool) str
 
 func markdownReferences(query *policy.Mquery) string {
 	var items []string
-	for _, ref := range queryRefs(query) {
+	for _, ref := range reportdoc.QueryRefs(query) {
 		title := ref.Title
 		if title == "" {
 			title = ref.Url
@@ -1094,4 +1025,24 @@ func sortedKeys[V any](m map[string]V) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// riskSarifLevel maps a cnspec risk value to a SARIF level. The bands are the same
+// ones GitHub code scanning uses for security-severity (>= 7.0 error, >= 4.0
+// warning), which keeps level and security-severity consistent.
+func riskSarifLevel(risk int32) string {
+	switch {
+	case risk >= 70:
+		return "error"
+	case risk >= 40:
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+// securitySeverity renders a cnspec risk value (0-100) as the 0.0-10.0 string that
+// GitHub code scanning reads from the "security-severity" rule property.
+func securitySeverity(risk int32) string {
+	return strconv.FormatFloat(float64(risk)/10, 'f', 1, 64)
 }

--- a/cli/reporter/sarif_test.go
+++ b/cli/reporter/sarif_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/cli/reporter/internal/reportfixture"
+	"go.mondoo.com/cnspec/cli/reporter/reportdoc"
 	"go.mondoo.com/cnspec/policy"
 	"go.mondoo.com/mql/cli/printer"
 	"go.mondoo.com/mql/llx"
@@ -53,7 +55,7 @@ func resultsForRule(run *sarif.Run, id string) []*sarif.Result {
 	return res
 }
 
-// indented renders a help section body the way writeDetailSection does, so tests
+// indented renders a help section body the way reportdoc.WriteDetailSection does, so tests
 // can look for it verbatim inside the rendered help.
 func indented(body string) string {
 	return strings.TrimRight(stringx.Indent(2, body), "\n")
@@ -67,7 +69,7 @@ func ruleHelpText(rule *sarif.ReportingDescriptor) string {
 }
 
 func TestSarifConverter(t *testing.T) {
-	yr := sampleReportCollection()
+	yr := reportfixture.Sample()
 	buf := bytes.Buffer{}
 	writer := iox.IOWriter{Writer: &buf}
 	err := ConvertToSarif(yr, &writer)
@@ -128,7 +130,7 @@ func TestSarifConverter(t *testing.T) {
 }
 
 func TestSarifDeterministicOutput(t *testing.T) {
-	yr := sampleReportCollection()
+	yr := reportfixture.Sample()
 
 	// Run twice and verify identical output
 	buf1 := bytes.Buffer{}
@@ -304,7 +306,7 @@ func TestSarifQueryRuleID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, queryRuleID(tt.query))
+			assert.Equal(t, tt.expected, reportdoc.QueryRuleID(tt.query))
 		})
 	}
 }
@@ -365,7 +367,7 @@ func TestSarifLocationFingerprint(t *testing.T) {
 }
 
 func TestSarifRunMetadata(t *testing.T) {
-	report := toSarif(t, sampleReportCollection())
+	report := toSarif(t, reportfixture.Sample())
 	require.Len(t, report.Runs, 1)
 	run := report.Runs[0]
 
@@ -395,7 +397,7 @@ func TestSarifRunMetadata(t *testing.T) {
 }
 
 func TestSarifResultKinds(t *testing.T) {
-	report := toSarif(t, sampleReportCollection())
+	report := toSarif(t, reportfixture.Sample())
 	run := report.Runs[0]
 
 	kinds := map[string]string{}
@@ -599,7 +601,7 @@ func TestSarifMatchesDetailedJunitContent(t *testing.T) {
 	}
 
 	bundle := yr.Bundle.ToMap()
-	queries := reporterQueryMap(bundle)
+	queries := reportdoc.QueryMap(bundle)
 
 	checked := 0
 	for assetMrn, asset := range yr.Assets {
@@ -610,7 +612,7 @@ func TestSarifMatchesDetailedJunitContent(t *testing.T) {
 		resolved := yr.ResolvedPolicies[assetMrn]
 		require.NotNil(t, policyReport)
 		require.NotNil(t, resolved)
-		platformKeys := platformRemediationKeys(asset.Platform)
+		platformKeys := reportdoc.PlatformRemediationKeys(asset.Platform)
 
 		for id, score := range policyReport.Scores {
 			if _, ok := resolved.CollectorJob.ReportingQueries[id]; !ok {
@@ -631,7 +633,7 @@ func TestSarifMatchesDetailedJunitContent(t *testing.T) {
 			}
 			checked++
 
-			ruleID := queryRuleID(query)
+			ruleID := reportdoc.QueryRuleID(query)
 			rule := findRule(run, ruleID)
 			require.NotNil(t, rule, "no SARIF rule for %s", ruleID)
 			results := resultsForRule(run, ruleID)
@@ -645,21 +647,21 @@ func TestSarifMatchesDetailedJunitContent(t *testing.T) {
 			}
 
 			help := ruleHelpText(rule)
-			if desc := strings.TrimSpace(queryDescription(query)); desc != "" {
+			if desc := strings.TrimSpace(reportdoc.QueryDescription(query)); desc != "" {
 				require.NotNil(t, rule.FullDescription)
 				assert.Equal(t, desc, *rule.FullDescription.Text, "description missing for %s", ruleID)
 				assert.Contains(t, help, desc, "description missing from help of %s", ruleID)
 			}
 			// help sections are indented by two spaces, exactly like the JUnit body
-			if mql := strings.TrimSpace(queryMql(query)); mql != "" {
+			if mql := strings.TrimSpace(reportdoc.QueryMql(query)); mql != "" {
 				assert.Contains(t, help, indented(mql), "query missing from help of %s", ruleID)
 				assert.Equal(t, mql, rule.Properties["mql"])
 			}
-			if rem := queryRemediation(query, platformKeys); rem != "" {
+			if rem := reportdoc.QueryRemediation(query, platformKeys); rem != "" {
 				assert.Contains(t, help, indented(rem), "remediation missing from help of %s", ruleID)
 				assert.Equal(t, rem, rule.Properties["remediation"])
 			}
-			if refs := queryReferences(query); refs != "" {
+			if refs := reportdoc.QueryReferences(query); refs != "" {
 				assert.Contains(t, help, indented(refs), "references missing from help of %s", ruleID)
 			}
 			if msg := score.MessageLine(); msg != "" {

--- a/content/README.md
+++ b/content/README.md
@@ -212,11 +212,23 @@ cnspec scan local -o sarif > results.sarif
 # JUnit XML (for CI/CD integration)
 cnspec scan local -o junit > results.xml
 
+# OHDF/HDF (Heimdall, the MITRE SAF CLI, and anything that reads InSpec exec-json)
+cnspec scan local -o hdf > results.hdf.json
+
+# An OHDF document describes one asset, so a multi-asset scan writes a file each
+cnspec scan k8s -o hdf --output-target ./hdf-results/
+
 # Full detailed output
 cnspec scan local -o full
 ```
 
-The full set is `compact` (the default), `csv`, `full`, `json`, `json-v1`, `json-v2`, `junit`, `report`, `sarif`, `summary`, `yaml`, `yaml-v1`, and `yaml-v2`. Run `cnspec scan --help` for the current list.
+The full set is `compact` (the default), `csv`, `full`, `hdf`, `json`, `json-v1`, `json-v2`, `junit`, `report`, `sarif`, `summary`, `yaml`, `yaml-v1`, and `yaml-v2`. Run `cnspec scan --help` for the current list.
+
+`hdf` is the one format whose document is per-asset: Heimdall and the SAF CLI resolve
+an OHDF document down to a single profile, so several assets in one file would lose
+all but the first. Point `--output-target` at a directory (an existing one, or a path
+ending in `/`) to get one `<asset>.hdf.json` per asset. Sent to stdout, a multi-asset
+scan comes out as a JSON array of documents instead.
 
 ## Policy Structure
 

--- a/docs/cli/cnspec_scan.md
+++ b/docs/cli/cnspec_scan.md
@@ -190,7 +190,7 @@ cnspec scan --inventory-file FILENAME
       --inventory-format-domainlist   Set the inventory format to domain list.
   -j, --json                          Run the query and return the object in a JSON structure.
   -o, --output string                 Set output format: compact, csv, full, json, json-v1, json-v2, junit, report, summary, yaml, yaml-v1, yaml-v2 (default "compact")
-      --output-target string          Set output target to which the asset report will be sent. Currently only supports AWS SQS topic URLs and local files
+      --output-target string          Set the output target for the asset report: a local file, an AWS SQS topic URL, or - with -o hdf - a directory to write one OHDF file per asset into
       --platform-id string            Select a specific target asset by providing its platform ID.
       --policy strings                Lists policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY.
   -f, --policy-bundle strings         Path to local policy file

--- a/docs/results.mdx
+++ b/docs/results.mdx
@@ -22,6 +22,106 @@ For `FILENAME`, substitute the name you want to give the file. For example, this
 cnspec scan k8s -o json > k8s-test-results.json
 ```
 
+## Export results as OHDF for Heimdall and the MITRE SAF CLI
+
+cnspec can write scan results as [OHDF](https://saf.mitre.org/) (the OASIS Heimdall
+Data Format, formerly HDF) — the normalized result schema of the MITRE Security
+Automation Framework, and the same schema InSpec emits as `exec-json`. Anything that
+reads InSpec results reads a cnspec scan directly, with no `saf convert` step:
+
+```bash
+cnspec scan local -o hdf > results.hdf.json
+```
+
+Open the file in [Heimdall Lite](https://heimdall-lite.mitre.org/), or feed it to the
+[SAF CLI](https://saf-cli.mitre.org/):
+
+```bash
+saf summary -i results.hdf.json            # pass/fail/error counts and compliance %
+saf view heimdall -f results.hdf.json      # the Heimdall UI, locally
+saf convert hdf2csv -i results.hdf.json -o results.csv
+```
+
+### Scanning more than one asset
+
+An OHDF document describes a **single** asset. Heimdall and the SAF CLI resolve a
+document down to one profile and count only that one, so several assets in a single
+file would lose everything but the first.
+
+Point `--output-target` at a directory to get one `ASSET.hdf.json` per asset:
+
+```bash
+cnspec scan k8s -o hdf --output-target ./hdf-results/
+```
+
+A target counts as a directory if it already exists as one, or if the path ends in a
+`/`. cnspec creates it if needed. Filenames come from the asset name with anything
+that is not a letter, digit, `.`, `_`, or `-` replaced by `-`; assets that end up
+sharing a name get a `-2`, `-3` suffix so none overwrites another.
+
+Sent to stdout, a multi-asset scan comes out as a JSON array of documents and cnspec
+warns you. Split it with `jq` if you cannot use a directory:
+
+```bash
+cnspec scan k8s -o hdf | jq -c '.[]' | while read -r doc; do
+  echo "$doc" | jq . > "$(echo "$doc" | jq -r '.platform.target_id | split("/") | last').hdf.json"
+done
+```
+
+### How cnspec results map onto OHDF
+
+| cnspec | OHDF |
+| --- | --- |
+| Asset | The document's `platform`, and its one `profile` |
+| Policy | A control `group` inside that profile |
+| Check | A `control` — title, description, references, and the MQL as `code` |
+| Check result | A control `result` — `passed`, `failed`, `error`, or `skipped` |
+| Remediation | A control description labeled `fix` |
+| Audit steps | A control description labeled `check` |
+| Vulnerability advisory | A `control` in the profile's Vulnerabilities group |
+| Asset scan failure | An `asset-error` control with an `error` result |
+
+Severity converts directly: a cnspec impact of 70 (HIGH) becomes an OHDF impact of
+0.7, which Heimdall also reads as high. Two impact values are reserved. Checks that
+the scan deliberately excluded — skipped, out of scope, or disabled — get impact `0`,
+which Heimdall renders as **Not Applicable**. Checks with no configured severity are
+floored at `0.1` so they still appear in the SAF summary rather than dropping out of
+the tally.
+
+Checks carrying a `compliance/nist-sp-800-53-rev5` tag are mapped onto the control's
+`nist` tag (`nist-sp-800-53-rev5-si-7` becomes `SI-7`), which is what drives
+Heimdall's NIST 800-53 compliance views. Checks with no NIST mapping are tagged
+`UM-1`, MITRE's marker for unmapped controls. Every other `compliance/*` mapping —
+CIS, ISO 27001, PCI DSS, SOC 2, and the rest — is carried through on the control tags
+under its own key.
+
+Details that OHDF has no field for — the asset MRN, its platform IDs, and the overall
+cnspec score and letter grade — travel in the document's `passthrough.auxiliary_data`.
+
+### Use OHDF to gate a CI pipeline
+
+The SAF CLI can fail a build when results fall below a threshold. Write a threshold
+file:
+
+```yaml
+# threshold.yaml
+failed:
+  critical:
+    max: 0
+  high:
+    max: 0
+```
+
+Then scan and check it:
+
+```bash
+cnspec scan local -o hdf > results.hdf.json
+saf validate threshold -i results.hdf.json -T threshold.yaml
+```
+
+`saf validate threshold` exits non-zero when the scan breaches the threshold, failing
+the pipeline step.
+
 ## View and print results in the Mondoo App
 
 When cnspec completes a scan, it provides a link to the Mondoo App, where you can view graphical results.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.0
 	github.com/tliron/glsp v0.2.2
+	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260819000633-f705b63814ae
 	go.mondoo.com/mql v0.0.0-20260820153852-05e74586f59d
@@ -324,6 +325,8 @@ require (
 	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.45.0 // indirect

--- a/test/cli/testdata/cnspec_scan.ct
+++ b/test/cli/testdata/cnspec_scan.ct
@@ -29,8 +29,8 @@ Flags:
       --inventory-format-ansible      Set the inventory format to Ansible
       --inventory-format-domainlist   Set the inventory format to domain list
   -j, --json                          Run the query and return the object in a JSON structure
-  -o, --output string                 Set the output format: compact, csv, full, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "compact")
-      --output-target string          Set the output target for the asset report. Currently only supports AWS SQS topic URLs and local files
+  -o, --output string                 Set the output format: compact, csv, full, hdf, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "compact")
+      --output-target string          Set the output target for the asset report: a local file, an AWS SQS topic URL, or - with -o hdf - a directory to write one OHDF file per asset into
       --parallelism int               Set the number of assets to scan in parallel. Defaults to a per-provider value capped by the CPUs available on this machine. Use 1 for sequential
       --platform-id string            Select a specific target asset by providing its platform ID
       --policy strings                Specify policies to execute. This requires --policy-bundle. You can pass multiple policies using --policy POLICY

--- a/test/cli/testdata/cnspec_vuln.ct
+++ b/test/cli/testdata/cnspec_vuln.ct
@@ -12,7 +12,7 @@ Flags:
       --inventory-ansible       Set the inventory format to Ansible
       --inventory-domainlist    Set the inventory format to domain list
       --inventory-file string   Set the path to the inventory file
-  -o, --output string           Set the output format: compact, csv, full, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
+  -o, --output string           Set the output format: compact, csv, full, hdf, json, json-v1, json-v2, junit, report, sarif, summary, yaml, yaml-v1, yaml-v2 (default "full")
       --platform-id string      Select a specific target asset by providing its platform ID
 
 Global Flags:


### PR DESCRIPTION
Adds `cnspec scan -o hdf`, emitting the [OASIS Heimdall Data Format](https://saf.mitre.org/) (OHDF, formerly HDF) — the normalized result schema of the MITRE Security Automation Framework, and the same schema InSpec emits as `exec-json`.

Anything that reads InSpec results reads a cnspec scan directly, with no `saf convert` shim in between:

```bash
cnspec scan local -o hdf > results.hdf.json
saf summary -i results.hdf.json
saf view heimdall -f results.hdf.json
```

It also unlocks Heimdall's compliance views: cnspec content already carries `compliance/nist-sp-800-53-rev5` tags on ~3000 checks, and those map onto the `nist` control tag the NIST 800-53 treemap keys off.

## Mapping

| cnspec | OHDF |
| --- | --- |
| Asset | the document's `platform`, and its one `profile` |
| Policy | a control `group` inside that profile |
| Check | a `control` — title, description, references, MQL as `code` |
| Check result | a control `result` — `passed`, `failed`, `error`, `skipped` |
| Remediation / audit steps | control descriptions labeled `fix` / `check` |
| Vulnerability advisory | a `control` in the Vulnerabilities group |
| Asset scan failure | an `asset-error` control with an `error` result |

Severity converts by division — cnspec impact 70 (HIGH) is OHDF impact 0.7, which Heimdall also reads as high. Two values are reserved: impact `0` means "Not Applicable" and is kept for checks the scan deliberately excluded (skipped, out of scope, disabled), and checks with no configured severity are floored at `0.1`, the lowest impact the SAF summary actually counts.

Check documentation comes from the helpers in `query_docs.go` that JUnit and SARIF already share, so all three reporters surface identical content.

## One document per asset

An OHDF document describes a single target. Heimdall and the SAF CLI resolve a document down to one root profile and tally only that one, so findings in a second profile are dropped **without an error** — the scan reads cleaner than it is. This was measured, not assumed:

| shape | `saf summary` |
| --- | --- |
| vulnerabilities in their own profile | compliance 50%, `failed: 0` — the advisory vanished |
| everything in one profile | compliance 33%, `failed: 1` |
| two assets in one document | **all zeros** — every finding from both lost |

So a document covers one asset, holding one profile with its checks and its advisories, and multi-asset scans write a file each:

```bash
cnspec scan k8s -o hdf --output-target ./hdf-results/
```

A target counts as a directory if it exists as one or the path ends in `/`. On stdout a multi-asset scan comes out as a JSON array of documents with a warning pointing at the directory form — nothing is dropped silently.

## Verification

The published `exec-json.json` schema is checked in as a fixture and the converter's output is validated against it in tests, so conformance is proven on every run rather than by hand — covering the empty scan, checks with and without vulnerabilities, an asset error, a recorded scan, and every file of a directory write.

Output was also round-tripped through the real toolchain: `saf summary` reports 18 passed / 2 failed / 4 error on the recorded ubuntu scan, matching cnspec's own accounting exactly, and `saf convert hdf2csv` preserves all 24 controls with their remediation text and MQL.

Filename handling has its own test: asset names come from whatever was scanned (an image reference, an ARN, a Kubernetes object), so a path separator must never survive into a filename, names that sanitize away fall back to the MRN digest, and long names are capped without colliding.

## Performance

Profiled, not guessed. Output is compact, matching the SARIF reporter (which calls `Write`, not `PrettyWrite`) and `json-v2` — `MarshalIndent` was 27% of CPU for a second pass over a document nothing reads by eye. Documents are rendered and written one at a time rather than all up front.

| | before | after |
| --- | --- | --- |
| 1 asset | 1,186,795 ns/op · 441 KB | 632,404 ns/op · 313 KB |
| 200 assets | ~88 ms/op | 55 ms/op |
| 500 assets, resident heap | 34.3 MB | 4.4 MB (now O(1) in fleet size) |

Benchmarks are checked in so the next change here can be measured.

## Notes for review

- **`docs/cli/` is out of sync with the CLI**, independently of this PR. Regenerating it strips hand-authored prose from `cnspec_scan.md` and adds 16 pages for undocumented commands, so I updated only the one `--output-target` line by hand and left the rest for a deliberate pass.
- The schema fixture needs a manual refresh when MITRE revises it; the test comment names the upstream URL.
- `go.mod` gains `xeipuuv/gojsonschema` as a direct dependency — it was already in the module graph transitively, so no new code enters the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
