### PR TITLE
🌟 policy: generate MQL from a plain-language description

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -8,7 +8,7 @@ These skills are:
 
 IMPORTANT: You MUST read the SKILL.md file whenever the description of the skills matches the user intent, or may help accomplish their task.
 
-mql: `Use when writing MQL (Mondoo Query Language) queries, working with Mondoo MCP tools, or developing security policies`
+mql: `Use when writing MQL (Mondoo Query Language) queries, generating MQL from a check's title and description, or developing security policies`
 policy-graph: `Navigates cnspec policy/framework bundles using graph commands. Use when exploring policies, finding checks, tracing compliance mappings, or understanding policy structure.`
 
 Paths referenced within SKILL.md files are relative to that skill's directory.

--- a/apps/cnspec/cmd/interactive/author.go
+++ b/apps/cnspec/cmd/interactive/author.go
@@ -1,0 +1,490 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"go.mondoo.com/cnspec/cli/tui"
+	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/generate"
+)
+
+// Authoring a check is the launcher's second verb. The first -- scan -- asks
+// what an asset looks like; this one asks what it *should* look like, and
+// writes the answer into a bundle the next scan can run.
+//
+// It is the same flow the line-oriented wizard runs (`policy generate -i`), and
+// deliberately so: both drive internal/generate and both write through
+// bundle.AppendCheck. What differs is only the surface, which is why the shared
+// half lives in those packages rather than beside either front end.
+
+// authorStep is where the authoring pane is in its own small progression.
+type authorStep int
+
+const (
+	// authorIntent collects what the check should prove.
+	authorIntent authorStep = iota
+	// authorWorking is the agent running. It is a separate step rather than a
+	// flag because the pane draws nothing else while it holds.
+	authorWorking
+	// authorReview is the generated MQL on screen, awaiting a verdict. This is
+	// the human gate the whole design leans on, so it is never skipped -- not
+	// even when validation passed.
+	authorReview
+	// authorDone reports where the check landed.
+	authorDone
+)
+
+// authorField indexes the intent fields, in the order they are asked.
+type authorField int
+
+const (
+	fieldTitle authorField = iota
+	fieldDesc
+	fieldFilter
+	fieldFile
+	authorFieldCount
+)
+
+func (f authorField) label() string {
+	switch f {
+	case fieldTitle:
+		return "Title"
+	case fieldDesc:
+		return "What must be true"
+	case fieldFilter:
+		return "Asset filter"
+	default:
+		return "Write to"
+	}
+}
+
+func (f authorField) hint() string {
+	switch f {
+	case fieldTitle:
+		return "what the check proves, as a statement"
+	case fieldDesc:
+		return "the condition, in enough detail to be unambiguous"
+	case fieldFilter:
+		return "which assets it applies to (proposed from the title)"
+	default:
+		return "the bundle file the check is appended to"
+	}
+}
+
+// authorState is the authoring pane: the intent being described, the agent run
+// in flight, and the candidate awaiting a verdict.
+//
+// seq is what makes a late answer safe. Generation outlives the keystroke that
+// started it, so a result that arrives after the user moved on has to be
+// dropped rather than drawn over whatever is on screen now -- the same reason
+// pickerState and exportState carry one.
+type authorState struct {
+	seq     int
+	step    authorStep
+	fields  [authorFieldCount]string
+	cursor  authorField
+	touched bool // the filter was hand-edited, so stop re-proposing one
+
+	gen *generate.Generator
+
+	mql         string
+	explanation string
+	warn        string // the gate rejected it, but the candidate is still offered
+	err         string
+	wrote       string
+}
+
+// authorGeneratedMsg carries one agent run's outcome back to the event loop.
+type authorGeneratedMsg struct {
+	seq         int
+	mql         string
+	explanation string
+	warn        string
+	err         error
+}
+
+// authorWroteMsg reports the write-out.
+type authorWroteMsg struct {
+	seq  int
+	path string
+	err  error
+}
+
+// authorGenerateCmd runs one generation off the event loop.
+//
+// GenerateCheck validates internally and retries, so the command returns a
+// candidate plus whatever the gate said about it rather than a bare string: a
+// query that would not compile is still worth showing, because the reviewer can
+// fix it, and hiding it costs another billed run.
+func authorGenerateCmd(seq int, gen *generate.Generator, check generate.Check) tea.Cmd {
+	return func() tea.Msg {
+		res := gen.GenerateCheck(context.Background(), check)
+		msg := authorGeneratedMsg{seq: seq}
+		switch {
+		case res.Action == generate.ActionGenerated:
+			msg.mql = bundle.SanitizeText(res.MQL)
+			msg.explanation = bundle.SanitizeText(res.Explanation)
+		case res.MQL != "":
+			// a candidate that failed its gate: offer it, and say so
+			msg.mql = bundle.SanitizeText(res.MQL)
+			msg.warn = bundle.SanitizeText(res.Reason)
+		default:
+			msg.err = res.Err
+			if msg.err == nil {
+				msg.err = errFromReason(bundle.SanitizeText(res.Reason))
+			}
+		}
+		return msg
+	}
+}
+
+// authorWriteCmd appends the accepted check to its bundle.
+func authorWriteCmd(seq int, file, uid, title, desc, filter, mql string) tea.Cmd {
+	return func() tea.Msg {
+		taken := map[string]bool{}
+		if b, err := bundle.LoadFile(file); err == nil {
+			taken = bundle.QueryUIDs(b)
+		}
+		err := bundle.AppendCheck(file, bundle.NextFreeUID(uid, taken), title, desc, filter, mql)
+		return authorWroteMsg{seq: seq, path: file, err: err}
+	}
+}
+
+// openAuthor starts a new authoring session.
+func (m Model) openAuthor() (tea.Model, tea.Cmd) {
+	gen, err := newAuthorGenerator()
+	if err != nil {
+		m.lastErr = "cannot author checks: " + err.Error()
+		return m, nil
+	}
+
+	m.author = authorState{
+		seq:  m.author.seq + 1,
+		step: authorIntent,
+		gen:  gen,
+	}
+	m.author.fields[fieldFile] = defaultAuthorFile()
+	m.phase = phaseAuthoring
+	return m, nil
+}
+
+// defaultAuthorFile is where a check lands when the user does not say.
+func defaultAuthorFile() string {
+	return "generated-policy.mql.yaml"
+}
+
+// newAuthorGenerator builds the generator the pane drives.
+//
+// Validation is wired when the machine can do it and left out when it cannot,
+// rather than refusing to author: a missing provider means the query cannot be
+// compile-checked here, which is a weaker gate, not a reason to stop.
+func newAuthorGenerator() (*generate.Generator, error) {
+	backend, err := generate.Backend("")
+	if err != nil {
+		return nil, err
+	}
+	cfg := generate.Config{Backend: backend, Explain: true}
+	if v, verr := generate.NewCompileValidator(); verr == nil {
+		cfg.Validator = v
+	}
+	return generate.New(cfg)
+}
+
+// startAuthorGeneration hands the described intent to the agent.
+func (m Model) startAuthorGeneration() (tea.Model, tea.Cmd) {
+	a := &m.author
+	title := strings.TrimSpace(a.fields[fieldTitle])
+	if title == "" {
+		a.err = "a check needs a title"
+		return m, nil
+	}
+
+	a.seq++
+	a.step = authorWorking
+	a.err, a.warn, a.mql, a.explanation = "", "", "", ""
+
+	check := generate.Check{
+		UID:   bundle.Slugify(title),
+		Title: title,
+		Desc:  strings.TrimSpace(a.fields[fieldDesc]),
+	}
+	if f := strings.TrimSpace(a.fields[fieldFilter]); f != "" {
+		check.Filters = []string{f}
+	}
+	return m, tea.Batch(authorGenerateCmd(a.seq, a.gen, check), m.spinner.Tick)
+}
+
+// authorGenerated puts a finished run on screen, if it is still the current one.
+func (m Model) authorGenerated(msg authorGeneratedMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.author.seq || m.author.step != authorWorking {
+		return m, nil
+	}
+	if msg.err != nil {
+		m.author.step = authorIntent
+		m.author.err = tui.OneLine(msg.err.Error())
+		return m, nil
+	}
+	m.author.step = authorReview
+	m.author.mql = msg.mql
+	m.author.explanation = msg.explanation
+	m.author.warn = msg.warn
+	return m, nil
+}
+
+// authorWrote reports where the check landed.
+func (m Model) authorWrote(msg authorWroteMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.author.seq {
+		return m, nil
+	}
+	if msg.err != nil {
+		m.author.step = authorReview
+		m.author.err = tui.OneLine(msg.err.Error())
+		return m, nil
+	}
+	m.author.step = authorDone
+	m.author.wrote = msg.path
+	return m, nil
+}
+
+// acceptAuthored writes the candidate under review.
+func (m Model) acceptAuthored() (tea.Model, tea.Cmd) {
+	a := &m.author
+	if strings.TrimSpace(a.mql) == "" {
+		a.err = "there is no query to write"
+		return m, nil
+	}
+	a.seq++
+	return m, authorWriteCmd(a.seq,
+		strings.TrimSpace(a.fields[fieldFile]),
+		bundle.Slugify(a.fields[fieldTitle]),
+		strings.TrimSpace(a.fields[fieldTitle]),
+		strings.TrimSpace(a.fields[fieldDesc]),
+		strings.TrimSpace(a.fields[fieldFilter]),
+		a.mql,
+	)
+}
+
+// closeAuthor returns to the launcher.
+func (m Model) closeAuthor() (tea.Model, tea.Cmd) {
+	m.author = authorState{seq: m.author.seq}
+	m.phase = phaseForm
+	return m, nil
+}
+
+// proposeFilter fills the filter from the title, unless the user typed one.
+//
+// It is a proposal rather than a default: the same guess the wizard makes, put
+// where it can be seen and corrected before it is used, because a filter naming
+// a platform that does not exist matches no asset and fails silently.
+func (a *authorState) proposeFilter() {
+	if a.touched {
+		return
+	}
+	if f := generate.DefaultFilter(generate.GuessProvider(a.fields[fieldTitle])); f != "" {
+		a.fields[fieldFilter] = f
+	}
+}
+
+// errFromReason turns a bare reason string into an error.
+func errFromReason(reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return os.ErrInvalid
+	}
+	return &authorReasonErr{reason}
+}
+
+type authorReasonErr struct{ reason string }
+
+func (e *authorReasonErr) Error() string { return e.reason }
+
+// viewAuthor draws the authoring pane.
+func (m Model) viewAuthor(l layout) string {
+	a := m.author
+	boxW, contentW := modalGeom(l.Width)
+
+	var b strings.Builder
+	b.WriteString(tui.StyleAccent.Render(tui.Truncate("Author a check", contentW)))
+	b.WriteString("\n" + tui.StyleDim.Render(tui.Truncate(
+		"describe what must be true; the agent writes the MQL", contentW)))
+	b.WriteString("\n\n")
+
+	switch a.step {
+	case authorWorking:
+		b.WriteString(m.spinner.View() + " " +
+			tui.StyleDim.Render(tui.Truncate("generating…", contentW-2)))
+		b.WriteString("\n\n" + tui.StyleFaint.Render(tui.Truncate("esc cancel", contentW)))
+
+	case authorReview, authorDone:
+		b.WriteString(tui.StyleDim.Render(tui.Truncate(a.fields[fieldTitle], contentW)) + "\n\n")
+		for _, line := range tui.Wrap(a.mql, contentW) {
+			b.WriteString(tui.StyleText.Render(line) + "\n")
+		}
+		if a.explanation != "" {
+			b.WriteString("\n")
+			for _, line := range tui.WrapWords(a.explanation, contentW) {
+				b.WriteString(tui.StyleFaint.Render(line) + "\n")
+			}
+		}
+		if a.warn != "" {
+			b.WriteString("\n" + tui.StyleWarn.Render(tui.Truncate("! "+a.warn, contentW)) + "\n")
+		}
+		b.WriteString("\n")
+		if a.step == authorDone {
+			b.WriteString(tui.StyleAccent.Render(tui.Truncate("written to "+a.wrote, contentW)))
+			b.WriteString("\n\n" + tui.StyleFaint.Render(tui.Truncate(
+				"a author another · esc done", contentW)))
+		} else {
+			b.WriteString(tui.StyleFaint.Render(tui.Truncate(
+				"enter accept & write · r regenerate · esc cancel", contentW)))
+		}
+
+	default:
+		for f := authorField(0); f < authorFieldCount; f++ {
+			label := f.label()
+			value := a.fields[f]
+			line := tui.Truncate(label+": "+value, contentW-2)
+			if f == a.cursor {
+				b.WriteString(tui.Bar("▸ "+line+"▌", contentW, tui.BandSelected) + "\n")
+				continue
+			}
+			b.WriteString("  " + tui.StyleText.Render(line) + "\n")
+		}
+		b.WriteString("\n" + tui.StyleFaint.Render(tui.Truncate(a.cursor.hint(), contentW)))
+		b.WriteString("\n\n" + tui.StyleFaint.Render(tui.Truncate(
+			"↑/↓ move · type to edit · ^g generate · esc cancel", contentW)))
+	}
+
+	if a.err != "" {
+		b.WriteString("\n" + tui.StyleWarn.Render(tui.Truncate("! "+a.err, contentW)))
+	}
+
+	box := modalBox.Width(boxW).Render(b.String())
+	return lipgloss.Place(l.Width, l.BodyH, lipgloss.Center, lipgloss.Center, box)
+}
+
+// updateAuthoring drives the authoring pane. It owns the screen while it is up,
+// so it handles every message rather than falling through to the launcher --
+// the same contract phaseScanning and phaseViewing have.
+func (m Model) updateAuthoring(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if m.author.step != authorWorking {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case authorGeneratedMsg:
+		return m.authorGenerated(msg)
+
+	case authorWroteMsg:
+		return m.authorWrote(msg)
+
+	case tea.KeyMsg:
+		return m.authorKey(msg)
+	}
+	return m, nil
+}
+
+// authorKey is the pane's keyboard.
+func (m Model) authorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	a := &m.author
+
+	switch a.step {
+	case authorWorking:
+		// The run is not cancellable mid-flight -- the agent is a child process
+		// with its own timeout -- so esc leaves the pane and the late answer is
+		// dropped by its sequence number rather than drawn over the launcher.
+		if msg.String() == "esc" || msg.String() == "ctrl+c" {
+			a.seq++
+			return m.closeAuthor()
+		}
+		return m, nil
+
+	case authorReview:
+		switch msg.String() {
+		case "enter":
+			return m.acceptAuthored()
+		case "r":
+			return m.startAuthorGeneration()
+		case "esc":
+			return m.closeAuthor()
+		}
+		return m, nil
+
+	case authorDone:
+		switch msg.String() {
+		case "a":
+			// another check, same file: keep the destination, drop the intent
+			file := a.fields[fieldFile]
+			gen := a.gen
+			m.author = authorState{seq: a.seq + 1, gen: gen}
+			m.author.fields[fieldFile] = file
+			return m, nil
+		case "esc", "enter":
+			return m.closeAuthor()
+		}
+		return m, nil
+	}
+
+	// authorIntent
+	switch msg.String() {
+	case "esc":
+		return m.closeAuthor()
+	case "up", "shift+tab":
+		if a.cursor > 0 {
+			a.cursor--
+		}
+		return m, nil
+	case "down", "tab":
+		if a.cursor < authorFieldCount-1 {
+			a.cursor++
+		}
+		return m, nil
+	case "ctrl+g", "enter":
+		if a.cursor < authorFieldCount-1 && msg.String() == "enter" {
+			// enter advances through the fields; only the last one, or ^g
+			// anywhere, commits. Generating from a half-filled form wastes a
+			// billed run on an intent the user was still writing.
+			a.cursor++
+			a.proposeFilter()
+			return m, nil
+		}
+		return m.startAuthorGeneration()
+	case "backspace":
+		a.fields[a.cursor] = trimLastRune(a.fields[a.cursor])
+		if a.cursor == fieldFilter {
+			a.touched = true
+		}
+		return m, nil
+	}
+
+	if msg.Type == tea.KeyRunes {
+		a.fields[a.cursor] += string(msg.Runes)
+		if a.cursor == fieldFilter {
+			a.touched = true
+		}
+		if a.cursor == fieldTitle {
+			a.proposeFilter()
+		}
+		return m, nil
+	}
+	if msg.Type == tea.KeySpace {
+		a.fields[a.cursor] += " "
+		return m, nil
+	}
+	return m, nil
+}

--- a/apps/cnspec/cmd/interactive/author.go
+++ b/apps/cnspec/cmd/interactive/author.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"go.mondoo.com/cnspec/cli/tui"
@@ -66,6 +67,21 @@ func (f authorField) label() string {
 	}
 }
 
+// placeholder is what an empty field shows, so a blank row reads as "not filled
+// in yet" rather than as a value that failed to load.
+func (f authorField) placeholder() string {
+	switch f {
+	case fieldTitle:
+		return "SSH must not permit direct root login"
+	case fieldDesc:
+		return "PermitRootLogin must be set to no"
+	case fieldFilter:
+		return "proposed from the title once you type one"
+	default:
+		return "generated-policy.mql.yaml"
+	}
+}
+
 func (f authorField) hint() string {
 	switch f {
 	case fieldTitle:
@@ -95,11 +111,66 @@ type authorState struct {
 
 	gen *generate.Generator
 
+	// input edits whichever field has the cursor. It is the same arrangement
+	// detailState uses: one text box bound to the focused field, loaded on
+	// entry and stored on the way out, so the cursor is real rather than a
+	// block drawn at the end of a string.
+	input textinput.Model
+
 	mql         string
 	explanation string
 	warn        string // the gate rejected it, but the candidate is still offered
 	err         string
 	wrote       string
+}
+
+// loadField binds the text box to the field under the cursor.
+func (a *authorState) loadField() {
+	a.input.SetValue(a.fields[a.cursor])
+	a.input.CursorEnd()
+	a.input.Focus()
+}
+
+// storeField writes the text box back into the focused field.
+func (a *authorState) storeField() {
+	a.fields[a.cursor] = a.input.Value()
+}
+
+// moveCursor stores the field being left and binds the one being entered, so
+// the box and the field under the cursor never disagree.
+func (a *authorState) moveCursor(to authorField) {
+	if to < 0 || to >= authorFieldCount {
+		return
+	}
+	a.storeField()
+	a.cursor = to
+	a.loadField()
+}
+
+// newAuthorState builds an authoring pane ready to type into.
+//
+// It exists because every field of authorState has a usable zero value except
+// one: a zero textinput.Model panics the first time it is focused. Two paths
+// built the state by literal -- opening the pane and "author another" -- and
+// only one of them remembered the box.
+func newAuthorState(seq int, gen *generate.Generator, file string) authorState {
+	a := authorState{
+		seq:   seq,
+		step:  authorIntent,
+		gen:   gen,
+		input: newAuthorInput(),
+	}
+	a.fields[fieldFile] = file
+	a.loadField()
+	return a
+}
+
+// newAuthorInput is the text box the pane edits with.
+func newAuthorInput() textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = ""
+	ti.CharLimit = 0
+	return ti
 }
 
 // authorGeneratedMsg carries one agent run's outcome back to the event loop.
@@ -166,12 +237,7 @@ func (m Model) openAuthor() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	m.author = authorState{
-		seq:  m.author.seq + 1,
-		step: authorIntent,
-		gen:  gen,
-	}
-	m.author.fields[fieldFile] = defaultAuthorFile()
+	m.author = newAuthorState(m.author.seq+1, gen, defaultAuthorFile())
 	m.phase = phaseAuthoring
 	return m, nil
 }
@@ -347,15 +413,28 @@ func (m Model) viewAuthor(l layout) string {
 		}
 
 	default:
+		// Only the label takes the selection band; the value keeps its own
+		// styling so the text cursor stays visible. Banding the whole row is
+		// what a list does, and it turns an empty field into a solid slab --
+		// see the same split in view.go's field rows.
+		const labelW = 18
 		for f := authorField(0); f < authorFieldCount; f++ {
-			label := f.label()
+			label := tui.PadRight(f.label(), labelW)
+
 			value := a.fields[f]
-			line := tui.Truncate(label+": "+value, contentW-2)
+			display := value
 			if f == a.cursor {
-				b.WriteString(tui.Bar("▸ "+line+"▌", contentW, tui.BandSelected) + "\n")
+				display = a.input.View()
+			} else if strings.TrimSpace(value) == "" {
+				display = tui.StyleFaint.Render(f.placeholder())
+			}
+
+			if f == a.cursor {
+				b.WriteString(tui.BandSelected.Render(cursorMark+label) + " " + display + "\n")
 				continue
 			}
-			b.WriteString("  " + tui.StyleText.Render(line) + "\n")
+			b.WriteString("  " + tui.StyleDim.Render(label) + " " +
+				tui.Truncate(display, max(contentW-labelW-3, 8)) + "\n")
 		}
 		b.WriteString("\n" + tui.StyleFaint.Render(tui.Truncate(a.cursor.hint(), contentW)))
 		b.WriteString("\n\n" + tui.StyleFaint.Render(tui.Truncate(
@@ -429,10 +508,8 @@ func (m Model) authorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "a":
 			// another check, same file: keep the destination, drop the intent
-			file := a.fields[fieldFile]
-			gen := a.gen
-			m.author = authorState{seq: a.seq + 1, gen: gen}
-			m.author.fields[fieldFile] = file
+			// another check, same file: keep the destination, drop the intent
+			m.author = newAuthorState(a.seq+1, a.gen, a.fields[fieldFile])
 			return m, nil
 		case "esc", "enter":
 			return m.closeAuthor()
@@ -445,46 +522,38 @@ func (m Model) authorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		return m.closeAuthor()
 	case "up", "shift+tab":
-		if a.cursor > 0 {
-			a.cursor--
-		}
+		a.moveCursor(a.cursor - 1)
 		return m, nil
 	case "down", "tab":
-		if a.cursor < authorFieldCount-1 {
-			a.cursor++
-		}
+		a.moveCursor(a.cursor + 1)
+		a.proposeFilter()
 		return m, nil
-	case "ctrl+g", "enter":
-		if a.cursor < authorFieldCount-1 && msg.String() == "enter" {
-			// enter advances through the fields; only the last one, or ^g
-			// anywhere, commits. Generating from a half-filled form wastes a
-			// billed run on an intent the user was still writing.
-			a.cursor++
+	case "ctrl+g":
+		a.storeField()
+		return m.startAuthorGeneration()
+	case "enter":
+		// enter walks the fields; only the last one commits. Generating from a
+		// half-filled form spends a billed run on an intent still being
+		// written.
+		if a.cursor < authorFieldCount-1 {
+			a.moveCursor(a.cursor + 1)
 			a.proposeFilter()
 			return m, nil
 		}
+		a.storeField()
 		return m.startAuthorGeneration()
-	case "backspace":
-		a.fields[a.cursor] = trimLastRune(a.fields[a.cursor])
-		if a.cursor == fieldFilter {
-			a.touched = true
-		}
-		return m, nil
 	}
 
-	if msg.Type == tea.KeyRunes {
-		a.fields[a.cursor] += string(msg.Runes)
-		if a.cursor == fieldFilter {
-			a.touched = true
-		}
-		if a.cursor == fieldTitle {
-			a.proposeFilter()
-		}
-		return m, nil
+	// everything else is typing: the text box handles runes, backspace, and
+	// the cursor keys within the line.
+	var cmd tea.Cmd
+	a.input, cmd = a.input.Update(msg)
+	a.storeField()
+	if a.cursor == fieldFilter {
+		a.touched = true
 	}
-	if msg.Type == tea.KeySpace {
-		a.fields[a.cursor] += " "
-		return m, nil
+	if a.cursor == fieldTitle {
+		a.proposeFilter()
 	}
-	return m, nil
+	return m, cmd
 }

--- a/apps/cnspec/cmd/interactive/author_test.go
+++ b/apps/cnspec/cmd/interactive/author_test.go
@@ -21,8 +21,7 @@ func authoringModel(t *testing.T) Model {
 	t.Helper()
 	m := newTestModel()
 	m.phase = phaseAuthoring
-	m.author = authorState{seq: 1, step: authorIntent}
-	m.author.fields[fieldFile] = filepath.Join(t.TempDir(), "out.mql.yaml")
+	m.author = newAuthorState(1, nil, filepath.Join(t.TempDir(), "out.mql.yaml"))
 	return m
 }
 
@@ -217,5 +216,68 @@ func TestAuthorSurfacesAWriteFailure(t *testing.T) {
 	}
 	if m.author.step == authorDone {
 		t.Error("a failed write was reported as done")
+	}
+}
+
+// TestAuthorAnotherCheckAcceptsTyping pins a crash: "author another" rebuilt
+// the pane by struct literal and left the text box zero-valued, so the next
+// keystroke panicked on a nil cursor. Every field of authorState has a usable
+// zero value except that one, which is why construction goes through
+// newAuthorState.
+func TestAuthorAnotherCheckAcceptsTyping(t *testing.T) {
+	m := authoringModel(t)
+	m.author.step = authorDone
+	m.author.wrote = "out.mql.yaml"
+
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = nm.(Model)
+	if m.author.step != authorIntent {
+		t.Fatalf("'a' did not start another check, step=%d", m.author.step)
+	}
+
+	// the keystroke that used to panic
+	m = typeString(m, "another check")
+	if got := m.author.fields[fieldTitle]; got != "another check" {
+		t.Errorf("typing after 'author another' did not reach the title: %q", got)
+	}
+}
+
+// TestAuthorFocusedRowDrawsTheLiveInput pins the difference between a form
+// field and a menu row.
+//
+// The focused row has to draw the text box, because that is what carries the
+// cursor. Drawing the stored string instead -- or banding the whole row the way
+// a list selection does -- leaves an empty field as a slab of accent colour
+// with nothing to show where typing would go. view.go makes the same split for
+// the connector form: only the label takes the band.
+//
+// The assertion is on the value drawn rather than on colour, because lipgloss
+// emits no escape codes without a TTY and a test for them passes vacuously in
+// CI.
+func TestAuthorFocusedRowDrawsTheLiveInput(t *testing.T) {
+	m := authoringModel(t)
+	m.author.moveCursor(fieldTitle)
+
+	// force a divergence the renderer has to resolve one way or the other
+	m.author.fields[fieldTitle] = "STORED"
+	m.author.input.SetValue("LIVE")
+
+	view := m.View()
+	if !strings.Contains(view, "LIVE") {
+		t.Error("the focused row does not draw the text box, so it carries no cursor")
+	}
+	if strings.Contains(view, "STORED") {
+		t.Error("the focused row drew the stored value instead of the live input")
+	}
+}
+
+// TestAuthorEmptyFieldShowsAPlaceholder: a blank row must read as "not filled
+// in yet", not as a value that failed to load.
+func TestAuthorEmptyFieldShowsAPlaceholder(t *testing.T) {
+	m := authoringModel(t)
+	m.author.moveCursor(fieldTitle) // so Desc is unfocused and empty
+
+	if !strings.Contains(m.View(), fieldDesc.placeholder()) {
+		t.Errorf("an empty unfocused field shows nothing at all:\n%s", m.View())
 	}
 }

--- a/apps/cnspec/cmd/interactive/author_test.go
+++ b/apps/cnspec/cmd/interactive/author_test.go
@@ -1,0 +1,221 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package interactive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/internal/bundle"
+)
+
+// authoringModel opens the authoring pane without requiring a coding agent on
+// the machine: openAuthor builds a real generator, which needs an installed
+// agent CLI, and nothing below exercises generation itself.
+func authoringModel(t *testing.T) Model {
+	t.Helper()
+	m := newTestModel()
+	m.phase = phaseAuthoring
+	m.author = authorState{seq: 1, step: authorIntent}
+	m.author.fields[fieldFile] = filepath.Join(t.TempDir(), "out.mql.yaml")
+	return m
+}
+
+func TestAuthorPaneTakesTheScreen(t *testing.T) {
+	m := authoringModel(t)
+	view := m.View()
+	if !strings.Contains(view, "Author a check") {
+		t.Fatalf("authoring pane is not on screen:\n%s", view)
+	}
+	// the launcher behind it must not also be drawing its list
+	if strings.Contains(view, "a remote system via SSH") {
+		t.Error("the connector list is visible behind the authoring pane")
+	}
+}
+
+func TestAuthorFooterHintIsOffered(t *testing.T) {
+	m := newTestModel()
+	if !strings.Contains(m.View(), "^g") {
+		t.Error("the launcher does not offer the authoring key")
+	}
+}
+
+func TestCtrlGOpensAuthoring(t *testing.T) {
+	m := newTestModel()
+	nm, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	got := nm.(Model)
+	// On a machine with no coding agent installed openAuthor reports why
+	// instead of opening; either outcome is correct, silence is not.
+	if got.phase != phaseAuthoring && got.lastErr == "" {
+		t.Error("^g neither opened the authoring pane nor said why it could not")
+	}
+}
+
+// TestAuthorEnterAdvancesRatherThanGenerating pins the guard on a billed call:
+// enter walks the fields, and only the last one commits.
+func TestAuthorEnterAdvancesRatherThanGenerating(t *testing.T) {
+	m := authoringModel(t)
+	m = typeString(m, "SSH must not permit root login")
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = nm.(Model)
+	if m.author.cursor != fieldDesc {
+		t.Fatalf("enter did not advance to the description, cursor=%d", m.author.cursor)
+	}
+	if m.author.step == authorWorking || cmd != nil {
+		t.Error("enter on the first field started a generation")
+	}
+}
+
+// TestAuthorProposesFilterFromTitle pins that the guess is shown for review
+// rather than applied invisibly, and that it uses a platform name that exists.
+func TestAuthorProposesFilterFromTitle(t *testing.T) {
+	m := authoringModel(t)
+	m = typeString(m, "kubernetes pod must not run privileged")
+
+	got := m.author.fields[fieldFilter]
+	if got == "" {
+		t.Fatal("no asset filter was proposed for a Kubernetes check")
+	}
+	if strings.Contains(got, `asset.platform == "k8s"`) {
+		t.Errorf("proposed a platform that does not exist: %q", got)
+	}
+	if !strings.Contains(got, "k8s-cluster") {
+		t.Errorf("proposed filter does not scope to a real k8s platform: %q", got)
+	}
+}
+
+// TestAuthorKeepsAHandEditedFilter: a proposal must never overwrite the user.
+func TestAuthorKeepsAHandEditedFilter(t *testing.T) {
+	m := authoringModel(t)
+	m.author.cursor = fieldFilter
+	m = typeString(m, "asset.platform == \"custom\"")
+
+	m.author.cursor = fieldTitle
+	m = typeString(m, "aws s3 bucket must be encrypted")
+
+	if got := m.author.fields[fieldFilter]; got != `asset.platform == "custom"` {
+		t.Errorf("a hand-written filter was overwritten by a proposal: %q", got)
+	}
+}
+
+// TestAuthorDropsStaleGeneration is why authorState carries a sequence number.
+//
+// The hazard is not a result arriving after the pane closed -- the phase
+// dispatch already drops that, without consulting seq. It is a result from an
+// abandoned run arriving while a *later* run is in flight: both are addressed
+// to an open authoring pane, and only the sequence number tells them apart. A
+// test that merely cancels and delivers proves nothing; this one passed with
+// the guard deleted until it was rewritten to start the second run.
+func TestAuthorDropsStaleGeneration(t *testing.T) {
+	m := authoringModel(t)
+	m.author.step = authorWorking
+	stale := m.author.seq
+
+	// the user regenerates: run one is abandoned, run two is now in flight
+	m.author.seq++
+	current := m.author.seq
+
+	nm, _ := m.Update(authorGeneratedMsg{seq: stale, mql: "should.not.appear"})
+	m = nm.(Model)
+
+	if m.author.mql == "should.not.appear" {
+		t.Error("an abandoned run's answer replaced the one in flight")
+	}
+	if m.author.step != authorWorking {
+		t.Errorf("an abandoned run's answer ended the wait for the current one, step=%d", m.author.step)
+	}
+
+	// and the run actually in flight still lands
+	nm, _ = m.Update(authorGeneratedMsg{seq: current, mql: "expected.query"})
+	m = nm.(Model)
+	if m.author.mql != "expected.query" {
+		t.Errorf("the current run's answer did not land, got %q", m.author.mql)
+	}
+}
+
+// TestAuthorWritesScannableBundle is the end of the flow: what the pane accepts
+// has to be a bundle cnspec can actually scan, which means a policy group and
+// not a bare top-level query.
+func TestAuthorWritesScannableBundle(t *testing.T) {
+	m := authoringModel(t)
+	file := m.author.fields[fieldFile]
+	m.author.fields[fieldTitle] = "SSH must not permit root login"
+	m.author.fields[fieldDesc] = "PermitRootLogin must be no"
+	m.author.fields[fieldFilter] = `asset.family.contains("linux")`
+	m.author.mql = `sshd.config.params["PermitRootLogin"] == "no"`
+	m.author.step = authorReview
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = nm.(Model)
+	if cmd == nil {
+		t.Fatal("accepting the candidate produced no write")
+	}
+	msg := cmd()
+	nm, _ = m.Update(msg)
+	m = nm.(Model)
+
+	if m.author.step != authorDone {
+		t.Fatalf("write did not complete: step=%d err=%q", m.author.step, m.author.err)
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("nothing was written: %v", err)
+	}
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		t.Fatalf("what was written does not parse: %v", err)
+	}
+	if len(b.Policies) == 0 {
+		t.Fatal("no policy was written; a bare top-level query is not scannable")
+	}
+	var found bool
+	for _, g := range b.Policies[0].Groups {
+		for _, c := range g.Checks {
+			if c != nil && strings.Contains(c.Mql, "PermitRootLogin") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("the accepted check is not in a policy group:\n%s", data)
+	}
+}
+
+// TestAuthorRefusesAnEmptyQuery: accepting nothing must not write a check with
+// an empty body, which lints clean and never fails.
+func TestAuthorRefusesAnEmptyQuery(t *testing.T) {
+	m := authoringModel(t)
+	m.author.step = authorReview
+	m.author.fields[fieldTitle] = "something"
+
+	nm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = nm.(Model)
+	if cmd != nil {
+		t.Error("accepting an empty candidate started a write")
+	}
+	if m.author.err == "" {
+		t.Error("accepting an empty candidate said nothing")
+	}
+}
+
+// TestAuthorSurfacesAWriteFailure: a check the user accepted and that did not
+// land has to say so, not return to the launcher as though it had.
+func TestAuthorSurfacesAWriteFailure(t *testing.T) {
+	m := authoringModel(t)
+	m.author.step = authorReview
+	nm, _ := m.Update(authorWroteMsg{seq: m.author.seq, err: errors.New("disk full")})
+	m = nm.(Model)
+	if !strings.Contains(m.author.err, "disk full") {
+		t.Errorf("a failed write was not reported: %q", m.author.err)
+	}
+	if m.author.step == authorDone {
+		t.Error("a failed write was reported as done")
+	}
+}

--- a/apps/cnspec/cmd/interactive/model.go
+++ b/apps/cnspec/cmd/interactive/model.go
@@ -66,6 +66,13 @@ type Model struct {
 	// outlives a keypress the same way launching does, and for the same reason
 	// -- the OS keychain dialog.
 	export exportState
+	// author is the check-authoring pane: the intent being described, the
+	// agent run in flight, and the candidate awaiting a verdict. See author.go.
+	//
+	// A sibling of scan for the same reason export is a sibling of launching:
+	// it outlives the keypress that started it, and the run it is waiting on
+	// answers to a sequence number rather than to whatever is on screen.
+	author authorState
 
 	// --- the launcher's own chrome ------------------------------------------
 
@@ -276,6 +283,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateScanning(msg)
 	case phaseViewing:
 		return m.updateViewing(msg)
+	case phaseAuthoring:
+		return m.updateAuthoring(msg)
 	}
 
 	switch msg := msg.(type) {
@@ -398,6 +407,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// up and must not be left standing behind another box.
 	if msg.String() == "ctrl+e" {
 		return m.openExport()
+	}
+
+	// Authoring is the launcher's other verb: it writes a check rather than
+	// running one. Reachable from the form for the same reason export is --
+	// it acts on the session, not on the connector under the cursor.
+	if msg.String() == "ctrl+g" {
+		return m.openAuthor()
 	}
 
 	// The report of the last scan is still in memory, so leaving the viewer is

--- a/apps/cnspec/cmd/interactive/phases.go
+++ b/apps/cnspec/cmd/interactive/phases.go
@@ -26,6 +26,10 @@ const (
 	phaseForm phase = iota
 	phaseScanning
 	phaseViewing
+	// phaseAuthoring is the check-authoring pane. It leads back to phaseForm
+	// like the other two: the point of holding the terminal is that the next
+	// thing the user does does not need a new program.
+	phaseAuthoring
 )
 
 // startScan moves the launcher onto the scanning screen and forks the child.

--- a/apps/cnspec/cmd/interactive/view.go
+++ b/apps/cnspec/cmd/interactive/view.go
@@ -88,6 +88,12 @@ func (m Model) View() string {
 			clipLines(m.scan.view(l, m.spinner.View()), l.BodyH) + "\n" + m.scan.viewFooter(l)
 	}
 
+	// Authoring takes the body outright: it is a different verb from the one
+	// the two panes behind it describe, and its keys mean what it says they do.
+	if m.phase == phaseAuthoring {
+		return m.viewHeader(l) + "\n" + clipLines(m.viewAuthor(l), l.BodyH) + "\n" + m.viewFooter(l)
+	}
+
 	// An open picker takes over the body: nothing moves behind it, and the
 	// arrow keys mean one thing while it is up.
 	// The reporting chooser takes the body the way a picker does: while it is
@@ -592,6 +598,7 @@ func (m Model) viewFooter(l layout) string {
 	// Shown even without credentials: the chooser is where a user finds out
 	// why their scans stay local and what to do about it.
 	hints += tui.HintSep + tui.Kbd("^r", "reporting")
+	hints += tui.HintSep + tui.Kbd("^g", "author")
 	hints += m.exportHint()
 	if m.viewer.loaded {
 		// Only offered once there is one. A key hint for a report that does not

--- a/apps/cnspec/cmd/policy_generate.go
+++ b/apps/cnspec/cmd/policy_generate.go
@@ -1,0 +1,482 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/generate"
+	"go.mondoo.com/cnspec/policy"
+)
+
+func init() {
+	policyGenerateCmd.Flags().StringP("output", "o", "", "Write the result to this file (default: stdout, unless --in-place)")
+	policyGenerateCmd.Flags().Bool("in-place", false, "Modify the input file(s) directly")
+	policyGenerateCmd.Flags().Bool("dry-run", false, "Preview what would be generated without writing anything")
+	policyGenerateCmd.Flags().Bool("force", false, "Regenerate queries that already have mql (overwrites existing MQL)")
+	policyGenerateCmd.Flags().Bool("explain", false, "Include the agent's reasoning for each generated query")
+	policyGenerateCmd.Flags().String("agent", "", "Coding agent backend: "+strings.Join(generate.BackendNames(), ", ")+" (default: auto-detect)")
+	policyGenerateCmd.Flags().String("model", "", "Model to pass through to the agent CLI")
+	policyGenerateCmd.Flags().String("corpus", "", "Path to policy bundles used as grounding examples (default: ./content if present, else the input files)")
+	policyGenerateCmd.Flags().Bool("no-validate", false, "Skip in-process MQL compile validation of generated queries")
+	policyGenerateCmd.Flags().String("test-target", "", "Execute-and-assert generated MQL against this live target (e.g. local, aws, gcp, azure): requires each query to resolve to a concrete true/false verdict, not just compile")
+	policyGenerateCmd.Flags().String("test-recording", "", "Execute-and-assert generated MQL against a recording file (reproducible, no live credentials)")
+	policyGenerateCmd.Flags().BoolP("interactive", "i", false, "Guided authoring: describe a check, generate, review (accept/edit/regenerate), and write it out")
+	policyCmd.AddCommand(policyGenerateCmd)
+}
+
+var policyGenerateCmd = &cobra.Command{
+	Use:   "generate [path ...]",
+	Short: "Generate MQL for policy checks from their title and description",
+	Long: `Generate MQL for policy checks that have a title and description but no mql yet.
+
+cnspec drives the workflow — reading each check's intent, resolving its target
+provider from filters, searching similar existing checks for grounding, and
+validating the result — and delegates the model call to a coding-agent CLI you
+already have installed and authenticated (Claude Code, Codex, Kimi, DeepSeek).
+cnspec ships no LLM SDK and stores no API keys; the agent brings its own model.
+
+Checks that already have mql are left untouched unless you pass --force. The
+generated MQL is validated by compiling it in-process before it is written.
+
+Security note: each check's title and description are sent to the coding-agent
+CLI as its prompt. Because that agent can run tools and commands, only run this
+on policy bundles you trust — a crafted description in an untrusted bundle is
+prompt-injection input to your agent.
+
+Examples:
+  cnspec policy generate policy.mql.yaml --in-place
+  cnspec policy generate policy.mql.yaml --agent codex --explain
+  cnspec policy generate ./content --dry-run
+  cnspec policy generate --interactive          # guided, one check at a time`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runPolicyGenerate,
+}
+
+func runPolicyGenerate(cmd *cobra.Command, args []string) error {
+	inPlace, _ := cmd.Flags().GetBool("in-place")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	force, _ := cmd.Flags().GetBool("force")
+	explain, _ := cmd.Flags().GetBool("explain")
+	noValidate, _ := cmd.Flags().GetBool("no-validate")
+	agentName, _ := cmd.Flags().GetString("agent")
+	model, _ := cmd.Flags().GetString("model")
+	outputFile, _ := cmd.Flags().GetString("output")
+	corpusPath, _ := cmd.Flags().GetString("corpus")
+	testTarget, _ := cmd.Flags().GetString("test-target")
+	testRecording, _ := cmd.Flags().GetString("test-recording")
+	interactive, _ := cmd.Flags().GetBool("interactive")
+
+	if testTarget != "" && testRecording != "" {
+		return fmt.Errorf("use only one of --test-target or --test-recording")
+	}
+	if noValidate && (testTarget != "" || testRecording != "") {
+		return fmt.Errorf("--no-validate cannot be combined with --test-target/--test-recording (they request validation)")
+	}
+
+	// Guided authoring when explicitly requested, or when no path is given and we
+	// have an interactive terminal.
+	interactive = interactive || (len(args) == 0 && isatty.IsTerminal(os.Stdin.Fd()))
+
+	// The guided flow writes each accepted check into the bundle file you name,
+	// which is already "in place"; --in-place has nothing to modify there.
+	// Accepting it silently (as it did) reads as if it took effect. Note this is
+	// reachable without typing -i: it turns itself on for a bare tty run.
+	if interactive && inPlace {
+		return fmt.Errorf("--in-place cannot be combined with the guided flow (--interactive); the wizard writes into the bundle file you name")
+	}
+
+	backend, err := generate.Backend(agentName)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Using agent backend: %s\n", backend.Name())
+
+	var validator generate.Validator
+	switch {
+	case noValidate:
+		validator = generate.NoopValidator{}
+		fmt.Fprintln(os.Stderr, "Warning: MQL validation disabled (--no-validate); generated queries are not compile-checked.")
+	case testTarget != "" || testRecording != "":
+		var runtime generate.RuntimeLike
+		var cleanup func()
+		var label string
+		if testRecording != "" {
+			runtime, cleanup, err = generate.ConnectRecording(testRecording)
+			label = "recording " + testRecording
+		} else {
+			// Executing agent-generated MQL against a live target runs it before
+			// human review; on the os provider that includes command()/file().
+			// Only safe with trusted bundles. --test-recording avoids this.
+			fmt.Fprintf(os.Stderr, "Warning: --test-target %q executes generated MQL against a live system before you review it; only use it with policy bundles you trust.\n", testTarget)
+			runtime, cleanup, err = generate.ConnectTarget(testTarget)
+			label = "target " + testTarget
+		}
+		if err != nil {
+			return fmt.Errorf("could not connect to %s: %w", label, err)
+		}
+		defer cleanup()
+		validator, err = generate.NewExecuteValidator(generate.NewRuntimeRunner(runtime), nil)
+		if err != nil {
+			return fmt.Errorf("could not initialize execute-and-assert validation: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Validation: compile + execute-and-assert against %s\n", label)
+	default:
+		validator, err = generate.NewCompileValidator()
+		if err != nil {
+			validator = generate.NoopValidator{}
+			log.Warn().Err(err).Msg("could not initialize MQL validation; generated queries will not be compile-checked")
+		}
+	}
+
+	corpus := loadGenerateCorpus(corpusPath, args)
+
+	gen, err := generate.New(generate.Config{
+		Backend:    backend,
+		Corpus:     corpus,
+		Validator:  validator,
+		Model:      model,
+		Force:      force,
+		Explain:    explain,
+		SkillPaths: findSkills(),
+	})
+	if err != nil {
+		return err
+	}
+
+	if interactive {
+		opts := wizardOpts{
+			In:     cmd.InOrStdin(),
+			Out:    os.Stderr,
+			DryRun: dryRun,
+		}
+		switch {
+		case outputFile != "":
+			// --output names the bundle to write to, so don't ask for it again
+			opts.File, opts.FileFromFlag = outputFile, true
+		case len(args) > 0:
+			opts.File = args[0]
+		}
+		return runGenerateWizard(cmd.Context(), gen, opts)
+	}
+
+	files, err := policy.WalkPolicyBundleFiles(args...)
+	if err != nil {
+		return fmt.Errorf("could not find bundle files: %w", err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no .mql.yaml bundle files found; pass a bundle path or use --interactive")
+	}
+	if len(files) > 1 && outputFile != "" {
+		return fmt.Errorf("--output cannot be used with multiple input files; use --in-place")
+	}
+	if len(files) > 1 && !inPlace && !dryRun && outputFile == "" {
+		return fmt.Errorf("multiple input files require --in-place (or --dry-run to preview)")
+	}
+
+	var totalGenerated, totalFailed int
+	var fileErrs []string
+	for _, f := range files {
+		// A hard error on one file must not abort the batch or leave the user
+		// guessing which files were written; record it and continue.
+		g, failed, ferr := generateForFile(cmd.Context(), gen, f, force, dryRun, inPlace, outputFile, explain)
+		totalGenerated += g
+		totalFailed += failed
+		if ferr != nil {
+			fmt.Fprintf(os.Stderr, "  error on %s: %v\n", f, ferr)
+			fileErrs = append(fileErrs, f+": "+ferr.Error())
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\nDone: %d generated, %d failed across %d file(s)\n", totalGenerated, totalFailed, len(files))
+	if len(fileErrs) > 0 {
+		return fmt.Errorf("%d file(s) errored:\n  %s", len(fileErrs), strings.Join(fileErrs, "\n  "))
+	}
+	if totalFailed > 0 {
+		return fmt.Errorf("%d check(s) failed to generate", totalFailed)
+	}
+	return nil
+}
+
+func generateForFile(ctx context.Context, gen *generate.Generator, file string, force, dryRun, inPlace bool, outputFile string, explain bool) (generated, failed int, err error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return 0, 0, fmt.Errorf("could not read %s: %w", file, err)
+	}
+	raw, err := bundle.ParseYaml(data)
+	if err != nil {
+		return 0, 0, fmt.Errorf("could not parse %s: %w", file, err)
+	}
+
+	// Enumerate query definitions, skipping uid-only references (a policy group's
+	// `checks:` entry that points at a top-level definition would otherwise be
+	// processed twice). We keep the query pointers aligned with the checks so
+	// generated MQL is written back to the exact definition. Variant leaves
+	// inherit their intent from the parent that declares them.
+	variantParents := bundle.VariantParents(raw)
+	var targets []*bundle.Mquery
+	var checks []generate.Check
+	for _, q := range bundle.AllQueries(raw) {
+		title := q.Title
+		desc := bundle.QueryDesc(q)
+		props := bundleProps(q)
+		if strings.TrimSpace(title) == "" && strings.TrimSpace(desc) == "" {
+			if parent, ok := variantParents[q.Uid]; ok {
+				title = parent.Title
+				desc = bundle.QueryDesc(parent)
+				// the leaf's intent came from the parent; the props its wording
+				// references live on the parent too, so inherit them when the leaf
+				// declares none of its own.
+				if len(props) == 0 {
+					props = bundleProps(parent)
+				}
+			}
+		}
+		if strings.TrimSpace(title) == "" && strings.TrimSpace(desc) == "" && strings.TrimSpace(q.Mql) == "" {
+			continue // pure reference or empty stub — nothing to generate or write
+		}
+		targets = append(targets, q)
+		checks = append(checks, generate.Check{
+			UID:         q.Uid,
+			Title:       title,
+			Desc:        desc,
+			Filters:     bundle.QueryFilterStrings(q),
+			Mql:         q.Mql,
+			Props:       props,
+			HasVariants: bundle.QueryHasVariants(q),
+		})
+	}
+
+	needGen := 0
+	for _, c := range checks {
+		willGenerate := !c.HasVariants && (strings.TrimSpace(c.Mql) == "" || force)
+		if willGenerate {
+			needGen++
+		}
+	}
+
+	// stdout is the output *file* in this mode (`generate in.yaml > out.yaml`), so
+	// it has to carry the bundle even when nothing changed — see passThrough.
+	stdoutMode := !dryRun && !inPlace && outputFile == ""
+
+	fmt.Fprintf(os.Stderr, "\nGenerating MQL: %s\n", file)
+	fmt.Fprintf(os.Stderr, "  Total queries:   %d\n", len(checks))
+	fmt.Fprintf(os.Stderr, "  Need generation: %d\n\n", needGen)
+	if needGen == 0 {
+		fmt.Fprintln(os.Stderr, "  Nothing to generate.")
+		if stdoutMode {
+			passThrough(data)
+		}
+		return 0, 0, nil
+	}
+
+	results := gen.Generate(ctx, checks, func(r generate.Result) {
+		switch r.Action {
+		// everything printed here comes from outside cnspec — the uid from a bundle
+		// this run did not author, the explanation and reason from the agent — so
+		// it goes through the same normalization that writes text into a bundle.
+		// Otherwise an ANSI escape in any of them repaints this progress log.
+		case generate.ActionGenerated:
+			fmt.Fprintf(os.Stderr, "  ✓ %s: generated\n", bundle.SanitizeText(r.UID))
+			if explain && r.Explanation != "" {
+				fmt.Fprintf(os.Stderr, "      %s\n", bundle.SanitizeText(r.Explanation))
+			}
+		case generate.ActionFailed:
+			fmt.Fprintf(os.Stderr, "  ✗ %s: %s\n", bundle.SanitizeText(r.UID), bundle.SanitizeText(r.Reason))
+		case generate.ActionSkipped:
+			// skips are expected and numerous (existing mql, variant parents);
+			// the summary reports the count, so stay quiet here.
+		}
+	})
+
+	// apply generated MQL back onto the exact query definition (targets is
+	// index-aligned with checks and results)
+	for i, r := range results {
+		switch r.Action {
+		case generate.ActionGenerated:
+			targets[i].Mql = r.MQL
+			generated++
+		case generate.ActionFailed:
+			failed++
+		}
+	}
+
+	if generated == 0 {
+		// nothing to write back, but stdout still owes the caller the bundle
+		if stdoutMode {
+			passThrough(data)
+		}
+		return generated, failed, nil
+	}
+
+	fmtData, err := bundle.FormatBundle(raw, false)
+	if err != nil {
+		return generated, failed, fmt.Errorf("could not format %s: %w", file, err)
+	}
+
+	switch {
+	case dryRun:
+		fmt.Fprintf(os.Stderr, "\n--- %s (dry run, %d generated, not written) ---\n", file, generated)
+		fmt.Print(string(fmtData))
+	case inPlace:
+		if err := writeFileAtomic(file, fmtData); err != nil {
+			return generated, failed, fmt.Errorf("could not write %s: %w", file, err)
+		}
+		fmt.Fprintf(os.Stderr, "  Updated: %s\n", file)
+	case outputFile != "":
+		if err := writeFileAtomic(outputFile, fmtData); err != nil {
+			return generated, failed, fmt.Errorf("could not write %s: %w", outputFile, err)
+		}
+		fmt.Fprintf(os.Stderr, "  Wrote: %s\n", outputFile)
+	default:
+		fmt.Print(string(fmtData))
+	}
+
+	return generated, failed, nil
+}
+
+// passThrough copies the input bundle to stdout unchanged.
+//
+// In stdout mode the shell has already created — and truncated — the destination
+// of `cnspec policy generate in.yaml > out.yaml`. Printing nothing when there was
+// nothing to generate left a 0-byte file and exit 0, so a scripted
+// `generate in.yaml > out.yaml && mv out.yaml in.yaml` destroyed the bundle. The
+// original bytes go out rather than a re-format, so a run that changed nothing
+// is byte-identical to its input.
+func passThrough(data []byte) {
+	fmt.Print(string(data))
+}
+
+// writeFileAtomic writes data to path via a temp file in the same directory
+// followed by a rename, so an interrupted or failed write cannot truncate or
+// corrupt the existing policy file. The rename is atomic on the same filesystem.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".gen-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	// flush to disk before the rename so a crash cannot leave a zero-length file
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// preserve the existing file's permissions rather than widening to 0644
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// loadGenerateCorpus picks the grounding corpus: an explicit --corpus path, else
+// ./content when present, else the input paths themselves. A failure to load is
+// non-fatal — generation still works without grounding, just less accurately.
+func loadGenerateCorpus(corpusPath string, inputPaths []string) *generate.Corpus {
+	var paths []string
+	switch {
+	case corpusPath != "":
+		paths = []string{corpusPath}
+	case dirExists("content"):
+		paths = []string{"content"}
+	default:
+		paths = inputPaths
+	}
+
+	corpus, err := generate.LoadCorpus(paths...)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not load grounding corpus; continuing without examples")
+		return nil
+	}
+	if corpus.Size() == 0 {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "Grounding on %d example checks from %s\n", corpus.Size(), strings.Join(paths, ", "))
+	return corpus
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// bundleProps converts a query's parameterized properties into the neutral shape
+// the generator embeds in its prompt.
+func bundleProps(q *bundle.Mquery) []generate.Prop {
+	if q == nil || len(q.Props) == 0 {
+		return nil
+	}
+	out := make([]generate.Prop, 0, len(q.Props))
+	for _, p := range q.Props {
+		if p == nil {
+			continue
+		}
+		// a prop is referenced in MQL by its uid; without one there is no valid
+		// props.<name> to hand the agent, so skip it rather than emit garbage.
+		name := strings.TrimSpace(p.Uid)
+		if name == "" {
+			continue
+		}
+		// authored props carry their human-readable summary in `title`; fall back
+		// to it when there is no explicit `desc`.
+		desc := strings.TrimSpace(p.Desc)
+		if desc == "" {
+			desc = strings.TrimSpace(p.Title)
+		}
+		out = append(out, generate.Prop{
+			Name: name,
+			Type: strings.TrimSpace(p.Type),
+			Desc: desc,
+			// most authored props declare no `type:`, so the prop's own query is
+			// the only thing that can type `props.<name>` for the compiler.
+			Mql: strings.TrimSpace(p.Mql),
+		})
+	}
+	return out
+}
+
+// findSkills returns the paths to any discoverable cnspec skill files (the mql
+// and policy-graph skills) so the agent can read them. It checks the working
+// directory, its parent, and the directory next to the cnspec binary — covering
+// both "run from a checkout" and "run beside an installed skills/ dir". Empty
+// when none are found, in which case the prompt falls back to a name-based hint.
+func findSkills() []string {
+	dirs := []string{"skills", filepath.Join("..", "skills")}
+	if exe, err := os.Executable(); err == nil {
+		dirs = append(dirs, filepath.Join(filepath.Dir(exe), "skills"))
+	}
+
+	var out []string
+	for _, name := range []string{"mql", "policy-graph"} {
+		for _, d := range dirs {
+			p := filepath.Join(d, name, "SKILL.md")
+			if _, err := os.Stat(p); err == nil {
+				out = append(out, p)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/apps/cnspec/cmd/policy_generate.go
+++ b/apps/cnspec/cmd/policy_generate.go
@@ -50,8 +50,9 @@ generated MQL is validated by compiling it in-process before it is written.
 
 Security note: each check's title and description are sent to the coding-agent
 CLI as its prompt. Because that agent can run tools and commands, only run this
-on policy bundles you trust — a crafted description in an untrusted bundle is
-prompt-injection input to your agent.
+in a directory you trust, on bundles you trust — a crafted description is
+prompt-injection input to your agent, and the grounding corpus and agent skill
+files are resolved relative to the working directory.
 
 Examples:
   cnspec policy generate policy.mql.yaml --in-place

--- a/apps/cnspec/cmd/policy_generate_interactive.go
+++ b/apps/cnspec/cmd/policy_generate_interactive.go
@@ -10,14 +10,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnspec/internal/bundle"
 	"go.mondoo.com/cnspec/internal/generate"
-	"go.mondoo.com/mql/providers"
 )
 
 // errInputClosed reports that the wizard's input stream ended (EOF: Ctrl-D, a
@@ -30,11 +27,9 @@ import (
 // loop, and `[a]ccept` on a successful one, which wrote MQL no human ever saw.
 var errInputClosed = errors.New("input closed")
 
-// errUIDExists reports that a check uid is already taken in the target bundle.
-var errUIDExists = errors.New("uid already used in this bundle")
+// bundle.ErrUIDExists reports that a check uid is already taken in the target bundle.
 
-// generatedGroupTitle is the policy group the wizard adds its checks to.
-const generatedGroupTitle = "Generated checks"
+// bundle.GeneratedGroupTitle is the policy group the wizard adds its checks to.
 
 // wizardOpts is everything the wizard needs from the command line. In and Out
 // are injected so the flow can be driven by a test with scripted stdin.
@@ -129,11 +124,11 @@ func (w *wizard) loop(ctx context.Context, file string) error {
 		if err != nil {
 			return err
 		}
-		provider, err := w.line("Target provider (aws, gcp, azure, os, k8s, …)", guessProvider(title))
+		provider, err := w.line("Target provider (aws, gcp, azure, os, k8s, …)", generate.GuessProvider(title))
 		if err != nil {
 			return err
 		}
-		filter, err := w.line("Asset filter", defaultFilter(provider))
+		filter, err := w.line("Asset filter", generate.DefaultFilter(provider))
 		if err != nil {
 			return err
 		}
@@ -141,7 +136,7 @@ func (w *wizard) loop(ctx context.Context, file string) error {
 		w.showGrounding(title+" "+desc, provider)
 
 		check := generate.Check{
-			UID:   slugify(title),
+			UID:   bundle.Slugify(title),
 			Title: title,
 			Desc:  desc,
 		}
@@ -191,16 +186,16 @@ func (w *wizard) showGrounding(intent, provider string) {
 // writeCheck asks for the uid and adds the accepted check to the bundle, or
 // previews it under --dry-run.
 func (w *wizard) writeCheck(file, title, desc, filter, mql string) error {
-	uid, err := w.uniqueUID(file, slugify(title))
+	uid, err := w.uniqueUID(file, bundle.Slugify(title))
 	if err != nil {
 		return err
 	}
 
-	b, err := loadBundleFile(file)
+	b, err := bundle.LoadFile(file)
 	if err != nil {
 		return err
 	}
-	if err := addCheck(b, policyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
+	if err := bundle.AddCheck(b, bundle.PolicyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
 		return err
 	}
 	out, err := bundle.FormatBundle(b, false)
@@ -225,14 +220,14 @@ func (w *wizard) writeCheck(file, title, desc, filter, mql string) error {
 // the target bundle: appending a duplicate produces a bundle that fails
 // `cnspec policy lint` with query-uid-unique, which the user only finds later.
 func (w *wizard) uniqueUID(file, suggested string) (string, error) {
-	b, err := loadBundleFile(file)
+	b, err := bundle.LoadFile(file)
 	if err != nil {
 		return "", err
 	}
 	taken := bundle.QueryUIDs(b)
 
 	for {
-		uid, err := w.line("Check UID", nextFreeUID(suggested, taken))
+		uid, err := w.line("Check UID", bundle.NextFreeUID(suggested, taken))
 		if err != nil {
 			return "", err
 		}
@@ -245,20 +240,6 @@ func (w *wizard) uniqueUID(file, suggested string) (string, error) {
 		}
 		fmt.Fprintf(w.out, "  uid %q is already used in %s; pick another.\n", uid, file)
 		suggested = uid
-	}
-}
-
-// nextFreeUID suffixes a uid until it is free, so the prompt's default is one
-// the user can accept rather than a collision they have to resolve by hand.
-func nextFreeUID(uid string, taken map[string]bool) string {
-	if uid == "" || !taken[uid] {
-		return uid
-	}
-	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", uid, i)
-		if !taken[candidate] {
-			return candidate
-		}
 	}
 }
 
@@ -419,134 +400,6 @@ func editViaEditor(editor, current string) (string, error) {
 
 // loadBundleFile parses a bundle file, returning an empty bundle when the file
 // does not exist yet.
-func loadBundleFile(file string) (*bundle.Bundle, error) {
-	data, err := os.ReadFile(file)
-	if os.IsNotExist(err) {
-		return &bundle.Bundle{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	b, err := bundle.ParseYaml(data)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not parse %s", file)
-	}
-	return b, nil
-}
-
-// appendCheck adds a new check to a bundle file (creating it if absent),
-// preserving existing formatting/comments and writing atomically.
-func appendCheck(file, uid, title, desc, filter, mql string) error {
-	b, err := loadBundleFile(file)
-	if err != nil {
-		return err
-	}
-	if err := addCheck(b, policyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
-		return err
-	}
-	out, err := bundle.FormatBundle(b, false)
-	if err != nil {
-		return err
-	}
-	return writeFileAtomic(file, out)
-}
-
-// addCheck places a check inside a policy group.
-//
-// A check that lives only in the top-level `queries:` block is not scannable:
-// lint reports it as query-unassigned and `cnspec scan --policy-bundle` then
-// fails with "a policy or framework mrn is required". The wizard tells the user
-// to lint and scan what it wrote, so what it writes has to survive both.
-func addCheck(b *bundle.Bundle, policyUID, uid, title, desc, filter, mql string) error {
-	if b == nil {
-		return errors.New("no bundle to add the check to")
-	}
-	if strings.TrimSpace(uid) == "" {
-		return errors.New("a check needs a uid")
-	}
-	if bundle.QueryUIDs(b)[uid] {
-		return errors.Wrapf(errUIDExists, "check %q", uid)
-	}
-
-	q := &bundle.Mquery{Uid: uid, Title: title, Mql: mql}
-	if strings.TrimSpace(filter) != "" {
-		q.Filters = &bundle.Filters{Items: map[string]*bundle.Mquery{"": {Mql: filter}}}
-	}
-	if strings.TrimSpace(desc) != "" {
-		q.Docs = &bundle.MqueryDocs{Desc: desc}
-	}
-
-	group := generatedGroup(targetPolicy(b, policyUID))
-	group.Checks = append(group.Checks, q)
-	return nil
-}
-
-// targetPolicy returns the policy new checks join: the bundle's first policy
-// when it has one, otherwise a new minimal policy (uid + name + semver version
-// are what `cnspec policy lint` requires).
-func targetPolicy(b *bundle.Bundle, policyUID string) *bundle.Policy {
-	if len(b.Policies) > 0 && b.Policies[0] != nil {
-		return b.Policies[0]
-	}
-	p := &bundle.Policy{
-		Uid:     policyUID,
-		Name:    humanize(policyUID),
-		Version: "1.0.0",
-	}
-	b.Policies = append(b.Policies, p)
-	return p
-}
-
-// generatedGroup returns the group new checks are appended to, creating it when
-// needed.
-//
-// It is deliberately a group of its own rather than the policy's first group: a
-// group-level filter gates every check inside it, so dropping a fresh check into
-// an existing group can silently restrict it to assets it was never written for
-// (a group filtered to hosts running kube-apiserver, say). The checks carry
-// their own filters, which is what policy-missing-asset-filter asks for.
-func generatedGroup(p *bundle.Policy) *bundle.PolicyGroup {
-	for _, g := range p.Groups {
-		if g != nil && g.Title == generatedGroupTitle && (g.Filters == nil || len(g.Filters.Items) == 0) {
-			return g
-		}
-	}
-	g := &bundle.PolicyGroup{Title: generatedGroupTitle}
-	p.Groups = append(p.Groups, g)
-	return g
-}
-
-// policyUidRe mirrors the uid requirement `cnspec policy lint` enforces on a
-// policy (bundle-invalid-uid): 4-100 characters of lowercase letters, digits,
-// dashes and underscores.
-var policyUidRe = regexp.MustCompile(`^([\d\-_]|[a-z]){4,100}$`)
-
-// policyUIDForFile derives the uid of the policy the wizard creates from the
-// bundle's file name, falling back to a generic uid when that would not lint.
-func policyUIDForFile(file string) string {
-	base := filepath.Base(file)
-	base = strings.TrimSuffix(base, ".yaml")
-	base = strings.TrimSuffix(base, ".yml")
-	base = strings.TrimSuffix(base, ".mql")
-	uid := slugify(base)
-	if !policyUidRe.MatchString(uid) {
-		return "generated-policy"
-	}
-	return uid
-}
-
-// humanize turns a uid into a policy name ("aws-s3" -> "Aws S3").
-func humanize(uid string) string {
-	fields := strings.FieldsFunc(uid, func(r rune) bool { return r == '-' || r == '_' })
-	for i, f := range fields {
-		fields[i] = strings.ToUpper(f[:1]) + f[1:]
-	}
-	if len(fields) == 0 {
-		return uid
-	}
-	return strings.Join(fields, " ")
-}
-
 // --- small prompt + text helpers -------------------------------------------
 
 // rawLine reads one line, reporting errInputClosed at EOF. A final line without
@@ -619,153 +472,6 @@ func (w *wizard) choice(label string, opts ...string) (string, error) {
 
 // guessProvider makes a light guess at the target provider from the title so the
 // prompt can offer a sensible default.
-func guessProvider(title string) string {
-	t := strings.ToLower(title)
-	switch {
-	case containsAny(t, "aws", "s3", "ec2", "iam", "cloudtrail", "rds", "eks", "lambda"):
-		return "aws"
-	case containsAny(t, "gcp", "gke", "bigquery", "cloud sql", "compute engine"):
-		return "gcp"
-	case containsAny(t, "azure", "aks", "blob"):
-		return "azure"
-	case containsAny(t, "ssh", "sshd", "kernel", "linux", "package", "systemd", "sudo", "pam"):
-		return "os"
-	case containsAny(t, "kubernetes", "k8s", "pod", "container"):
-		return "k8s"
-	}
-	return ""
-}
-
-// curatedFilters maps a provider to the asset filter the wizard proposes.
-//
-// These are *platform* names, not provider names, and the two differ for most
-// providers. A filter naming a platform that does not exist is dead: it lints
-// clean, it scans clean, and it never matches an asset — which is what
-// `asset.platform == "gcp"` and `asset.platform == "k8s"` were, since neither
-// name exists (gcp's platforms are gcp-project, gcp-gke-cluster, …; "k8s" is a
-// platform *family*, and its platforms are k8s-cluster, k8s-pod, …).
-//
-// Every name here is taken from installed provider metadata
-// (~/.config/mondoo/providers/<n>/<n>.json, Platforms[].name and .family) and is
-// in use by real checks in content/ — see TestDefaultFilterUsesRealPlatformNames,
-// which re-derives both. The choice among a provider's platforms is the scope
-// where that provider's account-wide resources resolve.
-var curatedFilters = map[string]string{
-	// the account-level asset; content/ uses it for ~200 checks
-	"aws": `asset.platform == "aws"`,
-	// the subscription-level asset
-	"azure": `asset.platform == "azure"`,
-	// there is no platform named "gcp"; the project is the account-level asset
-	"gcp": `asset.platform == "gcp-project"`,
-	// cluster and manifest are the two scopes where the cluster-wide k8s.*
-	// resources resolve; workload platforms (k8s-pod, k8s-deployment, …) are
-	// per-object and too narrow to guess at
-	"k8s": `asset.platform == "k8s-cluster" || asset.platform == "k8s-manifest"`,
-	// os platforms are per-distribution (ubuntu, redhat, …); the family is the
-	// portable way to say "any Linux"
-	"os": `asset.family.contains("linux")`,
-}
-
-// defaultFilter proposes an asset filter for a provider: a curated one where the
-// provider has many platforms and only some are plausible, otherwise one derived
-// from the installed provider metadata. Returns "" when neither knows the
-// provider — an empty prompt the user fills in beats a filter that silently
-// matches nothing.
-func defaultFilter(provider string) string {
-	provider = strings.TrimSpace(provider)
-	if provider == "" {
-		return ""
-	}
-	if f, ok := curatedFilters[provider]; ok {
-		return f
-	}
-	name, family := lookupPlatform(provider)
-	switch {
-	case name != "":
-		return fmt.Sprintf(`asset.platform == %q`, name)
-	case family != "":
-		return fmt.Sprintf(`asset.family.contains(%q)`, family)
-	}
-	return ""
-}
-
-// installedPlatforms reports the platform names and families a provider
-// declares. It is a variable so tests can drive defaultFilter without depending
-// on which providers happen to be installed.
-var installedPlatforms = func(provider string) (names []string, families []string) {
-	// ListAll only reads the installed provider metadata: no network, no
-	// installs, and resource schemas stay unparsed.
-	all, err := providers.ListAll()
-	if err != nil {
-		return nil, nil
-	}
-	seen := map[string]bool{}
-	for _, p := range all {
-		if p == nil || p.Provider == nil || p.Name != provider {
-			continue
-		}
-		for _, pl := range p.Platforms {
-			if pl == nil {
-				continue
-			}
-			names = append(names, pl.Name)
-			for _, f := range pl.Family {
-				if !seen[f] {
-					seen[f] = true
-					families = append(families, f)
-				}
-			}
-		}
-	}
-	return names, families
-}
-
-// lookupPlatform resolves a provider name against installed metadata: an exact
-// platform of that name (aws, digitalocean, oci, …), else a family of that name
-// (github, terraform, …). Anything more ambiguous is left to the user.
-func lookupPlatform(provider string) (name, family string) {
-	names, families := installedPlatforms(provider)
-	for _, n := range names {
-		if n == provider {
-			return n, ""
-		}
-	}
-	for _, f := range families {
-		if f == provider {
-			return "", f
-		}
-	}
-	return "", ""
-}
-
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		if strings.Contains(s, sub) {
-			return true
-		}
-	}
-	return false
-}
-
-// slugify turns a title into a lowercase, dash-separated uid.
-func slugify(s string) string {
-	var b strings.Builder
-	lastDash := false
-	for _, r := range strings.ToLower(s) {
-		switch {
-		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
-			b.WriteRune(r)
-			lastDash = false
-		default:
-			if !lastDash && b.Len() > 0 {
-				b.WriteByte('-')
-				lastDash = true
-			}
-		}
-	}
-	return strings.Trim(b.String(), "-")
-}
-
 func indentBlock(s string) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	for i := range lines {

--- a/apps/cnspec/cmd/policy_generate_interactive.go
+++ b/apps/cnspec/cmd/policy_generate_interactive.go
@@ -1,0 +1,786 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/generate"
+	"go.mondoo.com/mql/providers"
+)
+
+// errInputClosed reports that the wizard's input stream ended (EOF: Ctrl-D, a
+// closed pipe, or a script that ran out of answers).
+//
+// Every prompt must surface this instead of returning its default. When EOF fell
+// through to the default, `promptRequired` re-printed its prompt forever (tens of
+// megabytes of stderr per second), `promptChoice` picked opts[0] — `[r]etry` on a
+// failed generation, which re-invoked the coding agent in a tight unattended
+// loop, and `[a]ccept` on a successful one, which wrote MQL no human ever saw.
+var errInputClosed = errors.New("input closed")
+
+// errUIDExists reports that a check uid is already taken in the target bundle.
+var errUIDExists = errors.New("uid already used in this bundle")
+
+// generatedGroupTitle is the policy group the wizard adds its checks to.
+const generatedGroupTitle = "Generated checks"
+
+// wizardOpts is everything the wizard needs from the command line. In and Out
+// are injected so the flow can be driven by a test with scripted stdin.
+type wizardOpts struct {
+	In  io.Reader
+	Out io.Writer
+	// File is the bundle to write checks into. FileFromFlag marks it as an
+	// explicit --output, which is used as-is instead of being offered as the
+	// default of a prompt.
+	File         string
+	FileFromFlag bool
+	// DryRun previews each accepted check instead of writing it.
+	DryRun bool
+}
+
+type wizard struct {
+	in    *bufio.Reader
+	out   io.Writer
+	gen   *generate.Generator
+	opts  wizardOpts
+	added int
+}
+
+// runGenerateWizard is the interactive, guided authoring experience: describe a
+// check in plain language, watch cnspec generate and validate the MQL, then
+// accept / edit / regenerate, and write it into a bundle — one check at a time.
+func runGenerateWizard(ctx context.Context, gen *generate.Generator, opts wizardOpts) error {
+	if opts.In == nil {
+		opts.In = os.Stdin
+	}
+	if opts.Out == nil {
+		opts.Out = os.Stderr
+	}
+	w := &wizard{in: bufio.NewReader(opts.In), out: opts.Out, gen: gen, opts: opts}
+	return w.run(ctx)
+}
+
+func (w *wizard) run(ctx context.Context) error {
+	fmt.Fprintln(w.out, "\nInteractive MQL generation")
+	fmt.Fprintln(w.out, "Describe a check in plain language; cnspec generates and validates the MQL.")
+	fmt.Fprintln(w.out, "Press Ctrl-C any time to exit.")
+	if w.opts.DryRun {
+		fmt.Fprintln(w.out, "--dry-run: accepted checks are previewed, not written.")
+	}
+
+	file, err := w.targetFile()
+	if err == nil {
+		err = w.loop(ctx, file)
+	}
+
+	verb := "added"
+	if w.opts.DryRun {
+		verb = "would add"
+	}
+	if file != "" {
+		fmt.Fprintf(w.out, "\nDone: %s %d check(s) to %s\n", verb, w.added, file)
+		if w.added > 0 && !w.opts.DryRun {
+			fmt.Fprintf(w.out, "Next: `cnspec policy lint %s` and `cnspec scan <target> --policy-bundle %s`, then commit.\n", file, file)
+		}
+	}
+
+	// EOF is a legitimate way to end a session (Ctrl-D, or a script whose input
+	// ran out); it is not an error, but it must never be mistaken for an answer.
+	if errors.Is(err, errInputClosed) {
+		fmt.Fprintln(w.out, "Input ended; nothing was written for the check in progress.")
+		return nil
+	}
+	return err
+}
+
+// targetFile resolves the bundle the wizard writes to: an explicit --output is
+// taken as given, anything else is a prompt seeded with the path argument.
+func (w *wizard) targetFile() (string, error) {
+	if w.opts.FileFromFlag {
+		return w.opts.File, nil
+	}
+	def := w.opts.File
+	if def == "" {
+		def = "policy.mql.yaml"
+	}
+	return w.line("Bundle file to write checks to", def)
+}
+
+func (w *wizard) loop(ctx context.Context, file string) error {
+	for {
+		fmt.Fprintln(w.out, "\n── New check ──────────────────────────────")
+		title, err := w.required("What should this check verify?")
+		if err != nil {
+			return err
+		}
+		desc, err := w.line("More detail (optional)", "")
+		if err != nil {
+			return err
+		}
+		provider, err := w.line("Target provider (aws, gcp, azure, os, k8s, …)", guessProvider(title))
+		if err != nil {
+			return err
+		}
+		filter, err := w.line("Asset filter", defaultFilter(provider))
+		if err != nil {
+			return err
+		}
+
+		w.showGrounding(title+" "+desc, provider)
+
+		check := generate.Check{
+			UID:   slugify(title),
+			Title: title,
+			Desc:  desc,
+		}
+		if filter != "" {
+			check.Filters = []string{filter}
+		}
+
+		mql, ok, err := w.review(ctx, check)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if err := w.writeCheck(file, title, desc, filter, mql); err != nil {
+				if errors.Is(err, errInputClosed) {
+					return err
+				}
+				fmt.Fprintf(w.out, "  could not write check: %v\n", err)
+			}
+		}
+
+		again, err := w.yesNo("Add another check?")
+		if err != nil {
+			return err
+		}
+		if !again {
+			return nil
+		}
+	}
+}
+
+// showGrounding previews the real precedents the generator also feeds the agent.
+func (w *wizard) showGrounding(intent, provider string) {
+	examples := w.gen.Ground(intent, provider, 3)
+	if len(examples) == 0 {
+		return
+	}
+	fmt.Fprintln(w.out, "\nSimilar existing checks (used as grounding):")
+	for _, e := range examples {
+		name := e.Title
+		if name == "" {
+			name = e.UID
+		}
+		fmt.Fprintf(w.out, "  • %s\n      %s\n", name, oneLineMQL(e.Mql, 100))
+	}
+}
+
+// writeCheck asks for the uid and adds the accepted check to the bundle, or
+// previews it under --dry-run.
+func (w *wizard) writeCheck(file, title, desc, filter, mql string) error {
+	uid, err := w.uniqueUID(file, slugify(title))
+	if err != nil {
+		return err
+	}
+
+	b, err := loadBundleFile(file)
+	if err != nil {
+		return err
+	}
+	if err := addCheck(b, policyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
+		return err
+	}
+	out, err := bundle.FormatBundle(b, false)
+	if err != nil {
+		return err
+	}
+
+	if w.opts.DryRun {
+		fmt.Fprintf(w.out, "\n--- %s (dry run, not written) ---\n%s\n", file, out)
+		w.added++
+		return nil
+	}
+	if err := writeFileAtomic(file, out); err != nil {
+		return err
+	}
+	fmt.Fprintf(w.out, "  ✓ added %s to %s\n", uid, file)
+	w.added++
+	return nil
+}
+
+// uniqueUID prompts for the check uid and refuses one that is already defined in
+// the target bundle: appending a duplicate produces a bundle that fails
+// `cnspec policy lint` with query-uid-unique, which the user only finds later.
+func (w *wizard) uniqueUID(file, suggested string) (string, error) {
+	b, err := loadBundleFile(file)
+	if err != nil {
+		return "", err
+	}
+	taken := bundle.QueryUIDs(b)
+
+	for {
+		uid, err := w.line("Check UID", nextFreeUID(suggested, taken))
+		if err != nil {
+			return "", err
+		}
+		if uid == "" {
+			fmt.Fprintln(w.out, "  (a check needs a uid)")
+			continue
+		}
+		if !taken[uid] {
+			return uid, nil
+		}
+		fmt.Fprintf(w.out, "  uid %q is already used in %s; pick another.\n", uid, file)
+		suggested = uid
+	}
+}
+
+// nextFreeUID suffixes a uid until it is free, so the prompt's default is one
+// the user can accept rather than a collision they have to resolve by hand.
+func nextFreeUID(uid string, taken map[string]bool) string {
+	if uid == "" || !taken[uid] {
+		return uid
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", uid, i)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}
+
+// review generates MQL for a check and drives the accept/edit/regenerate review.
+// Returns the chosen MQL and whether the user accepted anything.
+func (w *wizard) review(ctx context.Context, check generate.Check) (string, bool, error) {
+	for {
+		fmt.Fprintln(w.out, "\nGenerating…")
+		res := w.gen.GenerateCheck(ctx, check)
+
+		if res.Action != generate.ActionGenerated {
+			fmt.Fprintf(w.out, "  generation failed: %s\n", bundle.SanitizeText(res.Reason))
+			choice, err := w.choice("  [r]etry, [e]dit manually, [s]kip", "r", "e", "s")
+			if err != nil {
+				return "", false, err
+			}
+			switch choice {
+			case "r":
+				continue
+			case "e":
+				return w.editAndValidate("", check.Props)
+			default:
+				return "", false, nil
+			}
+		}
+
+		// render the agent's output through the same normalization that writes it
+		// to disk, so the text under review is the text that gets committed
+		mql := bundle.SanitizeText(res.MQL)
+		explanation := bundle.SanitizeText(res.Explanation)
+
+		regenerate := false
+		for !regenerate {
+			fmt.Fprintln(w.out, "\nGenerated MQL:")
+			fmt.Fprintln(w.out, indentBlock(mql))
+			if explanation != "" {
+				fmt.Fprintf(w.out, "  (%s)\n", explanation)
+			}
+
+			choice, err := w.choice("  [a]ccept, [e]dit, [r]egenerate with feedback, [s]kip", "a", "e", "r", "s")
+			if err != nil {
+				return "", false, err
+			}
+			switch choice {
+			case "a":
+				return mql, true, nil
+			case "e":
+				// Backing out of the editor returns to *this* candidate. Falling
+				// through to the outer loop would call the agent again — a second
+				// billed invocation that replaces the query the user was reviewing
+				// with a different one.
+				edited, ok, err := w.editAndValidate(mql, check.Props)
+				if err != nil {
+					return "", false, err
+				}
+				if ok {
+					return edited, true, nil
+				}
+			case "r":
+				feedback, err := w.required("  What should change?")
+				if err != nil {
+					return "", false, err
+				}
+				check.Guidance = strings.TrimSpace(check.Guidance + " " + feedback)
+				regenerate = true
+			default:
+				return "", false, nil
+			}
+		}
+	}
+}
+
+// editAndValidate lets the user hand-edit MQL and compile-checks the result,
+// offering to keep an invalid query, re-edit, or cancel.
+func (w *wizard) editAndValidate(current string, props []generate.Prop) (string, bool, error) {
+	for {
+		mql, err := w.editMQL(current)
+		if err != nil {
+			return "", false, err
+		}
+		if strings.TrimSpace(mql) == "" {
+			return "", false, nil
+		}
+		if err := w.gen.Validate(mql, props...); err != nil {
+			fmt.Fprintf(w.out, "  does not validate: %v\n", err)
+			choice, cerr := w.choice("  [e]dit again, [k]eep anyway, [c]ancel", "e", "k", "c")
+			if cerr != nil {
+				return "", false, cerr
+			}
+			switch choice {
+			case "e":
+				current = mql
+				continue
+			case "k":
+				return mql, true, nil
+			default:
+				return "", false, nil
+			}
+		}
+		return mql, true, nil
+	}
+}
+
+// editMQL opens $EDITOR on the current MQL, falling back to inline multi-line
+// entry (terminated by a blank line) when no editor is set or it fails.
+func (w *wizard) editMQL(current string) (string, error) {
+	if editor := strings.TrimSpace(os.Getenv("EDITOR")); editor != "" {
+		if edited, err := editViaEditor(editor, current); err == nil {
+			return strings.TrimSpace(edited), nil
+		}
+		fmt.Fprintln(w.out, "  (editor failed)")
+	}
+	fmt.Fprintln(w.out, "  Enter MQL, end with a blank line:")
+	var lines []string
+	for {
+		line, err := w.rawLine()
+		if err != nil {
+			// EOF ends the entry with whatever was typed; it must not be read as
+			// an endless supply of blank lines.
+			if errors.Is(err, errInputClosed) && len(lines) > 0 {
+				break
+			}
+			return "", err
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+		lines = append(lines, line)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n")), nil
+}
+
+func editViaEditor(editor, current string) (string, error) {
+	f, err := os.CreateTemp("", "cnspec-mql-*.mql")
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	defer os.Remove(name)
+	if _, err := f.WriteString(current); err != nil {
+		f.Close()
+		return "", err
+	}
+	f.Close()
+
+	// EDITOR may include arguments (e.g. "code --wait")
+	parts := strings.Fields(editor)
+	cmd := exec.Command(parts[0], append(parts[1:], name)...) //nolint:gosec // user's own $EDITOR
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	out, err := os.ReadFile(name)
+	return string(out), err
+}
+
+// --- bundle writing ---------------------------------------------------------
+
+// loadBundleFile parses a bundle file, returning an empty bundle when the file
+// does not exist yet.
+func loadBundleFile(file string) (*bundle.Bundle, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return &bundle.Bundle{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse %s", file)
+	}
+	return b, nil
+}
+
+// appendCheck adds a new check to a bundle file (creating it if absent),
+// preserving existing formatting/comments and writing atomically.
+func appendCheck(file, uid, title, desc, filter, mql string) error {
+	b, err := loadBundleFile(file)
+	if err != nil {
+		return err
+	}
+	if err := addCheck(b, policyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
+		return err
+	}
+	out, err := bundle.FormatBundle(b, false)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(file, out)
+}
+
+// addCheck places a check inside a policy group.
+//
+// A check that lives only in the top-level `queries:` block is not scannable:
+// lint reports it as query-unassigned and `cnspec scan --policy-bundle` then
+// fails with "a policy or framework mrn is required". The wizard tells the user
+// to lint and scan what it wrote, so what it writes has to survive both.
+func addCheck(b *bundle.Bundle, policyUID, uid, title, desc, filter, mql string) error {
+	if b == nil {
+		return errors.New("no bundle to add the check to")
+	}
+	if strings.TrimSpace(uid) == "" {
+		return errors.New("a check needs a uid")
+	}
+	if bundle.QueryUIDs(b)[uid] {
+		return errors.Wrapf(errUIDExists, "check %q", uid)
+	}
+
+	q := &bundle.Mquery{Uid: uid, Title: title, Mql: mql}
+	if strings.TrimSpace(filter) != "" {
+		q.Filters = &bundle.Filters{Items: map[string]*bundle.Mquery{"": {Mql: filter}}}
+	}
+	if strings.TrimSpace(desc) != "" {
+		q.Docs = &bundle.MqueryDocs{Desc: desc}
+	}
+
+	group := generatedGroup(targetPolicy(b, policyUID))
+	group.Checks = append(group.Checks, q)
+	return nil
+}
+
+// targetPolicy returns the policy new checks join: the bundle's first policy
+// when it has one, otherwise a new minimal policy (uid + name + semver version
+// are what `cnspec policy lint` requires).
+func targetPolicy(b *bundle.Bundle, policyUID string) *bundle.Policy {
+	if len(b.Policies) > 0 && b.Policies[0] != nil {
+		return b.Policies[0]
+	}
+	p := &bundle.Policy{
+		Uid:     policyUID,
+		Name:    humanize(policyUID),
+		Version: "1.0.0",
+	}
+	b.Policies = append(b.Policies, p)
+	return p
+}
+
+// generatedGroup returns the group new checks are appended to, creating it when
+// needed.
+//
+// It is deliberately a group of its own rather than the policy's first group: a
+// group-level filter gates every check inside it, so dropping a fresh check into
+// an existing group can silently restrict it to assets it was never written for
+// (a group filtered to hosts running kube-apiserver, say). The checks carry
+// their own filters, which is what policy-missing-asset-filter asks for.
+func generatedGroup(p *bundle.Policy) *bundle.PolicyGroup {
+	for _, g := range p.Groups {
+		if g != nil && g.Title == generatedGroupTitle && (g.Filters == nil || len(g.Filters.Items) == 0) {
+			return g
+		}
+	}
+	g := &bundle.PolicyGroup{Title: generatedGroupTitle}
+	p.Groups = append(p.Groups, g)
+	return g
+}
+
+// policyUidRe mirrors the uid requirement `cnspec policy lint` enforces on a
+// policy (bundle-invalid-uid): 4-100 characters of lowercase letters, digits,
+// dashes and underscores.
+var policyUidRe = regexp.MustCompile(`^([\d\-_]|[a-z]){4,100}$`)
+
+// policyUIDForFile derives the uid of the policy the wizard creates from the
+// bundle's file name, falling back to a generic uid when that would not lint.
+func policyUIDForFile(file string) string {
+	base := filepath.Base(file)
+	base = strings.TrimSuffix(base, ".yaml")
+	base = strings.TrimSuffix(base, ".yml")
+	base = strings.TrimSuffix(base, ".mql")
+	uid := slugify(base)
+	if !policyUidRe.MatchString(uid) {
+		return "generated-policy"
+	}
+	return uid
+}
+
+// humanize turns a uid into a policy name ("aws-s3" -> "Aws S3").
+func humanize(uid string) string {
+	fields := strings.FieldsFunc(uid, func(r rune) bool { return r == '-' || r == '_' })
+	for i, f := range fields {
+		fields[i] = strings.ToUpper(f[:1]) + f[1:]
+	}
+	if len(fields) == 0 {
+		return uid
+	}
+	return strings.Join(fields, " ")
+}
+
+// --- small prompt + text helpers -------------------------------------------
+
+// rawLine reads one line, reporting errInputClosed at EOF. A final line without
+// a trailing newline is still an answer; the EOF surfaces on the next read.
+func (w *wizard) rawLine() (string, error) {
+	s, err := w.in.ReadString('\n')
+	s = strings.TrimRight(s, "\r\n")
+	if err != nil {
+		if strings.TrimSpace(s) == "" {
+			return "", errInputClosed
+		}
+		return s, nil
+	}
+	return s, nil
+}
+
+func (w *wizard) line(label, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(w.out, "%s [%s]: ", label, def)
+	} else {
+		fmt.Fprintf(w.out, "%s: ", label)
+	}
+	s, err := w.rawLine()
+	if err != nil {
+		return "", err
+	}
+	if s = strings.TrimSpace(s); s == "" {
+		return def, nil
+	}
+	return s, nil
+}
+
+func (w *wizard) required(label string) (string, error) {
+	for {
+		s, err := w.line(label, "")
+		if err != nil {
+			return "", err
+		}
+		if s != "" {
+			return s, nil
+		}
+		fmt.Fprintln(w.out, "  (required)")
+	}
+}
+
+func (w *wizard) yesNo(msg string) (bool, error) {
+	s, err := w.line(msg+" [Y/n]", "y")
+	if err != nil {
+		return false, err
+	}
+	s = strings.ToLower(s)
+	return s == "y" || s == "yes", nil
+}
+
+func (w *wizard) choice(label string, opts ...string) (string, error) {
+	for {
+		s, err := w.line(label, opts[0])
+		if err != nil {
+			return "", err
+		}
+		s = strings.ToLower(s)
+		for _, o := range opts {
+			if s == o {
+				return o, nil
+			}
+		}
+		fmt.Fprintf(w.out, "  choose one of: %s\n", strings.Join(opts, ", "))
+	}
+}
+
+// guessProvider makes a light guess at the target provider from the title so the
+// prompt can offer a sensible default.
+func guessProvider(title string) string {
+	t := strings.ToLower(title)
+	switch {
+	case containsAny(t, "aws", "s3", "ec2", "iam", "cloudtrail", "rds", "eks", "lambda"):
+		return "aws"
+	case containsAny(t, "gcp", "gke", "bigquery", "cloud sql", "compute engine"):
+		return "gcp"
+	case containsAny(t, "azure", "aks", "blob"):
+		return "azure"
+	case containsAny(t, "ssh", "sshd", "kernel", "linux", "package", "systemd", "sudo", "pam"):
+		return "os"
+	case containsAny(t, "kubernetes", "k8s", "pod", "container"):
+		return "k8s"
+	}
+	return ""
+}
+
+// curatedFilters maps a provider to the asset filter the wizard proposes.
+//
+// These are *platform* names, not provider names, and the two differ for most
+// providers. A filter naming a platform that does not exist is dead: it lints
+// clean, it scans clean, and it never matches an asset — which is what
+// `asset.platform == "gcp"` and `asset.platform == "k8s"` were, since neither
+// name exists (gcp's platforms are gcp-project, gcp-gke-cluster, …; "k8s" is a
+// platform *family*, and its platforms are k8s-cluster, k8s-pod, …).
+//
+// Every name here is taken from installed provider metadata
+// (~/.config/mondoo/providers/<n>/<n>.json, Platforms[].name and .family) and is
+// in use by real checks in content/ — see TestDefaultFilterUsesRealPlatformNames,
+// which re-derives both. The choice among a provider's platforms is the scope
+// where that provider's account-wide resources resolve.
+var curatedFilters = map[string]string{
+	// the account-level asset; content/ uses it for ~200 checks
+	"aws": `asset.platform == "aws"`,
+	// the subscription-level asset
+	"azure": `asset.platform == "azure"`,
+	// there is no platform named "gcp"; the project is the account-level asset
+	"gcp": `asset.platform == "gcp-project"`,
+	// cluster and manifest are the two scopes where the cluster-wide k8s.*
+	// resources resolve; workload platforms (k8s-pod, k8s-deployment, …) are
+	// per-object and too narrow to guess at
+	"k8s": `asset.platform == "k8s-cluster" || asset.platform == "k8s-manifest"`,
+	// os platforms are per-distribution (ubuntu, redhat, …); the family is the
+	// portable way to say "any Linux"
+	"os": `asset.family.contains("linux")`,
+}
+
+// defaultFilter proposes an asset filter for a provider: a curated one where the
+// provider has many platforms and only some are plausible, otherwise one derived
+// from the installed provider metadata. Returns "" when neither knows the
+// provider — an empty prompt the user fills in beats a filter that silently
+// matches nothing.
+func defaultFilter(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return ""
+	}
+	if f, ok := curatedFilters[provider]; ok {
+		return f
+	}
+	name, family := lookupPlatform(provider)
+	switch {
+	case name != "":
+		return fmt.Sprintf(`asset.platform == %q`, name)
+	case family != "":
+		return fmt.Sprintf(`asset.family.contains(%q)`, family)
+	}
+	return ""
+}
+
+// installedPlatforms reports the platform names and families a provider
+// declares. It is a variable so tests can drive defaultFilter without depending
+// on which providers happen to be installed.
+var installedPlatforms = func(provider string) (names []string, families []string) {
+	// ListAll only reads the installed provider metadata: no network, no
+	// installs, and resource schemas stay unparsed.
+	all, err := providers.ListAll()
+	if err != nil {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	for _, p := range all {
+		if p == nil || p.Provider == nil || p.Name != provider {
+			continue
+		}
+		for _, pl := range p.Platforms {
+			if pl == nil {
+				continue
+			}
+			names = append(names, pl.Name)
+			for _, f := range pl.Family {
+				if !seen[f] {
+					seen[f] = true
+					families = append(families, f)
+				}
+			}
+		}
+	}
+	return names, families
+}
+
+// lookupPlatform resolves a provider name against installed metadata: an exact
+// platform of that name (aws, digitalocean, oci, …), else a family of that name
+// (github, terraform, …). Anything more ambiguous is left to the user.
+func lookupPlatform(provider string) (name, family string) {
+	names, families := installedPlatforms(provider)
+	for _, n := range names {
+		if n == provider {
+			return n, ""
+		}
+	}
+	for _, f := range families {
+		if f == provider {
+			return "", f
+		}
+	}
+	return "", ""
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// slugify turns a title into a lowercase, dash-separated uid.
+func slugify(s string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func indentBlock(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := range lines {
+		lines[i] = "    " + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// oneLineMQL collapses a query to a single display line. It sanitizes because
+// its input is bundle text from the grounding corpus, which cnspec does not
+// author: a control character in there would otherwise reach the terminal.
+func oneLineMQL(s string, max int) string {
+	s = strings.Join(strings.Fields(bundle.SanitizeText(s)), " ")
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}

--- a/apps/cnspec/cmd/policy_generate_interactive_test.go
+++ b/apps/cnspec/cmd/policy_generate_interactive_test.go
@@ -1,0 +1,686 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/generate"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"S3 buckets must be encrypted": "s3-buckets-must-be-encrypted",
+		"  Trim  --  dashes  ":         "trim-dashes",
+		"CIS 1.2: root/login!":         "cis-1-2-root-login",
+		"":                             "",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGuessProvider(t *testing.T) {
+	if p := guessProvider("S3 buckets must be encrypted"); p != "aws" {
+		t.Errorf("aws guess = %q", p)
+	}
+	if p := guessProvider("SSH root login disabled"); p != "os" {
+		t.Errorf("os guess = %q", p)
+	}
+	if p := guessProvider("Something generic"); p != "" {
+		t.Errorf("expected no guess, got %q", p)
+	}
+}
+
+// --- default asset filters ---------------------------------------------------
+
+var (
+	platformFilterRe = regexp.MustCompile(`asset\.platform\s*==\s*"([a-z0-9._-]+)"`)
+	familyFilterRe   = regexp.MustCompile(`asset\.family\.contains\("([a-z0-9._-]+)"\)`)
+)
+
+// TestDefaultFilterUsesRealPlatformNames validates every filter the wizard
+// proposes against authorities outside this file: the platform and family names
+// that real checks in content/ filter on, and — when providers are installed —
+// the Platforms[] metadata of the provider itself.
+//
+// It replaces a test that restated defaultFilter's implementation back to
+// itself, which is how `asset.platform == "gcp"` and `asset.platform == "k8s"`
+// shipped green: neither name exists (gcp's platforms are gcp-project,
+// gcp-gke-cluster, …; k8s is a family, its platforms are k8s-cluster, k8s-pod,
+// …), so both filters matched no asset, ever, while lint stayed silent.
+func TestDefaultFilterUsesRealPlatformNames(t *testing.T) {
+	contentPlatforms, contentFamilies := contentFilterNames(t)
+	if len(contentPlatforms) == 0 {
+		t.Fatal("found no asset.platform filters in content/; the corpus this test derives from is missing")
+	}
+
+	var checkedMeta, skippedMeta int
+	for provider := range curatedFilters {
+		filter := defaultFilter(provider)
+		platforms := allSubmatches(platformFilterRe, filter)
+		families := allSubmatches(familyFilterRe, filter)
+		if len(platforms)+len(families) == 0 {
+			t.Errorf("defaultFilter(%q) = %q names neither a platform nor a family", provider, filter)
+			continue
+		}
+
+		for _, name := range platforms {
+			if !contentPlatforms[name] {
+				t.Errorf("defaultFilter(%q) = %q filters on platform %q, which no check in content/ uses; a platform name that does not exist matches no asset", provider, filter, name)
+			}
+		}
+		for _, name := range families {
+			if !contentFamilies[name] {
+				t.Errorf("defaultFilter(%q) = %q filters on family %q, which no check in content/ uses", provider, filter, name)
+			}
+		}
+
+		// second authority: the provider's own metadata, when it is installed
+		metaPlatforms, metaFamilies := installedPlatforms(provider)
+		if len(metaPlatforms) == 0 {
+			skippedMeta++
+			continue
+		}
+		checkedMeta++
+		known := map[string]bool{}
+		for _, n := range metaPlatforms {
+			known[n] = true
+		}
+		knownFamily := map[string]bool{}
+		for _, f := range metaFamilies {
+			knownFamily[f] = true
+		}
+		for _, name := range platforms {
+			if !known[name] {
+				t.Errorf("defaultFilter(%q) = %q filters on platform %q, which the installed %s provider does not declare (Platforms[].name)", provider, filter, name, provider)
+			}
+		}
+		for _, name := range families {
+			if !knownFamily[name] {
+				t.Errorf("defaultFilter(%q) = %q filters on family %q, which the installed %s provider does not declare (Platforms[].family)", provider, filter, name, provider)
+			}
+		}
+	}
+
+	// CI runs with no providers installed, so say out loud how much of this test
+	// actually ran instead of reporting a vacuous pass.
+	t.Logf("checked %d/%d provider default(s) against installed provider metadata (%d skipped: provider not installed); all %d checked against content/",
+		checkedMeta, len(curatedFilters), skippedMeta, len(curatedFilters))
+}
+
+// TestDefaultFilterDerivesUnknownProviders covers the providers with no curated
+// default: the filter has to come from installed metadata, and when metadata
+// cannot answer, the wizard must offer no default at all rather than the old
+// `asset.platform == <provider name>` guess, which is dead for every provider
+// whose platforms are not named after it (github, terraform, gitlab, …).
+func TestDefaultFilterDerivesUnknownProviders(t *testing.T) {
+	orig := installedPlatforms
+	t.Cleanup(func() { installedPlatforms = orig })
+	installedPlatforms = func(provider string) ([]string, []string) {
+		switch provider {
+		case "github":
+			return []string{"github-org", "github-user", "github-repo"}, []string{"github"}
+		case "digitalocean":
+			return []string{"digitalocean", "digitalocean-database"}, []string{"digitalocean"}
+		}
+		return nil, nil
+	}
+
+	cases := map[string]string{
+		// a platform is named after the provider: use it
+		"digitalocean": `asset.platform == "digitalocean"`,
+		// none is, but the family is: use the family
+		"github": `asset.family.contains("github")`,
+		// nothing knows this provider: no default beats a dead one
+		"nosuchprovider": "",
+		"":               "",
+	}
+	for provider, want := range cases {
+		if got := defaultFilter(provider); got != want {
+			t.Errorf("defaultFilter(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+// contentFilterNames returns the platform and family names that checks in
+// content/ actually filter on.
+func contentFilterNames(t *testing.T) (platforms, families map[string]bool) {
+	t.Helper()
+	platforms, families = map[string]bool{}, map[string]bool{}
+
+	files, err := filepath.Glob(filepath.Join("..", "..", "..", "content", "*.mql.yaml"))
+	if err != nil {
+		t.Fatalf("glob content: %v", err)
+	}
+	packs, err := filepath.Glob(filepath.Join("..", "..", "..", "content", "querypacks", "*.mql.yaml"))
+	if err != nil {
+		t.Fatalf("glob querypacks: %v", err)
+	}
+	for _, f := range append(files, packs...) {
+		fh, err := os.Open(f)
+		if err != nil {
+			t.Fatalf("open %s: %v", f, err)
+		}
+		sc := bufio.NewScanner(fh)
+		sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for sc.Scan() {
+			line := sc.Text()
+			for _, m := range allSubmatches(platformFilterRe, line) {
+				platforms[m] = true
+			}
+			for _, m := range allSubmatches(familyFilterRe, line) {
+				families[m] = true
+			}
+		}
+		fh.Close()
+	}
+	return platforms, families
+}
+
+func allSubmatches(re *regexp.Regexp, s string) []string {
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(s, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// --- wizard plumbing for tests ----------------------------------------------
+
+// cappedBuffer is a concurrency-safe writer that stops growing past a limit. The
+// cap matters: a wizard that mishandles EOF spins, and an unbounded buffer turns
+// a failing test into an out-of-memory one (the real bug produced 73 MB of
+// stderr in six seconds).
+type cappedBuffer struct {
+	mu  sync.Mutex
+	b   strings.Builder
+	max int
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.b.Len() < c.max {
+		c.b.Write(p)
+	}
+	return len(p), nil
+}
+
+func (c *cappedBuffer) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.b.String()
+}
+
+// driveWizard runs the wizard against scripted stdin and fails the test if it
+// does not return: every prompt has to end the session at EOF instead of
+// answering itself with its default.
+func driveWizard(t *testing.T, gen *generate.Generator, opts wizardOpts, script string) (string, error) {
+	t.Helper()
+	out := &cappedBuffer{max: 1 << 20}
+	opts.In = strings.NewReader(script)
+	opts.Out = out
+
+	done := make(chan error, 1)
+	go func() { done <- runGenerateWizard(context.Background(), gen, opts) }()
+
+	select {
+	case err := <-done:
+		return out.String(), err
+	case <-time.After(10 * time.Second):
+		t.Fatalf("wizard did not return within 10s; output so far:\n%s", out.String())
+		return "", nil
+	}
+}
+
+// scriptedAgent writes a stub agent CLI that records every invocation in a
+// counter file and prints body. Counting invocations is the point: two of the
+// bugs here (EOF picking [r]etry, backing out of [e]dit) show up as extra calls
+// to a billed backend, not as a wrong file.
+func scriptedAgent(t *testing.T, body string) (bin, counter string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin = filepath.Join(dir, "agent.sh")
+	counter = filepath.Join(dir, "calls")
+	script := "#!/usr/bin/env bash\necho call >> " + counter + "\ncat <<'AGENTEOF'\n" + body + "\nAGENTEOF\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub agent: %v", err)
+	}
+	return bin, counter
+}
+
+func agentCalls(t *testing.T, counter string) int {
+	t.Helper()
+	data, err := os.ReadFile(counter)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return len(strings.Fields(string(data)))
+}
+
+func testGenerator(t *testing.T, bin string) *generate.Generator {
+	t.Helper()
+	t.Setenv("CNSPEC_AGENT_CLAUDE_BIN", bin)
+	backend, err := generate.Backend("claude")
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	gen, err := generate.New(generate.Config{
+		Backend:     backend,
+		Validator:   generate.NoopValidator{}, // no providers needed offline
+		MaxAttempts: 1,
+	})
+	if err != nil {
+		t.Fatalf("new generator: %v", err)
+	}
+	return gen
+}
+
+const okAgentReply = "```json\n{\"mql\": \"aws.s3.buckets.all(encryption != empty)\"}\n```"
+
+// --- EOF handling ------------------------------------------------------------
+
+// TestWizardEOFAtRequiredPromptEnds pins the runaway loop: promptRequired used to
+// re-print its prompt forever once stdin was at EOF.
+func TestWizardEOFAtRequiredPromptEnds(t *testing.T) {
+	bin, counter := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	// answers the bundle-file prompt, then stdin ends at the required title
+	out, err := driveWizard(t, gen, wizardOpts{File: file}, file+"\n")
+	if err != nil {
+		t.Fatalf("wizard returned %v, want a clean exit at EOF", err)
+	}
+	if n := strings.Count(out, "(required)"); n > 1 {
+		t.Errorf("re-prompted %d times at EOF; want at most one", n)
+	}
+	if calls := agentCalls(t, counter); calls != 0 {
+		t.Errorf("agent called %d times; EOF before any check must call it none", calls)
+	}
+}
+
+// TestWizardEOFDoesNotAcceptGeneratedMQL pins the guardrail from
+// docs/policy-generation-ux.md: generated MQL is never applied silently. At EOF
+// the review prompt used to return its first option — [a]ccept.
+func TestWizardEOFDoesNotAcceptGeneratedMQL(t *testing.T) {
+	bin, _ := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	// title, desc, provider, filter — then stdin ends at the review prompt
+	script := "S3 buckets must be encrypted\n\n\n\n"
+	out, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script)
+	if err != nil {
+		t.Fatalf("wizard returned %v, want a clean exit at EOF", err)
+	}
+	if _, statErr := os.Stat(file); statErr == nil {
+		data, _ := os.ReadFile(file)
+		t.Fatalf("EOF at the review prompt wrote unreviewed MQL to %s:\n%s", file, data)
+	}
+	if !strings.Contains(out, "added 0 check(s)") {
+		t.Errorf("expected a zero-check summary, got:\n%s", out)
+	}
+}
+
+// TestWizardEOFOnFailedGenerationDoesNotRetry pins the unattended-loop bug: when
+// generation failed, the choice prompt returned [r]etry at EOF and the wizard
+// re-invoked the agent as fast as it could return (270 invocations in 5s).
+func TestWizardEOFOnFailedGenerationDoesNotRetry(t *testing.T) {
+	bin, counter := scriptedAgent(t, "this is not a json envelope")
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	script := "S3 buckets must be encrypted\n\n\n\n"
+	if _, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script); err != nil {
+		t.Fatalf("wizard returned %v, want a clean exit at EOF", err)
+	}
+	if calls := agentCalls(t, counter); calls != 1 {
+		t.Errorf("agent invoked %d times after a failed generation; EOF must not retry", calls)
+	}
+}
+
+// --- review loop -------------------------------------------------------------
+
+// TestWizardEditBackoutKeepsCandidate pins that backing out of [e]dit returns to
+// the query under review instead of re-entering generation, which cost a second
+// billed invocation and swapped the query the user was looking at.
+func TestWizardEditBackoutKeepsCandidate(t *testing.T) {
+	t.Setenv("EDITOR", "") // force the inline editor, not a real one
+	bin, counter := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	// title, desc, provider, filter, [e]dit, empty edit (backs out), [s]kip, no
+	script := "S3 buckets must be encrypted\n\n\n\ne\n\ns\nn\n"
+	out, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if calls := agentCalls(t, counter); calls != 1 {
+		t.Errorf("agent invoked %d times; backing out of an edit must not regenerate", calls)
+	}
+	if n := strings.Count(out, "Generated MQL:"); n != 2 {
+		t.Errorf("candidate shown %d times, want 2 (before the edit and after backing out):\n%s", n, out)
+	}
+}
+
+// TestWizardRendersModelOutputWithoutControlCharacters pins that what the
+// reviewer sees is what gets written: an ANSI erase sequence in a generated
+// query can repaint the review line, hiding the rest of the query behind
+// innocuous-looking text, and FormatBundle strips those on write — so the screen
+// showed something the file did not contain.
+func TestWizardRendersModelOutputWithoutControlCharacters(t *testing.T) {
+	bin, _ := scriptedAgent(t, "```json\n{\"mql\": \"aws.s3.buckets.all(x)\\u001b[2K\\u001b[1G BACKDOOR\"}\n```")
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	// title, desc, provider, filter, [a]ccept, uid, no
+	script := "S3 buckets must be encrypted\n\n\n\na\ns3-check\nn\n"
+	out, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("review screen rendered a raw escape sequence:\n%q", out)
+	}
+	if !strings.Contains(out, "BACKDOOR") {
+		t.Errorf("the hidden part of the query was not shown to the reviewer:\n%s", out)
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		t.Fatalf("parse back: %v", err)
+	}
+	written := writtenCheck(t, b, "s3-check").Mql
+	if !strings.Contains(out, written) {
+		t.Errorf("what was written is not what was reviewed:\nwritten: %q\nshown:\n%s", written, out)
+	}
+}
+
+// --- what the wizard writes --------------------------------------------------
+
+// TestWizardWritesScannableBundle pins that an accepted check lands in a policy
+// group. A check that lives only in the top-level `queries:` block lints with a
+// query-unassigned warning and then fails `cnspec scan --policy-bundle` with
+// "a policy or framework mrn is required" — while the wizard tells the user to
+// lint it and commit it.
+func TestWizardWritesScannableBundle(t *testing.T) {
+	bin, _ := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "aws-s3.mql.yaml")
+
+	script := "S3 buckets must be encrypted\nAll buckets need SSE\n\n\na\ns3-encrypted\nn\n"
+	if _, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script); err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		t.Fatalf("parse back: %v\n%s", err, data)
+	}
+	if len(b.Policies) != 1 {
+		t.Fatalf("expected exactly one policy, got %d:\n%s", len(b.Policies), data)
+	}
+	p := b.Policies[0]
+	if p.Uid != "aws-s3" || p.Name == "" || p.Version == "" {
+		t.Errorf("policy needs a uid, name and version to lint: uid=%q name=%q version=%q", p.Uid, p.Name, p.Version)
+	}
+	if len(p.Groups) != 1 || len(p.Groups[0].Checks) != 1 {
+		t.Fatalf("expected one group with one check, got %+v", p.Groups)
+	}
+	if got := p.Groups[0].Checks[0].Uid; got != "s3-encrypted" {
+		t.Errorf("check uid = %q", got)
+	}
+	if len(b.Queries) != 0 {
+		t.Errorf("check was left dangling in the top-level queries block: %d entries", len(b.Queries))
+	}
+	q := writtenCheck(t, b, "s3-encrypted")
+	if q.Filters == nil {
+		t.Error("check lost its asset filter")
+	}
+	if q.Docs == nil || q.Docs.Desc != "All buckets need SSE" {
+		t.Error("check lost its description")
+	}
+}
+
+// TestWizardJoinsExistingPolicy pins that a check added to a bundle that already
+// has a policy joins it, rather than dangling next to it in `queries:`.
+func TestWizardJoinsExistingPolicy(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "existing.mql.yaml")
+	existing := `policies:
+  - uid: existing-policy
+    name: Existing policy
+    version: 1.0.0
+    groups:
+      - title: Kubernetes API Server
+        filters: |
+          asset.family.contains('linux')
+          processes.where( executable == /kube-apiserver/ ).list != []
+        checks:
+          - uid: existing-check
+            title: An existing check
+            mql: existing.value == 1
+`
+	if err := os.WriteFile(file, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendCheck(file, "new-check", "A new check", "", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+		t.Fatalf("appendCheck: %v", err)
+	}
+
+	data, _ := os.ReadFile(file)
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(b.Policies) != 1 {
+		t.Fatalf("expected the check to join the existing policy, got %d policies:\n%s", len(b.Policies), data)
+	}
+	if len(b.Queries) != 0 {
+		t.Errorf("check dangled in the top-level queries block:\n%s", data)
+	}
+	p := b.Policies[0]
+	if len(p.Groups) != 2 {
+		t.Fatalf("expected a group of its own, got %d groups:\n%s", len(p.Groups), data)
+	}
+	// the new check must not inherit the existing group's filter — that group is
+	// scoped to hosts running kube-apiserver, which would make an aws check dead
+	newGroup := p.Groups[1]
+	if newGroup.Filters != nil && len(newGroup.Filters.Items) > 0 {
+		t.Errorf("the generated group carries a filter that would gate the check: %+v", newGroup.Filters)
+	}
+	if len(newGroup.Checks) != 1 || newGroup.Checks[0].Uid != "new-check" {
+		t.Errorf("unexpected group contents: %+v", newGroup.Checks)
+	}
+}
+
+// TestAppendCheck covers the field-level round trip: a scalar filter, a
+// description, and a second check landing beside the first.
+func TestAppendCheck(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	if err := appendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+		t.Fatalf("appendCheck 1: %v", err)
+	}
+	if err := appendCheck(file, "c2", "Second check", "", "", "users.all(uid >= 0)"); err != nil {
+		t.Fatalf("appendCheck 2: %v", err)
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// scalar filter must round-trip (not the map form)
+	if !strings.Contains(string(data), `filters: asset.platform == "aws"`) {
+		t.Errorf("filter not scalar-serialized:\n%s", data)
+	}
+
+	b, err := bundle.ParseYaml(data)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	c1, c2 := writtenCheck(t, b, "c1"), writtenCheck(t, b, "c2")
+	if c1.Mql != "aws.s3.buckets.length > 0" {
+		t.Errorf("c1 mql = %q", c1.Mql)
+	}
+	if c1.Docs == nil || c1.Docs.Desc != "does a thing" {
+		t.Error("c1 desc missing")
+	}
+	if c2.Filters != nil {
+		t.Error("c2 should have no filter")
+	}
+}
+
+// TestAppendCheckRejectsDuplicateUID pins that a colliding uid is refused rather
+// than appended: two queries with the same uid in one file is a lint error
+// (query-uid-unique) the user only discovers later.
+func TestAppendCheckRejectsDuplicateUID(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+	if err := appendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+		t.Fatalf("appendCheck 1: %v", err)
+	}
+	err := appendCheck(file, "c1", "Second check", "", "", "users.all(uid >= 0)")
+	if err == nil {
+		t.Fatal("appending a duplicate uid succeeded; want an error")
+	}
+	if !strings.Contains(err.Error(), "c1") {
+		t.Errorf("error should name the uid: %v", err)
+	}
+
+	data, _ := os.ReadFile(file)
+	b, _ := bundle.ParseYaml(data)
+	if n := len(bundle.QueryUIDs(b)); n != 1 {
+		t.Errorf("bundle has %d uids, want 1 (the duplicate must not be written)", n)
+	}
+}
+
+// TestWizardRePromptsOnUIDCollision pins the interactive half of the same bug:
+// the Check UID prompt re-asks instead of writing a bundle that fails lint.
+func TestWizardRePromptsOnUIDCollision(t *testing.T) {
+	bin, _ := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+	if err := appendCheck(file, "taken", "Existing", "", `asset.platform == "aws"`, "existing.value == 1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// title, desc, provider, filter, [a]ccept, colliding uid, free uid, no
+	script := "S3 buckets must be encrypted\n\n\n\na\ntaken\nfree-uid\nn\n"
+	out, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if !strings.Contains(out, "already used") {
+		t.Errorf("collision was not reported to the user:\n%s", out)
+	}
+
+	data, _ := os.ReadFile(file)
+	b, _ := bundle.ParseYaml(data)
+	uids := bundle.QueryUIDs(b)
+	if !uids["taken"] || !uids["free-uid"] || len(uids) != 2 {
+		t.Errorf("unexpected uids %v in:\n%s", uids, data)
+	}
+}
+
+// TestWizardDryRunWritesNothing pins --dry-run, which the wizard ignored: help
+// says "Preview what would be generated without writing anything", and the flag
+// is reachable without -i because a bare tty run turns the wizard on itself.
+func TestWizardDryRunWritesNothing(t *testing.T) {
+	bin, _ := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
+
+	script := "S3 buckets must be encrypted\n\n\n\na\ns3-check\nn\n"
+	out, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true, DryRun: true}, script)
+	if err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		data, _ := os.ReadFile(file)
+		t.Fatalf("--dry-run wrote %s:\n%s", file, data)
+	}
+	if !strings.Contains(out, "dry run") || !strings.Contains(out, "s3-check") {
+		t.Errorf("dry run did not preview the check:\n%s", out)
+	}
+}
+
+// TestWizardOutputFlagIsHonoured pins that -o names the bundle instead of being
+// ignored while the wizard prompts for a file of its own.
+func TestWizardOutputFlagIsHonoured(t *testing.T) {
+	bin, _ := scriptedAgent(t, okAgentReply)
+	gen := testGenerator(t, bin)
+	file := filepath.Join(t.TempDir(), "chosen-by-flag.mql.yaml")
+
+	// no answer for a bundle-file prompt is scripted: there must not be one
+	script := "S3 buckets must be encrypted\n\n\n\na\ns3-check\nn\n"
+	if _, err := driveWizard(t, gen, wizardOpts{File: file, FileFromFlag: true}, script); err != nil {
+		t.Fatalf("wizard: %v", err)
+	}
+	if _, err := os.Stat(file); err != nil {
+		t.Fatalf("--output file not written: %v", err)
+	}
+}
+
+func TestNextFreeUID(t *testing.T) {
+	taken := map[string]bool{"a": true, "a-2": true}
+	if got := nextFreeUID("a", taken); got != "a-3" {
+		t.Errorf("nextFreeUID = %q, want a-3", got)
+	}
+	if got := nextFreeUID("b", taken); got != "b" {
+		t.Errorf("nextFreeUID = %q, want b", got)
+	}
+}
+
+func TestPolicyUIDForFile(t *testing.T) {
+	cases := map[string]string{
+		"aws-s3.mql.yaml":            "aws-s3",
+		"/tmp/policy.mql.yaml":       "policy",
+		"x.yaml":                     "generated-policy", // too short to lint
+		"My Bundle.mql.yaml":         "my-bundle",
+		"/tmp/dir/checks.mql.yml":    "checks",
+		"/tmp/dir/checks.mql.foobar": "checks-mql-foobar",
+	}
+	for in, want := range cases {
+		if got := policyUIDForFile(in); got != want {
+			t.Errorf("policyUIDForFile(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func writtenCheck(t *testing.T, b *bundle.Bundle, uid string) *bundle.Mquery {
+	t.Helper()
+	for _, q := range bundle.AllQueries(b) {
+		if q != nil && q.Uid == uid {
+			return q
+		}
+	}
+	t.Fatalf("check %q not found in bundle", uid)
+	return nil
+}

--- a/apps/cnspec/cmd/policy_generate_interactive_test.go
+++ b/apps/cnspec/cmd/policy_generate_interactive_test.go
@@ -4,11 +4,9 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -17,188 +15,6 @@ import (
 	"go.mondoo.com/cnspec/internal/bundle"
 	"go.mondoo.com/cnspec/internal/generate"
 )
-
-func TestSlugify(t *testing.T) {
-	cases := map[string]string{
-		"S3 buckets must be encrypted": "s3-buckets-must-be-encrypted",
-		"  Trim  --  dashes  ":         "trim-dashes",
-		"CIS 1.2: root/login!":         "cis-1-2-root-login",
-		"":                             "",
-	}
-	for in, want := range cases {
-		if got := slugify(in); got != want {
-			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-func TestGuessProvider(t *testing.T) {
-	if p := guessProvider("S3 buckets must be encrypted"); p != "aws" {
-		t.Errorf("aws guess = %q", p)
-	}
-	if p := guessProvider("SSH root login disabled"); p != "os" {
-		t.Errorf("os guess = %q", p)
-	}
-	if p := guessProvider("Something generic"); p != "" {
-		t.Errorf("expected no guess, got %q", p)
-	}
-}
-
-// --- default asset filters ---------------------------------------------------
-
-var (
-	platformFilterRe = regexp.MustCompile(`asset\.platform\s*==\s*"([a-z0-9._-]+)"`)
-	familyFilterRe   = regexp.MustCompile(`asset\.family\.contains\("([a-z0-9._-]+)"\)`)
-)
-
-// TestDefaultFilterUsesRealPlatformNames validates every filter the wizard
-// proposes against authorities outside this file: the platform and family names
-// that real checks in content/ filter on, and — when providers are installed —
-// the Platforms[] metadata of the provider itself.
-//
-// It replaces a test that restated defaultFilter's implementation back to
-// itself, which is how `asset.platform == "gcp"` and `asset.platform == "k8s"`
-// shipped green: neither name exists (gcp's platforms are gcp-project,
-// gcp-gke-cluster, …; k8s is a family, its platforms are k8s-cluster, k8s-pod,
-// …), so both filters matched no asset, ever, while lint stayed silent.
-func TestDefaultFilterUsesRealPlatformNames(t *testing.T) {
-	contentPlatforms, contentFamilies := contentFilterNames(t)
-	if len(contentPlatforms) == 0 {
-		t.Fatal("found no asset.platform filters in content/; the corpus this test derives from is missing")
-	}
-
-	var checkedMeta, skippedMeta int
-	for provider := range curatedFilters {
-		filter := defaultFilter(provider)
-		platforms := allSubmatches(platformFilterRe, filter)
-		families := allSubmatches(familyFilterRe, filter)
-		if len(platforms)+len(families) == 0 {
-			t.Errorf("defaultFilter(%q) = %q names neither a platform nor a family", provider, filter)
-			continue
-		}
-
-		for _, name := range platforms {
-			if !contentPlatforms[name] {
-				t.Errorf("defaultFilter(%q) = %q filters on platform %q, which no check in content/ uses; a platform name that does not exist matches no asset", provider, filter, name)
-			}
-		}
-		for _, name := range families {
-			if !contentFamilies[name] {
-				t.Errorf("defaultFilter(%q) = %q filters on family %q, which no check in content/ uses", provider, filter, name)
-			}
-		}
-
-		// second authority: the provider's own metadata, when it is installed
-		metaPlatforms, metaFamilies := installedPlatforms(provider)
-		if len(metaPlatforms) == 0 {
-			skippedMeta++
-			continue
-		}
-		checkedMeta++
-		known := map[string]bool{}
-		for _, n := range metaPlatforms {
-			known[n] = true
-		}
-		knownFamily := map[string]bool{}
-		for _, f := range metaFamilies {
-			knownFamily[f] = true
-		}
-		for _, name := range platforms {
-			if !known[name] {
-				t.Errorf("defaultFilter(%q) = %q filters on platform %q, which the installed %s provider does not declare (Platforms[].name)", provider, filter, name, provider)
-			}
-		}
-		for _, name := range families {
-			if !knownFamily[name] {
-				t.Errorf("defaultFilter(%q) = %q filters on family %q, which the installed %s provider does not declare (Platforms[].family)", provider, filter, name, provider)
-			}
-		}
-	}
-
-	// CI runs with no providers installed, so say out loud how much of this test
-	// actually ran instead of reporting a vacuous pass.
-	t.Logf("checked %d/%d provider default(s) against installed provider metadata (%d skipped: provider not installed); all %d checked against content/",
-		checkedMeta, len(curatedFilters), skippedMeta, len(curatedFilters))
-}
-
-// TestDefaultFilterDerivesUnknownProviders covers the providers with no curated
-// default: the filter has to come from installed metadata, and when metadata
-// cannot answer, the wizard must offer no default at all rather than the old
-// `asset.platform == <provider name>` guess, which is dead for every provider
-// whose platforms are not named after it (github, terraform, gitlab, …).
-func TestDefaultFilterDerivesUnknownProviders(t *testing.T) {
-	orig := installedPlatforms
-	t.Cleanup(func() { installedPlatforms = orig })
-	installedPlatforms = func(provider string) ([]string, []string) {
-		switch provider {
-		case "github":
-			return []string{"github-org", "github-user", "github-repo"}, []string{"github"}
-		case "digitalocean":
-			return []string{"digitalocean", "digitalocean-database"}, []string{"digitalocean"}
-		}
-		return nil, nil
-	}
-
-	cases := map[string]string{
-		// a platform is named after the provider: use it
-		"digitalocean": `asset.platform == "digitalocean"`,
-		// none is, but the family is: use the family
-		"github": `asset.family.contains("github")`,
-		// nothing knows this provider: no default beats a dead one
-		"nosuchprovider": "",
-		"":               "",
-	}
-	for provider, want := range cases {
-		if got := defaultFilter(provider); got != want {
-			t.Errorf("defaultFilter(%q) = %q, want %q", provider, got, want)
-		}
-	}
-}
-
-// contentFilterNames returns the platform and family names that checks in
-// content/ actually filter on.
-func contentFilterNames(t *testing.T) (platforms, families map[string]bool) {
-	t.Helper()
-	platforms, families = map[string]bool{}, map[string]bool{}
-
-	files, err := filepath.Glob(filepath.Join("..", "..", "..", "content", "*.mql.yaml"))
-	if err != nil {
-		t.Fatalf("glob content: %v", err)
-	}
-	packs, err := filepath.Glob(filepath.Join("..", "..", "..", "content", "querypacks", "*.mql.yaml"))
-	if err != nil {
-		t.Fatalf("glob querypacks: %v", err)
-	}
-	for _, f := range append(files, packs...) {
-		fh, err := os.Open(f)
-		if err != nil {
-			t.Fatalf("open %s: %v", f, err)
-		}
-		sc := bufio.NewScanner(fh)
-		sc.Buffer(make([]byte, 1024*1024), 1024*1024)
-		for sc.Scan() {
-			line := sc.Text()
-			for _, m := range allSubmatches(platformFilterRe, line) {
-				platforms[m] = true
-			}
-			for _, m := range allSubmatches(familyFilterRe, line) {
-				families[m] = true
-			}
-		}
-		fh.Close()
-	}
-	return platforms, families
-}
-
-func allSubmatches(re *regexp.Regexp, s string) []string {
-	var out []string
-	for _, m := range re.FindAllStringSubmatch(s, -1) {
-		out = append(out, m[1])
-	}
-	return out
-}
-
-// --- wizard plumbing for tests ----------------------------------------------
 
 // cappedBuffer is a concurrency-safe writer that stops growing past a limit. The
 // cap matters: a wizard that mishandles EOF spins, and an unbounded buffer turns
@@ -491,7 +307,7 @@ func TestWizardJoinsExistingPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := appendCheck(file, "new-check", "A new check", "", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+	if err := bundle.AppendCheck(file, "new-check", "A new check", "", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
 		t.Fatalf("appendCheck: %v", err)
 	}
 
@@ -526,10 +342,10 @@ func TestWizardJoinsExistingPolicy(t *testing.T) {
 func TestAppendCheck(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
 
-	if err := appendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+	if err := bundle.AppendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
 		t.Fatalf("appendCheck 1: %v", err)
 	}
-	if err := appendCheck(file, "c2", "Second check", "", "", "users.all(uid >= 0)"); err != nil {
+	if err := bundle.AppendCheck(file, "c2", "Second check", "", "", "users.all(uid >= 0)"); err != nil {
 		t.Fatalf("appendCheck 2: %v", err)
 	}
 
@@ -563,10 +379,10 @@ func TestAppendCheck(t *testing.T) {
 // (query-uid-unique) the user only discovers later.
 func TestAppendCheckRejectsDuplicateUID(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
-	if err := appendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
+	if err := bundle.AppendCheck(file, "c1", "First check", "does a thing", `asset.platform == "aws"`, "aws.s3.buckets.length > 0"); err != nil {
 		t.Fatalf("appendCheck 1: %v", err)
 	}
-	err := appendCheck(file, "c1", "Second check", "", "", "users.all(uid >= 0)")
+	err := bundle.AppendCheck(file, "c1", "Second check", "", "", "users.all(uid >= 0)")
 	if err == nil {
 		t.Fatal("appending a duplicate uid succeeded; want an error")
 	}
@@ -587,7 +403,7 @@ func TestWizardRePromptsOnUIDCollision(t *testing.T) {
 	bin, _ := scriptedAgent(t, okAgentReply)
 	gen := testGenerator(t, bin)
 	file := filepath.Join(t.TempDir(), "policy.mql.yaml")
-	if err := appendCheck(file, "taken", "Existing", "", `asset.platform == "aws"`, "existing.value == 1"); err != nil {
+	if err := bundle.AppendCheck(file, "taken", "Existing", "", `asset.platform == "aws"`, "existing.value == 1"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -650,10 +466,10 @@ func TestWizardOutputFlagIsHonoured(t *testing.T) {
 
 func TestNextFreeUID(t *testing.T) {
 	taken := map[string]bool{"a": true, "a-2": true}
-	if got := nextFreeUID("a", taken); got != "a-3" {
+	if got := bundle.NextFreeUID("a", taken); got != "a-3" {
 		t.Errorf("nextFreeUID = %q, want a-3", got)
 	}
-	if got := nextFreeUID("b", taken); got != "b" {
+	if got := bundle.NextFreeUID("b", taken); got != "b" {
 		t.Errorf("nextFreeUID = %q, want b", got)
 	}
 }
@@ -668,8 +484,8 @@ func TestPolicyUIDForFile(t *testing.T) {
 		"/tmp/dir/checks.mql.foobar": "checks-mql-foobar",
 	}
 	for in, want := range cases {
-		if got := policyUIDForFile(in); got != want {
-			t.Errorf("policyUIDForFile(%q) = %q, want %q", in, got, want)
+		if got := bundle.PolicyUIDForFile(in); got != want {
+			t.Errorf("bundle.PolicyUIDForFile(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/apps/cnspec/cmd/policy_generate_test.go
+++ b/apps/cnspec/cmd/policy_generate_test.go
@@ -1,0 +1,317 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/generate"
+)
+
+// stubAgent writes an executable shell script that emits a fixed JSON envelope,
+// standing in for a coding-agent CLI so the command can be exercised offline.
+func stubAgent(t *testing.T, dir, mql string) string {
+	t.Helper()
+	path := filepath.Join(dir, "stub-agent.sh")
+	script := "#!/usr/bin/env bash\ncat <<'EOF'\n```json\n{\"mql\": \"" + mql + "\"}\n```\nEOF\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+const genCmdFixture = `queries:
+  - uid: empty-check
+    title: Empty check that needs mql
+    filters: asset.platform == "aws"
+    docs:
+      desc: All buckets must be encrypted.
+  - uid: has-check
+    title: Already implemented
+    mql: |
+      existing.value == 1
+  - uid: variant-parent
+    title: Parent intent for variants
+    docs:
+      desc: The intent lives here, not on the leaves.
+    variants:
+      - uid: variant-parent-aws
+  - uid: variant-parent-aws
+    filters: asset.platform == "aws"
+`
+
+func TestPolicyGenerate_WriteBack(t *testing.T) {
+	dir := t.TempDir()
+	agent := stubAgent(t, dir, "generated.value == true")
+	t.Setenv("CNSPEC_AGENT_CLAUDE_BIN", agent)
+
+	file := filepath.Join(dir, "policy.mql.yaml")
+	if err := os.WriteFile(file, []byte(genCmdFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	backend, err := generate.Backend("claude")
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	gen, err := generate.New(generate.Config{
+		Backend:   backend,
+		Validator: generate.NoopValidator{}, // no providers needed offline
+	})
+	if err != nil {
+		t.Fatalf("new generator: %v", err)
+	}
+
+	generated, failed, err := generateForFile(context.Background(), gen, file, false, false, true, "", false)
+	if err != nil {
+		t.Fatalf("generateForFile: %v", err)
+	}
+	if failed != 0 {
+		t.Fatalf("expected 0 failed, got %d", failed)
+	}
+	// empty-check and variant-parent-aws (leaf) should generate; parent and
+	// has-check should not.
+	if generated != 2 {
+		t.Fatalf("expected 2 generated, got %d", generated)
+	}
+
+	out, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	b, err := bundle.ParseYaml(out)
+	if err != nil {
+		t.Fatalf("parse back: %v", err)
+	}
+	byUID := map[string]*bundle.Mquery{}
+	for _, q := range bundle.AllQueries(b) {
+		byUID[q.Uid] = q
+	}
+
+	if got := byUID["empty-check"].Mql; got != "generated.value == true" {
+		t.Errorf("empty-check mql = %q, want generated", got)
+	}
+	if got := byUID["variant-parent-aws"].Mql; got != "generated.value == true" {
+		t.Errorf("variant leaf mql = %q, want generated (inherited intent)", got)
+	}
+	if got := strings.TrimSpace(byUID["has-check"].Mql); got != "existing.value == 1" {
+		t.Errorf("has-check mql changed to %q, want untouched", got)
+	}
+	if got := strings.TrimSpace(byUID["variant-parent"].Mql); got != "" {
+		t.Errorf("variant parent got mql %q, want empty", got)
+	}
+}
+
+func TestPolicyGenerate_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	agent := stubAgent(t, dir, "fresh.value == true")
+	t.Setenv("CNSPEC_AGENT_CLAUDE_BIN", agent)
+
+	file := filepath.Join(dir, "policy.mql.yaml")
+	src := "queries:\n  - uid: c1\n    title: A check\n    filters: asset.platform == \"aws\"\n    mql: old.value == 1\n"
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	backend, _ := generate.Backend("claude")
+	gen, _ := generate.New(generate.Config{Backend: backend, Validator: generate.NoopValidator{}, Force: true})
+
+	generated, _, err := generateForFile(context.Background(), gen, file, true, false, true, "", false)
+	if err != nil {
+		t.Fatalf("generateForFile: %v", err)
+	}
+	if generated != 1 {
+		t.Fatalf("expected 1 generated with --force, got %d", generated)
+	}
+	out, _ := os.ReadFile(file)
+	if !strings.Contains(string(out), "fresh.value == true") {
+		t.Fatalf("force did not overwrite; file:\n%s", out)
+	}
+}
+
+// TestPolicyGenerate_StdoutPassThrough pins that stdout mode always emits the
+// bundle. `cnspec policy generate in.yaml > out.yaml` with nothing to generate
+// used to print nothing at all, leaving a 0-byte out.yaml and exit 0 — so a
+// scripted `... && mv out.yaml in.yaml` destroyed the bundle.
+func TestPolicyGenerate_StdoutPassThrough(t *testing.T) {
+	dir := t.TempDir()
+	agent := stubAgent(t, dir, "unused.value == true")
+	t.Setenv("CNSPEC_AGENT_CLAUDE_BIN", agent)
+
+	file := filepath.Join(dir, "policy.mql.yaml")
+	// every check already has mql, so there is nothing to generate
+	src := "queries:\n  - uid: c1\n    title: A check\n    filters: asset.platform == \"aws\"\n    mql: old.value == 1\n"
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	backend, _ := generate.Backend("claude")
+	gen, _ := generate.New(generate.Config{Backend: backend, Validator: generate.NoopValidator{}})
+
+	stdout := captureStdout(t, func() {
+		generated, failed, err := generateForFile(context.Background(), gen, file, false, false, false, "", false)
+		if err != nil {
+			t.Fatalf("generateForFile: %v", err)
+		}
+		if generated != 0 || failed != 0 {
+			t.Fatalf("expected nothing to generate, got %d generated / %d failed", generated, failed)
+		}
+	})
+
+	if stdout == "" {
+		t.Fatal("stdout mode emitted nothing; a redirected run would truncate the caller's file")
+	}
+	if stdout != src {
+		t.Errorf("stdout is not the input bundle:\ngot:\n%s\nwant:\n%s", stdout, src)
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe while fn runs. fmt.Print resolves
+// os.Stdout at call time, so this catches what the command writes.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		io.Copy(&sb, r) //nolint:errcheck // the pipe read ends when the writer closes
+		done <- sb.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	w.Close()
+	out := <-done
+	r.Close()
+	return out
+}
+
+// TestPolicyGenerate_InteractiveRejectsInPlace pins that a flag the guided flow
+// cannot honour is refused rather than silently ignored. It is reachable without
+// typing -i: a bare tty run turns the wizard on by itself.
+func TestPolicyGenerate_InteractiveRejectsInPlace(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().AddFlagSet(policyGenerateCmd.Flags())
+	if err := cmd.Flags().Set("interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("in-place", "true"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		policyGenerateCmd.Flags().Set("interactive", "false") //nolint:errcheck // restoring shared flag state
+		policyGenerateCmd.Flags().Set("in-place", "false")    //nolint:errcheck // restoring shared flag state
+	})
+
+	err := runPolicyGenerate(cmd, nil)
+	if err == nil {
+		t.Fatal("--in-place with --interactive was accepted; want an error")
+	}
+	if !strings.Contains(err.Error(), "--in-place") {
+		t.Errorf("error should name the flag: %v", err)
+	}
+}
+
+// TestBundlePropsCarriesDefiningQuery pins the wiring that makes prop-typing
+// work at all. A prop resolves `props.<name>` for the compiler only if it has a
+// type, and content props almost never declare `type:` — 80 prop-using queries
+// in content/ and the common shape is a bare `mql: '12'`. The type therefore has
+// to come from compiling the prop's own defining query, so dropping Mql here
+// leaves every prop typed `any` and every comparison against one uncompilable.
+func TestBundlePropsCarriesDefiningQuery(t *testing.T) {
+	q := &bundle.Mquery{
+		Uid: "check-with-props",
+		Props: []*bundle.Property{
+			{Uid: "minLength", Mql: "12", Title: "Minimum password length"},
+			{Uid: "typed", Mql: "\"x\"", Type: "string", Desc: "declared type wins"},
+		},
+	}
+
+	props := bundleProps(q)
+	if len(props) != 2 {
+		t.Fatalf("got %d props, want 2", len(props))
+	}
+	if props[0].Name != "minLength" || props[0].Mql != "12" {
+		t.Errorf("prop without a declared type lost its defining query: %+v", props[0])
+	}
+	// the title is the only human summary an authored prop usually has
+	if props[0].Desc != "Minimum password length" {
+		t.Errorf("desc fallback to title broke: %q", props[0].Desc)
+	}
+	if props[1].Type != "string" || props[1].Mql != "\"x\"" {
+		t.Errorf("declared type and defining query must both survive: %+v", props[1])
+	}
+}
+
+// TestPropUsingContentChecksValidate walks every prop-using check in content/
+// and compiles it through the same path `cnspec policy generate` uses to gate a
+// generated query. It is the end-to-end proof for prop typing: the props a
+// check declares must reach the compiler carrying enough type information to
+// resolve `props.<name>`.
+func TestPropUsingContentChecksValidate(t *testing.T) {
+	v, err := generate.NewCompileValidator()
+	if err != nil {
+		t.Skipf("no validator: %v", err)
+	}
+	if err := v.(generate.ProviderChecker).CheckProvider("core"); err != nil {
+		t.Skipf("providers unavailable: %v", err)
+	}
+
+	root := "../../../content"
+	files, _ := filepath.Glob(filepath.Join(root, "*.mql.yaml"))
+	if len(files) == 0 {
+		t.Skip("content/ not present")
+	}
+
+	var checked, ok, failed int
+	var failures []string
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		b, err := bundle.ParseYaml(data)
+		if err != nil {
+			continue
+		}
+		for _, q := range b.Queries {
+			if q == nil || len(q.Props) == 0 || strings.TrimSpace(q.Mql) == "" {
+				continue
+			}
+			if !strings.Contains(q.Mql, "props.") {
+				continue
+			}
+			checked++
+			if err := v.Validate(generate.ValidationRequest{MQL: q.Mql, Props: bundleProps(q)}); err != nil {
+				failed++
+				if len(failures) < 5 {
+					failures = append(failures, q.Uid+": "+err.Error())
+				}
+				continue
+			}
+			ok++
+		}
+	}
+	t.Logf("prop-using checks: %d checked, %d compiled, %d failed", checked, ok, failed)
+	if checked == 0 {
+		t.Fatal("checked 0 prop-using checks — the corpus walk found nothing, so this test asserts nothing")
+	}
+	if failed != 0 {
+		t.Errorf("%d/%d prop-using checks failed to compile:\n%s", failed, checked, strings.Join(failures, "\n"))
+	}
+}

--- a/apps/cnspec/cmd/policy_generate_test.go
+++ b/apps/cnspec/cmd/policy_generate_test.go
@@ -263,22 +263,33 @@ func TestBundlePropsCarriesDefiningQuery(t *testing.T) {
 // generated query. It is the end-to-end proof for prop typing: the props a
 // check declares must reach the compiler carrying enough type information to
 // resolve `props.<name>`.
+//
+// Whether a check can say anything is decided by asking the provider registry
+// what is installed, never by inspecting the compile error. Both failures look
+// alike from the outside — a missing provider and an untyped prop each end in
+// "does not compile" — so a test that inferred the environment from the error
+// would quietly reclassify a real regression as "provider not installed" and
+// skip. It did exactly that when first written.
+//
+// Checks whose provider is installed are held strictly: they must compile. The
+// rest are unverifiable here and are counted, so a run that proved nothing
+// cannot be mistaken for a run that passed.
 func TestPropUsingContentChecksValidate(t *testing.T) {
 	v, err := generate.NewCompileValidator()
 	if err != nil {
-		t.Skipf("no validator: %v", err)
+		t.Skipf("no validator available: %v", err)
 	}
-	if err := v.(generate.ProviderChecker).CheckProvider("core"); err != nil {
-		t.Skipf("providers unavailable: %v", err)
+	checker, ok := v.(generate.ProviderChecker)
+	if !ok {
+		t.Skip("validator cannot report which providers are installed")
 	}
 
-	root := "../../../content"
-	files, _ := filepath.Glob(filepath.Join(root, "*.mql.yaml"))
+	files, _ := filepath.Glob(filepath.Join("../../../content", "*.mql.yaml"))
 	if len(files) == 0 {
 		t.Skip("content/ not present")
 	}
 
-	var checked, ok, failed int
+	var found, verified, unverifiable, failed int
 	var failures []string
 	for _, f := range files {
 		data, err := os.ReadFile(f)
@@ -296,22 +307,41 @@ func TestPropUsingContentChecksValidate(t *testing.T) {
 			if !strings.Contains(q.Mql, "props.") {
 				continue
 			}
-			checked++
-			if err := v.Validate(generate.ValidationRequest{MQL: q.Mql, Props: bundleProps(q)}); err != nil {
+			found++
+
+			props := bundleProps(q)
+			provider, _ := generate.ResolveProvider(generate.Check{
+				UID:     q.Uid,
+				Filters: bundle.QueryFilterStrings(q),
+			})
+			// an unresolved provider is not a safe "check it anyway": these are
+			// the os/network checks, whose resources are just as absent on a bare
+			// box as a named provider's would be.
+			if provider == "" || checker.CheckProvider(provider) != nil {
+				unverifiable++
+				continue
+			}
+
+			verified++
+			if err := v.Validate(generate.ValidationRequest{MQL: q.Mql, Props: props}); err != nil {
 				failed++
 				if len(failures) < 5 {
 					failures = append(failures, q.Uid+": "+err.Error())
 				}
-				continue
 			}
-			ok++
 		}
 	}
-	t.Logf("prop-using checks: %d checked, %d compiled, %d failed", checked, ok, failed)
-	if checked == 0 {
-		t.Fatal("checked 0 prop-using checks — the corpus walk found nothing, so this test asserts nothing")
+
+	t.Logf("prop-using checks: %d found, %d verified against installed providers, %d unverifiable",
+		found, verified, unverifiable)
+	if found == 0 {
+		t.Fatal("found 0 prop-using checks — the corpus walk found nothing, so this test asserts nothing")
 	}
-	if failed != 0 {
-		t.Errorf("%d/%d prop-using checks failed to compile:\n%s", failed, checked, strings.Join(failures, "\n"))
+	if failed > 0 {
+		t.Errorf("%d of %d verifiable prop-using checks failed to compile (first %d shown):\n%s",
+			failed, verified, len(failures), strings.Join(failures, "\n"))
+	}
+	if verified == 0 {
+		t.Skipf("no provider for any of the %d prop-using checks is installed; prop typing was not exercised", found)
 	}
 }

--- a/apps/cnspec/cmd/policy_graph.go
+++ b/apps/cnspec/cmd/policy_graph.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"go.mondoo.com/cnspec/internal/bundle"
+	"go.mondoo.com/cnspec/internal/textrank"
 )
 
 func init() {
@@ -40,6 +41,8 @@ func init() {
 	policyGraphSearchCmd.Flags().Int("impact", 0, "Minimum impact score")
 	policyGraphSearchCmd.Flags().Int("limit", 50, "Maximum results")
 	policyGraphSearchCmd.Flags().Bool("json", false, "Output as JSON")
+	policyGraphSearchCmd.Flags().Bool("similar", false, "Rank checks by relevance to the query (BM25 over title+MQL) instead of identifier matching")
+	policyGraphSearchCmd.Flags().String("provider", "", "With --similar, bias results toward this provider")
 	policyGraphCmd.AddCommand(policyGraphSearchCmd)
 }
 
@@ -210,25 +213,42 @@ var policyGraphExportCmd = &cobra.Command{
 
 var policyGraphSearchCmd = &cobra.Command{
 	Use:   "search <query> <path>",
-	Short: "Search for nodes by name, title, or UID",
-	Long:  "Find policy graph nodes using multi-strategy search: exact name, prefix, or substring match across names, qualified names, and titles.",
-	Args:  cobra.MinimumNArgs(2),
+	Short: "Search for nodes by name/title/UID, or by relevance with --similar",
+	Long: `Find policy graph nodes.
+
+By default this is identifier navigation: exact name, prefix, or substring match
+across names, qualified names, and titles.
+
+With --similar it becomes relevance ranking: checks are scored by BM25 over their
+title and MQL, so you can find existing checks to mirror when authoring or
+generating a new one. Use --provider to bias toward a provider.
+
+Examples:
+  cnspec policy graph search aws.s3 ./content
+  cnspec policy graph search "buckets must be encrypted" ./content --similar --provider aws`,
+	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		query, paths := args[0], args[1:]
 		g := mustBuildGraph(paths)
-		idx := g.BuildNodeIndex()
-
-		kind, _ := cmd.Flags().GetString("kind")
-		tag, _ := cmd.Flags().GetString("tag")
-		impact, _ := cmd.Flags().GetInt("impact")
 		limit, _ := cmd.Flags().GetInt("limit")
 
-		results := idx.Search(query, bundle.SearchOpts{
-			Kind:      bundle.NodeKind(kind),
-			TagKey:    tag,
-			MinImpact: impact,
-			Limit:     limit,
-		})
+		var results []*bundle.GraphNode
+		if similar, _ := cmd.Flags().GetBool("similar"); similar {
+			// relevance ranking over check bodies, for finding checks to mirror
+			provider, _ := cmd.Flags().GetString("provider")
+			results = rankSimilarNodes(g, query, provider, limit)
+		} else {
+			// identifier/substring navigation over the node graph
+			kind, _ := cmd.Flags().GetString("kind")
+			tag, _ := cmd.Flags().GetString("tag")
+			impact, _ := cmd.Flags().GetInt("impact")
+			results = g.BuildNodeIndex().Search(query, bundle.SearchOpts{
+				Kind:      bundle.NodeKind(kind),
+				TagKey:    tag,
+				MinImpact: impact,
+				Limit:     limit,
+			})
+		}
 
 		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
 			printJSON(results)
@@ -246,6 +266,49 @@ var policyGraphSearchCmd = &cobra.Command{
 			fmt.Printf("%-12s %-50s %-40s (%s:%d)\n", n.Kind, qualName, title, n.File, n.Line)
 		}
 	},
+}
+
+// rankSimilarNodes ranks check/query nodes by BM25 relevance to the query,
+// optionally biased toward a provider. This is the "find checks like this"
+// counterpart to the identifier navigation of NodeIndex.Search.
+func rankSimilarNodes(g *bundle.PolicyGraph, query, provider string, limit int) []*bundle.GraphNode {
+	byID := map[string]*bundle.GraphNode{}
+	var docs []textrank.Document
+	for _, n := range g.Nodes {
+		if n == nil {
+			continue
+		}
+		if strings.TrimSpace(n.MQL) == "" && strings.TrimSpace(n.Title) == "" {
+			continue // structural nodes with no body/title aren't useful matches
+		}
+		byID[n.ID] = n
+		docs = append(docs, textrank.Document{
+			ID: n.ID,
+			Parts: []textrank.WeightedText{
+				{Text: n.Title, Weight: 3},
+				{Text: n.QualName, Weight: 1},
+				{Text: n.MQL, Weight: 1},
+			},
+		})
+	}
+
+	scored := textrank.Build(docs).SearchBonus(query, limit, func(id string) float64 {
+		if provider == "" {
+			return 0
+		}
+		if n := byID[id]; n != nil && strings.HasPrefix(strings.TrimSpace(n.MQL), provider+".") {
+			return 5.0
+		}
+		return 0
+	})
+
+	out := make([]*bundle.GraphNode, 0, len(scored))
+	for _, s := range scored {
+		if n := byID[s.ID]; n != nil {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 func mustBuildGraph(paths []string) *bundle.PolicyGraph {

--- a/docs/adr/0004-description-first-policy-authoring.md
+++ b/docs/adr/0004-description-first-policy-authoring.md
@@ -1,0 +1,392 @@
+# ADR-0004: Description-First Policy Authoring
+
+**Date:** 2026-08-08
+**Status:** Accepted (implemented)
+
+## Context
+
+Writing MQL requires specialized knowledge: cnspec resource schemas and field
+names (`aws.s3.buckets.encryption.rules`), MQL syntax (`.all()`, `.none()`,
+`.where()`), null/empty edge-case handling, and platform-specific details across
+AWS, GCP, Azure, Kubernetes, Linux, and Windows. Security teams generally know
+*what* they want to check but not *how* to express it in MQL, which creates a
+bottleneck: policy authors depend on MQL experts to implement their intent.
+
+Today a query carries both the human intent and the implementation, authored
+separately and by hand:
+
+```yaml
+- uid: s3-encryption
+  title: S3 buckets must be encrypted
+  docs:
+    desc: All S3 buckets must have server-side encryption enabled using AES-256 or KMS.
+  mql: |
+    aws.s3.buckets.all(encryption.rules.all(
+      applyServerSideEncryptionByDefault.sseAlgorithm == "AES256" ||
+      applyServerSideEncryptionByDefault.sseAlgorithm == "aws:kms"))
+```
+
+The `desc` and the `mql` drift apart, the MQL can silently contradict the
+description, and new team members cannot easily verify correctness.
+
+A prior RFC proposed embedding an LLM client (Anthropic SDK, API keys) inside
+cnspec and routing schema lookup and validation through a **cnspec MCP server**.
+Investigation of the codebase found that the MCP server does not exist, that
+everything it would expose already exists as deterministic CLI commands
+(`cnspec providers resources … --json`, `cnspec run … --ast`), and that cnspec
+already ships an `mql` agent skill (`skills/mql/SKILL.md`). The right move is not
+to reimplement an agent loop with a raw SDK, but to build the tools well and let
+capable coding agents (which users already run) do the generation.
+
+This ADR makes the two intended use cases **explicit**, because they have
+different drivers and must both be first-class:
+
+- **UC1 — Coding agents generate policies using cnspec's tools.** The agent
+  (Claude Code, Codex, Kimi 3, DeepSeek, or any future one) is the driver. cnspec
+  provides everything the agent needs to be effective: schema discovery, MQL
+  validation, similar-query search, and a maintained skill.
+- **UC2 — cnspec drives the user through the policy-writing journey.** cnspec is
+  the driver. `cnspec policy generate` walks the user through choosing a
+  **target**, stating **what will be tested**, **searching similar existing
+  queries** to ground generation, and producing validated MQL — using an agent
+  CLI as its backend under the hood.
+
+The key design property: **both use cases consume one shared tool layer.** UC1 is
+that layer exposed to an external agent; UC2 is cnspec orchestrating the same
+layer for a human. We build the tools once.
+
+## Decision
+
+### 1. Support both use cases explicitly, over one shared tool layer
+
+```
+                    ┌───────────────────────────────────────┐
+   UC1: agent  ───► │  Shared tool layer                    │
+   drives          │   • schema discovery                   │
+                    │   • MQL validation (compile + assert)  │ ◄─── UC2: cnspec
+   UC2: cnspec ───► │   • similar-query search               │      drives user
+   drives          │   • maintained mql skill               │      + agent backend
+                    └───────────────────────────────────────┘
+```
+
+Neither use case gets a private mechanism. Anything UC2's guided flow needs is a
+command/tool that UC1's agents can also call, and vice versa. This keeps the two
+consistent and avoids a second, divergent code path.
+
+Common to both: cnspec ships **no** LLM SDK, **no** API-key handling, and **no**
+MCP server for this. When a model call is needed it is delegated to an agent CLI
+the user already configured. Scan-time execution is untouched and fully
+deterministic — generation is a dev-time step producing committed MQL.
+
+### 2. The shared tool layer
+
+| Capability | Command | Status |
+|------------|---------|--------|
+| List resources for a provider | `cnspec providers resources <provider> --json` | ships today |
+| Inspect a resource's fields/types | `cnspec providers resources <provider> <resource> --json` | ships today |
+| Validate MQL compiles against schema | `cnspec run <conn> -c "<mql>" --ast` (exit 1 on bad resource/field) | ships today |
+| Execute-and-assert (semantics, §5) | `cnspec run <conn> -c "<mql>"` against a fixture | new gate (§5) |
+| Search similar existing queries (§4) | `cnspec policy graph search "<intent>" <path> --similar [--provider <p>]` | new (§4) |
+| Lint / format a bundle | `cnspec policy lint … -o sarif` / `cnspec policy format …` | ships today |
+| MQL know-how + correctness rules | `skills/mql/SKILL.md` | ships; needs updates (§6) |
+
+The two genuinely new build items are the **execute-and-assert** gate (§5) and
+**similar-query search** (§4). Everything else already ships.
+
+### 3. UC1 — cnspec as tool provider for coding agents
+
+The agent's own harness is the driver; cnspec is the toolbox. The **contract is
+the `mql` skill**: it documents every tool above and the MQL correctness rules,
+and is surfaced to each agent through its native entry file — same content,
+different front door:
+
+| Agent | Entry point |
+|-------|-------------|
+| Claude Code | `CLAUDE.md` + `skills/mql/SKILL.md` (plugin, auto-loads on MQL intent) |
+| Codex | `agents/AGENTS.md` → `skills/mql/SKILL.md` |
+| Kimi 3 | `AGENTS.md` (agentic-coding convention) |
+| DeepSeek | `AGENTS.md` / explicit skill path |
+
+Because the contract is "read a skill, run a CLI," UC1 works for any repo-aware
+agent; the four above are the supported/tested set. No cnspec orchestration
+process is involved in UC1 — the agent calls the commands directly.
+
+### 4. UC2 — cnspec drives the policy-writing journey
+
+`cnspec policy generate <bundle.mql.yaml>` (interactive) walks the user through
+the journey and orchestrates a coding-agent CLI as its generation **backend**:
+
+1. **Target.** Pick the provider/platform the check applies to. cnspec resolves
+   this to the check's `filters:` (`asset.platform == "..."`) — the authoritative
+   provider signal — rather than guessing from the UID.
+2. **Intent.** Capture *what will be tested* from `title` + `docs.desc` (or
+   prompt the user for a missing `desc`).
+3. **Search similar.** Query the existing corpus (`content/*.mql.yaml`, 68
+   policies today) for checks with similar intent/target via
+   `cnspec policy graph search --similar`, and feed the top matches to the backend as grounding
+   examples. This is the highest-leverage accuracy lever — real, validated MQL
+   for the same provider beats generating from schema alone. It builds on the
+   existing `policy-graph search` (`apps/cnspec/cmd/policy_graph.go:212`);
+   whether structural search suffices or we add semantic/embedding search is an
+   open question (§ below; no embedding libs present today).
+4. **Generate + validate.** cnspec hands the backend the intent, the resolved
+   target's schema, the similar-query examples, and the skill; the backend runs
+   its own validate/fix loop calling the shared commands (`--ast`,
+   execute-and-assert); cnspec **owns the write-back** (sets `q.Mql`, runs
+   `policy format`).
+
+**Pluggable backends.** cnspec talks to agent CLIs through a small adapter
+interface; each adapter knows one CLI's headless invocation.
+
+```go
+// generate/backend.go
+type AgentBackend interface {
+    Name() string
+    Available() bool                              // CLI installed + authed?
+    Generate(ctx context.Context, t GenTask) (GenResult, error)
+}
+```
+
+| Backend | Headless invocation | Selected by |
+|---------|---------------------|-------------|
+| Claude Code | `claude -p …` | `--agent claude` (default if present) |
+| Codex | `codex exec …` | `--agent codex` |
+| Kimi 3 | Kimi CLI, non-interactive | `--agent kimi` |
+| DeepSeek | DeepSeek CLI, non-interactive | `--agent deepseek` |
+
+```
+cnspec policy generate <bundle.mql.yaml> [flags]
+  --in-place        modify the input file (default: stdout)
+  --dry-run         preview without writing
+  --force           regenerate queries that already have mql
+  --agent string    backend: claude | codex | kimi | deepseek (default: auto)
+  --model string    model passed through to the agent CLI
+  --explain         include the agent's reasoning per query
+  --non-interactive skip the guided prompts (batch fill empty mql)
+```
+
+Per query: empty `mql` → generate; else skip (unless `--force`). Existing MQL is
+never touched without `--force`. No schema change — `Mquery` already has
+`Title`, `Docs.Desc`, `Mql` (`policy/cnspec_policy.pb.go:1616-1628`).
+
+### 5. Validation must go past "it compiles"
+
+Compilation (`--ast`) is necessary but **far** from sufficient. `cnspec/CLAUDE.md`
+is largely a catalog of MQL that compiles cleanly and returns the *wrong*
+verdict: `null && null` is **`true`** (a check passes when both operands never
+resolved); a dotted path that is also a resource name compiles to a fieldless
+husk where every field reads `null` and `null != "x"` is `true`; `.all()` on
+`null` errors; `!= ""` is not null-safe (`!= empty` is).
+
+An LLM backend will hit all of these and a compile check catches none. So the
+shared layer includes an **execute-and-assert** gate: run the query against a
+recorded/fixture asset and confirm it *distinguishes* compliant from
+non-compliant. A query returning `true` for both is rejected regardless of
+compilation. This is the main correctness gate for both use cases and is the
+highest-leverage item alongside similar-query search.
+
+Framing: this feature is **agent-assisted drafting with mandatory expert
+review**, not a replacement for MQL expertise.
+
+### 6. Skill updates (serves both use cases)
+
+The skill is the UC1 contract and the UC2 backend prompt, so it is shipped
+product kept in sync with `CLAUDE.md`:
+
+- Demote MCP to an optional footnote; make the deterministic CLI the single
+  documented path (`skills/mql/SKILL.md`, `skills/mql/README.md`,
+  `skills/README.md`, `skills/mql/.claude-plugin/plugin.json`, `agents/AGENTS.md`).
+- Add the generation workflow (§4), the execute-and-assert gate, and
+  similar-query search usage.
+- Expand "Anti-Patterns" into a real **correctness-traps** reference from
+  `cnspec/CLAUDE.md` (null three-valued logic, dotted-path husks, null-safe
+  emptiness, `.all()`-on-null, newline-as-AND, `filters:` is selection not logic).
+- Add provider-selection-from-`filters:` and variants guidance
+  (`content/CLAUDE.md`: variant siblings differ in strictness; don't unify by
+  copying one body).
+
+## Implementation
+
+Shipped in this change (all in the cnspec repo; no mql or schema changes):
+
+- `internal/generate/` — the shared, backend-agnostic core:
+  - `backend.go` — `AgentBackend` interface and CLI adapters for claude / codex /
+    kimi / deepseek, with PATH-based availability detection, per-backend
+    `CNSPEC_AGENT_*_BIN` overrides, and auto-selection.
+  - `response.go` — defensive parsing of agent output (fenced ```json, bare
+    balanced objects, ```mql fallback).
+  - `corpus.go` + `text.go` — the example corpus and BM25 similarity search
+    with provider bias (backs both `policy graph search --similar` and generation grounding).
+  - `target.go` — provider resolution from `filters:` (with hyphenated-platform
+    and UID fallbacks).
+  - `validate.go` + `props.go` — in-process `mqlc.Compile` gate mirroring the
+    linter, plus the execute-and-assert gate (`QueryRunner` + `executeValidator`).
+    A validator is handed a `ValidationRequest` (query, props, target provider),
+    not a bare string: `props.<name>` only compiles when the props travel with
+    the query, and the target provider is what lets the gate say "that provider
+    is not installed" instead of blaming the query for an unknown resource. The
+    gate also asserts the query answers a verdict (bool, a scoring `switch`, or a
+    block that asserts) rather than returning data.
+  - `execrunner.go` — `RuntimeRunner` (executes a query against a connected
+    provider runtime via `exec.ExecuteCode`) and `ConnectTarget` for the
+    `--test-target` flag.
+  - `prompt.go` — prompt assembly, including the correctness-trap rules.
+  - `generator.go` — the per-check skip/generate/validate/retry loop.
+- `internal/bundle/generate_io.go` — `AllQueries` / `QueryDesc` /
+  `QueryFilterStrings` / `VariantParents`, the comment-preserving read/write seam
+  reusing `ParseYaml` + `FormatBundle`.
+- `internal/textrank/` — the shared BM25 ranker (tokenizer + stemmer + index)
+  used by both the generation grounding search and `policy graph search
+  --similar`. There is no separate `policy search` command: relevance ranking is
+  a `--similar` mode on the existing `policy graph search`, so structural
+  navigation and semantic ranking live under one verb.
+- `internal/generate/harness.go` + `testdata/harness_cases.yaml` — the
+  intent→MQL generation-quality harness: golden cases (intent + expectation) run
+  by `RunCases`, deterministic offline with a scripted backend (regression guard)
+  and reusable against a real agent to measure a model.
+- `apps/cnspec/cmd/policy_generate.go` — the `cnspec policy generate` command (UC2
+  driver): batch fill-in over bundle files.
+- `apps/cnspec/cmd/policy_generate_interactive.go` — `--interactive` (`-i`): the
+  guided authoring flow (describe → guess target/filter → show grounding →
+  generate → accept/edit/regenerate → write one check at a time). This is the
+  defined end-to-end experience for authoring from scratch.
+- `apps/cnspec/cmd/policy_graph.go` — the shared grounding tool: `--similar`
+  relevance ranking added to `cnspec policy graph search`.
+- `skills/mql/` and `agents/AGENTS.md` — MCP demoted to the CLI path; generation
+  workflow and correctness-traps reference added (the UC1 contract).
+- Tests: `internal/generate/generate_test.go`,
+  `internal/bundle/generate_io_test.go`.
+
+Execute-and-assert ships opt-in via `--test-target <provider>` (live) or
+`--test-recording <file>` (reproducible, offline — the recording provider is
+built in, so no live credentials or provider binary are needed): the generated
+query must compile AND run, resolving to a concrete true/false verdict (a null
+result — the null-unsafe / dotted-path-husk class — is rejected). Default remains
+compile-only.
+
+Variant leaves inherit their intent (title/description) from the parent that
+declares them, so per-platform variants generate correctly; parents are skipped.
+Parameterized `props` are passed to the agent with name/type/description so it
+references `props.<name>` instead of hardcoding literals. Similar-query ranking
+is BM25 with field weighting (title > description > MQL) and light stemming;
+embedding-based semantic search is intentionally not added, to keep cnspec free
+of a model/embedding dependency (the same principle that keeps the LLM out of the
+binary).
+
+## Security considerations
+
+- **Untrusted policy text is prompt-injection input.** A check's `title` and
+  `docs.desc` become the prompt sent to the coding-agent CLI, and that agent can
+  run tools and commands. Generating from an untrusted third-party bundle is
+  therefore equivalent to feeding attacker-controlled text to your agent. The
+  command documents this and it is a trust boundary users must respect; we do not
+  sandbox the agent (it is the user's own tool, invoked with their environment).
+- **cnspec adds no credentials, and forwards only an allowlisted environment.**
+  cnspec holds no model credentials and stores none; the agent uses its own
+  configured auth. It does not follow that the agent sees nothing sensitive: a
+  subprocess inherits its parent's environment unless told otherwise, so the
+  agent was being handed every cloud credential in the operator's shell —
+  `AWS_SECRET_ACCESS_KEY`, `MONDOO_API_TOKEN`, `SSH_AUTH_SOCK` and the rest — to
+  a program that runs tools on text an untrusted bundle supplied. The backend
+  now builds the child's environment from an allowlist (`internal/generate/env.go`):
+  what the process needs to start (PATH, HOME, TMPDIR, terminal and locale,
+  proxy and CA settings) and the agent's own auth (`ANTHROPIC_*`, `OPENAI_*`,
+  `CODEX_*`, `KIMI_*`, `MOONSHOT_*`, `DEEPSEEK_*`), and nothing else.
+  `CNSPEC_AGENT_ENV=NAME,OTHER` forwards more by name, and `CNSPEC_AGENT_ENV=*`
+  restores the old inherit-everything behavior for whoever needs it. The agent
+  still runs in the operator's working directory, because inspecting the bundle
+  it is authoring is the point. The prompt is passed as a subprocess argument (no
+  shell), so there is no shell-injection surface from prompt content.
+- **The agent's output is model-authored text on a terminal.** The
+  accept/edit/regenerate loop is the control this design leans on, and a terminal
+  renders control characters rather than showing them: a returned query carrying
+  `ESC[2K ESC[1G` compiled fine and *displayed* as a harmless one-liner while
+  containing something else. Everything the agent returns — MQL, explanation, and
+  its own stdout/stderr quoted into errors — goes through
+  `generate.SanitizeModelText`, which escapes C0/C1 controls, DEL, bidi overrides
+  and invalid UTF-8 into visible `\xNN` / `\uNNNN` form (newline and tab survive,
+  since MQL uses them and they cannot repaint a line).
+- **The agent subprocess is bounded.** It runs in its own process group with a
+  `WaitDelay`, so a timeout kills the tree rather than blocking on a forked
+  helper that still holds the stdout pipe, and its output is capped (8 MiB
+  stdout, 256 KiB stderr) with the overflow reported rather than parsed.
+- **`--test-target` executes agent-generated MQL against a live system before a
+  human reviews it.** Most MQL reads state, but the `os` provider exposes
+  `command()`/`file()` which run on the target — so a prompt-injected query could
+  execute there. It is opt-in, off by default, prints a warning, and should only
+  be used with trusted bundles. `--test-recording` replays a recording instead
+  and executes nothing on a live system — the safe default for validation.
+  `--no-validate` is rejected together with either flag so validation can't be
+  silently dropped.
+- **Write-back reformats the whole file** through the same formatter as
+  `cnspec policy format` (comment-preserving, canonical layout); it carries the
+  same round-trip contract and is intended to run under version control.
+
+## Consequences
+
+**Positive**
+- Two use cases, one tool layer — no divergent second code path; UC1 and UC2 stay
+  consistent by construction.
+- Scan-time stays deterministic and model-free.
+- cnspec takes on no LLM SDK, no API keys, no MCP server; the model call is
+  delegated to a CLI the user already authed.
+- Reuses shipping commands; UC1 is largely functional today once the skill is
+  updated.
+- Similar-query search grounds generation in 68 policies of real, validated MQL —
+  the biggest accuracy win available.
+- No schema change.
+
+**Negative / risks**
+- UC2 adds a runtime dependency: a supported agent CLI installed and authed.
+  Fail fast with a clear message when none is `Available()`. UC1 has no such
+  dependency (the agent brings its own model).
+- Output quality varies by backend; keep an intent→expected-MQL regression corpus
+  per backend and per skill change.
+- Correctness rests on skill quality + execute-and-assert, not a compiler
+  guarantee; a stale skill silently degrades both use cases.
+- Non-determinism between runs; mitigated by skip-unless-`--force`.
+- No automatic staleness detection when `desc` changes but `mql` doesn't; if
+  wanted later, a `tags: cnspec.io/generated: <hash>` — additive, out of scope.
+
+## Alternatives considered
+
+- **Embed an LLM client + build a cnspec MCP server** (prior RFC). Rejected: MCP
+  server doesn't exist and would wrap capabilities the binary already calls
+  directly; forces a cloud LLM dependency and key management into a security CLI.
+- **One use case only.** Supporting only UC1 abandons non-agent users; only UC2
+  ignores the reality that many users already author inside a coding agent.
+  Both are real; the shared tool layer makes supporting both cheap.
+- **Agent edits YAML in place** (UC2) instead of cnspec write-back. Gives up
+  canonical formatting and deterministic file handling; revisit if structured
+  per-uid return proves awkward.
+- **Compile-only validation.** Insufficient — the hardest MQL bugs compile clean.
+- **New `intent:` field / separate source files / `_compiled` metadata.**
+  Schema/layout churn for marginal benefit over `title` + `docs.desc` (+ `tags`).
+
+## Resolved during implementation
+
+1. **Similar-query search depth.** BM25 over a field-weighted term bag (title >
+   description > MQL) with light stemming, in a shared `internal/textrank`
+   package. Exposed as `policy graph search --similar` (relevance ranking beside
+   the existing identifier navigation — no duplicate `policy search` command) and
+   reused for generation grounding. Embedding/semantic search is deliberately
+   declined to avoid a model dependency.
+4. **Regression harness.** `internal/generate/harness.go` runs an intent→MQL
+   golden corpus; deterministic offline with a scripted backend, reusable against
+   a real agent to measure a model.
+2. **Execute-and-assert fixtures.** Both a live target (`--test-target`) and the
+   built-in recording provider (`--test-recording`) are supported; the recording
+   path is reproducible and needs no live credentials.
+3. **Variants & props.** Variant leaves inherit parent intent and generate;
+   parents are skipped. Props are surfaced to the agent by name/type/description.
+
+## Open questions
+
+1. **Backend invocation contract.** Exact headless flags and prompt shape per CLI
+   (`claude -p`, `codex exec`, Kimi, DeepSeek); how each is pointed at the skill;
+   how structured per-uid MQL is returned and parsed. (Adapters localize this and
+   are overridable via `CNSPEC_AGENT_*_BIN`.)
+2. **UC2 UX when no backend is available.** Detection, messaging, recommended
+   default agent.
+3. **Staleness detection.** Optional `tags: cnspec.io/generated: <hash>` to flag
+   when `desc` changed but `mql` didn't.

--- a/docs/adr/0004-description-first-policy-authoring.md
+++ b/docs/adr/0004-description-first-policy-authoring.md
@@ -281,6 +281,18 @@ binary).
   therefore equivalent to feeding attacker-controlled text to your agent. The
   command documents this and it is a trust boundary users must respect; we do not
   sandbox the agent (it is the user's own tool, invoked with their environment).
+- **The trust boundary is the working directory, not just the bundle.** Two of
+  the agent's inputs are resolved relative to the current directory rather than
+  to the install: the grounding corpus defaults to `./content` when present, and
+  `findSkills()` (`apps/cnspec/cmd/policy_generate.go`) probes `./skills` and
+  `../skills` *before* the executable's own directory, so a `skills/mql/SKILL.md`
+  planted in the working tree is handed to the agent as instructions in
+  preference to the shipped one. That is an injection route with no bundle
+  involved, so "only generate from bundles you trust" understates it: the
+  accurate guidance is to run `policy generate` only in a directory you trust.
+  Pinning skills to the install directory and requiring `--corpus` to be explicit
+  would close it; that is deferred, and the help text states the boundary as it
+  actually stands.
 - **cnspec adds no credentials, and forwards only an allowlisted environment.**
   cnspec holds no model credentials and stores none; the agent uses its own
   configured auth. It does not follow that the agent sees nothing sensitive: a

--- a/docs/policy-generation-ux.md
+++ b/docs/policy-generation-ux.md
@@ -1,0 +1,138 @@
+# Policy Generation: From Requirement to Check
+
+This document defines the user experience for turning a security **requirement**
+(what you want to check) into a validated MQL **check** (what cnspec runs),
+without writing MQL by hand.
+
+## The promise
+
+> Describe a check in plain language. cnspec generates the MQL, grounds it in
+> your existing policies, validates it, and lets you review before it's written.
+> The result is ordinary, committed MQL — scans never call a model.
+
+You bring the *intent*; cnspec produces the *implementation* and you approve it.
+
+## The journey
+
+```
+  REQUIREMENT            INTENT              TARGET            GROUNDING
+  "S3 buckets    ──►  title + desc    ──►  provider +   ──►  similar
+   must be              (plain language)    filter            existing checks
+   encrypted"                               (auto-guessed)    (BM25 over content)
+                                                                    │
+                                                                    ▼
+     SHIP        ◄──   REVIEW        ◄──   VALIDATE      ◄──   GENERATE
+  lint + commit        accept /            compile             agent CLI writes
+  + scan               edit /              (+ optional          candidate MQL
+                       regenerate          execute-assert)
+```
+
+Every stage has a defined input, a defined cnspec action, and a defined output.
+
+| Stage | You provide | cnspec does | Output |
+|-------|-------------|-------------|--------|
+| **Requirement** | The thing to check, in your head or a compliance control | — | A one-line intent |
+| **Intent** | `title` (+ optional `docs.desc`) | Captures it (prompts for it in `-i`) | Natural-language intent |
+| **Target** | Confirm/adjust the provider | Guesses the provider from the title and proposes the asset `filter` | `provider` + `filters:` |
+| **Grounding** | — | Ranks similar existing checks (BM25 over `./content`) and shows/feeds the top matches | Few-shot examples |
+| **Generate** | — | Builds a prompt (intent + schema hints + examples + correctness rules) and calls your agent CLI | Candidate MQL |
+| **Validate** | — | Compiles the MQL in-process; optionally executes it and requires a true/false verdict | Pass/fail + errors |
+| **Review** | `accept` / `edit` / `regenerate with feedback` | Applies feedback, re-validates edits | Approved MQL |
+| **Ship** | — | Writes the check into the bundle (atomic, formatting preserved); points you at `lint` | A committed check |
+
+## Three ways to start
+
+The stages are the same; only the driver differs.
+
+### 1. Guided (the defined default) — `cnspec policy generate -i`
+An interactive session, one check at a time. cnspec asks what to verify, guesses
+the target, shows grounding, generates, and walks you through
+accept / edit / regenerate before writing. Best for authoring from scratch.
+
+### 2. Batch — `cnspec policy generate <bundle> --in-place`
+You pre-write checks with `title` + `docs.desc` but no `mql`; cnspec fills them
+all in. Best for backfilling a bundle or a directory of policies.
+
+### 3. Agent-driven — you're already in Claude Code / Codex
+You don't call `generate`; your agent does, using cnspec as the toolbox
+(`cnspec providers resources`, `cnspec policy graph search --similar`,
+`cnspec run --ast`) guided by the `mql` and `policy-graph` skills.
+
+## Worked example
+
+**Requirement:** "S3 buckets must be encrypted." (e.g. a CIS AWS control.)
+
+```
+$ cnspec policy generate -i
+What should this check verify?: S3 buckets must be encrypted
+More detail (optional): All S3 buckets need server-side encryption
+Target provider [aws]:                      ← guessed from the title
+Asset filter [asset.platform == "aws"]:     ← proposed from the provider
+
+Similar existing checks (used as grounding):
+  • mondoo-aws-security-s3-bucket-server-side-encryption-enabled-aws
+      aws.s3.bucket.encrypted == true
+
+Generated MQL:
+    aws.s3.buckets.all(encryption != empty)
+  [a]ccept, [e]dit, [r]egenerate with feedback, [s]kip [a]: a
+  ✓ added s3-buckets-must-be-encrypted to aws-s3.mql.yaml
+```
+
+**Output** — written into the bundle, ready to `lint`, `scan` and commit:
+
+```yaml
+policies:
+  - uid: aws-s3
+    name: Aws S3
+    version: 1.0.0
+    groups:
+      - title: Generated checks
+        checks:
+          - uid: s3-buckets-must-be-encrypted
+            title: S3 buckets must be encrypted
+            filters: asset.platform == "aws"
+            mql: aws.s3.buckets.all(encryption != empty)
+            docs:
+              desc: All S3 buckets need server-side encryption
+```
+
+The check goes into a policy group, not the top-level `queries:` block. A query
+that belongs to no policy lints with a `query-unassigned` warning and then fails
+`cnspec scan --policy-bundle` with *"a policy or framework mrn is required"* —
+so a bundle that only lints is not enough. When the file already has a policy,
+the check joins it (in a group of its own, so it does not inherit a group filter
+that was written for other checks).
+
+Then: `cnspec policy lint aws-s3.mql.yaml` → `cnspec scan aws --policy-bundle
+aws-s3.mql.yaml` → commit.
+
+## Validation depth (you choose how sure to be)
+
+| Mode | Flag | What it proves | Runs on live infra? |
+|------|------|----------------|---------------------|
+| Compile (default) | — | Resources/fields exist, syntax valid | No |
+| Execute-and-assert (recording) | `--test-recording <file>` | Query resolves to a concrete true/false verdict | No (replay) |
+| Execute-and-assert (live) | `--test-target <provider>` | Same, against a real asset | **Yes** — warns first |
+
+Compilation alone can't catch the semantic traps (`null && null == true`,
+dotted-path husks); execute-and-assert can. Prefer `--test-recording` for
+reproducible, credential-free validation.
+
+## Guardrails
+
+- **Human-in-the-loop.** Generated MQL is a reviewed, committed diff — never
+  applied silently, never run at scan time. A prompt that cannot be answered
+  ends the session: at EOF (Ctrl-D, a closed pipe, a script that ran out of
+  answers) the wizard exits instead of taking its own default, so a
+  non-interactive run can never "accept" on your behalf.
+- **What you review is what is written.** Model output is rendered through the
+  same normalization that writes it into the bundle, so an ANSI escape sequence
+  in a generated query cannot repaint the review line and hide part of the query.
+- **Trusted input only.** A check's description becomes the agent's prompt, and
+  the agent can run tools; only generate on bundles you trust.
+- **No lock-in.** cnspec ships no LLM SDK and stores no keys; it drives the
+  coding-agent CLI you already have (`--agent claude|codex|kimi|deepseek`).
+
+See `docs/adr/0004-description-first-policy-authoring.md` for the design
+rationale.

--- a/internal/bundle/generate_io.go
+++ b/internal/bundle/generate_io.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import "strings"
+
+// AllQueries returns pointers to every query definition in a bundle, in a
+// stable order: top-level shared queries first, then checks and data queries in
+// policy groups, then query-pack queries. Callers can read intent fields and
+// write Mql back through these pointers; changes are reflected when the bundle
+// is re-formatted via FormatBundle.
+//
+// This is the seam used by `cnspec policy generate` — it keeps knowledge of the
+// comment-preserving internal bundle structs in this package so the command and
+// the generator stay decoupled from the YAML layer.
+func AllQueries(b *Bundle) []*Mquery {
+	if b == nil {
+		return nil
+	}
+	var out []*Mquery
+	out = append(out, b.Queries...)
+	for _, p := range b.Policies {
+		if p == nil {
+			continue
+		}
+		for _, g := range p.Groups {
+			if g == nil {
+				continue
+			}
+			out = append(out, g.Checks...)
+			out = append(out, g.Queries...)
+		}
+	}
+	for _, pack := range b.Packs {
+		if pack == nil {
+			continue
+		}
+		out = append(out, pack.Queries...)
+		for _, g := range pack.Groups {
+			if g == nil {
+				continue
+			}
+			out = append(out, g.Queries...)
+		}
+	}
+	return out
+}
+
+// QueryDesc returns a query's description, preferring docs.desc and falling back
+// to the legacy top-level desc.
+func QueryDesc(q *Mquery) string {
+	if q == nil {
+		return ""
+	}
+	if q.Docs != nil && strings.TrimSpace(q.Docs.Desc) != "" {
+		return q.Docs.Desc
+	}
+	return q.Desc
+}
+
+// QueryFilterStrings returns the filter MQL expressions attached to a query.
+func QueryFilterStrings(q *Mquery) []string {
+	if q == nil || q.Filters == nil {
+		return nil
+	}
+	var out []string
+	for _, f := range q.Filters.Items {
+		if f != nil && strings.TrimSpace(f.Mql) != "" {
+			out = append(out, f.Mql)
+		}
+	}
+	return out
+}
+
+// QueryHasVariants reports whether a query delegates its MQL to per-platform
+// variants (so the parent must not receive generated MQL).
+func QueryHasVariants(q *Mquery) bool {
+	return q != nil && len(q.Variants) > 0
+}
+
+// VariantParents maps each variant child's uid to the parent query that declares
+// it. A variant leaf usually carries only filters + mql and inherits its intent
+// (title/description) from the parent, so the generator uses this to give leaves
+// something to generate from.
+func VariantParents(b *Bundle) map[string]*Mquery {
+	out := map[string]*Mquery{}
+	if b == nil {
+		return out
+	}
+	for _, q := range AllQueries(b) {
+		for _, v := range q.Variants {
+			if v != nil && v.Uid != "" {
+				out[v.Uid] = q
+			}
+		}
+	}
+	return out
+}
+
+// QueryUIDs returns the set of uids already defined by queries in a bundle —
+// the top-level `queries:` block, policy groups, and query packs.
+//
+// `cnspec policy generate` looks this up before it adds a check: two queries
+// sharing a uid in one file is a lint error (`query-uid-unique`), and a bundle
+// that fails lint is a worse outcome than re-asking for the uid.
+func QueryUIDs(b *Bundle) map[string]bool {
+	out := map[string]bool{}
+	for _, q := range AllQueries(b) {
+		if q != nil && q.Uid != "" {
+			out[q.Uid] = true
+		}
+	}
+	return out
+}
+
+// SanitizeText applies the same normalization FormatBundle performs on a string
+// it writes into a bundle: tabs expanded, CR folded into LF, trailing whitespace
+// trimmed, and every non-graphic character (NUL, ANSI escape sequences, …)
+// removed.
+//
+// Model-authored text reaches the user twice — once on the review screen, once
+// in the file — and only the terminal can be lied to: an ESC[2K / ESC[1G pair
+// inside a generated query repaints the line the reviewer is approving, so what
+// was reviewed and what was committed are not the same text. Rendering through
+// this function makes the review screen show exactly the bytes FormatBundle
+// will write, which is the assumption the human-in-the-loop gate rests on.
+func SanitizeText(s string) string {
+	return sanitizeStringForYaml(s)
+}

--- a/internal/bundle/generate_io_test.go
+++ b/internal/bundle/generate_io_test.go
@@ -1,0 +1,122 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"strings"
+	"testing"
+)
+
+const genIOFixture = `# managed policy bundle
+policies:
+  - uid: example-policy
+    name: Example
+    groups:
+      - filters: asset.family.contains("linux")
+        checks:
+          - uid: inline-check
+            title: Inline check
+queries:
+  - uid: needs-mql
+    title: S3 buckets must be encrypted
+    filters: asset.platform == "aws"
+    docs:
+      desc: All S3 buckets must have server-side encryption enabled.
+  - uid: has-mql
+    title: Already done
+    mql: |
+      aws.s3.buckets.all(encryption != empty)
+`
+
+func TestAllQueriesAndWriteBack(t *testing.T) {
+	b, err := ParseYaml([]byte(genIOFixture))
+	if err != nil {
+		t.Fatalf("ParseYaml: %v", err)
+	}
+
+	queries := AllQueries(b)
+	// top-level: needs-mql, has-mql ; group check: inline-check
+	byUID := map[string]*Mquery{}
+	for _, q := range queries {
+		byUID[q.Uid] = q
+	}
+	for _, want := range []string{"needs-mql", "has-mql", "inline-check"} {
+		if byUID[want] == nil {
+			t.Fatalf("AllQueries missing %q (got %d queries)", want, len(queries))
+		}
+	}
+
+	// intent extraction
+	if got := QueryDesc(byUID["needs-mql"]); !strings.Contains(got, "server-side encryption") {
+		t.Fatalf("QueryDesc = %q", got)
+	}
+	if got := QueryFilterStrings(byUID["needs-mql"]); len(got) != 1 || !strings.Contains(got[0], "aws") {
+		t.Fatalf("QueryFilterStrings = %v", got)
+	}
+
+	// write MQL back and re-format
+	byUID["needs-mql"].Mql = "aws.s3.buckets.all(encryption != empty)"
+	out, err := FormatBundle(b, false)
+	if err != nil {
+		t.Fatalf("FormatBundle: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "aws.s3.buckets.all(encryption != empty)") {
+		t.Fatalf("formatted output missing generated mql:\n%s", s)
+	}
+	// document-level comment preserved (same guarantee as `cnspec policy format`)
+	if !strings.Contains(s, "# managed policy bundle") {
+		t.Fatalf("document comment not preserved:\n%s", s)
+	}
+	if strings.Count(s, "aws.s3.buckets.all(encryption != empty)") != 2 {
+		t.Fatalf("expected both queries to carry the mql, got:\n%s", s)
+	}
+}
+
+func TestQueryUIDs(t *testing.T) {
+	b, err := ParseYaml([]byte(genIOFixture))
+	if err != nil {
+		t.Fatalf("ParseYaml: %v", err)
+	}
+	uids := QueryUIDs(b)
+	// a uid taken by an inline group check counts as taken, same as a top-level
+	// one: `cnspec policy generate` uses this to refuse a colliding new check
+	for _, want := range []string{"needs-mql", "has-mql", "inline-check"} {
+		if !uids[want] {
+			t.Errorf("QueryUIDs missing %q: %v", want, uids)
+		}
+	}
+	if len(uids) != 3 {
+		t.Errorf("QueryUIDs = %v, want 3 entries", uids)
+	}
+	if QueryUIDs(nil) == nil {
+		t.Error("QueryUIDs(nil) should return an empty map, not nil")
+	}
+}
+
+// TestSanitizeTextMatchesFormatBundle pins the property the review gate depends
+// on: text rendered through SanitizeText is byte-identical to what FormatBundle
+// writes for the same input, so what a reviewer approves is what lands on disk.
+func TestSanitizeTextMatchesFormatBundle(t *testing.T) {
+	// an erase-line + cursor-home pair: on a terminal this repaints the line,
+	// hiding everything before it while the file keeps the whole query
+	const hostile = "aws.s3.buckets.all(x)\x1b[2K\x1b[1G BACKDOOR"
+
+	shown := SanitizeText(hostile)
+	if strings.ContainsRune(shown, 0x1b) {
+		t.Errorf("SanitizeText left an escape sequence: %q", shown)
+	}
+	if !strings.Contains(shown, "BACKDOOR") {
+		t.Errorf("SanitizeText dropped visible text: %q", shown)
+	}
+
+	b := &Bundle{Queries: []*Mquery{{Uid: "c1", Title: "t", Mql: hostile}}}
+	out, err := FormatBundle(b, false)
+	if err != nil {
+		t.Fatalf("FormatBundle: %v", err)
+	}
+	if !strings.Contains(string(out), shown) {
+		t.Errorf("what FormatBundle wrote is not what SanitizeText shows:\nshown: %q\nfile:\n%s", shown, out)
+	}
+}

--- a/internal/bundle/generate_write.go
+++ b/internal/bundle/generate_write.go
@@ -1,0 +1,226 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// This is the write half of the `policy generate` seam: turning an accepted
+// check into bytes in a bundle file. It lives here rather than beside a command
+// because there are two front ends over it -- the line-oriented wizard and the
+// launcher's authoring pane -- and `apps/cnspec/cmd` imports the launcher, so
+// the launcher cannot import it back.
+
+// ErrUIDExists reports a uid already present in the bundle. Callers offer a
+// different uid rather than overwriting a check the user did not name.
+var ErrUIDExists = errors.New("uid already used in this bundle")
+
+// GeneratedGroupTitle names the group generated checks are appended to.
+const GeneratedGroupTitle = "Generated checks"
+
+// LoadFile reads a bundle, treating a missing file as an empty one so a check
+// can be written into a path that does not exist yet.
+func LoadFile(file string) (*Bundle, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return &Bundle{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	b, err := ParseYaml(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse %s", file)
+	}
+	return b, nil
+}
+
+// AppendCheck adds a new check to a bundle file (creating it if absent),
+// preserving existing formatting/comments and writing atomically.
+func AppendCheck(file, uid, title, desc, filter, mql string) error {
+	b, err := LoadFile(file)
+	if err != nil {
+		return err
+	}
+	if err := AddCheck(b, PolicyUIDForFile(file), uid, title, desc, filter, mql); err != nil {
+		return err
+	}
+	out, err := FormatBundle(b, false)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(file, out)
+}
+
+// AddCheck places a check inside a policy group.
+//
+// A check that lives only in the top-level `queries:` block is not scannable:
+// lint reports it as query-unassigned and `cnspec scan --policy-bundle` then
+// fails with "a policy or framework mrn is required". Both front ends tell the
+// user to lint and scan what was written, so what is written has to survive
+// both.
+func AddCheck(b *Bundle, policyUID, uid, title, desc, filter, mql string) error {
+	if b == nil {
+		return errors.New("no bundle to add the check to")
+	}
+	if strings.TrimSpace(uid) == "" {
+		return errors.New("a check needs a uid")
+	}
+	if QueryUIDs(b)[uid] {
+		return errors.Wrapf(ErrUIDExists, "check %q", uid)
+	}
+
+	q := &Mquery{Uid: uid, Title: title, Mql: mql}
+	if strings.TrimSpace(filter) != "" {
+		q.Filters = &Filters{Items: map[string]*Mquery{"": {Mql: filter}}}
+	}
+	if strings.TrimSpace(desc) != "" {
+		q.Docs = &MqueryDocs{Desc: desc}
+	}
+
+	group := generatedGroup(targetPolicy(b, policyUID))
+	group.Checks = append(group.Checks, q)
+	return nil
+}
+
+// targetPolicy returns the policy new checks join: the bundle's first policy
+// when it has one, otherwise a new minimal policy (uid + name + semver version
+// are what `cnspec policy lint` requires).
+func targetPolicy(b *Bundle, policyUID string) *Policy {
+	if len(b.Policies) > 0 && b.Policies[0] != nil {
+		return b.Policies[0]
+	}
+	p := &Policy{
+		Uid:     policyUID,
+		Name:    humanize(policyUID),
+		Version: "1.0.0",
+	}
+	b.Policies = append(b.Policies, p)
+	return p
+}
+
+// generatedGroup returns the group new checks are appended to, creating it when
+// needed.
+//
+// It is deliberately a group of its own rather than the policy's first group: a
+// group-level filter gates every check inside it, so dropping a fresh check into
+// an existing group can silently restrict it to assets it was never written for
+// (a group filtered to hosts running kube-apiserver, say). The checks carry
+// their own filters, which is what policy-missing-asset-filter asks for.
+func generatedGroup(p *Policy) *PolicyGroup {
+	for _, g := range p.Groups {
+		if g != nil && g.Title == GeneratedGroupTitle && (g.Filters == nil || len(g.Filters.Items) == 0) {
+			return g
+		}
+	}
+	g := &PolicyGroup{Title: GeneratedGroupTitle}
+	p.Groups = append(p.Groups, g)
+	return g
+}
+
+// policyUidRe mirrors the uid requirement `cnspec policy lint` enforces on a
+// policy (bundle-invalid-uid): 4-100 characters of lowercase letters, digits,
+// dashes and underscores.
+var policyUidRe = regexp.MustCompile(`^([\d\-_]|[a-z]){4,100}$`)
+
+// PolicyUIDForFile derives the uid of a generated policy from the bundle's file
+// name, falling back to a generic uid when that would not lint.
+func PolicyUIDForFile(file string) string {
+	base := filepath.Base(file)
+	base = strings.TrimSuffix(base, ".yaml")
+	base = strings.TrimSuffix(base, ".yml")
+	base = strings.TrimSuffix(base, ".mql")
+	uid := Slugify(base)
+	if !policyUidRe.MatchString(uid) {
+		return "generated-policy"
+	}
+	return uid
+}
+
+// humanize turns a uid into a policy name ("aws-s3" -> "Aws S3").
+func humanize(uid string) string {
+	fields := strings.FieldsFunc(uid, func(r rune) bool { return r == '-' || r == '_' })
+	for i, f := range fields {
+		fields[i] = strings.ToUpper(f[:1]) + f[1:]
+	}
+	if len(fields) == 0 {
+		return uid
+	}
+	return strings.Join(fields, " ")
+}
+
+// Slugify turns a title into a lowercase, dash-separated uid.
+func Slugify(s string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// NextFreeUID suffixes a uid until it is free, so an offered default is one the
+// user can accept rather than a collision they have to resolve by hand.
+func NextFreeUID(uid string, taken map[string]bool) string {
+	if uid == "" || !taken[uid] {
+		return uid
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", uid, i)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}
+
+// writeFileAtomic writes data to path via a temp file in the same directory
+// followed by a rename, so an interrupted or failed write cannot truncate or
+// corrupt the existing policy file. The rename is atomic on the same filesystem.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".gen-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	// flush to disk before the rename so a crash cannot leave a zero-length file
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// preserve the existing file's permissions rather than widening to 0644
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/bundle/generate_write_test.go
+++ b/internal/bundle/generate_write_test.go
@@ -1,0 +1,20 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"S3 buckets must be encrypted": "s3-buckets-must-be-encrypted",
+		"  Trim  --  dashes  ":         "trim-dashes",
+		"CIS 1.2: root/login!":         "cis-1-2-root-login",
+		"":                             "",
+	}
+	for in, want := range cases {
+		if got := Slugify(in); got != want {
+			t.Errorf("Slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/generate/backend.go
+++ b/internal/generate/backend.go
@@ -1,0 +1,312 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package generate turns a policy check's natural-language intent (its title and
+// docs.desc) into validated MQL. cnspec drives the workflow and delegates the
+// model call to a coding-agent CLI (Claude Code, Codex, Kimi, DeepSeek) that the
+// user already has installed and authenticated. cnspec ships no LLM SDK and no
+// API-key handling of its own; the agent brings its own model access.
+//
+// See docs/adr/0004-description-first-policy-authoring.md for the design.
+package generate
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/errors"
+)
+
+// GenTask is a single generation request handed to a backend. The prompt is
+// fully rendered by the generator (see prompt.go) so backends stay dumb and
+// interchangeable.
+type GenTask struct {
+	// Prompt is the complete instruction, including intent, schema context, and
+	// grounding examples.
+	Prompt string
+	// Model optionally overrides the agent CLI's default model.
+	Model string
+}
+
+// GenResult is the parsed outcome of a generation request.
+type GenResult struct {
+	// MQL is the generated query. Empty if the backend could not produce one.
+	MQL string
+	// Explanation is the agent's plain-language reasoning, when requested.
+	Explanation string
+	// Raw is the unparsed agent output, kept for diagnostics.
+	Raw string
+}
+
+// AgentBackend is a pluggable generation backend. Each implementation drives one
+// coding-agent CLI in headless mode. New agents are new adapters, not core
+// changes.
+type AgentBackend interface {
+	// Name is the stable identifier used by the --agent flag.
+	Name() string
+	// Available reports whether the backend's CLI is installed and usable. A
+	// backend that is not available is skipped by auto-selection and produces a
+	// clear error when explicitly requested.
+	Available() bool
+	// Generate runs one task and returns the parsed result. Implementations must
+	// respect ctx for cancellation and timeouts.
+	Generate(ctx context.Context, t GenTask) (GenResult, error)
+}
+
+// cliBackend is the shared implementation behind every supported agent. It
+// invokes a CLI in non-interactive mode, passing the prompt as the final
+// argument and capturing stdout. The exact binary and flags are localized here
+// so the rest of cnspec stays backend-agnostic, and every field can be
+// overridden by an environment variable so the adapter survives CLI changes
+// without a code release.
+type cliBackend struct {
+	name string
+	// bin is the default executable name, looked up on PATH.
+	bin string
+	// binEnv is the environment variable that overrides bin (absolute path or
+	// alternate name).
+	binEnv string
+	// args returns the arguments that precede the prompt, given an optional
+	// model override.
+	args func(model string) []string
+	// maxStdout overrides the stdout cap; zero means maxAgentStdout. Only tests
+	// set it, so a runaway agent can be reproduced without producing megabytes.
+	maxStdout int
+}
+
+func (b *cliBackend) Name() string { return b.name }
+
+// binary resolves the executable, honoring the per-backend env override.
+func (b *cliBackend) binary() string {
+	if v := strings.TrimSpace(os.Getenv(b.binEnv)); v != "" {
+		return v
+	}
+	return b.bin
+}
+
+func (b *cliBackend) Available() bool {
+	_, err := exec.LookPath(b.binary())
+	return err == nil
+}
+
+// Output limits for one agent invocation. An answer is a fenced JSON object of
+// a few hundred bytes; anything past these caps is a runaway, not a response.
+// Reading an agent's stdout into an unbounded buffer cost 1.59 GB of RSS for
+// 400 MB of output.
+const (
+	maxAgentStdout = 8 << 20   // 8 MiB
+	maxAgentStderr = 256 << 10 // 256 KiB
+)
+
+func (b *cliBackend) Generate(ctx context.Context, t GenTask) (GenResult, error) {
+	if !b.Available() {
+		return GenResult{}, errors.Newf("agent %q is not available: %q not found on PATH (set %s to override)", b.name, b.binary(), b.binEnv)
+	}
+
+	argv := append(b.args(t.Model), t.Prompt)
+
+	limit := b.maxStdout
+	if limit <= 0 {
+		limit = maxAgentStdout
+	}
+	stdout := &cappedBuffer{max: limit}
+	stderr := &cappedBuffer{max: maxAgentStderr}
+	cmd := exec.CommandContext(ctx, b.binary(), argv...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	// The agent gets a deliberate environment, not ours: see agentEnv. It never
+	// gets our stdin; headless invocations must not block waiting for input.
+	cmd.Env = agentEnviron()
+	cmd.Stdin = nil
+	// An agent is a process tree. Cancelling has to stop the tree, not just stop
+	// waiting for it: os/exec's Wait returns when the stdout pipe closes, and a
+	// helper the agent forked holds that pipe open long after the timeout. The
+	// process group makes the tree killable with one signal (see proc_unix.go),
+	// and WaitDelay bounds the case where something still holds the pipe after
+	// the group is gone.
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error { return killTree(cmd) }
+	cmd.WaitDelay = 2 * time.Second
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return GenResult{}, errors.Wrapf(ctx.Err(), "agent %q timed out or was cancelled", b.name)
+		}
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		// The agent's own output goes into an error a human reads on a
+		// terminal, so it is sanitized like any other model-authored text.
+		return GenResult{}, errors.Wrapf(err, "agent %q failed: %s", b.name, SanitizeModelText(truncate(detail, 500)))
+	}
+
+	// A truncated response must not be parsed: the tail of a fenced block is
+	// where the answer ends, so half a response can parse into a query that was
+	// never returned. Report the runaway instead.
+	if stdout.Overflowed() {
+		return GenResult{}, errors.Newf("agent %q produced more than %d bytes of output (%d and counting); refusing to parse a truncated response",
+			b.name, stdout.max, stdout.Total())
+	}
+
+	raw := stdout.String()
+	res := parseResponse(raw)
+	res.Raw = raw
+	if res.MQL == "" {
+		return res, errors.Newf("agent %q returned no MQL; raw output: %s", b.name, SanitizeModelText(truncate(strings.TrimSpace(raw), 500)))
+	}
+	return res, nil
+}
+
+// cappedBuffer collects at most max bytes and counts everything else. It never
+// fails a write: returning an error would stop os/exec draining the pipe, and a
+// child blocked writing to a full pipe hangs until the timeout instead of
+// exiting. Discarding the overflow keeps memory bounded while letting the agent
+// finish, and Overflowed() lets the caller refuse the result outright.
+type cappedBuffer struct {
+	max   int
+	buf   bytes.Buffer
+	total int64
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	// n is what we report: an io.Writer that reports fewer bytes than it was
+	// given is a short write, which os/exec turns into an error on Wait.
+	n := len(p)
+	c.total += int64(n)
+	if room := c.max - c.buf.Len(); room > 0 {
+		if len(p) > room {
+			p = p[:room]
+		}
+		c.buf.Write(p)
+	}
+	return n, nil
+}
+
+func (c *cappedBuffer) String() string { return c.buf.String() }
+
+func (c *cappedBuffer) Total() int64 { return c.total }
+
+func (c *cappedBuffer) Overflowed() bool { return c.total > int64(c.max) }
+
+// registry holds the supported backends in a stable, documented order. Claude
+// Code is first so it wins auto-selection when multiple CLIs are installed.
+func registry() []AgentBackend {
+	return []AgentBackend{
+		&cliBackend{
+			name:   "claude",
+			bin:    "claude",
+			binEnv: "CNSPEC_AGENT_CLAUDE_BIN",
+			args: func(model string) []string {
+				a := []string{"-p", "--output-format", "text"}
+				if model != "" {
+					a = append(a, "--model", model)
+				}
+				return a
+			},
+		},
+		&cliBackend{
+			name:   "codex",
+			bin:    "codex",
+			binEnv: "CNSPEC_AGENT_CODEX_BIN",
+			args: func(model string) []string {
+				a := []string{"exec"}
+				if model != "" {
+					a = append(a, "--model", model)
+				}
+				return a
+			},
+		},
+		&cliBackend{
+			name:   "kimi",
+			bin:    "kimi",
+			binEnv: "CNSPEC_AGENT_KIMI_BIN",
+			args: func(model string) []string {
+				a := []string{}
+				if model != "" {
+					a = append(a, "--model", model)
+				}
+				return a
+			},
+		},
+		&cliBackend{
+			name:   "deepseek",
+			bin:    "deepseek",
+			binEnv: "CNSPEC_AGENT_DEEPSEEK_BIN",
+			args: func(model string) []string {
+				a := []string{}
+				if model != "" {
+					a = append(a, "--model", model)
+				}
+				return a
+			},
+		},
+	}
+}
+
+// BackendNames returns the supported agent identifiers in selection order.
+func BackendNames() []string {
+	bs := registry()
+	names := make([]string, len(bs))
+	for i, b := range bs {
+		names[i] = b.Name()
+	}
+	return names
+}
+
+// AvailableBackends returns the names of backends whose CLI is installed.
+func AvailableBackends() []string {
+	var names []string
+	for _, b := range registry() {
+		if b.Available() {
+			names = append(names, b.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Backend returns the named backend. An empty name auto-selects the first
+// available backend in registry order. It errors when the requested backend is
+// unknown or when no backend is available at all, with a message that tells the
+// user how to proceed.
+func Backend(name string) (AgentBackend, error) {
+	bs := registry()
+
+	if name == "" {
+		for _, b := range bs {
+			if b.Available() {
+				return b, nil
+			}
+		}
+		return nil, errors.Newf("no supported coding agent found on PATH; install one of %s, or set --agent and its CNSPEC_AGENT_*_BIN override", strings.Join(BackendNames(), ", "))
+	}
+
+	for _, b := range bs {
+		if b.Name() == name {
+			if !b.Available() {
+				return nil, errors.Newf("agent %q is not installed or not on PATH (set CNSPEC_AGENT_%s_BIN to override)", name, strings.ToUpper(name))
+			}
+			return b, nil
+		}
+	}
+	return nil, errors.Newf("unknown agent %q; supported agents: %s", name, strings.Join(BackendNames(), ", "))
+}
+
+// truncate shortens s to at most n bytes without splitting a multibyte rune.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	// back off to a rune boundary at or before n
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n] + "…"
+}

--- a/internal/generate/backend_unix_test.go
+++ b/internal/generate/backend_unix_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package generate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scriptedAgent writes an executable stand-in for an agent CLI and returns a
+// backend that runs it.
+func scriptedAgent(t *testing.T, body string) *cliBackend {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o700); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return &cliBackend{
+		name:   "scripted",
+		bin:    path,
+		binEnv: "CNSPEC_TEST_AGENT_BIN_UNSET",
+		args:   func(string) []string { return nil },
+	}
+}
+
+// TestBackendStopsAForkedHelper is the 601-seconds-against-a-180-second-timeout
+// case. The agent exits immediately but leaves a child holding the stdout pipe,
+// and os/exec's Wait waits for the pipe rather than for the process — so without
+// a process group to kill and a WaitDelay to bound it, the run outlives its
+// timeout by as long as the orphan lives.
+func TestBackendStopsAForkedHelper(t *testing.T) {
+	backend := scriptedAgent(t, "sleep 45 &\necho started\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := backend.Generate(ctx, GenTask{Prompt: "irrelevant"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the cancelled run to report an error")
+	}
+	// generous: the fix returns in about the timeout plus the 2s WaitDelay,
+	// while the bug returns only when the 45s orphan exits
+	if elapsed > 20*time.Second {
+		t.Fatalf("Generate took %s; the agent's process tree outlived its timeout", elapsed)
+	}
+}
+
+// TestBackendCapsStdout pins that a runaway agent is reported, not parsed. The
+// buffer used to be unbounded (400 MB of output cost 1.59 GB of RSS), and a
+// truncated capture must not be handed to the parser — half a response can parse
+// into a query the agent never returned.
+func TestBackendCapsStdout(t *testing.T) {
+	// a valid answer, then far more output than the cap allows
+	backend := scriptedAgent(t, `printf '{"mql": "aws.s3.buckets.all(encryption != empty)"}\n'
+i=0
+while [ $i -lt 200 ]; do
+  printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n'
+  i=$((i+1))
+done
+`)
+	backend.maxStdout = 512
+
+	res, err := backend.Generate(context.Background(), GenTask{Prompt: "irrelevant"})
+	if err == nil {
+		t.Fatalf("expected an error for a runaway agent, got MQL %q", res.MQL)
+	}
+	if !strings.Contains(err.Error(), "refusing to parse") {
+		t.Fatalf("error should say the output was refused, got: %v", err)
+	}
+	if res.MQL != "" {
+		t.Fatalf("a truncated capture must not yield MQL, got %q", res.MQL)
+	}
+}
+
+// TestBackendDoesNotForwardCredentials is the end-to-end half of
+// TestAgentEnvWithholdsCredentials: what the child process actually sees.
+func TestBackendDoesNotForwardCredentials(t *testing.T) {
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "leaked-to-the-agent")
+	t.Setenv("MONDOO_API_TOKEN", "leaked-to-the-agent")
+	t.Setenv("ANTHROPIC_API_KEY", "the-agents-own-key")
+
+	backend := scriptedAgent(t, "env\n")
+
+	res, err := backend.Generate(context.Background(), GenTask{Prompt: "irrelevant"})
+	// no MQL in `env` output, so Generate reports that; the raw output is what
+	// this test is after
+	if err == nil {
+		t.Fatal("expected 'no MQL' from an agent that prints its environment")
+	}
+	if strings.Contains(res.Raw, "leaked-to-the-agent") {
+		t.Errorf("the agent subprocess inherited a credential:\n%s", res.Raw)
+	}
+	if !strings.Contains(res.Raw, "the-agents-own-key") {
+		t.Errorf("the agent must keep its own auth, got:\n%s", res.Raw)
+	}
+}

--- a/internal/generate/corpus.go
+++ b/internal/generate/corpus.go
@@ -1,0 +1,166 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnspec/internal/textrank"
+	"go.mondoo.com/cnspec/policy"
+)
+
+// Field weights and the provider match bonus for grounding search. Title matches
+// dominate because a check's title is the most concentrated statement of intent;
+// a same-provider example is what the agent most needs, so it gets a large bonus
+// without excluding cross-provider matches.
+const (
+	weightTitle   = 3
+	weightDesc    = 1
+	weightMql     = 1
+	providerBonus = 5.0
+)
+
+// Example is one existing, validated check used to ground generation. Real MQL
+// for the same provider is the single biggest accuracy lever we have, so the
+// generator feeds the closest examples to the agent as few-shot context.
+type Example struct {
+	UID      string
+	Title    string
+	Desc     string
+	Mql      string
+	Provider string
+	// Score is the similarity to the query intent, set by Search.
+	Score float64
+}
+
+// Corpus is a searchable set of examples drawn from existing policy bundles
+// (content/*.mql.yaml by default), ranked with the shared BM25 text ranker.
+type Corpus struct {
+	byUID map[string]Example
+	index *textrank.Index
+}
+
+// LoadCorpus reads every query with MQL from the given bundle paths and builds a
+// searchable corpus.
+func LoadCorpus(paths ...string) (*Corpus, error) {
+	files, err := policy.WalkPolicyBundleFiles(paths...)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not enumerate corpus files")
+	}
+
+	var examples []Example
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue // a single unreadable file should not sink the corpus
+		}
+		b, err := policy.BundleFromYAML(data)
+		if err != nil {
+			continue
+		}
+		for _, q := range allBundleQueries(b) {
+			if strings.TrimSpace(q.Mql) == "" {
+				continue
+			}
+			examples = append(examples, exampleFromQuery(q))
+		}
+	}
+	return NewCorpus(examples), nil
+}
+
+// NewCorpus builds a corpus from in-memory examples (used in tests).
+func NewCorpus(examples []Example) *Corpus {
+	byUID := make(map[string]Example, len(examples))
+	docs := make([]textrank.Document, 0, len(examples))
+	for _, ex := range examples {
+		byUID[ex.UID] = ex
+		docs = append(docs, textrank.Document{
+			ID: ex.UID,
+			Parts: []textrank.WeightedText{
+				{Text: ex.Title, Weight: weightTitle},
+				{Text: ex.Desc, Weight: weightDesc},
+				{Text: ex.Mql, Weight: weightMql},
+			},
+		})
+	}
+	return &Corpus{byUID: byUID, index: textrank.Build(docs)}
+}
+
+// Size reports the number of examples in the corpus.
+func (c *Corpus) Size() int { return c.index.Len() }
+
+// Search returns up to limit examples most similar to the intent, ranked by
+// BM25 with a strong bonus for a matching provider.
+func (c *Corpus) Search(intent, provider string, limit int) []Example {
+	scored := c.index.SearchBonus(intent, limit, func(id string) float64 {
+		if provider != "" && c.byUID[id].Provider == provider {
+			return providerBonus
+		}
+		return 0
+	})
+	out := make([]Example, 0, len(scored))
+	for _, s := range scored {
+		ex := c.byUID[s.ID]
+		ex.Score = s.Score
+		out = append(out, ex)
+	}
+	return out
+}
+
+func exampleFromQuery(q *policy.Mquery) Example {
+	desc := ""
+	if q.Docs != nil {
+		desc = q.Docs.Desc
+	}
+	if desc == "" {
+		desc = q.Desc
+	}
+	provider, _ := ResolveProvider(Check{
+		UID:     q.Uid,
+		Filters: filterExpressions(q),
+	})
+	return Example{
+		UID:      q.Uid,
+		Title:    q.Title,
+		Desc:     desc,
+		Mql:      q.Mql,
+		Provider: provider,
+	}
+}
+
+// allBundleQueries enumerates every query definition in a bundle: top-level
+// shared queries, plus checks and data queries nested in policy and pack groups.
+func allBundleQueries(b *policy.Bundle) []*policy.Mquery {
+	var out []*policy.Mquery
+	out = append(out, b.Queries...)
+	for _, p := range b.Policies {
+		for _, g := range p.Groups {
+			out = append(out, g.Checks...)
+			out = append(out, g.Queries...)
+		}
+	}
+	for _, pack := range b.Packs {
+		out = append(out, pack.Queries...)
+		for _, g := range pack.Groups {
+			out = append(out, g.Queries...)
+		}
+	}
+	return out
+}
+
+// filterExpressions returns the filter MQL strings attached to a query.
+func filterExpressions(q *policy.Mquery) []string {
+	if q.Filters == nil {
+		return nil
+	}
+	var out []string
+	for _, f := range q.Filters.Items {
+		if f != nil && strings.TrimSpace(f.Mql) != "" {
+			out = append(out, f.Mql)
+		}
+	}
+	return out
+}

--- a/internal/generate/env.go
+++ b/internal/generate/env.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"os"
+	"strings"
+)
+
+// AgentEnvPassthroughVar names extra environment variables to forward to the
+// agent, comma-separated. It is the escape hatch for a setup the allowlist
+// below does not anticipate (a corporate proxy variable, a vendor-specific auth
+// var); `*` forwards the caller's entire environment, which is what cnspec used
+// to do unconditionally.
+const AgentEnvPassthroughVar = "CNSPEC_AGENT_ENV"
+
+// agentEnvAllowed is the set of variables the agent subprocess inherits.
+//
+// It exists because the alternative is what this code used to do: hand the
+// coding agent the operator's entire environment. That is every cloud
+// credential the shell is carrying — AWS_SECRET_ACCESS_KEY, MONDOO_API_TOKEN,
+// SSH_AUTH_SOCK and the rest — passed to a program that runs tools and acts on
+// text an untrusted policy bundle supplied. The agent needs to start, find its
+// own config, and reach its own API; it does not need to be able to sign an AWS
+// request.
+//
+// Everything here is either "the process cannot run without it" or "the agent's
+// own account", never a credential for a system cnspec scans.
+var agentEnvAllowed = map[string]bool{
+	// process basics
+	"PATH": true, "HOME": true, "USER": true, "LOGNAME": true, "SHELL": true,
+	"TMPDIR": true, "TMP": true, "TEMP": true, "PWD": true,
+	// terminal and locale, so the agent's own output is readable
+	"TERM": true, "COLORTERM": true, "NO_COLOR": true, "CLICOLOR": true,
+	"LANG": true, "LC_ALL": true, "LC_CTYPE": true, "TZ": true,
+	// where the agent keeps its own configuration
+	"XDG_CONFIG_HOME": true, "XDG_CACHE_HOME": true, "XDG_DATA_HOME": true,
+	"XDG_STATE_HOME": true, "XDG_RUNTIME_DIR": true,
+	// reaching its own API through the operator's network
+	"HTTP_PROXY": true, "HTTPS_PROXY": true, "ALL_PROXY": true, "NO_PROXY": true,
+	"SSL_CERT_FILE": true, "SSL_CERT_DIR": true, "NODE_EXTRA_CA_CERTS": true,
+	"REQUESTS_CA_BUNDLE": true, "CURL_CA_BUNDLE": true,
+	// Windows: a process started without these cannot resolve system DLLs or
+	// its own user profile
+	"SYSTEMROOT": true, "SYSTEMDRIVE": true, "WINDIR": true, "COMSPEC": true,
+	"PATHEXT": true, "APPDATA": true, "LOCALAPPDATA": true, "PROGRAMDATA": true,
+	"PROGRAMFILES": true, "PROGRAMFILES(X86)": true, "USERPROFILE": true,
+	"USERNAME": true, "HOMEDRIVE": true, "HOMEPATH": true,
+	"PROCESSOR_ARCHITECTURE": true, "NUMBER_OF_PROCESSORS": true, "OS": true,
+}
+
+// agentEnvAllowedPrefixes covers each supported agent's own auth and settings.
+// These are the agent's credentials, which is the whole premise of the design:
+// cnspec ships no model access and the agent brings its own.
+var agentEnvAllowedPrefixes = []string{
+	"ANTHROPIC_",
+	"CLAUDE_",
+	"OPENAI_",
+	"CODEX_",
+	"KIMI_",
+	"MOONSHOT_",
+	"DEEPSEEK_",
+	// the agent CLIs are Node programs; these decide how that runtime starts
+	"NODE_OPTIONS",
+	"NPM_CONFIG_",
+	// the generator's own knobs (CNSPEC_AGENT_*_BIN and the passthrough list)
+	"CNSPEC_AGENT_",
+}
+
+// agentEnv builds the environment for an agent invocation from environ (the
+// caller's, in os.Environ form). Order is preserved so a duplicated key still
+// resolves the way os/exec resolves it.
+func agentEnv(environ []string) []string {
+	extra, all := passthroughFrom(environ)
+	if all {
+		return environ
+	}
+
+	out := make([]string, 0, 32)
+	for _, kv := range environ {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if agentEnvAllows(name, extra) {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// agentEnvAllows reports whether one variable is forwarded. Matching is
+// case-insensitive: Windows environment names are, and `http_proxy` is as
+// common as `HTTP_PROXY` everywhere else.
+func agentEnvAllows(name string, extra map[string]bool) bool {
+	upper := strings.ToUpper(name)
+	if agentEnvAllowed[upper] || extra[upper] {
+		return true
+	}
+	for _, prefix := range agentEnvAllowedPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// passthroughFrom reads the operator's additions from environ itself, rather
+// than from os.Getenv, so the whole function stays testable without mutating
+// the test process's environment.
+func passthroughFrom(environ []string) (extra map[string]bool, all bool) {
+	extra = map[string]bool{}
+	for _, kv := range environ {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok || !strings.EqualFold(name, AgentEnvPassthroughVar) {
+			continue
+		}
+		for _, item := range strings.Split(value, ",") {
+			switch item = strings.TrimSpace(item); item {
+			case "":
+			case "*":
+				all = true
+			default:
+				extra[strings.ToUpper(item)] = true
+			}
+		}
+	}
+	return extra, all
+}
+
+// agentEnviron is agentEnv over this process's environment.
+func agentEnviron() []string { return agentEnv(os.Environ()) }

--- a/internal/generate/env_test.go
+++ b/internal/generate/env_test.go
@@ -1,0 +1,84 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestAgentEnvWithholdsCredentials is the whole point of the allowlist: the
+// agent is a program that runs tools on text an untrusted bundle supplied, and
+// it used to be handed every credential in the operator's shell.
+func TestAgentEnvWithholdsCredentials(t *testing.T) {
+	environ := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/op",
+		"TERM=xterm-256color",
+		"LANG=en_US.UTF-8",
+		"ANTHROPIC_API_KEY=agent-own-auth",
+		"CNSPEC_AGENT_CLAUDE_BIN=/opt/claude",
+		"HTTPS_PROXY=http://proxy:3128",
+		// none of these belong to the agent
+		"AWS_SECRET_ACCESS_KEY=leaked",
+		"AWS_SESSION_TOKEN=leaked",
+		"MONDOO_API_TOKEN=leaked",
+		"SSH_AUTH_SOCK=/tmp/agent.sock",
+		"GITHUB_TOKEN=leaked",
+		"KUBECONFIG=/home/op/.kube/config",
+		"AZURE_CLIENT_SECRET=leaked",
+		"GOOGLE_APPLICATION_CREDENTIALS=/home/op/gcp.json",
+		"VAULT_TOKEN=leaked",
+	}
+
+	got := agentEnv(environ)
+
+	for _, want := range []string{
+		"PATH=/usr/bin", "HOME=/home/op", "TERM=xterm-256color", "LANG=en_US.UTF-8",
+		"ANTHROPIC_API_KEY=agent-own-auth", "CNSPEC_AGENT_CLAUDE_BIN=/opt/claude",
+		"HTTPS_PROXY=http://proxy:3128",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("the agent needs %q, but it was dropped", want)
+		}
+	}
+	for _, kv := range got {
+		name, _, _ := strings.Cut(kv, "=")
+		switch name {
+		case "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "MONDOO_API_TOKEN",
+			"SSH_AUTH_SOCK", "GITHUB_TOKEN", "KUBECONFIG", "AZURE_CLIENT_SECRET",
+			"GOOGLE_APPLICATION_CREDENTIALS", "VAULT_TOKEN":
+			t.Errorf("credential %q was forwarded to the agent", name)
+		}
+	}
+}
+
+func TestAgentEnvPassthrough(t *testing.T) {
+	environ := []string{"PATH=/usr/bin", "AWS_SECRET_ACCESS_KEY=leaked", "CORP_CA=/etc/ca.pem"}
+
+	// named passthrough forwards exactly what was asked for, nothing more
+	got := agentEnv(append(slices.Clone(environ), AgentEnvPassthroughVar+"=CORP_CA"))
+	if !slices.Contains(got, "CORP_CA=/etc/ca.pem") {
+		t.Errorf("passthrough did not forward CORP_CA: %v", got)
+	}
+	if slices.Contains(got, "AWS_SECRET_ACCESS_KEY=leaked") {
+		t.Errorf("passthrough forwarded an unnamed variable: %v", got)
+	}
+
+	// `*` restores the old inherit-everything behavior, for whoever needs it
+	all := agentEnv(append(slices.Clone(environ), AgentEnvPassthroughVar+"=*"))
+	if !slices.Contains(all, "AWS_SECRET_ACCESS_KEY=leaked") {
+		t.Errorf("`*` should inherit the whole environment: %v", all)
+	}
+}
+
+func TestAgentEnvIsCaseInsensitive(t *testing.T) {
+	// http_proxy is as common as HTTP_PROXY, and Windows names are
+	// case-insensitive throughout
+	got := agentEnv([]string{"http_proxy=http://proxy:3128", "Path=C:\\bin"})
+	if len(got) != 2 {
+		t.Fatalf("expected both variables to be forwarded, got %v", got)
+	}
+}

--- a/internal/generate/execrunner.go
+++ b/internal/generate/execrunner.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/exec"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// RuntimeLike is the connected runtime returned by ConnectTarget/ConnectRecording,
+// aliased so callers need not import llx directly.
+type RuntimeLike = llx.Runtime
+
+// RuntimeRunner executes MQL against a connected provider runtime. It backs the
+// execute-and-assert validator when a --test-target is supplied.
+type RuntimeRunner struct {
+	runtime  llx.Runtime
+	features mql.Features
+}
+
+// Run compiles and executes the query against the connected runtime, returning
+// the boolean verdict and whether the query resolved to a concrete value. The
+// request's props reach the compiler for the same reason the compile gate needs
+// them: a query the prompt asked to reference props.<name> does not compile
+// without them.
+func (r *RuntimeRunner) Run(req ValidationRequest) (bool, bool, error) {
+	conf := mqlc.NewConfig(r.runtime.Schema(), r.features)
+	bundle, err := mqlc.Compile(req.MQL, newPropsHandler(req.Props, conf), conf)
+	if err != nil {
+		return false, false, errors.Wrap(err, "failed to compile")
+	}
+
+	results, err := exec.ExecuteCode(r.runtime, bundle, nil, r.features)
+	if err != nil {
+		return false, false, err
+	}
+
+	raw := lastEntrypointResult(bundle, results)
+	if raw == nil || raw.Data == nil {
+		return false, false, nil // no result -> unresolved
+	}
+	if raw.Data.Error != nil {
+		return false, false, raw.Data.Error
+	}
+	// IsTruthy returns (value, valid); valid is false for a null/unresolved
+	// result, which is exactly the failure we want execute-and-assert to catch.
+	value, valid := raw.Data.IsTruthy()
+	return value, valid, nil
+}
+
+// lastEntrypointResult returns the result for the query's final entrypoint (the
+// top-level verdict expression), mirroring how the test harness extracts a
+// query's outcome.
+func lastEntrypointResult(bundle *llx.CodeBundle, results map[string]*llx.RawResult) *llx.RawResult {
+	if bundle == nil || bundle.CodeV2 == nil {
+		return nil
+	}
+	entrypoints := bundle.CodeV2.Entrypoints()
+	if len(entrypoints) == 0 {
+		return nil
+	}
+	ref := entrypoints[len(entrypoints)-1]
+	checksum := bundle.CodeV2.Checksums[ref]
+	if r, ok := results[checksum]; ok {
+		return r
+	}
+	// fall back to any entrypoint result
+	for _, ep := range entrypoints {
+		if r, ok := results[bundle.CodeV2.Checksums[ep]]; ok {
+			return r
+		}
+	}
+	return nil
+}
+
+// ConnectTarget connects a provider runtime to a target for execute-and-assert.
+// target is a connection type/provider name such as "local", "aws", "gcp", or
+// "azure"; the provider connects with its ambient defaults (e.g. the local AWS
+// credentials, exactly like `cnspec scan aws`). Richer connection strings (ssh
+// host arguments, docker image references) are not yet parsed here.
+//
+// It returns the connected runtime and a cleanup function that releases it.
+func ConnectTarget(target string) (llx.Runtime, func(), error) {
+	if target == "" {
+		return nil, nil, errors.New("no test target specified")
+	}
+	return connectAsset(&inventory.Asset{
+		Connections: []*inventory.Config{{Type: target}},
+	}, "target "+strconv.Quote(target))
+}
+
+// ConnectRecording connects a runtime that replays a recording file, so
+// execute-and-assert can run reproducibly with no live credentials or network.
+// The recording provider is built in, so this works even when the target
+// provider's binary is not installed.
+func ConnectRecording(path string) (llx.Runtime, func(), error) {
+	if path == "" {
+		return nil, nil, errors.New("no recording path specified")
+	}
+	return connectAsset(&inventory.Asset{
+		Connections: []*inventory.Config{{Type: "recording", Path: path}},
+	}, "recording "+strconv.Quote(path))
+}
+
+// connectAsset selects a provider for the asset, connects it, and returns the
+// runtime plus a cleanup that releases it. label is used in error messages.
+func connectAsset(asset *inventory.Asset, label string) (llx.Runtime, func(), error) {
+	runtime, err := providers.Coordinator.RuntimeFor(asset, providers.DefaultRuntime())
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "could not select a provider for %s", label)
+	}
+
+	if err := runtime.Connect(&plugin.ConnectReq{
+		Asset:    asset,
+		Features: []byte(mql.DefaultFeatures),
+	}); err != nil {
+		// release the runtime we just acquired so a failed connect doesn't leak it
+		providers.Coordinator.RemoveRuntime(runtime)
+		return nil, nil, errors.Wrapf(err, "could not connect to %s", label)
+	}
+
+	cleanup := func() { providers.Coordinator.RemoveRuntime(runtime) }
+	return runtime, cleanup, nil
+}
+
+// NewRuntimeRunner builds a QueryRunner over a connected runtime.
+func NewRuntimeRunner(runtime llx.Runtime) *RuntimeRunner {
+	return &RuntimeRunner{runtime: runtime, features: mql.DefaultFeatures}
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,0 +1,371 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeBackend struct {
+	name      string
+	avail     bool
+	responses []string
+	calls     int
+	forcedErr error
+}
+
+func (f *fakeBackend) Name() string    { return f.name }
+func (f *fakeBackend) Available() bool { return f.avail }
+func (f *fakeBackend) Generate(_ context.Context, _ GenTask) (GenResult, error) {
+	if f.forcedErr != nil {
+		return GenResult{}, f.forcedErr
+	}
+	idx := f.calls
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	f.calls++
+	resp := f.responses[idx]
+	res := parseResponse(resp)
+	res.Raw = resp
+	if res.MQL == "" {
+		return res, errors.New("no mql")
+	}
+	return res, nil
+}
+
+type fakeValidator struct {
+	rejectN int
+	calls   int
+}
+
+func (v *fakeValidator) Validate(ValidationRequest) error {
+	v.calls++
+	if v.calls <= v.rejectN {
+		return errors.New("does not compile")
+	}
+	return nil
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestResolveProvider(t *testing.T) {
+	cases := []struct {
+		name     string
+		check    Check
+		provider string
+	}{
+		{"platform literal", Check{Filters: []string{`asset.platform == "aws"`}}, "aws"},
+		{"eks platform", Check{Filters: []string{`asset.platform == "aws-eks-cluster"`}}, "aws"},
+		{"linux family", Check{Filters: []string{`asset.family.contains("ubuntu")`}}, "os"},
+		{"windows", Check{Filters: []string{`asset.platform == "windows"`}}, "os"},
+		{"resource prefix", Check{Filters: []string{`aws.ec2.instances.any(_.state == "running")`}}, "aws"},
+		{"uid fallback", Check{UID: "mondoo-gcp-security-foo"}, "gcp"},
+		{"unknown", Check{Filters: []string{`asset.platform == "bogus"`}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := ResolveProvider(tc.check)
+			if got != tc.provider {
+				t.Fatalf("ResolveProvider = %q, want %q", got, tc.provider)
+			}
+		})
+	}
+}
+
+func TestParseResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			"fenced json",
+			"Here you go:\n```json\n{\"mql\": \"aws.s3.buckets.all(encryption != empty)\"}\n```\n",
+			"aws.s3.buckets.all(encryption != empty)",
+		},
+		{
+			"bare json object",
+			"prefix {\"mql\": \"users.all(uid >= 0)\", \"explanation\": \"x\"} suffix",
+			"users.all(uid >= 0)",
+		},
+		{
+			"json with braces in string",
+			"```json\n{\"mql\": \"a.where(b == \\\"{x}\\\")\"}\n```",
+			`a.where(b == "{x}")`,
+		},
+		{
+			"fenced mql fallback",
+			"I could not JSON but here:\n```mql\nsshd.config.params[\"X\"] == \"no\"\n```",
+			`sshd.config.params["X"] == "no"`,
+		},
+		{
+			"empty",
+			"I cannot help with that.",
+			"",
+		},
+		{
+			// M3: agent echoes an example envelope first, real answer second — last wins
+			"echoed example then answer",
+			"Example:\n```json\n{\"mql\": \"users.all(uid >= 0)\"}\n```\nMy answer:\n```json\n{\"mql\": \"aws.s3.buckets.all(encryption != empty)\"}\n```",
+			"aws.s3.buckets.all(encryption != empty)",
+		},
+		{
+			// M4: an explanation-only (empty mql) envelope must not shadow the real one
+			"empty-mql envelope then answer",
+			"```json\n{\"explanation\": \"thinking...\"}\n```\n```json\n{\"mql\": \"sshd.config.params[\\\"X\\\"] == \\\"no\\\"\"}\n```",
+			`sshd.config.params["X"] == "no"`,
+		},
+		{
+			// M3: an explanation-only json fence must NOT be returned as raw MQL
+			"explanation-only json is not mql",
+			"```json\n{\"explanation\": \"I could not produce a query\"}\n```",
+			"",
+		},
+		{
+			// the prompt tells the agent to verify with `cnspec run ... --ast`,
+			// so an agent that shows its work ends on a shell transcript. Taking
+			// the last block made the transcript the check.
+			"verification transcript does not beat the answer",
+			"```json\n{\"mql\": \"aws.s3.buckets.all(encryption != empty)\"}\n```\n" +
+				"I verified it:\n```\ncnspec run aws -c \"aws.s3.buckets.all(encryption != empty)\" --ast\n```",
+			"aws.s3.buckets.all(encryption != empty)",
+		},
+		{
+			// same, tagged as bash
+			"bash fence does not beat the answer",
+			"```mql\nsshd.config.params[\"X\"] == \"no\"\n```\n```bash\ncnspec run local -c 'sshd.config.params[\"X\"] == \"no\"' --ast\n```",
+			`sshd.config.params["X"] == "no"`,
+		},
+		{
+			// the agent echoes the prompt's own output format after answering
+			"echoed placeholder does not beat the answer",
+			"```json\n{\"mql\": \"aws.s3.buckets.all(encryption != empty)\"}\n```\n" +
+				"Format reminder:\n```json\n{\"mql\": \"<the query>\"}\n```",
+			"aws.s3.buckets.all(encryption != empty)",
+		},
+		{
+			// with nothing but a transcript there is no answer to fall back on
+			"transcript alone yields nothing",
+			"Let me check:\n```\ncnspec run aws -c \"aws.s3.buckets\" --ast\n```",
+			"",
+		},
+		{
+			"placeholder alone yields nothing",
+			"```json\n{\"mql\": \"<your mql>\"}\n```",
+			"",
+		},
+		{
+			"prose in a bare fence is not mql",
+			"```\nI could not determine which resource models this\n```",
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseResponse(tc.raw)
+			if got.MQL != tc.want {
+				t.Fatalf("parseResponse MQL = %q, want %q", got.MQL, tc.want)
+			}
+		})
+	}
+}
+
+func TestCorpusSearch(t *testing.T) {
+	corpus := NewCorpus([]Example{
+		{UID: "a", Title: "S3 buckets must be encrypted", Desc: "server-side encryption", Mql: "aws.s3.buckets.all(encryption != empty)", Provider: "aws"},
+		{UID: "b", Title: "Compute disks must be encrypted", Desc: "disk encryption at rest", Mql: "gcp.compute.disks.all(diskEncryptionKey != empty)", Provider: "gcp"},
+		{UID: "c", Title: "SSH root login disabled", Desc: "harden sshd", Mql: "sshd.config.params[\"PermitRootLogin\"] == \"no\"", Provider: "os"},
+	})
+
+	got := corpus.Search("bucket encryption enabled", "aws", 2)
+	if len(got) == 0 {
+		t.Fatal("expected results")
+	}
+	if got[0].UID != "a" {
+		t.Fatalf("expected s3 example first, got %q", got[0].UID)
+	}
+
+	// provider bias: gcp query should surface the gcp example first even though
+	// "encryption" matches both.
+	gotGCP := corpus.Search("disk encryption", "gcp", 1)
+	if len(gotGCP) != 1 || gotGCP[0].UID != "b" {
+		t.Fatalf("expected gcp example, got %+v", gotGCP)
+	}
+
+	// stemming: singular "bucket" query should still match the plural "buckets"
+	// example even without a provider hint.
+	gotStem := corpus.Search("bucket encrypt", "", 1)
+	if len(gotStem) != 1 || gotStem[0].UID != "a" {
+		t.Fatalf("expected stemmed match on s3 example, got %+v", gotStem)
+	}
+}
+
+func TestGeneratorSkip(t *testing.T) {
+	gen := mustGen(t, Config{Backend: &fakeBackend{avail: true, responses: []string{`{"mql":"x"}`}}})
+
+	// existing mql, no force -> skipped
+	res := gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "t", Mql: "already"})
+	if res.Action != ActionSkipped {
+		t.Fatalf("expected skipped, got %s", res.Action)
+	}
+	if res.MQL != "already" {
+		t.Fatalf("skip should preserve mql, got %q", res.MQL)
+	}
+
+	// no intent -> skipped
+	res = gen.GenerateCheck(context.Background(), Check{UID: "u"})
+	if res.Action != ActionSkipped {
+		t.Fatalf("expected skipped for no intent, got %s", res.Action)
+	}
+
+	// variant parent -> skipped even with intent and no mql
+	res = gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "parent", HasVariants: true})
+	if res.Action != ActionSkipped {
+		t.Fatalf("expected variant parent skipped, got %s", res.Action)
+	}
+}
+
+func TestGeneratorGenerate(t *testing.T) {
+	backend := &fakeBackend{avail: true, responses: []string{`{"mql":"aws.s3.buckets.all(encryption != empty)","explanation":"checks encryption"}`}}
+	gen := mustGen(t, Config{Backend: backend, Explain: true})
+
+	res := gen.GenerateCheck(context.Background(), Check{
+		UID:     "s3-enc",
+		Title:   "S3 buckets must be encrypted",
+		Filters: []string{`asset.platform == "aws"`},
+	})
+	if res.Action != ActionGenerated {
+		t.Fatalf("expected generated, got %s: %v", res.Action, res.Err)
+	}
+	if res.Provider != "aws" {
+		t.Fatalf("expected provider aws, got %q", res.Provider)
+	}
+	if !strings.Contains(res.MQL, "encryption") {
+		t.Fatalf("unexpected mql: %q", res.MQL)
+	}
+	if res.Explanation == "" {
+		t.Fatal("expected explanation")
+	}
+}
+
+func TestGeneratorValidationRetry(t *testing.T) {
+	// first response invalid per validator, second accepted
+	backend := &fakeBackend{avail: true, responses: []string{
+		`{"mql":"bad.query"}`,
+		`{"mql":"good.query != empty"}`,
+	}}
+	validator := &fakeValidator{rejectN: 1}
+	gen := mustGen(t, Config{Backend: backend, Validator: validator, MaxAttempts: 3})
+
+	res := gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "something"})
+	if res.Action != ActionGenerated {
+		t.Fatalf("expected generated after retry, got %s: %v", res.Action, res.Err)
+	}
+	if res.MQL != "good.query != empty" {
+		t.Fatalf("expected second response, got %q", res.MQL)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("expected 2 backend calls, got %d", backend.calls)
+	}
+}
+
+func TestGeneratorValidationExhausted(t *testing.T) {
+	backend := &fakeBackend{avail: true, responses: []string{`{"mql":"always.bad"}`}}
+	validator := &fakeValidator{rejectN: 100}
+	gen := mustGen(t, Config{Backend: backend, Validator: validator, MaxAttempts: 2})
+
+	res := gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "t"})
+	if res.Action != ActionFailed {
+		t.Fatalf("expected failed, got %s", res.Action)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("expected 2 attempts, got %d", backend.calls)
+	}
+}
+
+type fakeRunner struct {
+	value    bool
+	resolved bool
+	err      error
+}
+
+func (r fakeRunner) Run(ValidationRequest) (bool, bool, error) { return r.value, r.resolved, r.err }
+
+func TestExecuteValidator(t *testing.T) {
+	cases := []struct {
+		name    string
+		runner  fakeRunner
+		wantErr bool
+	}{
+		{"resolves true", fakeRunner{value: true, resolved: true}, false},
+		{"resolves false (still valid)", fakeRunner{value: false, resolved: true}, false},
+		{"null result rejected", fakeRunner{resolved: false}, true},
+		{"exec error rejected", fakeRunner{err: errors.New("boom")}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := NewExecuteValidator(tc.runner, NoopValidator{})
+			if err != nil {
+				t.Fatalf("NewExecuteValidator: %v", err)
+			}
+			err = v.Validate(ValidationRequest{MQL: "some.query != empty"})
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("Validate err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExecuteValidatorCompilesFirst(t *testing.T) {
+	// a compile failure must short-circuit before the runner is consulted
+	rejectCompile := failValidator{}
+	ran := &countingRunner{}
+	v, err := NewExecuteValidator(ran, rejectCompile)
+	if err != nil {
+		t.Fatalf("NewExecuteValidator: %v", err)
+	}
+	if err := v.Validate(ValidationRequest{MQL: "x"}); err == nil {
+		t.Fatal("expected compile error")
+	}
+	if ran.calls != 0 {
+		t.Fatalf("runner should not be called when compile fails, got %d calls", ran.calls)
+	}
+}
+
+type failValidator struct{}
+
+func (failValidator) Validate(ValidationRequest) error { return errors.New("does not compile") }
+
+type countingRunner struct{ calls int }
+
+func (r *countingRunner) Run(ValidationRequest) (bool, bool, error) {
+	r.calls++
+	return true, true, nil
+}
+
+func TestBackendSelection(t *testing.T) {
+	if _, err := Backend("does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+	names := BackendNames()
+	if len(names) != 4 || names[0] != "claude" {
+		t.Fatalf("unexpected backend names: %v", names)
+	}
+}
+
+func mustGen(t *testing.T, cfg Config) *Generator {
+	t.Helper()
+	g, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return g
+}

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -1,0 +1,269 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Config configures a Generator. Only Backend is required; the rest have safe
+// defaults.
+type Config struct {
+	// Backend is the coding-agent CLI used for generation (required).
+	Backend AgentBackend
+	// Corpus provides grounding examples. Nil disables few-shot grounding.
+	Corpus *Corpus
+	// Validator gates generated MQL. Nil means no validation (the caller should
+	// warn); use NewCompileValidator for the standard gate.
+	Validator Validator
+	// Model optionally overrides the agent's model.
+	Model string
+	// Force regenerates checks that already have MQL.
+	Force bool
+	// Explain requests a per-check explanation from the agent.
+	Explain bool
+	// SkillPaths point the agent at any discovered skill files (mql, policy-graph).
+	SkillPaths []string
+	// MaxAttempts bounds validation retries (total attempts, min 1). Default 3.
+	MaxAttempts int
+	// ExampleLimit caps grounding examples per check. Default 5.
+	ExampleLimit int
+	// Timeout bounds a single agent invocation. Default 180s.
+	Timeout time.Duration
+}
+
+// Generator produces MQL for policy checks by driving an agent backend, grounded
+// in similar existing checks and gated by validation.
+type Generator struct {
+	cfg Config
+}
+
+// New builds a Generator, applying defaults for unset fields.
+func New(cfg Config) (*Generator, error) {
+	if cfg.Backend == nil {
+		return nil, errors.New("a generation backend is required")
+	}
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 3
+	}
+	if cfg.ExampleLimit <= 0 {
+		cfg.ExampleLimit = 5
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 180 * time.Second
+	}
+	return &Generator{cfg: cfg}, nil
+}
+
+// ErrNoValidator reports that nothing checked a query. It is returned instead of
+// nil so a caller cannot mistake "no validator is configured" for "this query is
+// valid" — the interactive flow accepts hand-edited MQL on the strength of this
+// call, and silently accepting it unchecked is the failure it is meant to catch.
+// Callers that legitimately run without validation test for it with errors.Is.
+var ErrNoValidator = errors.Mark(errors.New("no validator is configured; the query was not checked"), ErrValidationUnavailable)
+
+// Validate runs the configured validator against a query (e.g. MQL a user edited
+// by hand in the interactive flow), with the check's props so `props.<name>`
+// resolves. It returns ErrNoValidator when no validator is configured.
+func (g *Generator) Validate(query string, props ...Prop) error {
+	if g.cfg.Validator == nil {
+		return ErrNoValidator
+	}
+	return g.cfg.Validator.Validate(ValidationRequest{MQL: query, Props: props})
+}
+
+// Ground returns up to n grounding examples for an intent+provider, or nil when
+// no corpus is configured. Used by the interactive flow to preview precedents.
+func (g *Generator) Ground(intent, provider string, n int) []Example {
+	if g.cfg.Corpus == nil {
+		return nil
+	}
+	return g.cfg.Corpus.Search(intent, provider, n)
+}
+
+// Generate processes a batch of checks in order, invoking progress (if non-nil)
+// as each result is ready so the CLI can render live status.
+func (g *Generator) Generate(ctx context.Context, checks []Check, progress func(Result)) []Result {
+	results := make([]Result, 0, len(checks))
+	report := func(res Result) {
+		results = append(results, res)
+		if progress != nil {
+			progress(res)
+		}
+	}
+	for i, c := range checks {
+		if err := ctx.Err(); err != nil {
+			// Report the tail rather than dropping it. A caller rendering one
+			// row per check (and GenerateCheck's own per-check cancel result
+			// promises exactly that) would otherwise leave every remaining row
+			// pending forever, with no result and no progress callback.
+			for _, remaining := range checks[i:] {
+				report(cancelledResult(remaining, err))
+			}
+			return results
+		}
+		report(g.GenerateCheck(ctx, c))
+	}
+	return results
+}
+
+// cancelledResult is the outcome recorded for a check the run never reached.
+func cancelledResult(c Check, err error) Result {
+	provider, _ := ResolveProvider(c)
+	return Result{
+		UID:      c.UID,
+		Action:   ActionFailed,
+		Provider: provider,
+		MQL:      c.Mql,
+		Reason:   "cancelled",
+		Err:      err,
+	}
+}
+
+// GenerateCheck produces MQL for one check. It never panics; failures are
+// reported in the Result.
+func (g *Generator) GenerateCheck(ctx context.Context, c Check) Result {
+	res := Result{UID: c.UID}
+
+	if c.HasVariants {
+		res.Action = ActionSkipped
+		res.Reason = "variant parent (mql lives in its variants)"
+		res.MQL = c.Mql
+		return res
+	}
+
+	if strings.TrimSpace(c.Mql) != "" && !g.cfg.Force {
+		res.Action = ActionSkipped
+		res.Reason = "already has mql (use --force to regenerate)"
+		res.MQL = c.Mql
+		return res
+	}
+
+	intent := strings.TrimSpace(c.Title + " " + c.Desc)
+	if strings.TrimSpace(c.Title) == "" && strings.TrimSpace(c.Desc) == "" {
+		res.Action = ActionSkipped
+		res.Reason = "no title or description to generate from"
+		return res
+	}
+
+	provider, _ := ResolveProvider(c)
+	res.Provider = provider
+
+	// Ask up front whether this provider can be validated at all. Discovering it
+	// afterwards costs MaxAttempts agent invocations and reports "cannot find
+	// resource for identifier 'aws'", which reads as a defect in the generated
+	// query rather than a provider that was never installed.
+	if checker, ok := g.cfg.Validator.(ProviderChecker); ok && g.cfg.Validator != nil {
+		if err := checker.CheckProvider(provider); err != nil {
+			res.Action = ActionFailed
+			res.Err = err
+			res.Reason = err.Error()
+			return res
+		}
+	}
+
+	var examples []Example
+	if g.cfg.Corpus != nil {
+		examples = g.cfg.Corpus.Search(intent, provider, g.cfg.ExampleLimit)
+		// never feed the check its own prior body back as an example
+		examples = filterExamples(examples, c.UID)
+	}
+
+	var lastErr error
+	var lastMQL string
+	for attempt := 1; attempt <= g.cfg.MaxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			res.Action = ActionFailed
+			res.Err = ctx.Err()
+			res.Reason = "cancelled"
+			return res
+		}
+
+		prompt := BuildPrompt(PromptData{
+			Title:       c.Title,
+			Desc:        c.Desc,
+			Provider:    provider,
+			Props:       c.Props,
+			Guidance:    c.Guidance,
+			Examples:    examples,
+			Explain:     g.cfg.Explain,
+			SkillPaths:  g.cfg.SkillPaths,
+			RetryError:  errString(lastErr),
+			PreviousMQL: lastMQL,
+		})
+
+		callCtx, cancel := context.WithTimeout(ctx, g.cfg.Timeout)
+		gen, err := g.cfg.Backend.Generate(callCtx, GenTask{Prompt: prompt, Model: g.cfg.Model})
+		cancel()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// An empty answer is not a generated check. The backend rejects one
+		// today, but the contract belongs here: a Result carrying ActionGenerated
+		// and no MQL would be written into a bundle as an empty check body.
+		mql := strings.TrimSpace(gen.MQL)
+		if mql == "" {
+			lastErr = errors.New("agent returned no MQL")
+			continue
+		}
+
+		lastMQL = mql
+		if v := g.cfg.Validator; v != nil {
+			verr := v.Validate(ValidationRequest{MQL: mql, Props: c.Props, Provider: provider})
+			if verr != nil {
+				// Retrying cannot fix an environment that cannot judge the
+				// answer; report that, rather than a count of attempts that
+				// makes it look like the agent kept getting it wrong.
+				if errors.Is(verr, ErrValidationUnavailable) {
+					res.Action = ActionFailed
+					res.Err = verr
+					res.Reason = verr.Error()
+					return res
+				}
+				lastErr = verr
+				continue
+			}
+		}
+
+		res.Action = ActionGenerated
+		res.MQL = mql
+		res.Explanation = gen.Explanation
+		return res
+	}
+
+	res.Action = ActionFailed
+	res.Err = lastErr
+	attempts := strconv.Itoa(g.cfg.MaxAttempts)
+	if lastErr != nil {
+		res.Reason = "failed after " + attempts + " attempts: " + lastErr.Error()
+	} else {
+		res.Reason = "failed after " + attempts + " attempts"
+	}
+	return res
+}
+
+func filterExamples(examples []Example, uid string) []Example {
+	out := examples[:0]
+	for _, ex := range examples {
+		if ex.UID == uid {
+			continue
+		}
+		out = append(out, ex)
+	}
+	return out
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/generate/generator_test.go
+++ b/internal/generate/generator_test.go
@@ -1,0 +1,226 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// spyValidator records what it was asked to judge.
+type spyValidator struct {
+	requests []ValidationRequest
+}
+
+func (v *spyValidator) Validate(req ValidationRequest) error {
+	v.requests = append(v.requests, req)
+	return nil
+}
+
+// unavailableValidator stands in for "this machine cannot compile-check that
+// provider".
+type unavailableValidator struct {
+	checked []string
+}
+
+func (v *unavailableValidator) Validate(ValidationRequest) error { return nil }
+
+func (v *unavailableValidator) CheckProvider(provider string) error {
+	v.checked = append(v.checked, provider)
+	if provider == "aws" {
+		return errors.Mark(errors.New("the \"aws\" provider is not installed"), ErrValidationUnavailable)
+	}
+	return nil
+}
+
+// TestGeneratorGivesTheValidatorItsProps is the engine half of the props fix:
+// the check's props have to travel with the query, or the compile gate judges a
+// prop-using answer without knowing the props exist.
+func TestGeneratorGivesTheValidatorItsProps(t *testing.T) {
+	backend := &fakeBackend{avail: true, responses: []string{`{"mql":"sshd.config.params[\"Ciphers\"] == props.ciphers"}`}}
+	validator := &spyValidator{}
+	gen := mustGen(t, Config{Backend: backend, Validator: validator})
+
+	props := []Prop{{Name: "ciphers", Mql: `return ["aes256-ctr"]`}}
+	res := gen.GenerateCheck(context.Background(), Check{
+		UID:     "sshd-ciphers",
+		Title:   "SSH must use strong ciphers",
+		Filters: []string{`asset.family.contains("linux")`},
+		Props:   props,
+	})
+	if res.Action != ActionGenerated {
+		t.Fatalf("expected generated, got %s: %v", res.Action, res.Err)
+	}
+	if len(validator.requests) != 1 {
+		t.Fatalf("expected one validation, got %d", len(validator.requests))
+	}
+	req := validator.requests[0]
+	if len(req.Props) != 1 || req.Props[0].Name != "ciphers" {
+		t.Fatalf("the check's props did not reach the validator: %+v", req.Props)
+	}
+	if req.Provider != "os" {
+		t.Fatalf("the target provider did not reach the validator, got %q", req.Provider)
+	}
+}
+
+// TestGeneratorRejectsEmptyMQL keeps the contract where the contract is
+// documented. The backend happens to reject an empty answer today; the engine
+// must not depend on that, because ActionGenerated with no MQL is written into
+// the bundle as an empty check body.
+func TestGeneratorRejectsEmptyMQL(t *testing.T) {
+	backend := &emptyAnswerBackend{}
+	gen := mustGen(t, Config{Backend: backend, MaxAttempts: 2})
+
+	res := gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "something"})
+	if res.Action == ActionGenerated {
+		t.Fatalf("an empty answer was reported as generated (mql %q)", res.MQL)
+	}
+	if res.MQL != "" {
+		t.Fatalf("expected no MQL, got %q", res.MQL)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("an empty answer should be retried like any other bad answer, got %d calls", backend.calls)
+	}
+}
+
+// emptyAnswerBackend returns whitespace and no error, the case a backend that
+// does not check for itself would let through.
+type emptyAnswerBackend struct{ calls int }
+
+func (b *emptyAnswerBackend) Name() string    { return "empty" }
+func (b *emptyAnswerBackend) Available() bool { return true }
+func (b *emptyAnswerBackend) Generate(context.Context, GenTask) (GenResult, error) {
+	b.calls++
+	return GenResult{MQL: "   \n"}, nil
+}
+
+// TestValidateWithoutAValidator: "nothing checked this" must not look like
+// "this is valid" to the caller accepting hand-edited MQL.
+func TestValidateWithoutAValidator(t *testing.T) {
+	gen := mustGen(t, Config{Backend: &fakeBackend{avail: true}})
+
+	err := gen.Validate("aws.s3.buckets.all(encryption != empty)")
+	if err == nil {
+		t.Fatal("Validate returned nil with no validator configured; the caller cannot tell that nothing checked the query")
+	}
+	if !errors.Is(err, ErrNoValidator) || !errors.Is(err, ErrValidationUnavailable) {
+		t.Fatalf("expected ErrNoValidator (and the unavailable marker), got %v", err)
+	}
+
+	// with a validator, it delegates and carries the props
+	spy := &spyValidator{}
+	gen = mustGen(t, Config{Backend: &fakeBackend{avail: true}, Validator: spy})
+	if err := gen.Validate("x != empty", Prop{Name: "p"}); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(spy.requests) != 1 || len(spy.requests[0].Props) != 1 {
+		t.Fatalf("props did not reach the validator: %+v", spy.requests)
+	}
+}
+
+// TestGenerateReportsTheCancelledTail: a caller rendering one row per check gets
+// a result for every check it handed over. Dropping the tail leaves those rows
+// pending forever, which is inconsistent with the per-check cancel result
+// GenerateCheck already returns.
+func TestGenerateReportsTheCancelledTail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := &cancellingBackend{cancel: cancel}
+	gen := mustGen(t, Config{Backend: backend, MaxAttempts: 1})
+
+	checks := []Check{
+		{UID: "first", Title: "one"},
+		{UID: "second", Title: "two"},
+		{UID: "third", Title: "three"},
+	}
+	var progressed []string
+	results := gen.Generate(ctx, checks, func(r Result) { progressed = append(progressed, r.UID) })
+
+	if len(results) != len(checks) {
+		t.Fatalf("expected a result per check, got %d of %d", len(results), len(checks))
+	}
+	if len(progressed) != len(checks) {
+		t.Fatalf("expected progress for every check, got %v", progressed)
+	}
+	for _, r := range results[1:] {
+		if r.Action != ActionFailed || r.Reason != "cancelled" {
+			t.Fatalf("check %q after cancellation should report cancelled, got %s/%q", r.UID, r.Action, r.Reason)
+		}
+	}
+}
+
+// cancellingBackend cancels the run while answering the first check.
+type cancellingBackend struct {
+	cancel func()
+	calls  int
+}
+
+func (b *cancellingBackend) Name() string    { return "cancelling" }
+func (b *cancellingBackend) Available() bool { return true }
+func (b *cancellingBackend) Generate(context.Context, GenTask) (GenResult, error) {
+	b.calls++
+	b.cancel()
+	return GenResult{MQL: "some.query != empty"}, nil
+}
+
+// TestGeneratorAsksBeforeSpendingAnAgentCall: an environment that cannot judge
+// the answer is reported before the agent runs, not discovered afterwards as
+// three compile errors about an unknown resource.
+func TestGeneratorAsksBeforeSpendingAnAgentCall(t *testing.T) {
+	backend := &fakeBackend{avail: true, responses: []string{`{"mql":"aws.s3.buckets.all(encryption != empty)"}`}}
+	validator := &unavailableValidator{}
+	gen := mustGen(t, Config{Backend: backend, Validator: validator, MaxAttempts: 3})
+
+	res := gen.GenerateCheck(context.Background(), Check{
+		UID:     "s3",
+		Title:   "S3 buckets must be encrypted",
+		Filters: []string{`asset.platform == "aws"`},
+	})
+	if res.Action != ActionFailed {
+		t.Fatalf("expected failure, got %s", res.Action)
+	}
+	if backend.calls != 0 {
+		t.Fatalf("the agent should not be invoked when the answer cannot be judged, got %d calls", backend.calls)
+	}
+	if !strings.Contains(res.Reason, "not installed") {
+		t.Fatalf("the reason should name the missing provider, got %q", res.Reason)
+	}
+
+	// a provider it can validate is generated normally
+	res = gen.GenerateCheck(context.Background(), Check{
+		UID:     "sshd",
+		Title:   "SSH root login must be disabled",
+		Filters: []string{`asset.family.contains("linux")`},
+	})
+	if res.Action != ActionGenerated {
+		t.Fatalf("expected generated for a checkable provider, got %s: %v", res.Action, res.Err)
+	}
+}
+
+// TestGeneratorStopsRetryingWhenValidationIsUnavailable: an unavailable
+// validator is not a wrong answer, so it must not be reported as "failed after 3
+// attempts" with three agent calls spent on it.
+func TestGeneratorStopsRetryingWhenValidationIsUnavailable(t *testing.T) {
+	backend := &fakeBackend{avail: true, responses: []string{`{"mql":"some.query != empty"}`}}
+	gen := mustGen(t, Config{Backend: backend, Validator: brokenValidator{}, MaxAttempts: 3})
+
+	res := gen.GenerateCheck(context.Background(), Check{UID: "u", Title: "t"})
+	if res.Action != ActionFailed {
+		t.Fatalf("expected failure, got %s", res.Action)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("expected a single attempt, got %d", backend.calls)
+	}
+	if strings.Contains(res.Reason, "attempts") {
+		t.Fatalf("the reason should explain that nothing could judge the query, got %q", res.Reason)
+	}
+}
+
+type brokenValidator struct{}
+
+func (brokenValidator) Validate(ValidationRequest) error {
+	return errors.Mark(errors.New("schema went away"), ErrValidationUnavailable)
+}

--- a/internal/generate/guess.go
+++ b/internal/generate/guess.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/mql/providers"
+)
+
+// Guessing a check's target from its wording is the front end's first act, and
+// both front ends -- the line wizard and the launcher's authoring pane -- have
+// to guess the same way, so it lives here beside ResolveProvider rather than
+// beside either of them.
+
+func GuessProvider(title string) string {
+	t := strings.ToLower(title)
+	switch {
+	case containsAny(t, "aws", "s3", "ec2", "iam", "cloudtrail", "rds", "eks", "lambda"):
+		return "aws"
+	case containsAny(t, "gcp", "gke", "bigquery", "cloud sql", "compute engine"):
+		return "gcp"
+	case containsAny(t, "azure", "aks", "blob"):
+		return "azure"
+	case containsAny(t, "ssh", "sshd", "kernel", "linux", "package", "systemd", "sudo", "pam"):
+		return "os"
+	case containsAny(t, "kubernetes", "k8s", "pod", "container"):
+		return "k8s"
+	}
+	return ""
+}
+
+// curatedFilters maps a provider to the asset filter the wizard proposes.
+//
+// These are *platform* names, not provider names, and the two differ for most
+// providers. A filter naming a platform that does not exist is dead: it lints
+// clean, it scans clean, and it never matches an asset — which is what
+// `asset.platform == "gcp"` and `asset.platform == "k8s"` were, since neither
+// name exists (gcp's platforms are gcp-project, gcp-gke-cluster, …; "k8s" is a
+// platform *family*, and its platforms are k8s-cluster, k8s-pod, …).
+//
+// Every name here is taken from installed provider metadata
+// (~/.config/mondoo/providers/<n>/<n>.json, Platforms[].name and .family) and is
+// in use by real checks in content/ — see TestDefaultFilterUsesRealPlatformNames,
+// which re-derives both. The choice among a provider's platforms is the scope
+// where that provider's account-wide resources resolve.
+var curatedFilters = map[string]string{
+	// the account-level asset; content/ uses it for ~200 checks
+	"aws": `asset.platform == "aws"`,
+	// the subscription-level asset
+	"azure": `asset.platform == "azure"`,
+	// there is no platform named "gcp"; the project is the account-level asset
+	"gcp": `asset.platform == "gcp-project"`,
+	// cluster and manifest are the two scopes where the cluster-wide k8s.*
+	// resources resolve; workload platforms (k8s-pod, k8s-deployment, …) are
+	// per-object and too narrow to guess at
+	"k8s": `asset.platform == "k8s-cluster" || asset.platform == "k8s-manifest"`,
+	// os platforms are per-distribution (ubuntu, redhat, …); the family is the
+	// portable way to say "any Linux"
+	"os": `asset.family.contains("linux")`,
+}
+
+// defaultFilter proposes an asset filter for a provider: a curated one where the
+// provider has many platforms and only some are plausible, otherwise one derived
+// from the installed provider metadata. Returns "" when neither knows the
+// provider — an empty prompt the user fills in beats a filter that silently
+// matches nothing.
+func DefaultFilter(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return ""
+	}
+	if f, ok := curatedFilters[provider]; ok {
+		return f
+	}
+	name, family := lookupPlatform(provider)
+	switch {
+	case name != "":
+		return fmt.Sprintf(`asset.platform == %q`, name)
+	case family != "":
+		return fmt.Sprintf(`asset.family.contains(%q)`, family)
+	}
+	return ""
+}
+
+// installedPlatforms reports the platform names and families a provider
+// declares. It is a variable so tests can drive DefaultFilter without depending
+// on which providers happen to be installed.
+var installedPlatforms = func(provider string) (names []string, families []string) {
+	// ListAll only reads the installed provider metadata: no network, no
+	// installs, and resource schemas stay unparsed.
+	all, err := providers.ListAll()
+	if err != nil {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	for _, p := range all {
+		if p == nil || p.Provider == nil || p.Name != provider {
+			continue
+		}
+		for _, pl := range p.Platforms {
+			if pl == nil {
+				continue
+			}
+			names = append(names, pl.Name)
+			for _, f := range pl.Family {
+				if !seen[f] {
+					seen[f] = true
+					families = append(families, f)
+				}
+			}
+		}
+	}
+	return names, families
+}
+
+// lookupPlatform resolves a provider name against installed metadata: an exact
+// platform of that name (aws, digitalocean, oci, …), else a family of that name
+// (github, terraform, …). Anything more ambiguous is left to the user.
+func lookupPlatform(provider string) (name, family string) {
+	names, families := installedPlatforms(provider)
+	for _, n := range names {
+		if n == provider {
+			return n, ""
+		}
+	}
+	for _, f := range families {
+		if f == provider {
+			return "", f
+		}
+	}
+	return "", ""
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/generate/guess_test.go
+++ b/internal/generate/guess_test.go
@@ -1,0 +1,180 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestGuessProvider(t *testing.T) {
+	if p := GuessProvider("S3 buckets must be encrypted"); p != "aws" {
+		t.Errorf("aws guess = %q", p)
+	}
+	if p := GuessProvider("SSH root login disabled"); p != "os" {
+		t.Errorf("os guess = %q", p)
+	}
+	if p := GuessProvider("Something generic"); p != "" {
+		t.Errorf("expected no guess, got %q", p)
+	}
+}
+
+// --- default asset filters ---------------------------------------------------
+
+var (
+	platformFilterRe = regexp.MustCompile(`asset\.platform\s*==\s*"([a-z0-9._-]+)"`)
+	familyFilterRe   = regexp.MustCompile(`asset\.family\.contains\("([a-z0-9._-]+)"\)`)
+)
+
+// TestDefaultFilterUsesRealPlatformNames validates every filter the wizard
+// proposes against authorities outside this file: the platform and family names
+// that real checks in content/ filter on, and — when providers are installed —
+// the Platforms[] metadata of the provider itself.
+//
+// It replaces a test that restated defaultFilter's implementation back to
+// itself, which is how `asset.platform == "gcp"` and `asset.platform == "k8s"`
+// shipped green: neither name exists (gcp's platforms are gcp-project,
+// gcp-gke-cluster, …; k8s is a family, its platforms are k8s-cluster, k8s-pod,
+// …), so both filters matched no asset, ever, while lint stayed silent.
+func TestDefaultFilterUsesRealPlatformNames(t *testing.T) {
+	contentPlatforms, contentFamilies := contentFilterNames(t)
+	if len(contentPlatforms) == 0 {
+		t.Fatal("found no asset.platform filters in content/; the corpus this test derives from is missing")
+	}
+
+	var checkedMeta, skippedMeta int
+	for provider := range curatedFilters {
+		filter := DefaultFilter(provider)
+		platforms := allSubmatches(platformFilterRe, filter)
+		families := allSubmatches(familyFilterRe, filter)
+		if len(platforms)+len(families) == 0 {
+			t.Errorf("DefaultFilter(%q) = %q names neither a platform nor a family", provider, filter)
+			continue
+		}
+
+		for _, name := range platforms {
+			if !contentPlatforms[name] {
+				t.Errorf("DefaultFilter(%q) = %q filters on platform %q, which no check in content/ uses; a platform name that does not exist matches no asset", provider, filter, name)
+			}
+		}
+		for _, name := range families {
+			if !contentFamilies[name] {
+				t.Errorf("DefaultFilter(%q) = %q filters on family %q, which no check in content/ uses", provider, filter, name)
+			}
+		}
+
+		// second authority: the provider's own metadata, when it is installed
+		metaPlatforms, metaFamilies := installedPlatforms(provider)
+		if len(metaPlatforms) == 0 {
+			skippedMeta++
+			continue
+		}
+		checkedMeta++
+		known := map[string]bool{}
+		for _, n := range metaPlatforms {
+			known[n] = true
+		}
+		knownFamily := map[string]bool{}
+		for _, f := range metaFamilies {
+			knownFamily[f] = true
+		}
+		for _, name := range platforms {
+			if !known[name] {
+				t.Errorf("DefaultFilter(%q) = %q filters on platform %q, which the installed %s provider does not declare (Platforms[].name)", provider, filter, name, provider)
+			}
+		}
+		for _, name := range families {
+			if !knownFamily[name] {
+				t.Errorf("DefaultFilter(%q) = %q filters on family %q, which the installed %s provider does not declare (Platforms[].family)", provider, filter, name, provider)
+			}
+		}
+	}
+
+	// CI runs with no providers installed, so say out loud how much of this test
+	// actually ran instead of reporting a vacuous pass.
+	t.Logf("checked %d/%d provider default(s) against installed provider metadata (%d skipped: provider not installed); all %d checked against content/",
+		checkedMeta, len(curatedFilters), skippedMeta, len(curatedFilters))
+}
+
+// TestDefaultFilterDerivesUnknownProviders covers the providers with no curated
+// default: the filter has to come from installed metadata, and when metadata
+// cannot answer, the wizard must offer no default at all rather than the old
+// `asset.platform == <provider name>` guess, which is dead for every provider
+// whose platforms are not named after it (github, terraform, gitlab, …).
+func TestDefaultFilterDerivesUnknownProviders(t *testing.T) {
+	orig := installedPlatforms
+	t.Cleanup(func() { installedPlatforms = orig })
+	installedPlatforms = func(provider string) ([]string, []string) {
+		switch provider {
+		case "github":
+			return []string{"github-org", "github-user", "github-repo"}, []string{"github"}
+		case "digitalocean":
+			return []string{"digitalocean", "digitalocean-database"}, []string{"digitalocean"}
+		}
+		return nil, nil
+	}
+
+	cases := map[string]string{
+		// a platform is named after the provider: use it
+		"digitalocean": `asset.platform == "digitalocean"`,
+		// none is, but the family is: use the family
+		"github": `asset.family.contains("github")`,
+		// nothing knows this provider: no default beats a dead one
+		"nosuchprovider": "",
+		"":               "",
+	}
+	for provider, want := range cases {
+		if got := DefaultFilter(provider); got != want {
+			t.Errorf("DefaultFilter(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+// contentFilterNames returns the platform and family names that checks in
+// content/ actually filter on.
+func contentFilterNames(t *testing.T) (platforms, families map[string]bool) {
+	t.Helper()
+	platforms, families = map[string]bool{}, map[string]bool{}
+
+	files, err := filepath.Glob(filepath.Join("..", "..", "content", "*.mql.yaml"))
+	if err != nil {
+		t.Fatalf("glob content: %v", err)
+	}
+	packs, err := filepath.Glob(filepath.Join("..", "..", "content", "querypacks", "*.mql.yaml"))
+	if err != nil {
+		t.Fatalf("glob querypacks: %v", err)
+	}
+	for _, f := range append(files, packs...) {
+		fh, err := os.Open(f)
+		if err != nil {
+			t.Fatalf("open %s: %v", f, err)
+		}
+		sc := bufio.NewScanner(fh)
+		sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for sc.Scan() {
+			line := sc.Text()
+			for _, m := range allSubmatches(platformFilterRe, line) {
+				platforms[m] = true
+			}
+			for _, m := range allSubmatches(familyFilterRe, line) {
+				families[m] = true
+			}
+		}
+		fh.Close()
+	}
+	return platforms, families
+}
+
+func allSubmatches(re *regexp.Regexp, s string) []string {
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(s, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// --- wizard plumbing for tests ----------------------------------------------

--- a/internal/generate/harness.go
+++ b/internal/generate/harness.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// Case is one intent→MQL evaluation case for the generation-quality harness. It
+// captures the natural-language intent and how to judge the generated MQL. This
+// is the corpus the ADR calls for to detect skill/backend regressions: run it
+// offline with a scripted backend in CI, or against a real agent (and a
+// --test-target/--test-recording validator) to measure a model.
+type Case struct {
+	Name     string   `yaml:"name"`
+	Intent   string   `yaml:"intent"` // becomes the check title
+	Desc     string   `yaml:"desc"`
+	Provider string   `yaml:"provider"` // informational
+	Filters  []string `yaml:"filters"`
+	Props    []Prop   `yaml:"props"`
+	// Want, when set, requires the generated MQL to equal this exactly
+	// (whitespace-normalized).
+	Want string `yaml:"want"`
+	// WantContains, when set, requires the generated MQL to contain every listed
+	// substring. Use this for robust checks that don't pin exact phrasing.
+	WantContains []string `yaml:"wantContains"`
+}
+
+// CaseResult is the outcome of evaluating one Case.
+type CaseResult struct {
+	Case   Case
+	Got    string
+	Action Action
+	Pass   bool
+	Reason string
+}
+
+// LoadCases reads harness cases from a YAML file: `cases: [ {name, intent, ...} ]`.
+func LoadCases(path string) ([]Case, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read cases file")
+	}
+	var doc struct {
+		Cases []Case `yaml:"cases"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, errors.Wrap(err, "could not parse cases file")
+	}
+	return doc.Cases, nil
+}
+
+// RunCases generates MQL for every case with the given generator and evaluates
+// the result. It is deterministic given a deterministic backend, so it doubles
+// as an offline regression test and an online model evaluation.
+func RunCases(ctx context.Context, g *Generator, cases []Case) []CaseResult {
+	out := make([]CaseResult, 0, len(cases))
+	for _, c := range cases {
+		res := g.GenerateCheck(ctx, c.toCheck())
+		out = append(out, evaluateCase(c, res))
+	}
+	return out
+}
+
+// PassRate returns the fraction of results that passed, and the pass/total
+// counts.
+func PassRate(results []CaseResult) (rate float64, passed, total int) {
+	total = len(results)
+	for _, r := range results {
+		if r.Pass {
+			passed++
+		}
+	}
+	if total > 0 {
+		rate = float64(passed) / float64(total)
+	}
+	return rate, passed, total
+}
+
+func (c Case) toCheck() Check {
+	return Check{
+		UID:     c.Name,
+		Title:   c.Intent,
+		Desc:    c.Desc,
+		Filters: c.Filters,
+		Props:   c.Props,
+	}
+}
+
+func evaluateCase(c Case, r Result) CaseResult {
+	cr := CaseResult{Case: c, Got: r.MQL, Action: r.Action}
+
+	if r.Action != ActionGenerated {
+		cr.Reason = "not generated: " + r.Reason
+		return cr
+	}
+
+	if c.Want != "" {
+		if normalizeMQL(r.MQL) == normalizeMQL(c.Want) {
+			cr.Pass = true
+		} else {
+			cr.Reason = "does not match expected MQL"
+		}
+		return cr
+	}
+
+	if len(c.WantContains) > 0 {
+		var missing []string
+		for _, sub := range c.WantContains {
+			if !strings.Contains(r.MQL, sub) {
+				missing = append(missing, sub)
+			}
+		}
+		if len(missing) == 0 {
+			cr.Pass = true
+		} else {
+			cr.Reason = "missing expected substrings: " + strings.Join(missing, ", ")
+		}
+		return cr
+	}
+
+	// no expectation beyond "it generated and validated"
+	cr.Pass = true
+	return cr
+}
+
+// normalizeMQL collapses whitespace so exact matches ignore trivial formatting.
+func normalizeMQL(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/generate/harness_agent_test.go
+++ b/internal/generate/harness_agent_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestHarness_RealAgent runs the golden intent→MQL cases against a real coding
+// agent (Claude Code, Codex, Kimi, DeepSeek) so you can measure how well a given
+// agent/model generates MQL. It is skipped by default so CI stays offline and
+// deterministic; opt in with environment variables:
+//
+//	# evaluate Claude Code
+//	CNSPEC_HARNESS_AGENT=claude go test ./internal/generate -run TestHarness_RealAgent -v
+//
+//	# evaluate Codex with a specific model, requiring at least 60% pass
+//	CNSPEC_HARNESS_AGENT=codex CNSPEC_HARNESS_MODEL=... \
+//	  CNSPEC_HARNESS_MIN_RATE=0.6 go test ./internal/generate -run TestHarness_RealAgent -v
+//
+// It reports the pass rate and every miss. By default it only fails if the agent
+// is unavailable or generation errors on every case (clearly broken); set
+// CNSPEC_HARNESS_MIN_RATE to enforce a quality floor.
+func TestHarness_RealAgent(t *testing.T) {
+	agent := os.Getenv("CNSPEC_HARNESS_AGENT")
+	if agent == "" {
+		t.Skip("set CNSPEC_HARNESS_AGENT=claude|codex|kimi|deepseek to run the real-agent harness")
+	}
+
+	backend, err := Backend(agent)
+	if err != nil {
+		t.Fatalf("agent %q not usable: %v", agent, err)
+	}
+
+	// Validate by compiling when a schema is available; otherwise report without
+	// validation rather than failing the whole run.
+	var validator Validator = NoopValidator{}
+	if v, verr := NewCompileValidator(); verr == nil {
+		validator = v
+	} else {
+		t.Logf("compile validation unavailable (%v); scoring generated MQL without it", verr)
+	}
+
+	cases, err := LoadCases("testdata/harness_cases.yaml")
+	if err != nil {
+		t.Fatalf("LoadCases: %v", err)
+	}
+
+	var corpus *Corpus
+	for _, p := range []string{"../../content", "content"} {
+		if c, cerr := LoadCorpus(p); cerr == nil && c.Size() > 0 {
+			corpus = c
+			t.Logf("grounding on %d examples from %s", c.Size(), p)
+			break
+		}
+	}
+
+	gen, err := New(Config{
+		Backend:   backend,
+		Corpus:    corpus,
+		Validator: validator,
+		Model:     os.Getenv("CNSPEC_HARNESS_MODEL"),
+		Timeout:   3 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	results := RunCases(context.Background(), gen, cases)
+	rate, passed, total := PassRate(results)
+	t.Logf("agent=%s model=%q pass=%d/%d (%.0f%%)", agent, os.Getenv("CNSPEC_HARNESS_MODEL"), passed, total, rate*100)
+	for _, r := range results {
+		if r.Pass {
+			t.Logf("  PASS %s", r.Case.Name)
+		} else {
+			t.Logf("  FAIL %s: %s (got: %q)", r.Case.Name, r.Reason, r.Got)
+		}
+	}
+
+	if passed == 0 {
+		t.Fatalf("agent %q generated nothing usable across %d cases", agent, total)
+	}
+	if min := envFloat("CNSPEC_HARNESS_MIN_RATE", 0); rate < min {
+		t.Fatalf("pass rate %.2f below required %.2f", rate, min)
+	}
+}
+
+func envFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}

--- a/internal/generate/harness_test.go
+++ b/internal/generate/harness_test.go
@@ -1,0 +1,158 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// scriptBackend returns canned MQL when the prompt contains a known marker,
+// making harness runs deterministic offline. Real evaluation swaps in a real
+// AgentBackend.
+type scriptBackend struct {
+	replies map[string]string // prompt substring -> MQL
+}
+
+func (s scriptBackend) Name() string    { return "script" }
+func (s scriptBackend) Available() bool { return true }
+func (s scriptBackend) Generate(_ context.Context, t GenTask) (GenResult, error) {
+	for marker, mql := range s.replies {
+		if strings.Contains(t.Prompt, marker) {
+			return GenResult{MQL: mql, Raw: mql}, nil
+		}
+	}
+	return GenResult{}, errors.New("no scripted reply for prompt")
+}
+
+// goldenReplies maps each case's intent to a canned "correct" MQL answer. Keying
+// by the full intent (which the prompt echoes verbatim) makes matches
+// unambiguous. This doubles as a check that every case's wantContains substrings
+// are self-consistent with a plausible correct query.
+var goldenReplies = map[string]string{
+	"S3 buckets must be encrypted":                               "aws.s3.buckets.all(encryption != empty)",
+	"EBS volumes must be encrypted by default":                   "aws.ec2.ebsEncryptionByDefault.values.all(_ == true)",
+	"CloudTrail must be enabled across all regions":              "aws.cloudtrail.trails.any(isMultiRegionTrail == true)",
+	"IAM Access Analyzer must be enabled":                        "aws.iam.accessAnalyzer.analyzers.length > 0",
+	"Compute disks must be encrypted with customer-managed keys": "gcp.project.computeService.disks.all(diskEncryptionKey != empty)",
+	"Cloud SQL instances must require SSL":                       "gcp.project.sqlService.instances.all(settings.ipConfiguration.requireSsl == true)",
+	"Load balancer backend services must have logging enabled":   "gcp.project.computeService.backendServices.all(logConfig != empty)",
+	"Storage accounts must not allow public blob access":         "azure.subscription.storage.accounts.all(allowBlobPublicAccess == false)",
+	"Managed disks must be encrypted":                            "azure.subscription.compute.disks.all(encryptionType != empty)",
+	"SQL servers must enforce Azure AD-only authentication":      "azure.subscription.sql.servers.all(azureAdOnlyAuthentication == true)",
+	"SSH root login must be disabled":                            `sshd.config.params["PermitRootLogin"] == "no"`,
+	"IP forwarding must be disabled":                             `kernel.parameters["net.ipv4.ip_forward"] == 0`,
+	"A file integrity tool must be installed":                    `package("aide").installed == true`,
+}
+
+func TestHarness_GoldenCases(t *testing.T) {
+	cases, err := LoadCases("testdata/harness_cases.yaml")
+	if err != nil {
+		t.Fatalf("LoadCases: %v", err)
+	}
+	if len(cases) < 10 {
+		t.Fatalf("expected the expanded corpus (>=10 cases), got %d", len(cases))
+	}
+
+	// every case must have a canned reply so the offline run is complete
+	for _, c := range cases {
+		if _, ok := goldenReplies[c.Intent]; !ok {
+			t.Fatalf("no golden reply for case %q (intent %q)", c.Name, c.Intent)
+		}
+	}
+
+	gen := mustGen(t, Config{Backend: scriptBackend{replies: goldenReplies}, Validator: NoopValidator{}})
+
+	results := RunCases(context.Background(), gen, cases)
+	rate, passed, total := PassRate(results)
+	if passed != total || rate != 1.0 {
+		for _, r := range results {
+			if !r.Pass {
+				t.Errorf("case %q failed: %s (got %q)", r.Case.Name, r.Reason, r.Got)
+			}
+		}
+		t.Fatalf("expected all %d cases to pass, got %d", total, passed)
+	}
+}
+
+// TestHarness_GoldenRepliesCompile checks the golden replies themselves. The
+// golden run above scores them with NoopValidator, so nothing there noticed that
+// three of the thirteen did not compile: they named a map as a bool, indexed a
+// resource as a dict, and read a field azure does not have. A reply that cannot
+// compile is not the "correct answer" the harness measures a model against.
+//
+// Compilation needs the provider schemas, and CI deliberately runs the Go tests
+// with no providers installed, so this reports what it checked and what it
+// skipped rather than passing silently on an empty run.
+func TestHarness_GoldenRepliesCompile(t *testing.T) {
+	validator, err := NewCompileValidator()
+	if err != nil {
+		t.Skipf("no compiler available (%v); cannot check the golden replies", err)
+	}
+	checker, _ := validator.(ProviderChecker)
+
+	cases, err := LoadCases("testdata/harness_cases.yaml")
+	if err != nil {
+		t.Fatalf("LoadCases: %v", err)
+	}
+
+	var checked, skipped int
+	for _, c := range cases {
+		reply, ok := goldenReplies[c.Intent]
+		if !ok {
+			t.Errorf("no golden reply for case %q", c.Name)
+			continue
+		}
+		provider, _ := ResolveProvider(c.toCheck())
+		if checker != nil && checker.CheckProvider(provider) != nil {
+			skipped++
+			continue
+		}
+		checked++
+		if err := validator.Validate(ValidationRequest{MQL: reply, Provider: provider, Props: c.Props}); err != nil {
+			t.Errorf("golden reply for %q does not validate: %v\n  %s", c.Name, err, reply)
+		}
+	}
+
+	t.Logf("golden replies: %d compiled, %d skipped (provider not installed)", checked, skipped)
+	if checked == 0 {
+		t.Skip("no target provider installed; no golden reply was actually checked")
+	}
+}
+
+func TestHarness_DetectsBadOutput(t *testing.T) {
+	// a reply that omits an expected substring must be scored as a failure — this
+	// is what lets the harness catch a regression.
+	c := Case{
+		Name:         "s3",
+		Intent:       "S3 buckets must be encrypted",
+		WantContains: []string{"aws.s3.buckets", "encryption"},
+	}
+	backend := scriptBackend{replies: map[string]string{
+		"S3 buckets must be encrypted": "aws.s3.buckets.length > 0", // missing "encryption"
+	}}
+	gen := mustGen(t, Config{Backend: backend, Validator: NoopValidator{}})
+
+	results := RunCases(context.Background(), gen, []Case{c})
+	if results[0].Pass {
+		t.Fatal("expected the case to fail (missing 'encryption')")
+	}
+	if !strings.Contains(results[0].Reason, "encryption") {
+		t.Fatalf("reason should name the missing substring, got %q", results[0].Reason)
+	}
+}
+
+func TestHarness_ExactMatch(t *testing.T) {
+	c := Case{Name: "x", Intent: "trivial", Want: "a == b"}
+	backend := scriptBackend{replies: map[string]string{"trivial": "a  ==   b"}} // whitespace differs
+	gen := mustGen(t, Config{Backend: backend, Validator: NoopValidator{}})
+
+	results := RunCases(context.Background(), gen, []Case{c})
+	if !results[0].Pass {
+		t.Fatalf("exact match should normalize whitespace; got %q, reason %q", results[0].Got, results[0].Reason)
+	}
+}

--- a/internal/generate/proc_unix.go
+++ b/internal/generate/proc_unix.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package generate
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// A coding agent is a process tree, not a process: it spawns tool subprocesses
+// and helpers, and those keep the stdout pipe open after the agent itself is
+// signalled. os/exec's Wait waits for the *pipe*, not for the process, so
+// killing only the direct child leaves Wait blocked on a grandchild — an agent
+// that forked a helper ran for 601 seconds against a 180-second timeout, and
+// the orphan outlived the run.
+//
+// Putting the agent in its own process group makes the whole tree killable with
+// one signal, so a timeout stops the work instead of only stopping the wait.
+// This mirrors cli/launcher/source/proc_unix.go, which was written for the same
+// failure.
+
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killTree signals the agent's whole group. The negative pid is the group.
+func killTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		// The group is gone if the agent already exited, which is not a failure
+		// to cancel. Fall back to the process itself in case the group was
+		// never established.
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/internal/generate/proc_windows.go
+++ b/internal/generate/proc_windows.go
@@ -1,0 +1,23 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package generate
+
+import "os/exec"
+
+// Windows has no process group to signal the way Unix does; killing a tree
+// needs a job object, which is more machinery than this call site justifies.
+// Killing the agent process itself is what we can do portably, and the
+// WaitDelay in the backend is the backstop that keeps a helper still holding
+// the output pipe from blocking Wait forever.
+
+func setProcessGroup(cmd *exec.Cmd) {}
+
+func killTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/generate/prompt.go
+++ b/internal/generate/prompt.go
@@ -1,0 +1,135 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PromptData is everything the prompt template needs for one check.
+type PromptData struct {
+	Title       string
+	Desc        string
+	Provider    string
+	Props       []Prop
+	Examples    []Example
+	Explain     bool
+	Guidance    string   // optional extra author steering
+	SkillPaths  []string // paths to any discovered skill files (mql, policy-graph)
+	RetryError  string   // compiler/validation error from the previous attempt
+	PreviousMQL string   // the MQL that failed, when retrying
+}
+
+// BuildPrompt renders the full instruction handed to a coding-agent backend. It
+// is deliberately explicit about the MQL correctness traps that a compile check
+// cannot catch, and it tells the agent to use cnspec's own commands to confirm
+// the schema and validate the query before returning.
+func BuildPrompt(d PromptData) string {
+	var b strings.Builder
+
+	b.WriteString("You are generating one MQL (Mondoo Query Language) query for a cnspec security policy check. ")
+	b.WriteString("Return a single boolean MQL expression that PASSES when the asset is compliant and FAILS otherwise.\n\n")
+
+	b.WriteString("## Intent\n")
+	fmt.Fprintf(&b, "Title: %s\n", strings.TrimSpace(d.Title))
+	if strings.TrimSpace(d.Desc) != "" {
+		fmt.Fprintf(&b, "Description: %s\n", strings.TrimSpace(d.Desc))
+	}
+	if d.Provider != "" {
+		fmt.Fprintf(&b, "Target provider: %s\n", d.Provider)
+	}
+	if strings.TrimSpace(d.Guidance) != "" {
+		fmt.Fprintf(&b, "Additional guidance from the author: %s\n", strings.TrimSpace(d.Guidance))
+	}
+	if len(d.Props) > 0 {
+		b.WriteString("Available properties (reference these as props.<name>, do not hardcode their values):\n")
+		for _, p := range d.Props {
+			fmt.Fprintf(&b, "  - props.%s", p.Name)
+			if p.Type != "" {
+				fmt.Fprintf(&b, " (%s)", p.Type)
+			}
+			if p.Desc != "" {
+				fmt.Fprintf(&b, ": %s", strings.TrimSpace(p.Desc))
+			}
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+
+	b.WriteString("## Use cnspec to ground and validate your query\n")
+	if d.Provider != "" {
+		fmt.Fprintf(&b, "- Run `cnspec providers resources %s --json` to list resources, and `cnspec providers resources %s <resource> --json` to confirm exact field names and types.\n", d.Provider, d.Provider)
+	} else {
+		b.WriteString("- Run `cnspec providers resources <provider> --json` and `cnspec providers resources <provider> <resource> --json` to confirm exact resource and field names.\n")
+	}
+	b.WriteString("- Validate that your query compiles before returning it: `cnspec run <connection> -c \"<your mql>\" --ast` (exit 0 = compiles, exit 1 = unknown resource/field or syntax error). Do not return a query that fails this check.\n")
+	if len(d.SkillPaths) > 0 {
+		b.WriteString("- Read these skill files for MQL syntax, patterns, and navigating existing policies:\n")
+		for _, p := range d.SkillPaths {
+			fmt.Fprintf(&b, "  - %s\n", p)
+		}
+	} else {
+		b.WriteString("- If your environment provides the cnspec `mql` or `policy-graph` skills, consult them for MQL syntax and for finding existing checks to mirror.\n")
+	}
+	b.WriteString("\n")
+
+	if len(d.Examples) > 0 {
+		b.WriteString("## Similar existing checks (validated MQL — mirror these patterns)\n")
+		for _, ex := range d.Examples {
+			title := ex.Title
+			if title == "" {
+				title = ex.UID
+			}
+			fmt.Fprintf(&b, "- %s\n  ```mql\n  %s\n  ```\n", strings.TrimSpace(title), indent(strings.TrimSpace(ex.Mql), "  "))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(correctnessRules)
+	b.WriteString("\n")
+
+	if d.RetryError != "" {
+		b.WriteString("## Your previous attempt failed validation — fix it\n")
+		if d.PreviousMQL != "" {
+			fmt.Fprintf(&b, "Previous MQL:\n```mql\n%s\n```\n", strings.TrimSpace(d.PreviousMQL))
+		}
+		fmt.Fprintf(&b, "Validation error: %s\n\n", strings.TrimSpace(d.RetryError))
+	}
+
+	b.WriteString("## Output format\n")
+	b.WriteString("Return ONLY a single fenced json block, nothing else:\n")
+	if d.Explain {
+		b.WriteString("```json\n{\"mql\": \"<the query>\", \"explanation\": \"<one or two sentences on how it maps to the intent>\"}\n```\n")
+	} else {
+		b.WriteString("```json\n{\"mql\": \"<the query>\"}\n```\n")
+	}
+	b.WriteString("The mql value must be a single expression. Do not include the `filters:` selector — that is handled separately.\n")
+
+	return b.String()
+}
+
+// correctnessRules are the semantic traps a compile check cannot catch, drawn
+// from cnspec/CLAUDE.md. They are the difference between MQL that compiles and
+// MQL that returns the right verdict.
+const correctnessRules = `## MQL correctness rules (a query can compile and still be wrong — follow these)
+- Assert presence before comparing. ` + "`null && null` evaluates to `true`" + `, so a check that only compares fields silently passes when the data never resolved. Write ` + "`field != empty && field == \"x\"`" + `, not ` + "`field == \"x\"`" + ` alone.
+- Use ` + "`!= empty`" + ` for non-empty checks, never ` + "`!= \"\"`" + ` (` + "`null != \"\"`" + ` is true, so it is not null-safe).
+- ` + "`.all()` / `.none()` on `null` errors" + `; on an empty list they pass vacuously. When a collection may be absent, guard it: ` + "`x == empty || x.all(...)`" + `.
+- Do not reach a sub-object through a path that is itself a resource name — it compiles to an empty husk and every field reads null. Prefer an accessor path or a block bound to the parent (` + "`parent { child.field != \"none\" }`" + `).
+- MQL has NO parenthesized grouping of boolean expressions. Rely on precedence (` + "`&&` binds tighter than `||`" + `) or split into separate ` + "`.any()` / `.all()`" + ` calls.
+- Regex match is ` + "`string == /pattern/`" + `, not ` + "`=~`" + `.
+- Multiple newline-separated lines in the query are implicitly AND-ed.
+- Keep asset selection (` + "`asset.platform == ...`" + `) OUT of the query — it belongs in filters, not here.`
+
+func indent(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		if i == 0 {
+			continue // first line already positioned by caller
+		}
+		lines[i] = prefix + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/generate/props.go
+++ b/internal/generate/props.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/types"
+)
+
+// propsHandler tells the compiler what `props.<name>` means. Without one, every
+// prop reference is an unknown symbol and the query is rejected — which is what
+// made the generator reject correct answers: the prompt asks the agent to
+// reference props, and the compile gate then refused every query that did. All
+// 49 prop-using checks in content/ fail to compile with a nil handler and all 49
+// compile with this one.
+//
+// It mirrors policy.QueryPropsResolver (bundle.go), the handler the bundle
+// compiler and `cnspec policy lint` use: a prop resolves to a bare primitive
+// carrying only its *type*, because the compiler needs the type to pick an
+// operator handler and nothing else.
+type propsHandler struct {
+	byName map[string]*llx.Primitive
+}
+
+// newPropsHandler resolves each prop to a type, in the same order of preference
+// the bundle compiler uses:
+//
+//  1. an explicitly declared type,
+//  2. the type of the prop's own MQL, compiled against the schema,
+//  3. types.Any as a last resort — the prop name then resolves, though a typed
+//     comparison against it will still fail ("cannot find operator handler"),
+//     which is the honest outcome when the bundle never says what the prop is.
+//
+// It returns nil when there are no props, so callers pass a nil PropsHandler and
+// the compiler keeps its "no props are available" behavior.
+func newPropsHandler(props []Prop, conf mqlc.CompilerConfig) mqlc.PropsHandler {
+	if len(props) == 0 {
+		return nil
+	}
+	byName := make(map[string]*llx.Primitive, len(props))
+	for _, p := range props {
+		name := strings.TrimSpace(p.Name)
+		if name == "" {
+			continue // a prop with no name has no props.<name> to resolve
+		}
+		byName[name] = &llx.Primitive{Type: string(propType(p, conf))}
+	}
+	if len(byName) == 0 {
+		return nil
+	}
+	return &propsHandler{byName: byName}
+}
+
+func (h *propsHandler) Get(name string) *llx.Primitive { return h.byName[name] }
+
+func (h *propsHandler) Available() map[string]*llx.Primitive { return h.byName }
+
+func (h *propsHandler) All() map[string]*llx.Primitive { return h.byName }
+
+// propType resolves one prop's type. See newPropsHandler for the order.
+func propType(p Prop, conf mqlc.CompilerConfig) types.Type {
+	if t := parsePropType(p.Type); t != types.NoType {
+		return t
+	}
+	if t := compiledType(p.Mql, conf); t != types.NoType {
+		return t
+	}
+	return types.Any
+}
+
+// compiledType compiles a snippet and reports the type of its result. This is
+// how a prop declared only as MQL (the shape used throughout content/) gets a
+// type, and it is what internal/lsp's YAMLPropsHandler does for the same reason.
+func compiledType(mql string, conf mqlc.CompilerConfig) types.Type {
+	if strings.TrimSpace(mql) == "" {
+		return types.NoType
+	}
+	bundle, err := mqlc.Compile(mql, nil, conf)
+	if err != nil || bundle == nil || bundle.CodeV2 == nil {
+		return types.NoType
+	}
+	entrypoints := bundle.CodeV2.Entrypoints()
+	if len(entrypoints) == 0 {
+		return types.NoType
+	}
+	chunk := bundle.CodeV2.Chunk(entrypoints[len(entrypoints)-1])
+	if chunk == nil {
+		return types.NoType
+	}
+	resolved := types.Type(chunk.DereferencedTypeV2(bundle.CodeV2))
+	if resolved == types.Unset {
+		// a snippet that compiles to nothing usable is no better than no type
+		return types.NoType
+	}
+	return resolved
+}
+
+// propTypeAliases are the human-readable spellings a hand-written bundle may use
+// in a prop's `type:` field. A compiled bundle instead stores the llx type code
+// (a string of control bytes), which parsePropType passes through untouched.
+var propTypeAliases = map[string]types.Type{
+	"string":  types.String,
+	"int":     types.Int,
+	"integer": types.Int,
+	"float":   types.Float,
+	"double":  types.Float,
+	"number":  types.Float,
+	"bool":    types.Bool,
+	"boolean": types.Bool,
+	"time":    types.Time,
+	"dict":    types.Dict,
+	"regex":   types.Regex,
+	"any":     types.Any,
+}
+
+// parsePropType turns a prop's declared type into an llx type. It accepts both
+// the stored llx code and the human spellings above, including `[]x` and
+// `map[string]x`, and returns NoType for anything it does not recognize so the
+// caller falls through to the next source rather than compiling against a
+// fabricated type. NoType is the "we do not know" answer rather than
+// types.Unset, because Unset is itself a valid llx type (`\x00`): handing it to
+// the compiler yields "cannot find field 'x' in unset" instead of falling back.
+func parsePropType(declared string) types.Type {
+	declared = strings.TrimSpace(declared)
+	if declared == "" {
+		return types.NoType
+	}
+
+	// A stored llx type is a string of control bytes, never printable text.
+	if !isPrintableASCII(declared) {
+		return types.Type(declared)
+	}
+
+	lower := strings.ToLower(declared)
+	if t, ok := propTypeAliases[lower]; ok {
+		return t
+	}
+	if rest, ok := strings.CutPrefix(lower, "[]"); ok {
+		if child := parsePropType(rest); child != types.NoType {
+			return types.Array(child)
+		}
+		return types.NoType
+	}
+	if rest, ok := strings.CutPrefix(lower, "map[string]"); ok {
+		if child := parsePropType(rest); child != types.NoType {
+			return types.Map(types.String, child)
+		}
+		return types.NoType
+	}
+	return types.NoType
+}
+
+func isPrintableASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] > 0x7e {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/generate/response.go
+++ b/internal/generate/response.go
@@ -1,0 +1,254 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// responseEnvelope is the structured output the prompt asks the agent to emit.
+type responseEnvelope struct {
+	MQL         string `json:"mql"`
+	Explanation string `json:"explanation"`
+}
+
+// parseResponse extracts the generated MQL from raw agent output. Agents are
+// instructed to return a single fenced ```json block, but real-world output is
+// noisy (preamble, trailing chatter, multiple fences), so parsing is defensive:
+//
+//  1. Prefer a fenced ```json block that decodes to the envelope.
+//  2. Fall back to the last balanced {...} object anywhere in the text.
+//  3. As a last resort, treat a fenced ```mql (or bare ```) block as the query.
+//
+// Every candidate has to look like MQL before it is accepted (see plausibleMQL).
+// Without that, the last-block-wins rule adopts whatever the agent printed last:
+// the prompt tells it to verify with `cnspec run ... --ast` and shows the answer
+// shape as `{"mql": "<the query>"}`, so an agent that shows its work ends with a
+// shell transcript or the prompt's own placeholder, and that became the check.
+//
+// It never errors; an empty MQL in the result signals "could not parse", which
+// the caller surfaces.
+func parseResponse(raw string) GenResult {
+	raw = strings.TrimSpace(raw)
+
+	// 1. fenced json blocks. Agents sometimes echo an example envelope before
+	// their real answer, so the LAST block with a usable mql wins. An envelope
+	// whose mql is empty or implausible is ignored so it can't shadow a real
+	// answer that came earlier.
+	if res, ok := lastEnvelopeWithMQL(fencedBlocks(raw, "json")); ok {
+		return res
+	}
+
+	// 2. any balanced object that decodes to the envelope, last usable wins
+	if res, ok := lastEnvelopeWithMQL(jsonObjects(raw)); ok {
+		return res
+	}
+
+	// 3. fenced mql / plain code block. The bare-fence ("") case matches any
+	// fence, so skip anything that is actually a JSON object — otherwise a
+	// ```json block with an empty mql would be returned verbatim as the query.
+	for _, lang := range []string{"mql", "coffee", ""} {
+		blocks := fencedBlocksMatching(raw, lang)
+		for i := len(blocks) - 1; i >= 0; i-- {
+			b := strings.TrimSpace(blocks[i].body)
+			if b == "" || strings.HasPrefix(b, "{") {
+				continue
+			}
+			if _, ok := decodeEnvelope(b); ok {
+				continue
+			}
+			if lang == "" && nonMQLFenceTags[blocks[i].tag] {
+				// a bare-fence pass matches every fence, including the ```bash
+				// one holding the verification command the prompt asked for
+				continue
+			}
+			if !plausibleMQL(b) {
+				continue
+			}
+			return GenResult{MQL: SanitizeModelText(b)}
+		}
+	}
+
+	return GenResult{}
+}
+
+// nonMQLFenceTags are language tags that cannot be MQL. The prompt asks the
+// agent to run `cnspec run ... --ast`, so a ```bash or ```console block holding
+// that transcript is the single most likely other fence in the response.
+var nonMQLFenceTags = map[string]bool{
+	"bash": true, "sh": true, "shell": true, "zsh": true, "fish": true,
+	"console": true, "shell-session": true, "terminal": true, "output": true,
+	"text": true, "txt": true, "log": true, "diff": true, "patch": true,
+	"json": true, "yaml": true, "yml": true, "toml": true, "xml": true,
+	"go": true, "python": true, "py": true, "javascript": true, "js": true,
+	"typescript": true, "ts": true, "ruby": true, "rust": true, "java": true,
+	"markdown": true, "md": true, "html": true, "sql": true, "powershell": true,
+	"ps1": true, "dockerfile": true, "hcl": true, "terraform": true,
+}
+
+// shellTranscriptPrefixes start a line that is a command, not a query. MQL has
+// no statement that begins with any of these.
+var shellTranscriptPrefixes = []string{
+	"$ ", "# ", "% ", "> ", "cnspec ", "cnquery ", "sudo ", "bash ", "sh ",
+	"echo ", "cat ", "curl ", "npm ", "npx ", "git ", "docker ", "kubectl ",
+	"export ", "cd ", "ls ", "grep ", "pip ", "brew ", "apt ", "yum ",
+}
+
+// placeholderRe matches the answer placeholders the prompt itself contains
+// (`<the query>`, `<your mql>`). An agent that echoes the output format after
+// its answer hands back the placeholder, and last-block-wins then stores it.
+var placeholderRe = regexp.MustCompile(`(?i)<\s*(the\s+|your\s+|a\s+)?(query|mql|expression|answer)[^>]*>`)
+
+// plausibleMQL reports whether a candidate can be a query at all. It is a
+// rejection filter, not a compiler: everything it lets through still faces the
+// compile gate. Its job is to stop an implausible candidate from *shadowing* a
+// real answer that appeared earlier in the response.
+func plausibleMQL(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	if placeholderRe.MatchString(s) {
+		return false
+	}
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		lower := strings.ToLower(line)
+		for _, prefix := range shellTranscriptPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				return false
+			}
+		}
+	}
+	// A query reads a field, calls something, or compares something. A bare
+	// prose sentence ("I could not determine the right resource") does none of
+	// those.
+	return strings.ContainsAny(s, ".([") || strings.Contains(s, "==") || strings.Contains(s, "!=")
+}
+
+// lastEnvelopeWithMQL scans candidate strings, decoding each as the response
+// envelope, and returns the last one that carries a usable mql. Requiring a
+// plausible, non-empty mql means an explanation-only envelope, or one holding
+// the prompt's placeholder, never shadows a real answer.
+func lastEnvelopeWithMQL(candidates []string) (GenResult, bool) {
+	var res GenResult
+	found := false
+	for _, c := range candidates {
+		env, ok := decodeEnvelope(c)
+		if !ok {
+			continue
+		}
+		mql := strings.TrimSpace(env.MQL)
+		if mql == "" || !plausibleMQL(mql) {
+			continue
+		}
+		res = GenResult{
+			// model-authored text reaches a terminal at the review gate
+			MQL:         SanitizeModelText(mql),
+			Explanation: SanitizeModelText(strings.TrimSpace(env.Explanation)),
+		}
+		found = true
+	}
+	return res, found
+}
+
+func decodeEnvelope(s string) (responseEnvelope, bool) {
+	var env responseEnvelope
+	dec := json.NewDecoder(strings.NewReader(s))
+	if err := dec.Decode(&env); err != nil {
+		return responseEnvelope{}, false
+	}
+	return env, true
+}
+
+// fencedBlock is one ```<tag> ... ``` block, keeping the tag so the caller can
+// tell an untagged block from a ```bash one.
+type fencedBlock struct {
+	tag  string
+	body string
+}
+
+// fencedBlocks returns the contents of all ```<lang> ... ``` blocks. An empty
+// lang matches a bare ``` fence (any or no language tag).
+func fencedBlocks(s, lang string) []string {
+	blocks := fencedBlocksMatching(s, lang)
+	out := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		out = append(out, b.body)
+	}
+	return out
+}
+
+func fencedBlocksMatching(s, lang string) []fencedBlock {
+	var out []fencedBlock
+	lines := strings.Split(s, "\n")
+	inBlock := false
+	openTag := ""
+	var buf []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			if strings.HasPrefix(trimmed, "```") {
+				tag := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "```")))
+				if lang == "" || tag == lang {
+					inBlock = true
+					openTag = tag
+					buf = nil
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```") {
+			out = append(out, fencedBlock{tag: openTag, body: strings.Join(buf, "\n")})
+			inBlock = false
+			continue
+		}
+		buf = append(buf, line)
+	}
+	return out
+}
+
+// jsonObjects returns every top-level balanced {...} substring, in order. It is
+// brace-counting with string-literal awareness so braces inside JSON strings do
+// not throw off the balance.
+func jsonObjects(s string) []string {
+	var out []string
+	depth := 0
+	start := -1
+	inStr := false
+	escaped := false
+	for i, r := range s {
+		if inStr {
+			switch {
+			case escaped:
+				escaped = false
+			case r == '\\':
+				escaped = true
+			case r == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch r {
+		case '"':
+			inStr = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && start >= 0 {
+					out = append(out, s[start:i+1])
+					start = -1
+				}
+			}
+		}
+	}
+	return out
+}

--- a/internal/generate/sanitize.go
+++ b/internal/generate/sanitize.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// SanitizeModelText makes model-authored text safe to print at the human review
+// gate. Everything the agent returns — the MQL, the explanation, its stdout and
+// stderr — is attacker-reachable text (a check's title and description become
+// the prompt), and the accept/edit/regenerate loop is the control this design
+// leans on. A terminal renders control characters instead of showing them, so
+// raw output lets the reviewed party choose what the reviewer sees: a query
+// carrying ESC[2K ESC[1G displays as one harmless-looking line while the string
+// actually stored in the bundle contains something else entirely.
+//
+// It escapes rather than deletes, so nothing is silently dropped: the reviewer
+// sees `\x1b[2K` and knows the model sent an escape sequence. Newline and tab
+// survive as themselves because MQL uses them and they cannot repaint a line.
+//
+// The characters it neutralizes:
+//   - C0 controls (except \n and \t), DEL and the C1 range — cursor movement,
+//     line erase, carriage return, and terminal-mode switches.
+//   - Unicode bidi overrides and invisible marks (the "trojan source" class),
+//     which reorder a line's rendering without changing its bytes.
+//   - Invalid UTF-8 bytes, which some terminals interpret as their own commands.
+func SanitizeModelText(s string) string {
+	if !needsSanitizing(s) {
+		return s // the overwhelmingly common case: return the input unchanged
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			// not valid UTF-8; show the raw byte rather than pass it through
+			b.WriteString(`\x` + hexByte(s[i]))
+			i++
+			continue
+		}
+		switch {
+		case r == '\n' || r == '\t':
+			b.WriteRune(r)
+		case r < 0x20 || r == 0x7f:
+			b.WriteString(`\x` + hexByte(byte(r)))
+		case r >= 0x80 && r <= 0x9f:
+			b.WriteString(`\u` + pad4(strconv.FormatInt(int64(r), 16)))
+		case isInvisibleFormatting(r):
+			b.WriteString(`\u` + pad4(strconv.FormatInt(int64(r), 16)))
+		default:
+			b.WriteRune(r)
+		}
+		i += size
+	}
+	return b.String()
+}
+
+// needsSanitizing reports whether s contains anything SanitizeModelText would
+// rewrite. Scanning first keeps the common path allocation-free.
+func needsSanitizing(s string) bool {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			return true
+		}
+		if r != '\n' && r != '\t' && (r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) || isInvisibleFormatting(r)) {
+			return true
+		}
+		i += size
+	}
+	return false
+}
+
+// isInvisibleFormatting covers the bidi overrides and invisible marks that
+// change how a line renders without changing what it says — the trojan-source
+// trick. They have no place in MQL or in a one-line explanation.
+func isInvisibleFormatting(r rune) bool {
+	switch {
+	case r == 0x200b, r == 0x200c, r == 0x200d: // zero width space/non-joiner/joiner
+		return true
+	case r == 0x200e, r == 0x200f: // LTR/RTL marks
+		return true
+	case r >= 0x202a && r <= 0x202e: // bidi embedding/override
+		return true
+	case r >= 0x2066 && r <= 0x2069: // bidi isolates
+		return true
+	case r == 0xfeff: // zero width no-break space / BOM
+		return true
+	default:
+		return false
+	}
+}
+
+func hexByte(b byte) string {
+	const hex = "0123456789abcdef"
+	return string([]byte{hex[b>>4], hex[b&0x0f]})
+}
+
+func pad4(s string) string {
+	for len(s) < 4 {
+		s = "0" + s
+	}
+	return s
+}

--- a/internal/generate/sanitize_test.go
+++ b/internal/generate/sanitize_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeModelText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text is untouched", "aws.s3.buckets.all(encryption != empty)", "aws.s3.buckets.all(encryption != empty)"},
+		{"newline and tab survive", "a == 1\n\tb == 2", "a == 1\n\tb == 2"},
+		{
+			// the spoof: the escape sequences erase the line and return the
+			// cursor, so a terminal shows only what follows them
+			"ansi erase sequence is escaped",
+			"asset.name != 'safe-looking'\x1b[2K\x1b[1GBACKDOOR",
+			`asset.name != 'safe-looking'\x1b[2K\x1b[1GBACKDOOR`,
+		},
+		{"carriage return is escaped", "safe\rmalicious", `safe\x0dmalicious`},
+		{"bell and delete are escaped", "a\x07b\x7fc", `a\x07b\x7fc`},
+		{"c1 controls are escaped", "a\u0085b", `a\u0085b`},
+		{"bidi override is escaped", "a\u202eb", `a\u202eb`},
+		{"zero width space is escaped", "a\u200bb", `a\u200bb`},
+		{"non-ascii text survives", "héllo — wörld ✓", "héllo — wörld ✓"},
+		{"invalid utf8 byte is escaped", "a\xffb", `a\xffb`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeModelText(tc.in)
+			if got != tc.want {
+				t.Fatalf("SanitizeModelText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.ContainsRune(got, 0x1b) {
+				t.Fatalf("result still contains ESC: %q", got)
+			}
+		})
+	}
+}
+
+// TestParseResponseSanitizesModelText pins the reason the sanitizer exists: the
+// query the reviewer reads must be the query that gets stored. A model answer
+// carrying terminal escapes displayed as one thing and contained another, and it
+// passed the compile gate because the escapes sat inside a string literal.
+func TestParseResponseSanitizesModelText(t *testing.T) {
+	raw := "```json\n{\"mql\": \"asset.name != 'safe\\u001b[2K\\u001b[1G BACKDOOR'\", \"explanation\": \"looks\\u001b[2K fine\"}\n```"
+
+	res := parseResponse(raw)
+	if strings.ContainsRune(res.MQL, 0x1b) {
+		t.Fatalf("parsed MQL still carries an escape sequence: %q", res.MQL)
+	}
+	if !strings.Contains(res.MQL, "BACKDOOR") {
+		t.Fatalf("the hidden part of the query must stay visible, got %q", res.MQL)
+	}
+	if strings.ContainsRune(res.Explanation, 0x1b) {
+		t.Fatalf("parsed explanation still carries an escape sequence: %q", res.Explanation)
+	}
+}

--- a/internal/generate/target.go
+++ b/internal/generate/target.go
@@ -1,0 +1,159 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"regexp"
+	"strings"
+)
+
+// platformToProvider maps common asset.platform / asset.family values to the
+// mql provider that models them. It is intentionally conservative: an unknown
+// platform yields no provider rather than a wrong guess.
+var platformToProvider = map[string]string{
+	"aws":        "aws",
+	"gcp":        "gcp",
+	"gcp-org":    "gcp",
+	"google":     "gcp",
+	"azure":      "azure",
+	"azurerm":    "azure",
+	"kubernetes": "k8s",
+	"k8s":        "k8s",
+	"github":     "github",
+	"gitlab":     "gitlab",
+	"ms365":      "ms365",
+	"microsoft":  "ms365",
+	"oci":        "oci",
+	"okta":       "okta",
+	"slack":      "slack",
+	"terraform":  "terraform",
+	"vsphere":    "vsphere",
+	"vmware":     "vsphere",
+	"arista":     "arista",
+	"atlassian":  "atlassian",
+	"snowflake":  "snowflake",
+	"cloudflare": "cloudflare",
+	// operating-system families all resolve to the os provider
+	"linux":       "os",
+	"unix":        "os",
+	"windows":     "os",
+	"darwin":      "os",
+	"macos":       "os",
+	"debian":      "os",
+	"ubuntu":      "os",
+	"redhat":      "os",
+	"rhel":        "os",
+	"centos":      "os",
+	"fedora":      "os",
+	"suse":        "os",
+	"alpine":      "os",
+	"amazonlinux": "os",
+	"rockylinux":  "os",
+	"almalinux":   "os",
+}
+
+// knownProviders is the set of provider names we recognize as a leading token in
+// a filter expression's resource path or in a query UID.
+var knownProviders = func() map[string]bool {
+	m := map[string]bool{}
+	for _, p := range platformToProvider {
+		m[p] = true
+	}
+	return m
+}()
+
+var quotedRe = regexp.MustCompile(`"([^"]+)"|'([^']+)'`)
+
+// ResolveProvider determines the target provider for a check, preferring the
+// authoritative filter expressions and falling back to hints in the UID. It
+// returns the provider name (empty if undetermined) and the platform strings it
+// observed, for reporting.
+func ResolveProvider(c Check) (provider string, platforms []string) {
+	seen := map[string]bool{}
+	addPlatform := func(p string) {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" && !seen[p] {
+			seen[p] = true
+			platforms = append(platforms, p)
+		}
+	}
+
+	for _, f := range c.Filters {
+		// 1. resource-path prefix, e.g. "aws.ec2.instances" in the filter
+		if p := leadingProvider(f); p != "" {
+			return p, platforms
+		}
+		// 2. quoted platform/family literals, e.g. asset.platform == "ubuntu"
+		// or a hyphenated platform id like "aws-eks-cluster".
+		for _, m := range quotedRe.FindAllStringSubmatch(f, -1) {
+			lit := m[1]
+			if lit == "" {
+				lit = m[2]
+			}
+			addPlatform(lit)
+			if p := platformForLiteral(lit); p != "" {
+				provider = p
+			}
+		}
+	}
+	if provider != "" {
+		return provider, platforms
+	}
+
+	// 3. UID hint, e.g. "mondoo-aws-security-..." -> aws
+	for _, tok := range strings.FieldsFunc(strings.ToLower(c.UID), func(r rune) bool {
+		return r == '-' || r == '_' || r == '.' || r == '/'
+	}) {
+		if knownProviders[tok] {
+			return tok, platforms
+		}
+		if p, ok := platformToProvider[tok]; ok {
+			return p, platforms
+		}
+	}
+
+	return "", platforms
+}
+
+// platformForLiteral maps a platform/family literal to a provider. It tries an
+// exact match first, then each hyphen-delimited segment, so ids like
+// "aws-eks-cluster" resolve to "aws".
+func platformForLiteral(lit string) string {
+	lit = strings.ToLower(strings.TrimSpace(lit))
+	if p, ok := platformToProvider[lit]; ok {
+		return p
+	}
+	for _, seg := range strings.Split(lit, "-") {
+		if p, ok := platformToProvider[seg]; ok {
+			return p
+		}
+		if knownProviders[seg] {
+			return seg
+		}
+	}
+	return ""
+}
+
+// leadingProvider returns the provider name when a filter references a
+// provider-scoped resource directly (e.g. "aws.ec2.instances.any(...)").
+func leadingProvider(filter string) string {
+	filter = strings.TrimSpace(filter)
+	// grab the first identifier token
+	i := 0
+	for i < len(filter) {
+		r := filter[i]
+		if r == '.' || r == ' ' || r == '(' || r == '[' || r == '=' || r == '!' || r == '<' || r == '>' {
+			break
+		}
+		i++
+	}
+	head := strings.ToLower(filter[:i])
+	if head == "asset" || head == "platform" || head == "mondoo" {
+		return ""
+	}
+	if knownProviders[head] {
+		return head
+	}
+	return ""
+}

--- a/internal/generate/testdata/harness_cases.yaml
+++ b/internal/generate/testdata/harness_cases.yaml
@@ -1,0 +1,135 @@
+# Golden intent→MQL cases for the generation-quality harness.
+#
+# Run offline with a scripted backend (TestHarness_GoldenCases) as a regression
+# guard, or against a real agent to measure a model:
+#   CNSPEC_HARNESS_AGENT=claude go test ./internal/generate -run TestHarness_RealAgent -v
+#
+# `wantContains` lists substrings a correct query must include — kept to the
+# resource root (and, where unambiguous, a key field) so the check is robust to
+# phrasing differences rather than pinning an exact query.
+cases:
+  # --- AWS ---------------------------------------------------------------
+  - name: aws-s3-encryption
+    intent: S3 buckets must be encrypted
+    desc: All S3 buckets must have server-side encryption enabled.
+    provider: aws
+    filters:
+      - asset.platform == "aws"
+    wantContains:
+      - aws.s3.bucket
+      - encryption
+
+  - name: aws-ebs-default-encryption
+    intent: EBS volumes must be encrypted by default
+    desc: The account must enable EBS encryption by default in every region.
+    provider: aws
+    filters:
+      - asset.platform == "aws"
+    wantContains:
+      - aws.ec2.ebsEncryptionByDefault
+
+  - name: aws-cloudtrail-multi-region
+    intent: CloudTrail must be enabled across all regions
+    desc: At least one multi-region CloudTrail trail must be configured.
+    provider: aws
+    filters:
+      - asset.platform == "aws"
+    wantContains:
+      - aws.cloudtrail.trail
+
+  - name: aws-iam-access-analyzer
+    intent: IAM Access Analyzer must be enabled
+    desc: An AWS IAM Access Analyzer must exist to detect external access.
+    provider: aws
+    filters:
+      - asset.platform == "aws"
+    wantContains:
+      - aws.iam.accessAnalyzer
+
+  # --- GCP ---------------------------------------------------------------
+  - name: gcp-compute-disk-encryption
+    intent: Compute disks must be encrypted with customer-managed keys
+    desc: All Compute Engine disks must use customer-managed encryption keys.
+    provider: gcp
+    filters:
+      - asset.platform == "gcp"
+    wantContains:
+      - gcp.project.computeService.disks
+
+  - name: gcp-cloudsql-ssl
+    intent: Cloud SQL instances must require SSL
+    desc: Every Cloud SQL database instance must enforce SSL connections.
+    provider: gcp
+    filters:
+      - asset.platform == "gcp"
+    wantContains:
+      - gcp.project.sqlService.instance
+
+  - name: gcp-backend-service-logging
+    intent: Load balancer backend services must have logging enabled
+    desc: Compute backend services must enable request logging.
+    provider: gcp
+    filters:
+      - asset.platform == "gcp"
+    wantContains:
+      - gcp.project.computeService.backendServices
+
+  # --- Azure -------------------------------------------------------------
+  - name: azure-storage-no-public-blob
+    intent: Storage accounts must not allow public blob access
+    desc: Blob public access must be disabled on all storage accounts.
+    provider: azure
+    filters:
+      - asset.platform == "azure"
+    wantContains:
+      - azure.subscription.storage.account
+      - allowBlobPublicAccess
+
+  - name: azure-disk-encryption
+    intent: Managed disks must be encrypted
+    desc: All Azure managed disks must have encryption enabled.
+    provider: azure
+    filters:
+      - asset.platform == "azure"
+    wantContains:
+      - azure.subscription.compute.disks
+
+  - name: azure-sql-ad-only-auth
+    intent: SQL servers must enforce Azure AD-only authentication
+    desc: Azure SQL servers must require Azure AD-only authentication.
+    provider: azure
+    filters:
+      - asset.platform == "azure"
+    wantContains:
+      - azure.subscription.sql.server
+
+  # --- OS ----------------------------------------------------------------
+  - name: os-ssh-root-login
+    intent: SSH root login must be disabled
+    desc: The SSH daemon must not permit root login.
+    provider: os
+    filters:
+      - asset.family.contains("linux")
+    wantContains:
+      - sshd.config
+      - PermitRootLogin
+
+  - name: os-kernel-ip-forward
+    intent: IP forwarding must be disabled
+    desc: The kernel must not forward IPv4 packets.
+    provider: os
+    filters:
+      - asset.family.contains("linux")
+    wantContains:
+      - kernel.parameters
+      - ip_forward
+
+  - name: os-aide-installed
+    intent: A file integrity tool must be installed
+    desc: The AIDE file integrity monitoring package must be installed.
+    provider: os
+    filters:
+      - asset.family.contains("linux")
+    wantContains:
+      - package
+      - aide

--- a/internal/generate/types.go
+++ b/internal/generate/types.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+// Check is the provider-neutral view of a policy query the generator works on.
+// The command layer converts bundle queries into Checks and writes generated MQL
+// back, so this package never depends on the YAML/bundle types directly.
+type Check struct {
+	// UID is the query's unique identifier, used for reporting and as a weak
+	// provider hint.
+	UID string
+	// Title and Desc are the natural-language intent, the source of generation.
+	Title string
+	Desc  string
+	// Filters holds the query's filter expressions (asset.platform == "...").
+	// They are the authoritative signal for the target provider.
+	Filters []string
+	// Mql is the existing query, empty when generation is requested.
+	Mql string
+	// Props are the parameterized properties available to the check, surfaced to
+	// the agent so it references them (props.<name>) rather than inventing
+	// literals.
+	Props []Prop
+	// HasVariants marks a variant-parent check whose MQL lives in its per-platform
+	// variants. Such a check must not get MQL generated onto the parent.
+	HasVariants bool
+	// Guidance is optional extra author steering (e.g. feedback from an
+	// interactive "regenerate" step), added to the prompt.
+	Guidance string
+}
+
+// Prop is a parameterized property a check can reference in its MQL.
+type Prop struct {
+	Name string
+	// Type is the property's declared type, when the bundle states one. Most
+	// authored props do not, which is why Mql matters.
+	Type string
+	Desc string
+	// Mql is the property's own defining query, and it is how a prop without a
+	// declared type gets one: the compiler needs a type to resolve
+	// `props.<name>`, and compiling this snippet is where that type comes from —
+	// the same thing the bundle compiler and the LSP do. Leaving it empty leaves
+	// the prop typed `any`, which compiles only until the query compares against
+	// it.
+	Mql string
+}
+
+// Action is the outcome of processing one check.
+type Action string
+
+const (
+	// ActionGenerated means new MQL was produced and validated.
+	ActionGenerated Action = "generated"
+	// ActionSkipped means the check already had MQL (and --force was not set) or
+	// lacked the intent needed to generate.
+	ActionSkipped Action = "skipped"
+	// ActionFailed means generation or validation failed for this check.
+	ActionFailed Action = "failed"
+)
+
+// Result is the per-check outcome returned to the caller.
+type Result struct {
+	UID         string
+	Action      Action
+	Provider    string
+	MQL         string
+	Explanation string
+	// Reason explains a skip or failure in one line.
+	Reason string
+	Err    error
+}

--- a/internal/generate/validate.go
+++ b/internal/generate/validate.go
@@ -1,0 +1,320 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/types"
+)
+
+// ValidationRequest is one query to check, with the context the compiler needs
+// to judge it. It exists because a query is not self-contained: `props.<name>`
+// only compiles when the validator is told which props the check declares — the
+// prompt asks the agent to use props, so a validator that cannot see them
+// rejects the correct answer.
+type ValidationRequest struct {
+	// MQL is the query to validate.
+	MQL string
+	// Props are the check's parameterized properties. Without them every
+	// props.<name> reference is an unknown symbol.
+	Props []Prop
+	// Provider is the target provider, used to report honestly when its schema
+	// is not installed rather than blaming the query for an unknown resource.
+	Provider string
+}
+
+// Validator checks a generated MQL query. Compilation is the guaranteed gate;
+// richer checks (execute-and-assert against a fixture) implement the same
+// interface. A nil error means the query passed.
+type Validator interface {
+	Validate(req ValidationRequest) error
+}
+
+// ProviderChecker is the optional half of a Validator: it reports up front
+// whether it can validate queries for a provider at all. The generator asks
+// before it spends an agent invocation, because "the aws provider is not
+// installed" must not be discovered three agent calls later disguised as three
+// compile errors about an unknown resource named `aws`.
+type ProviderChecker interface {
+	// CheckProvider returns nil when queries for this provider can be validated.
+	// An empty provider means "unknown", which is never an error.
+	CheckProvider(provider string) error
+}
+
+// ErrValidationUnavailable marks the errors that mean "this query was not
+// judged", as opposed to "this query is wrong". Callers use errors.Is to tell
+// the two apart, because retrying the agent cannot fix the first kind.
+var ErrValidationUnavailable = errors.New("MQL validation is unavailable")
+
+// compileValidator validates by compiling the query in-process against the
+// provider schema, exactly as `cnspec run --ast` and the bundle linter do.
+// Compilation is necessary but not sufficient — it catches unknown resources,
+// unknown fields, and syntax errors, but not the semantic traps documented in
+// cnspec/CLAUDE.md (null three-valued logic, dotted-path husks). Those are the
+// job of the execute-and-assert gate and expert review.
+type compileValidator struct {
+	schema   resources.ResourcesSchema
+	features mql.Features
+
+	// installed is the set of provider names with a locally installed schema,
+	// resolved once and reused. The compiler cannot distinguish "you named a
+	// resource that does not exist" from "the provider that defines it is not
+	// installed", so we answer that question before compiling.
+	installedOnce sync.Once
+	installed     map[string]bool
+	installedErr  error
+}
+
+// NewCompileValidator builds a validator against the default runtime schema
+// (every locally installed provider plus core). It mirrors the linter's
+// compiler configuration so a query that passes here passes lint.
+func NewCompileValidator() (Validator, error) {
+	runtime := providers.DefaultRuntime()
+	if runtime == nil {
+		return nil, errors.New("no default runtime available for validation")
+	}
+	schema := runtime.Schema()
+	if schema == nil {
+		return nil, errors.New("no schema available for validation")
+	}
+	features := mql.DefaultFeatures
+	features = append(features, byte(mql.FailIfNoEntryPoints))
+	return &compileValidator{schema: schema, features: features}, nil
+}
+
+func (v *compileValidator) config() mqlc.CompilerConfig {
+	return mqlc.NewConfig(v.schema, v.features)
+}
+
+// CheckProvider reports whether this validator can resolve resources for the
+// named provider. Constructing the validator cannot answer this: the default
+// runtime always hands out a schema, even one holding nothing but core, so on a
+// machine with no providers installed the validator builds happily and then
+// rejects every query with "cannot find resource for identifier 'aws'" — an
+// error that reads as a defect in the generated query rather than a missing
+// install.
+func (v *compileValidator) CheckProvider(provider string) error {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return nil // no target resolved; nothing to promise either way
+	}
+
+	v.installedOnce.Do(func() {
+		v.installed, v.installedErr = installedProviderNames()
+	})
+	if v.installedErr != nil {
+		return errors.Mark(
+			errors.Wrapf(v.installedErr, "cannot tell whether the %q provider is installed, so generated MQL cannot be compile-checked", provider),
+			ErrValidationUnavailable)
+	}
+	if v.installed[provider] {
+		return nil
+	}
+	return errors.Mark(
+		errors.Newf("the %q provider is not installed, so its resources cannot be compile-checked; install it with `cnspec providers install %s`, or re-run with --no-validate to generate without validation", provider, provider),
+		ErrValidationUnavailable)
+}
+
+func (v *compileValidator) Validate(req ValidationRequest) error {
+	query := strings.TrimSpace(req.MQL)
+	if query == "" {
+		return errors.New("empty query")
+	}
+	if err := v.CheckProvider(req.Provider); err != nil {
+		return err
+	}
+
+	conf := v.config()
+	bundle, err := mqlc.Compile(query, newPropsHandler(req.Props, conf), conf)
+	if err != nil {
+		return errors.Wrap(err, "MQL does not compile")
+	}
+	return assertVerdict(bundle)
+}
+
+// installedProviderNames returns the provider names available locally, builtin
+// ones included.
+func installedProviderNames() (map[string]bool, error) {
+	names := map[string]bool{}
+	for _, name := range providers.GetBuiltinProviderNames() {
+		names[name] = true
+	}
+	active, err := providers.ListActive()
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range active {
+		if p != nil && p.Provider != nil {
+			names[p.Name] = true
+		}
+	}
+	return names, nil
+}
+
+// assertVerdict rejects a query that compiles but does not answer pass/fail. A
+// scored check has to produce a verdict, and the cheapest way for generation to
+// go wrong is a truncated answer: `aws.s3.buckets` instead of
+// `aws.s3.buckets.all(...)` compiles, scores off whatever boolean fields the
+// resource happens to expose, and reads as a working check.
+//
+// Measured against every compiling check in content/ (1374 boolean, 135 block,
+// 44 list-of-block, 2 score): all 1555 pass this gate, while the truncation
+// shapes (`aws.s3.buckets`, `os.hostname`, `sshd.config`) are rejected.
+func assertVerdict(bundle *llx.CodeBundle) error {
+	if bundle == nil || bundle.CodeV2 == nil {
+		return errors.New("MQL compiled to no executable code")
+	}
+	code := bundle.CodeV2
+	entrypoints := code.Entrypoints()
+	if len(entrypoints) == 0 {
+		return errors.New("MQL produces no result to score")
+	}
+
+	// The last entrypoint is the query's verdict, the same convention the
+	// execute gate uses to read a result.
+	last := code.Chunk(entrypoints[len(entrypoints)-1])
+	if last == nil {
+		return errors.New("MQL produces no result to score")
+	}
+	resultType := types.Type(last.DereferencedTypeV2(code))
+
+	switch {
+	case resultType == types.Bool:
+		return nil
+	case resultType == types.Score:
+		// the `switch { case ...: score(N) }` form scores itself
+		return nil
+	case resultType == types.Block || (resultType.IsArray() && resultType.Child() == types.Block):
+		// A block scores on the assertions inside it. A block that only reads
+		// fields is a data query, not a check — and a bare resource compiles
+		// into exactly that shape, since the compiler fills the block with the
+		// resource's default fields.
+		if blockAsserts(code) {
+			return nil
+		}
+		return errors.New("MQL returns a block of field values, not a pass/fail verdict; assert on the fields (e.g. `resource { field == \"x\" }`) instead of listing them")
+	default:
+		return errors.Newf("MQL returns %s, not a pass/fail verdict; a scored check must evaluate to true (compliant) or false", resultType.Label())
+	}
+}
+
+// blockAsserts reports whether any block entrypoint is a boolean produced by an
+// assertion — a comparison, a logical operator, or a list predicate — rather
+// than a plain field read. Every block-form check in content/ has one; a bare
+// resource has only field reads, even when some of those fields are booleans.
+func blockAsserts(code *llx.CodeV2) bool {
+	for i := range code.Blocks {
+		for _, ref := range code.Blocks[i].Entrypoints {
+			chunk := code.Chunk(ref)
+			if chunk == nil {
+				continue
+			}
+			t := types.Type(chunk.DereferencedTypeV2(code))
+			if !isBoolish(t) {
+				continue
+			}
+			if isAssertionID(chunk.Id) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isBoolish reports whether a result is a verdict or a list of verdicts.
+func isBoolish(t types.Type) bool {
+	return t == types.Bool || (t.IsArray() && t.Child() == types.Bool)
+}
+
+// isAssertionID reports whether a chunk id names an assertion rather than a
+// field. Operators are punctuation (`==`, `!=`, `&&`) and the compiler's list
+// predicates are `$`-prefixed (`$all`, `$any`, `$none`); a field read is a plain
+// identifier.
+func isAssertionID(id string) bool {
+	if id == "" {
+		return false
+	}
+	if strings.HasPrefix(id, "$") {
+		return true
+	}
+	for _, r := range id {
+		isIdentifierRune := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if !isIdentifierRune {
+			return true
+		}
+	}
+	return false
+}
+
+// NoopValidator accepts every query. Used when validation is explicitly disabled
+// or a schema cannot be loaded; callers should warn when falling back to it.
+type NoopValidator struct{}
+
+func (NoopValidator) Validate(ValidationRequest) error { return nil }
+
+// QueryRunner executes an MQL query against a target asset and reports whether it
+// resolved to a concrete boolean verdict.
+type QueryRunner interface {
+	// Run executes the query. resolved is false when the query ran but produced
+	// null (data did not resolve) rather than a true/false verdict; err is set
+	// when execution itself failed.
+	Run(req ValidationRequest) (value bool, resolved bool, err error)
+}
+
+// executeValidator is the strongest gate: it compiles the query AND runs it
+// against a real target, requiring a concrete true/false verdict. This is what
+// catches the semantic traps a compile check cannot — a query that resolves to
+// null (a null-unsafe access, an unresolved field, or a dotted path that
+// compiles to an empty resource husk) is rejected here even though it compiled.
+type executeValidator struct {
+	compile Validator
+	runner  QueryRunner
+}
+
+// NewExecuteValidator wraps a compile validator with execution against runner. If
+// compile is nil, a standard compile validator is created.
+func NewExecuteValidator(runner QueryRunner, compile Validator) (Validator, error) {
+	if runner == nil {
+		return nil, errors.New("execute validation requires a query runner")
+	}
+	if compile == nil {
+		var err error
+		compile, err = NewCompileValidator()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &executeValidator{compile: compile, runner: runner}, nil
+}
+
+// CheckProvider defers to the compile stage, so a missing provider is still
+// reported before an agent call is spent.
+func (v *executeValidator) CheckProvider(provider string) error {
+	if c, ok := v.compile.(ProviderChecker); ok {
+		return c.CheckProvider(provider)
+	}
+	return nil
+}
+
+func (v *executeValidator) Validate(req ValidationRequest) error {
+	if err := v.compile.Validate(req); err != nil {
+		return err
+	}
+	_, resolved, err := v.runner.Run(req)
+	if err != nil {
+		return errors.Wrap(err, "query failed to execute against the test target")
+	}
+	if !resolved {
+		return errors.New("query executed but did not resolve to a concrete true/false verdict (result was null); likely a null-unsafe access, an unresolved field, or a dotted path that compiles to an empty resource")
+	}
+	return nil
+}

--- a/internal/generate/validate_test.go
+++ b/internal/generate/validate_test.go
@@ -1,0 +1,149 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/types"
+)
+
+// compileValidatorFor builds the real compile validator, skipping the test when
+// the provider whose resources it needs is not installed. CI runs the Go tests
+// with PROVIDERS_PATH pointed at an empty directory, so a test over the schema
+// has to say out loud that it checked nothing rather than pass on an empty run.
+func compileValidatorFor(t *testing.T, provider string) Validator {
+	t.Helper()
+	v, err := NewCompileValidator()
+	if err != nil {
+		t.Skipf("no compiler available: %v", err)
+	}
+	if checker, ok := v.(ProviderChecker); ok {
+		if err := checker.CheckProvider(provider); err != nil {
+			t.Skipf("provider %q not installed, nothing to check: %v", provider, err)
+		}
+	}
+	return v
+}
+
+// TestCompileValidatorResolvesProps is the measured blocker: the prompt tells the
+// agent to reference props.<name>, and the compile gate was called with a nil
+// props handler, so it rejected every query that did what the prompt asked. All
+// 49 prop-using checks in content/ fail to compile without a handler and all 49
+// compile with one.
+func TestCompileValidatorResolvesProps(t *testing.T) {
+	v := compileValidatorFor(t, "os")
+
+	props := []Prop{{
+		Name: "sshdCiphers",
+		// no declared type: the shape every prop in content/ has, so the type
+		// has to come from compiling this snippet
+		Mql: `return ["aes256-ctr", "aes192-ctr"]`,
+	}}
+	query := `sshd.config.params["Ciphers"].split(",").containsOnly(props.sshdCiphers)`
+
+	if err := v.Validate(ValidationRequest{MQL: query, Props: props, Provider: "os"}); err != nil {
+		t.Fatalf("a correct prop-using query was rejected: %v", err)
+	}
+
+	// and without the props it is genuinely unresolvable, which is what made the
+	// missing handler look like a bad answer from the agent
+	if err := v.Validate(ValidationRequest{MQL: query, Provider: "os"}); err == nil {
+		t.Fatal("expected an unknown-property error when the props are withheld")
+	}
+}
+
+func TestPropTypeResolution(t *testing.T) {
+	cases := []struct {
+		name     string
+		declared string
+		want     types.Type
+	}{
+		{"llx code passes through", string(types.String), types.String},
+		{"human alias", "int", types.Int},
+		{"human alias, mixed case", "Bool", types.Bool},
+		{"slice", "[]string", types.Array(types.String)},
+		{"map", "map[string]int", types.Map(types.String, types.Int)},
+		{"unknown is not guessed", "SomeResource", types.NoType},
+		{"empty is not guessed", "", types.NoType},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parsePropType(tc.declared); got != tc.want {
+				t.Fatalf("parsePropType(%q) = %q, want %q", tc.declared, got.Label(), tc.want.Label())
+			}
+		})
+	}
+}
+
+// TestCompileValidatorRejectsNonVerdicts covers the truncation shape: a query
+// that compiles and returns data rather than a pass/fail answer. `aws.s3.buckets`
+// was accepted as a scored check body.
+func TestCompileValidatorRejectsNonVerdicts(t *testing.T) {
+	v := compileValidatorFor(t, "aws")
+
+	accepted := []string{
+		"aws.s3.buckets.all(encryption != empty)",
+		`sshd.config { params["PermitRootLogin"] == "no" }`,
+		"aws.s3.buckets { encryption != empty }",
+	}
+	rejected := []string{
+		"aws.s3.buckets",          // the truncated answer
+		"aws.s3.buckets { name }", // a data query, not a check
+		"os.hostname",
+		"sshd.config",
+	}
+
+	for _, q := range accepted {
+		if err := v.Validate(ValidationRequest{MQL: q}); err != nil {
+			t.Errorf("a real check body was rejected: %q: %v", q, err)
+		}
+	}
+	for _, q := range rejected {
+		err := v.Validate(ValidationRequest{MQL: q})
+		if err == nil {
+			t.Errorf("a query that answers no verdict was accepted: %q", q)
+			continue
+		}
+		if !strings.Contains(err.Error(), "verdict") {
+			t.Errorf("the error should say the query answers no verdict, got %q: %v", q, err)
+		}
+	}
+}
+
+// TestCompileValidatorReportsAMissingProvider pins the honest-failure choice: on
+// a machine with no providers installed, NewCompileValidator used to succeed and
+// then reject every check with "cannot find resource for identifier 'aws'" —
+// three times per check, after three agent invocations, phrased as though the
+// generated query were at fault.
+func TestCompileValidatorReportsAMissingProvider(t *testing.T) {
+	v := &compileValidator{}
+	v.installedOnce.Do(func() { v.installed = map[string]bool{"os": true} })
+
+	if err := v.CheckProvider("os"); err != nil {
+		t.Fatalf("an installed provider must pass: %v", err)
+	}
+	if err := v.CheckProvider(""); err != nil {
+		t.Fatalf("an unresolved provider is not an error: %v", err)
+	}
+
+	err := v.CheckProvider("aws")
+	if err == nil {
+		t.Fatal("expected an error for a provider that is not installed")
+	}
+	if !errors.Is(err, ErrValidationUnavailable) {
+		t.Fatalf("the error must be marked as 'not validated', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cnspec providers install aws") {
+		t.Fatalf("the error should tell the user how to fix it, got: %v", err)
+	}
+
+	// and the same answer arrives through Validate, so a caller that never asks
+	// still cannot mistake it for a compile failure
+	if err := v.Validate(ValidationRequest{MQL: "aws.s3.buckets", Provider: "aws"}); !errors.Is(err, ErrValidationUnavailable) {
+		t.Fatalf("Validate must report the missing provider, got: %v", err)
+	}
+}

--- a/internal/textrank/text.go
+++ b/internal/textrank/text.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package textrank
+
+import (
+	"strings"
+	"unicode"
+)
+
+// stopwords are common English and policy-boilerplate terms that carry no
+// discriminating signal for ranking.
+var stopwords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true, "at": true,
+	"be": true, "but": true, "by": true, "for": true, "from": true, "has": true,
+	"have": true, "in": true, "is": true, "it": true, "its": true, "must": true,
+	"not": true, "of": true, "on": true, "or": true, "should": true, "that": true,
+	"the": true, "their": true, "them": true, "then": true, "there": true,
+	"these": true, "this": true, "to": true, "using": true, "via": true, "was": true,
+	"were": true, "which": true, "will": true, "with": true, "all": true,
+	"any": true, "each": true, "when": true, "where": true, "ensure": true,
+	"check": true, "enabled": true, "disabled": true, "configured": true,
+}
+
+// tokenize splits text into lowercase, stemmed word tokens, dropping stopwords
+// and single characters. It splits on any non-alphanumeric rune so identifiers
+// like "aws.s3.buckets" and "server-side" break into their parts.
+func tokenize(s string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		// keep 2-char tokens (s3, ip, ci, vm, db) which are meaningful resource
+		// shorthands; drop single characters and stopwords.
+		if len(f) < 2 || stopwords[f] {
+			continue
+		}
+		out = append(out, stem(f))
+	}
+	return out
+}
+
+// stem applies a light, conservative suffix stripper so that "buckets"/"bucket",
+// "policies"/"policy", and "encrypted"/"encrypt" match. It is deliberately
+// simple (not a full Porter stemmer) — good enough to improve recall without a
+// dependency, and it never touches short tokens where stripping would be noise.
+// It is applied identically at index and query time.
+func stem(w string) string {
+	switch {
+	case len(w) > 4 && strings.HasSuffix(w, "ies"):
+		return w[:len(w)-3] + "y" // policies -> policy
+	case len(w) > 4 && (strings.HasSuffix(w, "sses") || strings.HasSuffix(w, "ches") ||
+		strings.HasSuffix(w, "shes") || strings.HasSuffix(w, "xes") || strings.HasSuffix(w, "zes")):
+		return w[:len(w)-2] // classes -> class
+	case len(w) > 5 && strings.HasSuffix(w, "ing"):
+		return w[:len(w)-3] // encrypting -> encrypt
+	case len(w) > 4 && strings.HasSuffix(w, "ed"):
+		return w[:len(w)-2] // encrypted -> encrypt
+	case len(w) > 3 && strings.HasSuffix(w, "s") && !strings.HasSuffix(w, "ss"):
+		return w[:len(w)-1] // buckets -> bucket
+	}
+	return w
+}

--- a/internal/textrank/textrank.go
+++ b/internal/textrank/textrank.go
@@ -1,0 +1,173 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package textrank provides a small, dependency-free BM25 text ranker used to
+// find relevant policy checks by meaning (as opposed to the identifier/substring
+// matching in the policy graph's NodeIndex). It backs both `cnspec policy-graph
+// search --similar` and the grounding search inside `cnspec policy generate`.
+package textrank
+
+import (
+	"math"
+	"sort"
+)
+
+// BM25 parameters. k1 controls term-frequency saturation, b controls length
+// normalization. These are standard, robust defaults.
+const (
+	bm25K1 = 1.5
+	bm25B  = 0.75
+)
+
+// WeightedText is a piece of a document's text and how strongly it counts. A
+// higher weight makes matches in that field (e.g. a title) rank higher.
+type WeightedText struct {
+	Text   string
+	Weight int
+}
+
+// Document is one rankable item, identified by ID, composed of weighted fields.
+type Document struct {
+	ID    string
+	Parts []WeightedText
+}
+
+// Scored is a document ID and its relevance score.
+type Scored struct {
+	ID    string
+	Score float64
+}
+
+// Index is a prebuilt BM25 index. Build it once and Search it many times.
+type Index struct {
+	ids       []string
+	tf        []map[string]int // field-weighted term frequencies per document
+	docLen    []int            // total weighted length per document
+	idf       map[string]float64
+	avgDocLen float64
+}
+
+// Build constructs an index from documents, computing field-weighted term
+// frequencies and IDF weights up front.
+func Build(docs []Document) *Index {
+	ix := &Index{
+		ids:    make([]string, len(docs)),
+		tf:     make([]map[string]int, len(docs)),
+		docLen: make([]int, len(docs)),
+	}
+
+	var totalLen int
+	for i, d := range docs {
+		ix.ids[i] = d.ID
+		tf := map[string]int{}
+		for _, p := range d.Parts {
+			w := p.Weight
+			if w <= 0 {
+				w = 1
+			}
+			for _, t := range tokenize(p.Text) {
+				tf[t] += w
+			}
+		}
+		ix.tf[i] = tf
+		for _, n := range tf {
+			ix.docLen[i] += n
+		}
+		totalLen += ix.docLen[i]
+	}
+
+	n := float64(len(docs))
+	if n == 0 {
+		ix.idf = map[string]float64{}
+		ix.avgDocLen = 1
+		return ix
+	}
+	ix.avgDocLen = float64(totalLen) / n
+	if ix.avgDocLen == 0 {
+		ix.avgDocLen = 1
+	}
+
+	df := map[string]int{}
+	for _, tf := range ix.tf {
+		for t := range tf {
+			df[t]++
+		}
+	}
+	ix.idf = make(map[string]float64, len(df))
+	for t, d := range df {
+		// BM25 idf with +1 so it is always positive, even for very common terms
+		ix.idf[t] = math.Log(1 + (n-float64(d)+0.5)/(float64(d)+0.5))
+	}
+	return ix
+}
+
+// Len reports the number of indexed documents.
+func (ix *Index) Len() int { return len(ix.ids) }
+
+// Search returns up to limit documents ranked by BM25 relevance to query.
+func (ix *Index) Search(query string, limit int) []Scored {
+	return ix.SearchBonus(query, limit, nil)
+}
+
+// SearchBonus ranks documents by BM25 plus an optional per-document bonus (e.g.
+// a provider match), applied before sorting. A nil bonus is a plain BM25 search.
+func (ix *Index) SearchBonus(query string, limit int, bonus func(id string) float64) []Scored {
+	if limit <= 0 {
+		limit = 10
+	}
+	terms := dedupe(tokenize(query))
+	if len(terms) == 0 {
+		return nil
+	}
+
+	scored := make([]Scored, 0, len(ix.ids))
+	for i, id := range ix.ids {
+		score := ix.bm25(terms, i)
+		if bonus != nil {
+			score += bonus(id)
+		}
+		if score <= 0 {
+			continue
+		}
+		scored = append(scored, Scored{ID: id, Score: score})
+	}
+
+	sort.SliceStable(scored, func(a, b int) bool {
+		if scored[a].Score != scored[b].Score {
+			return scored[a].Score > scored[b].Score
+		}
+		return scored[a].ID < scored[b].ID
+	})
+
+	if len(scored) > limit {
+		scored = scored[:limit]
+	}
+	return scored
+}
+
+func (ix *Index) bm25(terms []string, i int) float64 {
+	tf := ix.tf[i]
+	dl := float64(ix.docLen[i])
+	var score float64
+	for _, t := range terms {
+		f := float64(tf[t])
+		if f == 0 {
+			continue
+		}
+		norm := f * (bm25K1 + 1) / (f + bm25K1*(1-bm25B+bm25B*dl/ix.avgDocLen))
+		score += ix.idf[t] * norm
+	}
+	return score
+}
+
+func dedupe(tokens []string) []string {
+	seen := map[string]bool{}
+	out := tokens[:0:0]
+	for _, t := range tokens {
+		if !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/textrank/textrank_test.go
+++ b/internal/textrank/textrank_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package textrank
+
+import "testing"
+
+func doc(id string, title, body string) Document {
+	return Document{ID: id, Parts: []WeightedText{
+		{Text: title, Weight: 3},
+		{Text: body, Weight: 1},
+	}}
+}
+
+func TestBM25Ranking(t *testing.T) {
+	ix := Build([]Document{
+		doc("s3", "S3 buckets must be encrypted", "aws.s3.buckets.all(encryption != empty)"),
+		doc("disk", "Compute disks must be encrypted", "gcp.compute.disks.all(diskEncryptionKey != empty)"),
+		doc("ssh", "SSH root login disabled", `sshd.config.params["PermitRootLogin"] == "no"`),
+	})
+
+	got := ix.Search("bucket encryption", 2)
+	if len(got) == 0 || got[0].ID != "s3" {
+		t.Fatalf("expected s3 first, got %+v", got)
+	}
+}
+
+func TestStemmingMatch(t *testing.T) {
+	ix := Build([]Document{
+		doc("a", "S3 buckets must be encrypted", ""),
+		doc("b", "SSH login policies", ""),
+	})
+	// singular query should match plural indexed term via stemming
+	got := ix.Search("bucket encrypt", 1)
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("expected stemmed match a, got %+v", got)
+	}
+}
+
+func TestSearchBonus(t *testing.T) {
+	ix := Build([]Document{
+		doc("aws", "storage encryption", "aws.s3"),
+		doc("gcp", "storage encryption", "gcp.storage"),
+	})
+	// identical text; the bonus must break the tie deterministically
+	got := ix.SearchBonus("storage encryption", 2, func(id string) float64 {
+		if id == "gcp" {
+			return 5
+		}
+		return 0
+	})
+	if len(got) != 2 || got[0].ID != "gcp" {
+		t.Fatalf("expected gcp first via bonus, got %+v", got)
+	}
+}
+
+func TestEmptyIndexAndQuery(t *testing.T) {
+	if got := Build(nil).Search("anything", 5); len(got) != 0 {
+		t.Fatalf("empty index should return no results, got %+v", got)
+	}
+	ix := Build([]Document{doc("a", "hello world", "")})
+	if got := ix.Search("", 5); len(got) != 0 {
+		t.Fatalf("empty query should return no results, got %+v", got)
+	}
+	// query of only stopwords tokenizes to nothing
+	if got := ix.Search("the a of", 5); len(got) != 0 {
+		t.Fatalf("stopword-only query should return no results, got %+v", got)
+	}
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -76,7 +76,7 @@ The MQL skill provides comprehensive guidance for writing MQL queries and securi
 
 - **MQL Reference** — Complete syntax documentation, best practices, and anti-patterns
 - **Platform Samples** — Ready-to-use patterns for AWS, Azure, Linux, Windows, and Microsoft 365
-- **Schema Discovery** — Real-time schema lookup via `cnspec` CLI or Mondoo MCP tools
+- **Schema Discovery** — Real-time schema lookup via the `cnspec` CLI
 - **Query Validation** — Compile-time syntax and semantic checking
 - **Policy Management** — Linting, formatting, and scaffolding policy bundles
 

--- a/skills/mql/.claude-plugin/plugin.json
+++ b/skills/mql/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mql",
   "version": "1.0.0",
-  "description": "MQL query development with syntax guidance, platform-specific patterns, and MCP tool integration",
+  "description": "MQL query development with syntax guidance, platform-specific patterns, and description-to-MQL generation",
   "author": {
     "name": "Mondoo, Inc."
   },

--- a/skills/mql/README.md
+++ b/skills/mql/README.md
@@ -1,6 +1,6 @@
 # mql
 
-An agent skill for MQL (Mondoo Query Language) development with syntax guidance, platform-specific patterns, and MCP tool integration.
+An agent skill for MQL (Mondoo Query Language) development with syntax guidance, platform-specific patterns, and description-to-MQL generation.
 
 ## What it does
 
@@ -8,7 +8,7 @@ Provides comprehensive guidance for writing MQL queries and security policies:
 
 - **MQL Reference** - Complete syntax documentation, best practices, and anti-patterns to avoid
 - **Platform Samples** - Ready-to-use patterns for AWS, Azure, Linux, Windows, and Microsoft 365
-- **Schema Discovery** - Real-time schema lookup via cnspec CLI or Mondoo MCP tools
+- **Schema Discovery** - Real-time schema lookup via the cnspec CLI
 - **Query Validation** - Compile-time syntax and semantic checking
 - **Policy Management** - Linting, formatting, and scaffolding policy bundles
 

--- a/skills/mql/SKILL.md
+++ b/skills/mql/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: mql
-description: Use when writing MQL (Mondoo Query Language) queries, working with Mondoo MCP tools, or developing security policies
+description: Use when writing MQL (Mondoo Query Language) queries, generating MQL from a check's title and description, or developing security policies
 ---
 
 # MQL Development Skill
 
 ## Overview
 
-This skill provides guidance for writing MQL (Mondoo Query Language) queries and validating them using either the cnspec CLI or Mondoo's MCP tools.
+This skill provides guidance for writing MQL (Mondoo Query Language) queries, generating them from natural-language check descriptions, and validating them using the cnspec CLI.
 
 **Two-tier knowledge system:**
-- **Reference Files** (static): MQL syntax docs, platform-specific examples
-- **Schema Tools** (live): Real-time schema lookup and query validation via cnspec CLI or MCP
+- **Reference Files** (static): MQL syntax docs, platform-specific examples, correctness traps
+- **Schema Tools** (live): Real-time schema lookup and query validation via the cnspec CLI
 
 ## When to Use
 
@@ -36,11 +36,7 @@ Located within this skill directory:
 
 ## Schema Discovery & Query Validation
 
-Two equivalent interfaces are available for real-time schema lookup and query validation. Use whichever is available in your environment — they provide the same data.
-
-### cnspec CLI (recommended — works everywhere)
-
-The cnspec CLI provides structured JSON output for all schema operations. No MCP server required.
+The cnspec CLI is the single source of schema data and query validation. It provides structured JSON output for all schema operations and works in any environment where cnspec is installed.
 
 #### List all providers
 
@@ -134,20 +130,16 @@ cnspec policy format policy.mql.yaml --sort
 cnspec policy init example.mql.yaml
 ```
 
-### Mondoo MCP Server Tools (alternative)
+### Find similar existing checks (grounding)
 
-If the Mondoo MCP server is available, you can use these tools instead of the CLI.
+Before writing MQL from scratch, look for a validated check that already does
+something similar and mirror its patterns — real MQL for the same provider is
+the strongest guide you have.
 
-| MCP Tool | CLI Equivalent |
-|----------|---------------|
-| `mcp__mondoo-mcp-http__mql-schema-providers` | `cnspec providers list --json` |
-| `mcp__mondoo-mcp-http__mql-schema-overview` | `cnspec providers resources <provider> --json` |
-| `mcp__mondoo-mcp-http__mql-schema-resource` | `cnspec providers resources <provider> <resource> --json` |
-| `mcp__mondoo-mcp-http__mql-schema-suggestion` | No CLI equivalent (use LSP) |
-| `mcp__mondoo-mcp-http__mql-compiler` | `cnspec run local -c "query" --ast` |
-| `mcp__mondoo-mcp-http__mql-bundle-lint` | `cnspec policy lint file.mql.yaml -o sarif` |
-| `mcp__mondoo-mcp-http__mql-bundle-format` | `cnspec policy format file.mql.yaml` |
-| `mcp__mondoo-mcp-http__mql-policy-bundle` | `cnspec policy init file.mql.yaml` |
+```bash
+cnspec policy graph search "s3 buckets must be encrypted" ./content --similar --provider aws
+cnspec policy graph search "containers must not run as root" ./content --similar --limit 5 --json
+```
 
 ### When to Use What
 
@@ -294,15 +286,77 @@ users.all(shell == "/bin/bash")                     # Bad
 users.where(shell != null).all(shell == "/bin/bash") # Good
 ```
 
+### Correctness Traps (a query can compile and still be wrong)
+
+Compilation (`--ast`) catches unknown resources, unknown fields, and syntax
+errors. It does NOT catch these semantic traps, which cause a check to return a
+confidently wrong verdict. Follow these rules — they are the difference between
+MQL that compiles and MQL that is correct:
+
+- **Assert presence before comparing.** `null && null` evaluates to **`true`**,
+  so a check that only compares fields silently *passes* when the data never
+  resolved. Write `field != empty && field == "x"`, not `field == "x"` alone.
+- **Use `!= empty`, never `!= ""`** for non-empty checks — `null != ""` is true,
+  so `!= ""` is not null-safe.
+- **`.all()` / `.none()` on `null` errors**; on an empty list they pass
+  vacuously. Guard absent collections: `x == empty || x.all(...)`.
+- **A dotted path that is also a resource name compiles to an empty husk** — every
+  field then reads `null` and `null != "x"` is true. Reach sub-objects through an
+  accessor path or a block bound to the parent: `parent { child.field != "none" }`.
+- **No parenthesized grouping** of booleans. Rely on precedence (`&&` binds
+  tighter than `||`) or split into separate `.any()` / `.all()` calls.
+- **Newline-as-AND**: multiple lines in an `mql:` block are implicitly AND-ed.
+- **`filters:` is asset selection, not logic.** Keep `asset.platform == ...` in
+  `filters:`; predicate logic belongs in `mql:`.
+
+## Generating MQL from a check's description
+
+`cnspec policy generate` fills in `mql:` for checks that have a `title` and
+`docs.desc` but no query yet. cnspec resolves each check's target provider from
+its `filters:`, searches similar existing checks for grounding, and validates
+the generated MQL by compiling it — delegating the model call to a coding-agent
+CLI you already have installed (Claude Code, Codex, Kimi, DeepSeek).
+
+```bash
+cnspec policy generate --interactive                   # guided: describe → generate → review → write
+cnspec policy generate policy.mql.yaml --in-place      # fill empty mql, write back
+cnspec policy generate policy.mql.yaml --dry-run       # preview without writing
+cnspec policy generate policy.mql.yaml --force         # also regenerate existing mql
+cnspec policy generate policy.mql.yaml --agent codex --explain
+cnspec policy generate policy.mql.yaml --test-target aws  # execute-and-assert, not just compile
+```
+
+`--interactive` (`-i`) is the guided authoring flow: it asks what the check
+should verify, guesses the provider and filter, shows similar existing checks as
+grounding, generates the MQL, and lets you accept / edit / regenerate-with-
+feedback before writing it into a bundle — one check at a time.
+
+By default generated MQL is validated by compiling it. Pass `--test-target
+<provider>` (e.g. `local`, `aws`, `gcp`, `azure`) to additionally run each query
+against a live asset, or `--test-recording <file>` to run against a recording
+(reproducible, no live credentials), and require it to resolve to a concrete
+true/false verdict. This catches the correctness traps below — a query that
+compiles but resolves to `null` (null-unsafe access, unresolved field, or a
+dotted-path husk) is rejected.
+
+When generating MQL by hand for a check, follow the same loop cnspec does:
+1. Read the intent from `title` + `docs.desc`.
+2. Resolve the provider from `filters:` (`asset.platform == "..."`).
+3. `cnspec policy graph search "<intent>" <path> --similar --provider <p>` to find checks to mirror.
+4. Confirm fields with `cnspec providers resources <provider> <resource> --json`.
+5. Apply the correctness traps above.
+6. Validate: `cnspec run <connection> -c "<mql>" --ast`.
+
 ## Workflow
 
 1. **Understand requirements** - What resources need to be checked?
 2. **Explore schema** - Use `cnspec providers resources <provider> --json`
-3. **Check samples** - Look for similar patterns in `samples/*.md`
-4. **Write query** - Follow patterns from `mql-reference.md`
-5. **Validate** - Use `cnspec run local -c "query" --ast` to verify syntax
-6. **Test** - Run with `cnspec run` against target systems
-7. **Wire up validation** - For policies in the cnspec repository, add fixtures for any IaC variant and register the policy with the validators that cover its remediation, in the same change. See [Wiring Policies into Content Validation](#wiring-policies-into-content-validation)
+3. **Find similar checks** - `cnspec policy graph search "<intent>" <path> --similar --provider <p>`
+4. **Check samples** - Look for similar patterns in `samples/*.md`
+5. **Write query** - Follow patterns from `mql-reference.md` and the correctness traps
+6. **Validate** - Use `cnspec run local -c "query" --ast` to verify it compiles
+7. **Test** - Run with `cnspec run` against target systems
+8. **Wire up validation** - For policies in the cnspec repository, add fixtures for any IaC variant and register the policy with the validators that cover its remediation, in the same change. See [Wiring Policies into Content Validation](#wiring-policies-into-content-validation)
 
 ## Platform-Specific Guidance
 

--- a/typos.toml
+++ b/typos.toml
@@ -50,6 +50,7 @@ unparseable = "unparseable"
 # Code identifiers and embedded data (CPU models, DMARC/registry values, ...)
 doamin = "doamin"       # typo baked into an existing querypack UID; can't rename
 attemps = "attemps"     # Alibaba RAM API parameter MaxLoginAttemps (upstream spelling)
+etry = "etry"           # bracketed-letter menu prompts, e.g. "[r]etry"
 encrypter = "encrypter"
 childs = "childs"
 datas = "datas"


### PR DESCRIPTION
Adds `cnspec policy generate` — describe a check in plain language, cnspec generates and validates the MQL, and writes it into a bundle.

Rebased from `claude/policy-mql-generation-dn3ni8`, whose base was 274 commits behind main. The feature turned out to be almost entirely disjoint from that drift: two conflicts, both trivial (an import block in `policy_graph.go`, and an additive collision in `skills/mql/SKILL.md`'s numbered workflow list — both sides kept). The rest is byte-identical to what its author wrote; I verified that by normalising the original blobs for the `/v13` module rename and diffing all 31 files.

**Draft** because the engine is intended to drive a TUI mode in `cnspec ui` (#3534) as a follow-up, and it is worth reviewing the engine before building a second front-end on it.

## Shape

| | |
|---|---|
| `internal/generate` | the engine — prompt, response, validation, grounding corpus, backends, test harness |
| `internal/textrank` | ranking, used to find similar existing checks as grounding |
| `apps/cnspec/cmd/policy_generate.go` | the command |
| `apps/cnspec/cmd/policy_generate_interactive.go` | a `bufio` wizard: describe → generate → accept/edit/regenerate/skip → validate → write |
| `internal/bundle/generate_io.go` | writing a generated check into a bundle |
| `docs/adr/0004-…` | the design record |

**No new dependencies** — `go.mod` and `go.sum` are unchanged.

## The engine is headless, deliberately

Worth stating because it shapes the review: `internal/generate` contains **no** `os.Stdin/Stdout/Stderr`, `fmt.Print*` or `bufio`. All 44 stdio call sites are in the cmd layer. The subprocess backend sets `cmd.Stdin = nil` and buffers both streams. `Generate` reports through a `progress func(Result)` callback rather than printing.

That is what makes a TUI port cheap later — it needs a new front-end, not a refactor.

## Worth reviewers' attention

The command's own help says it, and the ADR expands on it:

> on policy bundles you trust — a crafted description in an untrusted bundle is prompt-injection input to your agent.

Check titles and descriptions are sent to an agent CLI that can run tools. That is a documented, deliberate trade-off for a CLI where you type the description yourself. It is worth a second look before the TUI port, because browsing to a bundle makes it materially easier to point the feature at something you did not write.

## Verification

`go build ./...` · `go vet ./...` (47 lines, byte-identical to main's baseline — none added) · `go test -race ./apps/cnspec/... ./internal/...` · golangci-lint v2.13.1 both configs **0 issues** · `typos` clean · `go mod tidy` a no-op · `cnspec policy generate --help` smoke-tested.