### PR TITLE
🐛 reporter: render the same junit document for the same scan

### DIFF
--- a/cli/reporter/junit.go
+++ b/cli/reporter/junit.go
@@ -29,7 +29,10 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper, detailed b
 	// render asset errors
 	// r is nil if no assets were scanned
 	if r != nil {
-		for assetMrn, errMsg := range r.Errors {
+		// Sorted so a re-run of the same scan produces the same document. CI
+		// systems diff these, and Go randomises map iteration.
+		for _, assetMrn := range sortedKeys(r.Errors) {
+			errMsg := r.Errors[assetMrn]
 			a := r.Assets[assetMrn]
 
 			properties := []junit.Property{}
@@ -61,7 +64,8 @@ func ConvertToJunit(r *policy.ReportCollection, out iox.OutputHelper, detailed b
 		queries := reportdoc.QueryMap(bundle)
 
 		// iterate over asset mrns
-		for assetMrn, assetObj := range r.Assets {
+		for _, assetMrn := range sortedKeys(r.Assets) {
+			assetObj := r.Assets[assetMrn]
 			// add check results
 			ts := assetPolicyTests(r, assetMrn, assetObj, queries, detailed)
 			suites.Suites = append(suites.Suites, ts)
@@ -113,7 +117,8 @@ func assetPolicyTests(r *policy.ReportCollection, assetMrn string, assetObj *inv
 	// failed/errored checks carry their meta information (description, query, assessment,
 	// remediation, references) in the failure body below.
 	platformKeys := reportdoc.PlatformRemediationKeys(assetObj.Platform)
-	for id, score := range report.Scores {
+	for _, id := range sortedKeys(report.Scores) {
+		score := report.Scores[id]
 		_, ok := resolved.CollectorJob.ReportingQueries[id]
 		if !ok {
 			continue

--- a/cli/reporter/junit_test.go
+++ b/cli/reporter/junit_test.go
@@ -187,3 +187,40 @@ func TestQueryRemediationPlatformFilter(t *testing.T) {
 	// nil docs / nil remediation are safe
 	assert.Equal(t, "", reportdoc.QueryRemediation(&policy.Mquery{}, tfKeys))
 }
+
+// A JUnit document is consumed by CI systems that diff one run against the next,
+// so the same scan has to render the same bytes. Go randomises map iteration, and
+// three walks here read straight off maps until they were sorted: errors, assets
+// and scores.
+//
+// The shared fixture only catches the scores walk -- it has one asset and no
+// errors, so the other two are order-free in it and a regression would sail past.
+// This fixture carries several of each on purpose.
+func TestJunitOrderingIsDeterministic(t *testing.T) {
+	multi := func() *policy.ReportCollection {
+		r := reportfixture.Sample()
+		if r.Errors == nil {
+			r.Errors = map[string]string{}
+		}
+		for _, n := range []string{"aa", "bb", "cc", "dd"} {
+			mrn := reportfixture.AssetMrn + "-" + n
+			r.Assets[mrn] = &inventory.Asset{
+				Name:     "asset-" + n,
+				State:    inventory.State_STATE_ERROR,
+				Platform: &inventory.Platform{Name: "ubuntu", Version: "22.04"},
+			}
+			r.Errors[mrn] = "could not reach " + n
+		}
+		return r
+	}
+	render := func(r *policy.ReportCollection) string {
+		var buf bytes.Buffer
+		w := iox.IOWriter{Writer: &buf}
+		require.NoError(t, ConvertToJunit(r, &w, false))
+		return buf.String()
+	}
+	first := render(multi())
+	for i := 1; i < 50; i++ {
+		require.Equal(t, first, render(multi()), "render %d differs: the document is not deterministic", i)
+	}
+}


### PR DESCRIPTION
The junit reporter walked three maps directly — the asset errors, the assets, and each report's scores — so Go's randomised map iteration decided the order of testsuites and testcases.

Rendering the same `ReportCollection` twice in a row already produced different bytes:

```
render 1 differs from render 0 — JUnit output is not deterministic
```

That matters because of who reads this format. A junit file is consumed by CI, which diffs one run against the next to say what changed. A document that reorders itself makes every run look like a change, and hides the ones that are.

The three walks are sorted now, the same way `sarif.go` next door already sorted every equivalent walk (`sortedKeys(r.Assets)`, `sortedKeys(report.Scores)`, …).

### On the test

The regression test builds its own fixture instead of using the shared one, and that is the point rather than an accident. `reportfixture.Sample()` has **one asset and no errors**, so two of the three walks are order-free in it — the first version of this test passed with the asset sort reverted, which is precisely the regression it exists to catch.

With several assets and several errors, reverting any one of the three sorts fails it. Verified individually:

```
assets reverted -> FAILS (pinned)
errors reverted -> FAILS (pinned)
scores reverted -> FAILS (pinned)
```

### Verification

`go build ./...` · `go vet ./cli/...` · `go test -race ./cli/... ./apps/cnspec/...` · golangci-lint v2.13.1 both configs (`.golangci.yaml` 0 issues; `.github/.golangci.yaml --new=false` reports only the 5 pre-existing findings in `aibom.go`/`sbom.go`/`local_scanner_test.go`) · `typos` clean · `go mod tidy` a no-op.

Found while restructuring the report packages; it reproduces on unmodified `main` and is unrelated to that work, so it is here on its own.