### PR TITLE
🐛 ocsf: give a finding its own severity, identity and safe output files

### DIFF
--- a/cli/reporter/sarif.go
+++ b/cli/reporter/sarif.go
@@ -188,16 +188,19 @@ func addRunScoreProperties(props sarif.Properties, r *policy.ReportCollection, a
 			continue
 		}
 		total++
-		switch scoreToSarifKind(score) {
-		case "pass":
+		// The counts switch on the outcome, not on the SARIF kind. SARIF has no
+		// error kind, so scoreToSarifKind folds Error into "fail"; counting off it
+		// meant reaching back into policy.ScoreType to undo that fold right after
+		// the helper had discarded it. reportdoc.Outcome is the shared collapse
+		// that keeps the error case distinct, which is the whole reason it exists.
+		switch reportdoc.OutcomeOf(score) {
+		case reportdoc.OutcomePass:
 			passed++
-		case "fail":
-			if score != nil && score.Type == policy.ScoreType_Error {
-				errored++
-			} else {
-				failed++
-			}
-		case "notApplicable":
+		case reportdoc.OutcomeFail:
+			failed++
+		case reportdoc.OutcomeError:
+			errored++
+		case reportdoc.OutcomeSkipped:
 			skipped++
 		}
 	}

--- a/cli/reporter/sarif_test.go
+++ b/cli/reporter/sarif_test.go
@@ -385,8 +385,20 @@ func TestSarifRunMetadata(t *testing.T) {
 	assert.Equal(t, "22.04", run.Properties["platformVersion"])
 	assert.EqualValues(t, 3, run.Properties["checksTotal"])
 	assert.EqualValues(t, 1, run.Properties["checksPassed"])
+	assert.EqualValues(t, 0, run.Properties["checksFailed"])
 	assert.EqualValues(t, 1, run.Properties["checksErrored"])
 	assert.EqualValues(t, 1, run.Properties["checksSkipped"])
+
+	// A failing check is counted as failed and not as errored. SARIF has no error
+	// kind, so scoreToSarifKind folds Error into "fail"; the counts read
+	// reportdoc.Outcome, which keeps the two apart, rather than folding and then
+	// reaching back into policy.ScoreType to undo the fold.
+	failing := toSarif(t, reportfixture.Detailed()).Runs[0]
+	assert.EqualValues(t, 1, failing.Properties["checksTotal"])
+	assert.EqualValues(t, 1, failing.Properties["checksFailed"])
+	assert.EqualValues(t, 0, failing.Properties["checksErrored"])
+	assert.EqualValues(t, 0, failing.Properties["checksPassed"])
+	assert.EqualValues(t, 0, failing.Properties["checksSkipped"])
 
 	// vulnerability stats mirror the JUnit vulnerability suite properties
 	assert.EqualValues(t, 1, run.Properties["packagesTotal"])

--- a/docs/adr/0005-ocsf-type-generation.md
+++ b/docs/adr/0005-ocsf-type-generation.md
@@ -84,6 +84,11 @@ its tests pass, which is the whole of what publishing it would take — and that
 property is worth stating rather than leaving to be rediscovered. One `policy.Score` in here
 would end it.
 
+Stating it is not enough to keep it, so `TestPackageImportsNoCnspecPackage` in
+`reports/ocsf/deps_test.go` walks `go list -deps` over the package and fails on any
+`go.mondoo.com/cnspec/...` edge. It reads the transitive dependencies rather than the import
+block, because an indirect edge costs exactly as much as a direct one.
+
 So the mapping from a cnspec scan lives one directory down, in `reports/ocsf/convert`: which
 class a check becomes, how a score becomes a severity and a status, what travels in `unmapped`.
 The split is by direction of knowledge — `reports/ocsf` knows OCSF and nothing about cnspec,

--- a/reports/hdf/hdf.go
+++ b/reports/hdf/hdf.go
@@ -227,7 +227,11 @@ func ConvertToDir(r *policy.ReportCollection, dir string) ([]string, error) {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700, not 0755: an OHDF document carries the MQL source of every check, the
+	// rendered assessment with the observed values in it, and the asset's platform
+	// and cloud identity. A scan is routinely run as root, and a world-readable
+	// directory under it hands all of that to every local account.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -252,7 +256,8 @@ func ConvertToDir(r *policy.ReportCollection, dir string) ([]string, error) {
 
 // writeHDFFile renders one document to its own file.
 func writeHDFFile(report *hdfReport, path string) error {
-	f, err := os.Create(path)
+	// os.Create would leave the document 0644; see ConvertToDir for what is in it.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/reports/hdf/schema_test.go
+++ b/reports/hdf/schema_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -99,6 +100,34 @@ func TestHDFDirConformsToSchema(t *testing.T) {
 		doc, err := os.ReadFile(path)
 		require.NoError(t, err)
 		assertValidOHDF(t, schema, doc, filepath.Base(path))
+	}
+}
+
+// TestHDFDirWritesPrivateFiles pins the permissions of the output.
+//
+// An OHDF document carries the MQL source of every check, the rendered assessment
+// with the observed values in it, and the asset's platform and cloud identity. A
+// scan is routinely run as root, and 0755/0644 hands all of that to every local
+// account on the host.
+func TestHDFDirWritesPrivateFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not apply on Windows")
+	}
+	pinHDFClock(t)
+
+	dir := filepath.Join(t.TempDir(), "out")
+	files, err := ConvertToDir(multiAssetReportCollection(t), dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "the output directory is not world-readable")
+
+	for _, path := range files {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "%s is not world-readable", path)
 	}
 }
 

--- a/reports/ocsf/convert/asset.go
+++ b/reports/ocsf/convert/asset.go
@@ -138,7 +138,7 @@ func osTypeOf(platform *inventory.Platform) int {
 // buildCloud fills in the cloud environment of an asset. It returns nil for
 // assets that are not cloud resources, which keeps the cloud profile off those
 // events.
-func buildCloud(asset *inventory.Asset) *ocsf.Cloud {
+func buildCloud(asset *inventory.Asset, version ocsf.Version) *ocsf.Cloud {
 	provider := cloudProvider(asset)
 	if provider == "" {
 		return nil
@@ -153,7 +153,17 @@ func buildCloud(asset *inventory.Asset) *ocsf.Cloud {
 	}
 	for _, id := range asset.PlatformIds {
 		if project, ok := platformIDSegment(id, "/runtime/gcp/projects/"); ok {
-			res.ProjectUID = project
+			// A GCP project is the account of a GCP asset, and account.uid is where
+			// OCSF wants it. project_uid used to be the only home for it, but 1.9
+			// deprecates the attribute in favor of account.uid -- a validator warns
+			// on every event of a GCP asset that still carries it, so it is gated
+			// the same way compliance.status_detail and device_hw_info.cpu_type
+			// are. Setting the account regardless is what keeps the project id in
+			// the document at 1.9, where project_uid is gone.
+			res.Account = &ocsf.Account{UID: project, Type: "GCP Project"}
+			if !version.AtLeast(ocsf.Version190) {
+				res.ProjectUID = project
+			}
 		}
 		if sub, ok := platformIDSegment(id, "/runtime/azure/subscriptions/"); ok {
 			res.Account = &ocsf.Account{UID: sub, Type: "Azure Subscription"}

--- a/reports/ocsf/convert/checks.go
+++ b/reports/ocsf/convert/checks.go
@@ -68,10 +68,12 @@ func (c *converter) addAssetError(events *ocsf.Events, r *policy.ReportCollectio
 	events.ComplianceFindings = append(events.ComplianceFindings, c.complianceAssetError(errMsg, ctx))
 }
 
-// assetErrorInfo is the finding_info both classes give a failed scan.
-func (c *converter) assetErrorInfo() ocsf.FindingInfo {
+// assetErrorInfo is the finding_info both classes give a failed scan. Its uid is
+// per-asset for the same reason a check's is: a fleet scan where a hundred assets
+// were unreachable is a hundred findings, not one repeated.
+func (c *converter) assetErrorInfo(ctx *assetContext) ocsf.FindingInfo {
 	return ocsf.FindingInfo{
-		UID:         assetErrorUID,
+		UID:         findingUID(assetErrorUID, ctx),
 		Title:       "Asset scan error",
 		Desc:        "cnspec could not complete the scan of this asset. No policy results are available for it.",
 		CreatedTime: c.now,

--- a/reports/ocsf/convert/compliance.go
+++ b/reports/ocsf/convert/compliance.go
@@ -30,12 +30,12 @@ func (c *converter) complianceFinding(resolved *policy.ResolvedPolicy, report *p
 
 	finding := ocsf.NewComplianceFinding(ocsf.ComplianceFindingActivityCreate)
 	finding.Compliance = c.compliance(resolved, report, query, score, ctx)
-	finding.FindingInfo = c.findingInfo(query, score, title)
+	finding.FindingInfo = c.findingInfo(query, score, title, ctx)
 	finding.Resources = []ocsf.ResourceDetails{ctx.resource}
 	finding.Device = ctx.device
 	finding.Cloud = ctx.cloud
 	finding.Time = c.now
-	finding.SeverityID = checkSeverity(score)
+	finding.SeverityID = checkSeverity(query, score)
 	finding.Severity = ocsf.SeverityName(finding.SeverityID)
 	finding.StatusID, finding.Status = findingStatus(score)
 	finding.StatusCode = outcome
@@ -114,7 +114,7 @@ func (c *converter) complianceAssetError(errMsg string, ctx *assetContext) ocsf.
 	finding.Metadata = c.metadata(ctx.findingProfiles()...)
 	finding.Unmapped = assetErrorUnmapped(ctx)
 	finding.Compliance = c.errorCompliance(errMsg)
-	finding.FindingInfo = c.assetErrorInfo()
+	finding.FindingInfo = c.assetErrorInfo(ctx)
 	finding.Resources = []ocsf.ResourceDetails{ctx.resource}
 	finding.Device = ctx.device
 	finding.Cloud = ctx.cloud

--- a/reports/ocsf/convert/convert.go
+++ b/reports/ocsf/convert/convert.go
@@ -159,7 +159,7 @@ func (c *converter) stream(r *policy.ReportCollection, emit func(*ocsf.Events) e
 			platformKeys: reportdoc.PlatformRemediationKeys(asset.Platform),
 			policyTitles: policyTitles,
 			device:       buildDevice(asset, c.version),
-			cloud:        buildCloud(asset),
+			cloud:        buildCloud(asset, c.version),
 			resource:     buildResource(asset),
 		}
 

--- a/reports/ocsf/convert/convert_test.go
+++ b/reports/ocsf/convert/convert_test.go
@@ -34,6 +34,13 @@ func toOcsf(t *testing.T, r *policy.ReportCollection) *ocsf.Events {
 	return events
 }
 
+// findingByRule finds the finding a rule produced on the sample fixture's asset.
+// The lookup composes the uid rather than matching the rule id alone because
+// finding_info.uid identifies a check *on an asset*; see findingUID.
+func findingByRule(events *ocsf.Events, ruleID string) *ocsf.ComplianceFinding {
+	return findingByUID(events, ruleID+"/"+reportfixture.AssetMrn)
+}
+
 func findingByUID(events *ocsf.Events, uid string) *ocsf.ComplianceFinding {
 	for i := range events.ComplianceFindings {
 		if events.ComplianceFindings[i].FindingInfo.UID == uid {
@@ -65,7 +72,7 @@ func TestOcsfConverter(t *testing.T) {
 	}
 
 	// a passing check is informational and compliant
-	pass := findingByUID(events, "mondoo-linux-security-snmp-server-is-not-enabled")
+	pass := findingByRule(events, "mondoo-linux-security-snmp-server-is-not-enabled")
 	require.NotNil(t, pass)
 	assert.Equal(t, ocsf.SeverityInformational, pass.SeverityID)
 	assert.Equal(t, ocsf.ComplianceStatusPass, pass.Compliance.StatusID)
@@ -74,14 +81,14 @@ func TestOcsfConverter(t *testing.T) {
 	assert.Contains(t, pass.Message, "PASS")
 
 	// an errored check is reported as a coverage gap, not as a compliance verdict
-	errored := findingByUID(events, "mondoo-kubernetes-security-kubelet-event-record-qps")
+	errored := findingByRule(events, "mondoo-kubernetes-security-kubelet-event-record-qps")
 	require.NotNil(t, errored)
 	assert.Equal(t, ocsf.SeverityMedium, errored.SeverityID)
 	assert.Equal(t, ocsf.ComplianceStatusUnknown, errored.Compliance.StatusID)
 	assert.Equal(t, ocsf.StatusOther, errored.StatusID)
 
 	// a skipped check is suppressed
-	skipped := findingByUID(events, "mondoo-kubernetes-security-secure-scheduler_conf")
+	skipped := findingByRule(events, "mondoo-kubernetes-security-secure-scheduler_conf")
 	require.NotNil(t, skipped)
 	assert.Equal(t, ocsf.StatusSuppressed, skipped.StatusID)
 	assert.Equal(t, ocsf.ComplianceStatusOther, skipped.Compliance.StatusID)
@@ -110,7 +117,11 @@ func TestOcsfVulnerabilityFindings(t *testing.T) {
 	assert.Equal(t, ocsf.ClassUIDVulnerabilityFinding, vuln.ClassUID)
 	assert.EqualValues(t, ocsf.VulnerabilityFindingTypeUIDCreate, vuln.TypeUID)
 	assert.Equal(t, ocsf.SeverityCritical, vuln.SeverityID, "an advisory score of 95 is critical")
-	assert.Equal(t, "USN-1234-1", vuln.FindingInfo.UID)
+	// One finding is one advisory on one asset, so the uid carries both. The
+	// advisory id alone repeats across every asset it affects, which collapses a
+	// fleet to one row for anything correlating on this field.
+	assert.Equal(t, "USN-1234-1/"+reportfixture.AssetMrn, vuln.FindingInfo.UID)
+	assert.Contains(t, vuln.FindingInfo.UID, "USN-1234-1", "the advisory is still recoverable from the uid")
 
 	require.Len(t, vuln.Vulnerabilities, 1, "one entry per CVE of the advisory")
 	require.NotNil(t, vuln.Vulnerabilities[0].CVE)
@@ -178,7 +189,8 @@ func TestOcsfComplianceMappings(t *testing.T) {
 	assert.Equal(t, []string{"1.4", "a-8-24"}, finding.Compliance.Requirements)
 	assert.Equal(t, "1.4", finding.Compliance.Control)
 	assert.Equal(t, ocsf.ComplianceStatusFail, finding.Compliance.StatusID)
-	assert.Equal(t, ocsf.SeverityCritical, finding.SeverityID, "a score of 0 is a risk of 100")
+	assert.Equal(t, ocsf.SeverityCritical, finding.SeverityID,
+		"with no declared impact the risk stands in, and a score of 0 is a risk of 100")
 
 	// the check documentation travels with the finding
 	assert.Equal(t, "Root login over SSH should be disabled.", finding.FindingInfo.Desc)
@@ -238,7 +250,7 @@ func TestOcsfAssetError(t *testing.T) {
 	report.Errors = map[string]string{assetMrn: "could not connect to the asset"}
 
 	events := toOcsf(t, report)
-	errFinding := findingByUID(events, "asset-error")
+	errFinding := findingByRule(events, "asset-error")
 	require.NotNil(t, errFinding, "an asset that failed to scan must not look clean")
 	assert.Equal(t, ocsf.SeverityHigh, errFinding.SeverityID)
 	assert.Equal(t, ocsf.StatusOther, errFinding.StatusID)
@@ -486,7 +498,8 @@ func TestOcsfDetectionFindings(t *testing.T) {
 	finding := events.DetectionFindings[0]
 	assert.Equal(t, ocsf.ClassUIDDetectionFinding, finding.ClassUID)
 	assert.EqualValues(t, ocsf.DetectionFindingTypeUIDCreate, finding.TypeUID)
-	assert.Equal(t, ocsf.SeverityCritical, finding.SeverityID)
+	assert.Equal(t, ocsf.SeverityHigh, finding.SeverityID,
+		"the check declares impact 80, and severity follows the declared impact")
 
 	// the risk and impact attributes 2004 has, which 2003 does not
 	assert.Equal(t, 100, finding.RiskScore, "a score of 0 is a risk of 100")

--- a/reports/ocsf/convert/detection.go
+++ b/reports/ocsf/convert/detection.go
@@ -39,7 +39,7 @@ func (c *converter) detectionFinding(resolved *policy.ResolvedPolicy, report *po
 
 	finding := ocsf.NewDetectionFinding(ocsf.DetectionFindingActivityCreate)
 	finding.Time = c.now
-	finding.SeverityID = checkSeverity(score)
+	finding.SeverityID = checkSeverity(query, score)
 	finding.Severity = ocsf.SeverityName(finding.SeverityID)
 	finding.StatusID, finding.Status = findingStatus(score)
 	finding.StatusCode = outcome
@@ -48,7 +48,7 @@ func (c *converter) detectionFinding(resolved *policy.ResolvedPolicy, report *po
 	finding.Metadata = c.metadata(ctx.findingProfiles()...)
 	finding.Unmapped = c.detectionUnmapped(query, score, ctx)
 
-	finding.FindingInfo = c.findingInfo(query, score, title)
+	finding.FindingInfo = c.findingInfo(query, score, title, ctx)
 	finding.FindingInfo.Analytic = &ocsf.Analytic{
 		TypeID:   ocsf.AnalyticTypeRule,
 		Type:     ocsf.AnalyticTypeName(ocsf.AnalyticTypeRule),
@@ -120,7 +120,7 @@ func (c *converter) detectionAssetError(errMsg string, ctx *assetContext) ocsf.D
 	finding.Message = "Asset scan error: " + errMsg
 	finding.Metadata = c.metadata(ctx.findingProfiles()...)
 	finding.Unmapped = assetErrorUnmapped(ctx)
-	finding.FindingInfo = c.assetErrorInfo()
+	finding.FindingInfo = c.assetErrorInfo(ctx)
 	finding.Resources = []ocsf.ResourceDetails{ctx.resource}
 	finding.Device = ctx.device
 	finding.Cloud = ctx.cloud

--- a/reports/ocsf/convert/files.go
+++ b/reports/ocsf/convert/files.go
@@ -54,7 +54,12 @@ var allExtensions = []string{EncodingJSON.ext(), EncodingParquet.ext()}
 // asset at a time and the writers encode and drop each set, so a fleet scan does
 // not have to fit in memory twice.
 func ConvertToDir(r *policy.ReportCollection, dir string, opts Options, enc Encoding) ([]string, error) {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700, not 0755: these files carry cloud account ids, ARNs, the MQL source of
+	// every check and its rendered assessment with the observed values in it, and
+	// with Options.IncludeData the raw result of every data query. A scan is
+	// routinely run as root, and a world-readable directory under it hands all of
+	// that to every local account.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, errors.Wrapf(err, "failed to create the output directory %q", dir)
 	}
 
@@ -62,10 +67,23 @@ func ConvertToDir(r *policy.ReportCollection, dir string, opts Options, enc Enco
 	if err := Stream(r, files, opts); err != nil {
 		return nil, err
 	}
+
+	// A run that wrote nothing does not sweep. removeStale deletes every name
+	// cnspec knows, so on an empty conversion it would delete the whole of the
+	// previous run's output and return nil -- a scan that discovered no assets
+	// would erase a good report and exit 0, leaving "no findings" and "all clean"
+	// indistinguishable. The sweep exists to stop two runs' files being counted
+	// together; with no files of its own this run cannot cause that, so there is
+	// nothing for it to fix and everything for it to destroy. Skipping is chosen
+	// over erroring because an empty scan is not itself a failure -- the warning
+	// is what says the directory still holds an older run.
 	if len(files.written) == 0 {
-		log.Warn().Str("dir", dir).Msg("the scan produced no OCSF events, no files written")
+		log.Warn().Str("dir", dir).
+			Msg("the scan produced no OCSF events; no files written and the directory left as it was")
+		return files.written, nil
 	}
-	return files.written, files.removeStale()
+	files.removeStale()
+	return files.written, nil
 }
 
 // classFiles routes each event class to its own file, creating one the first
@@ -98,7 +116,15 @@ func (c *classFiles) writerFor(class string) (ocsf.Writer, error) {
 	}
 
 	path := filepath.Join(c.dir, class+c.enc.ext())
-	f, err := os.Create(path)
+	// Not os.Create: the eight class filenames are fixed and public, so anyone who
+	// can write the output directory can pre-place a symlink at one of them and
+	// have a scan -- frequently running as root -- truncate and overwrite its
+	// target with the findings. O_NOFOLLOW makes the open fail on a symlink
+	// instead of following it (see nofollow_unix.go). The mode is 0600 for the
+	// same reason the directory is 0700: the file carries account ids, MQL
+	// source, observed values and, under IncludeData, the raw output of every
+	// data query.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|oNoFollow, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -126,10 +152,11 @@ func (c *classFiles) writerFor(class string) (ocsf.Writer, error) {
 	return writer, nil
 }
 
-// removeStale deletes the per-class files this run did not write.
+// removeStale deletes the per-class files this run did not write. It reports
+// nothing: see the warning below for why a failure here is not the scan's.
 //
-// os.Create truncates only the files a run opens, and writerFor opens one only
-// for a class that produced an event. A directory reused across runs therefore
+// A run truncates only the files it opens, and writerFor opens one only for a
+// class that produced an event. A directory reused across runs therefore
 // keeps whatever the previous run left: switching -o ocsf-json,ocsf-findings from
 // detection to compliance is the ordinary way to get there, and it leaves the old
 // detection_finding.jsonl sitting next to the new compliance_finding.jsonl. A
@@ -140,13 +167,12 @@ func (c *classFiles) writerFor(class string) (ocsf.Writer, error) {
 //
 // Only the names cnspec itself writes are considered, so anything else in the
 // directory is left alone.
-func (c *classFiles) removeStale() error {
+func (c *classFiles) removeStale() {
 	written := make(map[string]bool, len(c.written))
 	for _, path := range c.written {
 		written[path] = true
 	}
 
-	var errs *multierror.Error
 	for _, class := range ocsf.AllClasses() {
 		for _, ext := range allExtensions {
 			path := filepath.Join(c.dir, class+ext)
@@ -157,11 +183,17 @@ func (c *classFiles) removeStale() error {
 			case err == nil:
 				log.Info().Str("file", path).Msg("removed a stale OCSF file from an earlier run")
 			case !os.IsNotExist(err):
-				errs = multierror.Append(errs, err)
+				// A warning, not an error. Every file of this run is already
+				// written and closed by the time the sweep runs, so failing here
+				// would turn a complete scan into a non-zero exit over a leftover
+				// the process does not own -- a root-written file from an earlier
+				// run is the ordinary way to get one. The warning names the file
+				// so the double-counting risk it leaves behind is visible.
+				log.Warn().Err(err).Str("file", path).
+					Msg("could not remove a stale OCSF file from an earlier run; a consumer reading this directory may count its events too")
 			}
 		}
 	}
-	return errs.ErrorOrNil()
 }
 
 // Close finalizes every file it opened. Every one is closed even if an earlier

--- a/reports/ocsf/convert/mapping.go
+++ b/reports/ocsf/convert/mapping.go
@@ -19,9 +19,37 @@ import (
 	"go.mondoo.com/mql/cli/printer"
 )
 
-func (c *converter) findingInfo(query *policy.Mquery, score *policy.Score, title string) ocsf.FindingInfo {
+// findingUID identifies one finding: one check on one asset.
+//
+// OCSF defines finding_info.uid as "the unique identifier of the reported
+// finding", and a finding is a check *on an asset* -- so the rule id alone is not
+// it. With the rule id there, count(DISTINCT finding_info.uid) over a 500-asset
+// scan returns the number of checks, and every asset's copy of a check collapses
+// onto one row in any consumer that keys on the uid. Prowler, the producer this
+// class is modeled on, splits the two the same way: the finding gets a per-asset
+// uid and the rule stays in analytic.uid, which is where cnspec already puts it
+// (and in compliance.control for class 2003).
+//
+// It is composed rather than hashed so it stays readable, and it is composed of
+// nothing but the two identities, so two runs of the same scan produce the same
+// uid.
+func findingUID(ruleID string, ctx *assetContext) string {
+	if ctx == nil {
+		return ruleID
+	}
+	asset := ctx.assetMrn
+	if asset == "" {
+		asset = ctx.resource.UID
+	}
+	if asset == "" {
+		return ruleID
+	}
+	return ruleID + "/" + asset
+}
+
+func (c *converter) findingInfo(query *policy.Mquery, score *policy.Score, title string, ctx *assetContext) ocsf.FindingInfo {
 	res := ocsf.FindingInfo{
-		UID:           reportdoc.QueryRuleID(query),
+		UID:           findingUID(reportdoc.QueryRuleID(query), ctx),
 		Title:         title,
 		Desc:          reportdoc.QueryDescription(query),
 		CreatedTime:   c.now,
@@ -123,8 +151,21 @@ func refURLs(query *policy.Mquery) []string {
 }
 
 // checkSeverity maps a check outcome to an OCSF severity. A check that passed
-// or did not run is informational; a failing one carries the severity of its risk.
-func checkSeverity(score *policy.Score) int {
+// or did not run is informational; a failing one carries the severity the policy
+// author gave it.
+//
+// That severity is the check's declared impact, not its risk. A leaf check's
+// score.Value is exactly 100 or 0 -- policy/executor/internal/nodes.go scores a
+// check as one or the other, never in between -- so ScoreRisk is 100 for every
+// failure, and deriving the severity from it reports the whole scan as Critical.
+// The declared impact is the only thing that distinguishes a failing check from
+// its neighbour, which is why the SARIF reporter has always read
+// reportdoc.QueryImpact for its severity and security-severity properties.
+//
+// Risk stays as the fallback for a check with no impact set, where it is the only
+// signal there is. Aggregate (non-leaf) scores do land between 0 and 100, and for
+// those the risk band is meaningful.
+func checkSeverity(query *policy.Mquery, score *policy.Score) int {
 	if score == nil {
 		return ocsf.SeverityInformational
 	}
@@ -136,6 +177,9 @@ func checkSeverity(score *policy.Score) int {
 	case policy.ScoreType_Result:
 		if score.Value == 100 {
 			return ocsf.SeverityInformational
+		}
+		if impact, ok := reportdoc.QueryImpact(query); ok {
+			return severityFromRisk(impact)
 		}
 		return severityFromRisk(reportdoc.ScoreRisk(score))
 	default:

--- a/reports/ocsf/convert/nofollow_unix.go
+++ b/reports/ocsf/convert/nofollow_unix.go
@@ -1,0 +1,13 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package convert
+
+import "syscall"
+
+// oNoFollow makes an open fail on a symlink instead of following it, which is
+// what stops a pre-placed link at one of the fixed class filenames redirecting a
+// scan's output onto a file outside the output directory.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/reports/ocsf/convert/nofollow_windows.go
+++ b/reports/ocsf/convert/nofollow_windows.go
@@ -1,0 +1,13 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package convert
+
+// oNoFollow has no Windows equivalent: the syscall package defines no
+// O_NOFOLLOW there and CreateFile has no flag for it. The exposure is also
+// smaller -- creating a symlink on Windows needs SeCreateSymbolicLinkPrivilege,
+// which an unprivileged account does not have by default -- so this is 0 rather
+// than a refusal to write.
+const oNoFollow = 0

--- a/reports/ocsf/convert/review_test.go
+++ b/reports/ocsf/convert/review_test.go
@@ -257,6 +257,19 @@ func TestOcsfVulnCvssScoreIsACvssScore(t *testing.T) {
 	require.Len(t, events.VulnerabilityFindings, 1)
 	assert.Equal(t, "9.5", events.VulnerabilityFindings[0].Unmapped["cvss_score"],
 		"the advisory scores 95 on cnspec's 0-100 scale, which is CVSS 9.5")
+
+	// A whole number keeps its decimal. Shortest-round-trip formatting renders
+	// 100 as "10", which reads like a different scale again next to "9.5", and
+	// CVSS is published with one decimal everywhere.
+	//
+	// Only non-zero scores: a zero advisory score falls back to the package's,
+	// so it cannot be used to probe the formatting.
+	for score, want := range map[int32]string{100: "10.0", 70: "7.0", 55: "5.5"} {
+		r := advisoryReportCollection()
+		r.VulnReports[reportfixture.AssetMrn].Advisories[0].Score = score
+		got := toOcsf(t, r).VulnerabilityFindings[0].Unmapped["cvss_score"]
+		assert.Equal(t, want, got, "cnspec score %d", score)
+	}
 }
 
 // TestConvertToDirEmptyScanKeepsPreviousOutput covers a conversion that produces

--- a/reports/ocsf/convert/review_test.go
+++ b/reports/ocsf/convert/review_test.go
@@ -1,0 +1,367 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnspec/internal/reportfixture"
+	"go.mondoo.com/cnspec/policy"
+	"go.mondoo.com/cnspec/reports/ocsf"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// TestOcsfSeverityFollowsDeclaredImpact pins that a failing check carries the
+// severity its author gave it.
+//
+// A leaf check scores exactly 100 or 0 -- policy/executor scores it as one or the
+// other, never in between -- so its risk is 100 whenever it fails, and a severity
+// derived from that risk is Critical for every failing check in every scan. The
+// declared impact is the only thing that tells one failing check from another,
+// and it is what the SARIF reporter has always used.
+//
+// Asserting over four impacts in one scan is the point: a single failing check
+// would still pass with the risk mapping, since risk 100 and impact 95 both land
+// in the Critical band.
+func TestOcsfSeverityFollowsDeclaredImpact(t *testing.T) {
+	impacts := map[string]struct {
+		impact       int32
+		wantSeverity int
+	}{
+		"critical": {95, ocsf.SeverityCritical},
+		"high":     {80, ocsf.SeverityHigh},
+		"medium":   {50, ocsf.SeverityMedium},
+		"low":      {20, ocsf.SeverityLow},
+	}
+
+	report := failingChecksWithImpacts(impacts)
+
+	t.Run("compliance", func(t *testing.T) {
+		events := toOcsf(t, report)
+		require.Len(t, events.ComplianceFindings, len(impacts))
+		for _, finding := range events.ComplianceFindings {
+			want := impacts[finding.Compliance.Control].wantSeverity
+			assert.Equal(t, want, finding.SeverityID,
+				"check %q declares impact %d", finding.Compliance.Control,
+				impacts[finding.Compliance.Control].impact)
+			assert.Equal(t, ocsf.SeverityName(want), finding.Severity)
+		}
+	})
+
+	t.Run("detection agrees with impact_id", func(t *testing.T) {
+		events, err := convertAt(report,
+			Options{Version: ocsf.DefaultVersion, Findings: ocsf.FindingsDetection}, fixedScanTime)
+		require.NoError(t, err)
+		require.Len(t, events.DetectionFindings, len(impacts))
+
+		for _, finding := range events.DetectionFindings {
+			// Class 2004 carries both severity_id and impact_id. They run on the
+			// same bands, so one event saying Critical severity and High impact was
+			// the event contradicting itself.
+			assert.Equal(t, impactLevel(int32(finding.ImpactScore)), finding.ImpactID)
+			assert.Equal(t, severityFromRisk(int32(finding.ImpactScore)), finding.SeverityID,
+				"severity and impact must not disagree inside one event")
+		}
+	})
+}
+
+// TestOcsfSeverityFallsBackToRisk covers a check with no declared impact, where
+// the risk is the only signal there is.
+func TestOcsfSeverityFallsBackToRisk(t *testing.T) {
+	events := toOcsf(t, reportfixture.Detailed())
+	require.Len(t, events.ComplianceFindings, 1)
+	assert.Equal(t, ocsf.SeverityCritical, events.ComplianceFindings[0].SeverityID)
+}
+
+// failingChecksWithImpacts is a scan of one asset where every check fails and
+// each declares a different impact. The check's compliance control is its name,
+// which is what the assertions key on.
+func failingChecksWithImpacts(impacts map[string]struct {
+	impact       int32
+	wantSeverity int
+},
+) *policy.ReportCollection {
+	const assetMrn = "//assets.api.mondoo.app/spaces/test/assets/impacts"
+
+	res := &policy.ReportCollection{
+		Assets: map[string]*inventory.Asset{
+			assetMrn: {Name: "X1", Platform: &inventory.Platform{Name: "ubuntu"}},
+		},
+		ResolvedPolicies: map[string]*policy.ResolvedPolicy{
+			assetMrn: {CollectorJob: &policy.CollectorJob{ReportingQueries: map[string]*policy.StringArray{}}},
+		},
+		Bundle:  &policy.Bundle{},
+		Reports: map[string]*policy.Report{assetMrn: {Scores: map[string]*policy.Score{}}},
+	}
+
+	for name, tc := range impacts {
+		codeID := "code-" + name
+		res.ResolvedPolicies[assetMrn].CollectorJob.ReportingQueries[codeID] = nil
+		res.Bundle.Queries = append(res.Bundle.Queries, &policy.Mquery{
+			Mrn:    "//policy.api.mondoo.app/queries/" + name,
+			CodeId: codeID,
+			Title:  "Check " + name,
+			Impact: &policy.Impact{Value: &policy.ImpactValue{Value: tc.impact}},
+			Tags:   map[string]string{"compliance/test": name},
+		})
+		// Value 0 is what a failing leaf check scores; that is the whole point.
+		res.Reports[assetMrn].Scores[codeID] = &policy.Score{Type: policy.ScoreType_Result, Value: 0}
+	}
+	return res
+}
+
+// TestOcsfFindingUIDIsPerAsset pins that finding_info.uid identifies a check on
+// an asset rather than the check alone.
+//
+// With the rule id alone there, count(DISTINCT finding_info.uid) over a fleet
+// scan returns the number of checks however many assets were scanned, and any
+// consumer keyed on the uid collapses every asset's copy onto one row.
+func TestOcsfFindingUIDIsPerAsset(t *testing.T) {
+	const assets, checks = 3, 2
+	events := toOcsf(t, largeReportCollection(assets, checks))
+	require.Len(t, events.ComplianceFindings, assets*checks)
+
+	uids := map[string]bool{}
+	for _, finding := range events.ComplianceFindings {
+		uids[finding.FindingInfo.UID] = true
+		require.Len(t, finding.Resources, 1)
+		rule := strings.TrimPrefix(finding.Unmapped["query_mrn"], "//policy.api.mondoo.app/queries/")
+		assert.Equal(t, rule+"/"+finding.Resources[0].UID, finding.FindingInfo.UID,
+			"the uid is the rule and the asset, and both stay recoverable from it")
+	}
+	assert.Len(t, uids, assets*checks, "one uid per check per asset")
+
+	// The rule id itself stays where a consumer looks for the rule.
+	detection, err := convertAt(largeReportCollection(assets, checks),
+		Options{Findings: ocsf.FindingsDetection}, fixedScanTime)
+	require.NoError(t, err)
+	analytics := map[string]bool{}
+	for _, finding := range detection.DetectionFindings {
+		require.NotNil(t, finding.FindingInfo.Analytic)
+		analytics[finding.FindingInfo.Analytic.UID] = true
+	}
+	assert.Len(t, analytics, checks, "analytic.uid is the rule, so it is shared across assets")
+}
+
+// TestOcsfAssetErrorUIDIsPerAsset covers the finding that stands in for a whole
+// failed scan. A fleet scan where a hundred assets were unreachable is a hundred
+// findings, not one repeated -- but every one of them used to carry the literal
+// "asset-error".
+func TestOcsfAssetErrorUIDIsPerAsset(t *testing.T) {
+	report := largeReportCollection(2, 1)
+	report.Errors = map[string]string{}
+	for mrn := range report.Assets {
+		report.Errors[mrn] = "could not connect to the asset"
+	}
+
+	events := toOcsf(t, report)
+
+	uids := map[string]bool{}
+	for _, finding := range events.ComplianceFindings {
+		if finding.FindingInfo.Title == "Asset scan error" {
+			uids[finding.FindingInfo.UID] = true
+		}
+	}
+	assert.Len(t, uids, 2, "each unreachable asset is its own finding")
+}
+
+// TestOcsfGcpAsset pins the mapping of a GCP asset's project id.
+//
+// project_uid is deprecated in OCSF 1.9 in favor of account.uid, and it was the
+// only place cnspec put a GCP project -- so at 1.9 the validator warned on every
+// event of a GCP asset, and dropping the deprecated attribute alone would have
+// lost the project id entirely.
+func TestOcsfGcpAsset(t *testing.T) {
+	report := gcpAssetReportCollection()
+
+	v13 := toOcsf(t, report)
+	cloud := v13.InventoryInfos[0].Cloud
+	require.NotNil(t, cloud)
+	assert.Equal(t, "GCP", cloud.Provider)
+	require.NotNil(t, cloud.Account, "the project is the account of a GCP asset")
+	assert.Equal(t, "mondoo-dev-262313", cloud.Account.UID)
+	assert.Equal(t, "mondoo-dev-262313", cloud.ProjectUID,
+		"1.3 still has project_uid, and a 1.3 consumer reads it there")
+
+	events19, err := convertAt(report, Options{Version: ocsf.Version190}, fixedScanTime)
+	require.NoError(t, err)
+	cloud19 := events19.InventoryInfos[0].Cloud
+	require.NotNil(t, cloud19)
+	require.NotNil(t, cloud19.Account)
+	assert.Equal(t, "mondoo-dev-262313", cloud19.Account.UID)
+	assert.Empty(t, cloud19.ProjectUID,
+		"project_uid is deprecated at 1.9; the validator warns on every event that carries it")
+}
+
+// gcpAssetReportCollection is the sample scan re-cast as a GCP compute instance,
+// so the deprecation gate on cloud.project_uid gets exercised. The only cloud
+// fixture before it was an EC2 instance, which has no project id at all -- so the
+// schema validator ran green over a mapping it never saw.
+func gcpAssetReportCollection() *policy.ReportCollection {
+	report := reportfixture.Sample()
+	for _, asset := range report.Assets {
+		asset.PlatformIds = []string{
+			"//platformid.api.mondoo.app/runtime/gcp/projects/mondoo-dev-262313/instances/1234567890",
+		}
+		asset.Platform = &inventory.Platform{
+			Name: "ubuntu", Runtime: "gcp-compute-instance", Kind: "virtualmachine",
+			Family: []string{"debian", "linux", "unix", "os"}, Version: "22.04", Arch: "amd64",
+		}
+	}
+	return report
+}
+
+// TestOcsfVulnMarksANonCVEIdentifier covers an advisory with no CVEs at 1.3.
+//
+// cve.uid is specified as the CVE-YYYY-NNNNN form, and 1.3 has no advisory object
+// to put a USN or RHSA in instead -- so the id stays in cve.uid, where a 1.3
+// consumer looks for it, and unmapped says it is not a CVE. Without the marker an
+// NVD join over cve.uid drops the row and reports nothing.
+func TestOcsfVulnMarksANonCVEIdentifier(t *testing.T) {
+	report := advisoryReportCollection()
+	report.VulnReports[reportfixture.AssetMrn].Advisories[0].Cves = nil
+
+	v13 := toOcsf(t, report)
+	require.Len(t, v13.VulnerabilityFindings, 1)
+	finding := v13.VulnerabilityFindings[0]
+	require.NotNil(t, finding.Vulnerabilities[0].CVE)
+	assert.Equal(t, "USN-1234-1", finding.Vulnerabilities[0].CVE.UID)
+	assert.Equal(t, "USN-1234-1", finding.Unmapped["non_cve_uid"],
+		"a consumer joining cve.uid against NVD has to be able to tell this apart from a CVE")
+
+	// A real CVE carries no marker.
+	withCVE := toOcsf(t, advisoryReportCollection())
+	require.Len(t, withCVE.VulnerabilityFindings, 1)
+	assert.NotContains(t, withCVE.VulnerabilityFindings[0].Unmapped, "non_cve_uid")
+
+	// 1.9 has the advisory object, so cve.uid is not misused there at all.
+	events19, err := convertAt(report, Options{Version: ocsf.Version190}, fixedScanTime)
+	require.NoError(t, err)
+	assert.NotContains(t, events19.VulnerabilityFindings[0].Unmapped, "non_cve_uid")
+}
+
+// TestOcsfVulnCvssScoreIsACvssScore pins the scale of unmapped.cvss_score.
+//
+// cnspec scores an advisory 0-100, so a CVSS 9.5 advisory carried "95" under a
+// key named cvss_score: every advisory in the report matched a `cvss_score > 7`
+// filter, and nothing about the value said it was on another scale.
+func TestOcsfVulnCvssScoreIsACvssScore(t *testing.T) {
+	events := toOcsf(t, advisoryReportCollection())
+	require.Len(t, events.VulnerabilityFindings, 1)
+	assert.Equal(t, "9.5", events.VulnerabilityFindings[0].Unmapped["cvss_score"],
+		"the advisory scores 95 on cnspec's 0-100 scale, which is CVSS 9.5")
+}
+
+// TestConvertToDirEmptyScanKeepsPreviousOutput covers a conversion that produces
+// no events at all -- a scan that discovered no assets, with a bundle that loaded
+// fine, so the "no policy bundle found" guard does not fire.
+//
+// The stale sweep deletes every filename cnspec knows, so running it after an
+// empty conversion emptied the directory of a previous good run and returned nil:
+// the report was gone and the scan exited 0, leaving "no findings" and "all
+// clean" indistinguishable downstream.
+func TestConvertToDirEmptyScanKeepsPreviousOutput(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "out")
+
+	written, err := ConvertToDir(advisoryReportCollection(), dir, Options{}, EncodingJSON)
+	require.NoError(t, err)
+	require.NotEmpty(t, written, "the first run writes a good report")
+
+	// A scan that discovered nothing: no assets, and a bundle that loaded.
+	empty := &policy.ReportCollection{Bundle: &policy.Bundle{}}
+	written, err = ConvertToDir(empty, dir, Options{}, EncodingJSON)
+	require.NoError(t, err)
+	assert.Empty(t, written)
+
+	for _, class := range []string{
+		ocsf.ClassComplianceFinding, ocsf.ClassVulnerabilityFinding, ocsf.ClassInventoryInfo,
+	} {
+		assert.FileExists(t, filepath.Join(dir, class+".jsonl"),
+			"an empty conversion must not delete the previous run's report")
+	}
+}
+
+// TestConvertToDirDoesNotFollowASymlink covers a symlink pre-placed at one of the
+// eight fixed, public class filenames.
+//
+// os.Create follows it and truncates whatever it points at, so anyone who can
+// write the output directory can redirect a scan -- frequently running as root --
+// onto a file of their choosing and have it overwritten with the findings.
+func TestConvertToDirDoesNotFollowASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("O_NOFOLLOW has no Windows equivalent; see nofollow_windows.go")
+	}
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "out")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	victim := filepath.Join(root, "victim")
+	require.NoError(t, os.WriteFile(victim, []byte("do not overwrite me"), 0o600))
+	require.NoError(t, os.Symlink(victim, filepath.Join(dir, ocsf.ClassComplianceFinding+".jsonl")))
+
+	_, err := ConvertToDir(advisoryReportCollection(), dir, Options{}, EncodingJSON)
+	require.Error(t, err, "the open has to fail rather than follow the link")
+
+	content, readErr := os.ReadFile(victim)
+	require.NoError(t, readErr)
+	assert.Equal(t, "do not overwrite me", string(content),
+		"the symlink target must not be truncated and rewritten with findings")
+}
+
+// TestConvertToDirWritesPrivateFiles pins the permissions of the output.
+//
+// These files carry cloud account ids and ARNs, the MQL source of every check,
+// rendered assessments showing the observed values, and under IncludeData the raw
+// output of every data query. A scan is routinely run as root, and 0755/0644
+// hands all of it to every local account on the host.
+func TestConvertToDirWritesPrivateFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not apply on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "out")
+	written, err := ConvertToDir(advisoryReportCollection(), dir, Options{}, EncodingJSON)
+	require.NoError(t, err)
+	require.NotEmpty(t, written)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "the output directory is not world-readable")
+
+	for _, path := range written {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "%s is not world-readable", path)
+	}
+}
+
+// TestConvertToDirSurvivesAnUnremovableStaleFile covers a leftover the sweep
+// cannot delete -- a root-owned file from an earlier run is the ordinary way to
+// get one; the test uses a non-empty directory, which os.Remove rejects the same
+// way.
+//
+// Every file of this run is already written and closed by the time the sweep
+// runs, so propagating the failure turned a complete scan into a non-zero exit
+// (log.Fatal, in apps/cnspec/cmd/scan.go) over work that had already succeeded.
+func TestConvertToDirSurvivesAnUnremovableStaleFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	// A stale name this run will not write, that os.Remove cannot delete.
+	stale := filepath.Join(dir, ocsf.ClassDetectionFinding+".jsonl")
+	require.NoError(t, os.Mkdir(stale, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(stale, "child"), []byte("x"), 0o600))
+
+	written, err := ConvertToDir(advisoryReportCollection(), dir, Options{}, EncodingJSON)
+	require.NoError(t, err, "the scan wrote every one of its files; cleanup is not its verdict")
+	assert.NotEmpty(t, written)
+	assert.FileExists(t, filepath.Join(dir, ocsf.ClassComplianceFinding+".jsonl"))
+}

--- a/reports/ocsf/convert/validate_test.go
+++ b/reports/ocsf/convert/validate_test.go
@@ -29,13 +29,27 @@ import (
 // not exist in the class, values of the wrong type, enum siblings that disagree,
 // missing required attributes, and profile attributes used without the profile
 // being declared. It is why cnspec output is safe to hand to a data lake.
+//
+// It only catches what a fixture puts in front of it, which is why the set is
+// wide rather than minimal. cloud.project_uid was set unconditionally and is
+// deprecated at 1.9, and this suite stayed green through it because the only
+// cloud fixture was an EC2 asset, which has no project id -- hence the GCP one.
 func TestOcsfSchemaValidation(t *testing.T) {
+	recorded, err := reportfixture.UbuntuScan()
+	require.NoError(t, err)
+
 	reports := map[string]*policy.ReportCollection{
 		"sample":     reportfixture.Sample(),
 		"detailed":   reportfixture.Detailed(),
 		"cloud":      cloudAssetReportCollection(),
+		"gcp":        gcpAssetReportCollection(),
 		"advisories": advisoryReportCollection(),
 		"scan error": erroredReportCollection(),
+		// The recorded scan is the only fixture with an ExecutionJob, so it is the
+		// only one that exercises checkAssessment -- the rendered "expected vs
+		// actual" that goes into compliance.status_detail and, on class 2004, into
+		// status_detail. The hand-built fixtures reach none of it.
+		"recorded": recorded,
 	}
 
 	// Both finding classes are validated: a check is reported as one or the

--- a/reports/ocsf/convert/vulnerability.go
+++ b/reports/ocsf/convert/vulnerability.go
@@ -206,8 +206,12 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 	// does it (cli/components.IntScore2Float, read by cli/reporter/json_vuln.go
 	// and csv_vuln.go). The division is inline rather than that call because this
 	// package sits under reports/ and does not import cli/.
+	//
+	// One decimal always, so a maximum score reads 10.0 like every other value
+	// rather than 10 -- shortest-round-trip formatting drops the point on whole
+	// numbers, and CVSS is written with one everywhere it is published.
 	unmapped := map[string]string{
-		"cvss_score": strconv.FormatFloat(float64(score)/10, 'f', -1, 64),
+		"cvss_score": strconv.FormatFloat(float64(score)/10, 'f', 1, 64),
 	}
 	if ctx.assetMrn != "" {
 		unmapped["asset_mrn"] = ctx.assetMrn

--- a/reports/ocsf/convert/vulnerability.go
+++ b/reports/ocsf/convert/vulnerability.go
@@ -127,6 +127,14 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 		References:       advisoryRefs(advisory),
 	}
 
+	// nonCVEUID is set when cve.uid ends up carrying something that is not a CVE
+	// id, so unmapped can say so. OCSF specifies cve.uid as the CVE-YYYY-NNNNN
+	// form; an advisory id such as USN-9999-1 in that field joins against nothing
+	// in NVD and does so silently. There is nowhere else to put it at 1.3 -- the
+	// advisory object arrives in 1.9 -- so the id stays where a 1.3 consumer will
+	// look for it, and the marker is what tells a pipeline not to treat it as a CVE.
+	var nonCVEUID string
+
 	vulns := []ocsf.Vulnerability{}
 	if advisory != nil {
 		for _, cve := range reportdoc.AdvisoryCves(advisory) {
@@ -146,8 +154,8 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 		if len(vulns) == 0 {
 			// An advisory with no CVEs still has to identify itself. 1.9 has the
 			// advisory object for exactly this; 1.3 has no such attribute, so the
-			// advisory id goes in cve.uid, which is where every OCSF producer puts
-			// a non-CVE vulnerability identifier.
+			// advisory id has to go in cve.uid, which is the only identifier the
+			// object has.
 			cur := vuln
 			if c.version.AtLeast(ocsf.Version190) {
 				cur.Advisory = &ocsf.Advisory{
@@ -158,6 +166,7 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 				}
 			} else {
 				cur.CVE = &ocsf.CVE{UID: advisory.ID, Title: advisory.Title, Desc: advisory.Description}
+				nonCVEUID = advisory.ID
 			}
 			vulns = append(vulns, cur)
 		}
@@ -165,7 +174,10 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 
 	finding := ocsf.NewVulnerabilityFinding(ocsf.VulnerabilityFindingActivityCreate)
 	finding.FindingInfo = ocsf.FindingInfo{
-		UID:           uid,
+		// One finding is one advisory on one asset. The advisory id alone is the
+		// same for every asset it affects, which collapses a fleet to one row for
+		// anything correlating on this field.
+		UID:           findingUID(uid, ctx),
 		Title:         title,
 		Desc:          desc,
 		CreatedTime:   c.now,
@@ -188,12 +200,23 @@ func (c *converter) vulnerabilityFinding(advisory *mvd.Advisory, pkgs []*mvd.Pac
 	finding.Message = title
 	finding.Metadata = c.metadata(ctx.findingProfiles()...)
 
-	unmapped := map[string]string{"cvss_score": strconv.Itoa(int(score))}
+	// The score here is cnspec's 0-100 rating, not a CVSS base score: an advisory
+	// of CVSS 9.5 carries 95. Calling it cvss_score made every advisory match a
+	// `cvss_score > 7` filter, so it is divided down the way every other reporter
+	// does it (cli/components.IntScore2Float, read by cli/reporter/json_vuln.go
+	// and csv_vuln.go). The division is inline rather than that call because this
+	// package sits under reports/ and does not import cli/.
+	unmapped := map[string]string{
+		"cvss_score": strconv.FormatFloat(float64(score)/10, 'f', -1, 64),
+	}
 	if ctx.assetMrn != "" {
 		unmapped["asset_mrn"] = ctx.assetMrn
 	}
 	if advisory != nil {
 		unmapped["advisory"] = advisory.ID
+	}
+	if nonCVEUID != "" {
+		unmapped["non_cve_uid"] = nonCVEUID
 	}
 	finding.Unmapped = unmapped
 

--- a/reports/ocsf/deps_test.go
+++ b/reports/ocsf/deps_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ocsf
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPackageImportsNoCnspecPackage is the whole reason reports/ocsf and
+// reports/ocsf/convert are two packages.
+//
+// This package is the OCSF schema and the writers for it, and nothing about
+// cnspec: that is what keeps it extractable as go.mondoo.com/ocsf, which
+// docs/adr/0005-ocsf-type-generation.md, doc.go and CLAUDE.md all state as the
+// reason for the split. Until now nothing enforced it, and the import that
+// breaks it is the easy one to add -- one policy.Score in a helper and the
+// package is no longer publishable, with every test still green.
+//
+// The check runs over the transitive dependencies, not the import block, because
+// an indirect edge costs the same as a direct one.
+func TestPackageImportsNoCnspecPackage(t *testing.T) {
+	// -deps of the package under test; the test files themselves are not included,
+	// which is right: a test may use whatever it likes, the shipped package may not.
+	out, err := exec.Command("go", "list", "-deps", ".").Output()
+	require.NoError(t, err, "go list failed")
+
+	var offenders []string
+	for _, dep := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		dep = strings.TrimSpace(dep)
+		// The package itself is go.mondoo.com/cnspec/reports/ocsf; everything else
+		// under go.mondoo.com/cnspec is an edge that must not exist.
+		if dep == "go.mondoo.com/cnspec/reports/ocsf" {
+			continue
+		}
+		if strings.HasPrefix(dep, "go.mondoo.com/cnspec") {
+			offenders = append(offenders, dep)
+		}
+	}
+
+	assert.Empty(t, offenders,
+		"reports/ocsf must import no cnspec package, so it stays extractable as go.mondoo.com/ocsf; "+
+			"the cnspec mapping belongs in reports/ocsf/convert")
+}

--- a/reports/ocsf/internal/gen/main.go
+++ b/reports/ocsf/internal/gen/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"compress/gzip"
 	"flag"
 	"fmt"
@@ -130,7 +131,7 @@ func run() error {
 	if len(paths) == 0 {
 		return fmt.Errorf("no compiled schemas in %s", filepath.Join(root, "schemas"))
 	}
-	sort.Strings(paths)
+	sortSchemaPaths(paths)
 
 	schemas := make([]schema, 0, len(paths))
 	for _, path := range paths {
@@ -138,7 +139,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		want := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "schema-"), ".json.gz")
+		want := schemaVersion(path)
 		if s.Version != want {
 			return fmt.Errorf("%s declares version %q", filepath.Base(path), s.Version)
 		}
@@ -167,6 +168,69 @@ func run() error {
 		}
 	}
 	return nil
+}
+
+// sortSchemaPaths orders the schema files oldest first, by version number rather
+// than by filename.
+//
+// lookup takes the caption and documentation of the first schema that has an
+// attribute, so this order decides which version's wording every generated field
+// carries. Lexicographically "schema-1.10.0" sorts before "schema-1.3.0", so
+// sorting the names as strings would silently make the newest schema the source
+// of truth for the oldest as soon as a 1.10 arrives -- rewriting every doc
+// comment in the generated file, from a change nobody would read as reordering
+// anything.
+func sortSchemaPaths(paths []string) {
+	slices.SortFunc(paths, func(a, b string) int {
+		return compareVersions(schemaVersion(a), schemaVersion(b))
+	})
+}
+
+// schemaVersion is the version a schema file's name declares, e.g. "1.9.0" for
+// schemas/schema-1.9.0.json.gz.
+func schemaVersion(path string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "schema-"), ".json.gz")
+}
+
+// compareVersions orders two dotted version numbers component by component, so
+// 1.9.0 sorts before 1.10.0. A component that is not a number sorts last and
+// then compares as text, which keeps the order total for a filename that is not
+// a version at all rather than silently treating it as 0.
+func compareVersions(a, b string) int {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		an, aok := parseUint(as[i])
+		bn, bok := parseUint(bs[i])
+		switch {
+		case aok && bok && an != bn:
+			return cmp.Compare(an, bn)
+		case aok != bok:
+			// the numeric component is the older-style one; it sorts first
+			if aok {
+				return -1
+			}
+			return 1
+		case !aok && as[i] != bs[i]:
+			return strings.Compare(as[i], bs[i])
+		}
+	}
+	return cmp.Compare(len(as), len(bs))
+}
+
+// parseUint is strconv.Atoi restricted to a non-negative number, reported as a
+// pair rather than an error because the caller only branches on it.
+func parseUint(raw string) (int, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range raw {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, true
 }
 
 // packageRoot is the ocsf package directory, two levels up from internal/gen.

--- a/reports/ocsf/internal/gen/main.go
+++ b/reports/ocsf/internal/gen/main.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -223,12 +224,17 @@ func parseUint(raw string) (int, bool) {
 	if raw == "" {
 		return 0, false
 	}
-	n := 0
 	for _, r := range raw {
 		if r < '0' || r > '9' {
 			return 0, false
 		}
-		n = n*10 + int(r-'0')
+	}
+	// Digits only above, so Atoi cannot see a sign here; it is used for the
+	// conversion because it reports overflow, which accumulating by hand does
+	// not -- a long enough numeric filename would have wrapped silently.
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
 	}
 	return n, true
 }

--- a/reports/ocsf/internal/gen/main_test.go
+++ b/reports/ocsf/internal/gen/main_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSchemaOrderIsBySemver pins the order the schemas are walked in.
+//
+// lookup takes the caption and documentation of the first schema that has an
+// attribute, so this order decides which version's wording every generated field
+// carries -- and the whole file is regenerated from it. Sorting the filenames as
+// strings puts "schema-1.10.0.json.gz" ahead of "schema-1.3.0.json.gz", so
+// adding a 1.10 schema would make the newest version the source of truth for the
+// oldest, rewriting every doc comment in types.gen.go with no line of the
+// generator having changed.
+func TestSchemaOrderIsBySemver(t *testing.T) {
+	paths := []string{
+		"schemas/schema-1.10.0.json.gz",
+		"schemas/schema-1.3.0.json.gz",
+		"schemas/schema-1.9.0.json.gz",
+		"schemas/schema-2.0.0.json.gz",
+	}
+	sortSchemaPaths(paths)
+
+	assert.Equal(t, []string{
+		"schemas/schema-1.3.0.json.gz",
+		"schemas/schema-1.9.0.json.gz",
+		"schemas/schema-1.10.0.json.gz",
+		"schemas/schema-2.0.0.json.gz",
+	}, paths, "oldest first, by version number rather than by filename")
+}
+
+func TestCompareVersions(t *testing.T) {
+	assert.Negative(t, compareVersions("1.9.0", "1.10.0"), "9 is before 10")
+	assert.Positive(t, compareVersions("1.10.0", "1.9.0"))
+	assert.Equal(t, 0, compareVersions("1.3.0", "1.3.0"))
+	assert.Negative(t, compareVersions("1.3", "1.3.1"), "a shorter version is the earlier one")
+	assert.Negative(t, compareVersions("1.3.0", "1.3.0-rc1"),
+		"a non-numeric component sorts after the numbers, so the order stays total")
+}
+
+func TestSchemaVersion(t *testing.T) {
+	assert.Equal(t, "1.9.0", schemaVersion("/x/schemas/schema-1.9.0.json.gz"))
+}


### PR DESCRIPTION
Review findings on the OCSF export merged in #3556. Three reviews ran over it — refactor equivalence, security/production-readiness, and fitness for the consumers it targets. The first came back clean; these are from the other two, plus one I found while fixing them.

Every finding below was reproduced by executing code before being fixed, and every behaviour change was canaried — fix reverted, test observed failing, fix restored.

## Every failing check was reported as Critical

`checkSeverity` took only a `*policy.Score` and derived severity from risk, which is `100 - Value`. A leaf check's `Value` is exactly `100` or `0` (`policy/executor/internal/nodes.go:576-590`), so **every** failure was risk 100 → Critical, whatever the check declared.

```
checkSeverity(&policy.Score{Type: ScoreType_Result, Value: 0}) → 5 (Critical)
```

A policy whose impacts run 20–100 reached a SIEM as one band, and severity is the first dimension anyone triages on. On class 2004 the same event carried `impact_id: 1 (Low)` beside `severity: Critical`.

It now prefers `reportdoc.QueryImpact(query)` and falls back to risk only where no impact is declared — which is what `sarif.go:281,330` already did on the same code path.

*Note the recorded fixture could not have caught this*: both its failing checks declare impact 100, so the two mappings agree on it. The new test builds four failing checks at impacts 95/80/50/20.

## A finding's uid was the rule id, not the finding id

OCSF defines `finding_info.uid` as "the unique identifier of the reported finding", and one finding is one check *on one asset*. This emitted the check id, so `count(DISTINCT finding_info.uid)` over a 500-asset scan returned the number of checks. Every failed asset shared the literal `"asset-error"`.

Vulnerability findings had the same defect one class over — an advisory id repeats across every asset it affects. Both compose rule/advisory + asset now. The bare rule id remains in `analytic.uid` and `compliance.control`, so nothing is lost. This is the split Prowler uses, which #3556 cites as its model for 2004.

## An empty scan deleted the previous run's output and exited 0

`ConvertToDir` warned that nothing was written and then ran the stale sweep anyway, deleting all eight known filenames and returning nil.

```
before: 2 files      after: 0 files      err=<nil>
```

Reachable whenever discovery returns zero assets — an expired role, a changed filter, an emptied namespace — since the bundle loaded fine and the `no policy bundle found` guard does not fire. Downstream, "no findings" became indistinguishable from "everything is clean".

The sweep is skipped when nothing was written. It exists so two runs' files cannot be counted together; a run with no files of its own cannot cause that, so it has nothing to clean and everything to destroy.

## Output files followed a symlink, and were world-readable

`os.Create` with no `O_NOFOLLOW`. The eight filenames are fixed and public, and `cnspec scan` frequently runs as root:

```
SYMLINK FOLLOWED: victim overwritten with 4496 bytes of findings
```

Now `O_WRONLY|O_CREATE|O_TRUNC|O_NOFOLLOW`, 0600 in a 0700 directory. These files carry cloud account ids, ARNs, the MQL source of every check, and rendered assessments; under `,data` the raw output of every data query. The same modes are applied to the OHDF export, which had inherited them.

`O_NOFOLLOW` is build-tagged — it does not exist on Windows, and the repo cross-compiles there.

## At OCSF 1.9, a GCP project id lived only in a deprecated attribute

`cloud.project_uid` is `@deprecated since 1.4.0`, and `buildCloud` never set `account.uid` for GCP. The project's own validator flags it on every event, and the suite fails on warnings — but the only cloud fixture was an **EC2** asset, so the gate was green while the defect shipped.

`account.uid` is set for GCP, `project_uid` is gated below 1.9, and there is now a GCP fixture.

## Smaller

- `unmapped.cvss_score` was cnspec's 0–100 score under a name meaning 0–10, so `cvss_score > 7` matched everything. Divided, matching `components.IntScore2Float`.
- An advisory id in `cve.uid` at 1.3 is marked as non-CVE in `unmapped`. It cannot simply be omitted: OCSF 1.3 requires one of `cve`/`cwe`, and the `advisory` object only arrives in 1.9.
- A leftover file that cannot be removed now warns instead of failing a scan whose output was already written correctly.

## Three gaps that let these through, closed with them

- **The recorded scan was not in the OCSF validation set.** It is the only fixture carrying an `ExecutionJob`, so the assessment path was never validated. Added — it passes clean.
- **Nothing enforced that `reports/ocsf` imports no cnspec package** — the property the package split exists to protect, stated in `doc.go`, ADR 0005 and `CLAUDE.md`. A test now walks `go list -deps` and fails on any such edge.
- **The generator sorted schemas lexically**, so adding `schema-1.10.0.json.gz` would have sorted it before `1.3.0` and silently made 1.10 the source of captions for every version. Sorted by version now.

Also folds in the fifth "undo the conflation" site that survived the `reportdoc.Outcome` refactor — `addRunScoreProperties` in `sarif.go` still reached behind `scoreToSarifKind` for `ScoreType_Error`. Output unchanged; `TestSarifRunProperties` now pins the four-way split.

## Verification

`go build ./...` · `GOOS=windows go build ./reports/...` · `go vet` (9 pre-existing `junit.Property` warnings, none added) · `go test -race ./cli/... ./reports/... ./internal/... ./apps/cnspec/... ./test/...` · golangci-lint v2.13.1 both configs **0 issues** · `typos` clean · `go mod tidy` a no-op · `TestOcsfSchemaValidation` 2 versions × 7 fixtures × 2 classes, all passing.