### PR TITLE
✨ ocsf: name the log an event came from

### DIFF
--- a/reports/ocsf/convert/convert.go
+++ b/reports/ocsf/convert/convert.go
@@ -18,6 +18,15 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/mvd"
 )
 
+// logNameScan and logNameVulnReport name the stream an event came out of, which
+// is what metadata.log_name is for: the two commands produce different events
+// about different things, and a SIEM routing or filtering on the log name should
+// be able to tell them apart.
+const (
+	logNameScan       = "cnspec scan"
+	logNameVulnReport = "cnspec vuln"
+)
+
 // productName and friends identify cnspec as the producer of the events.
 const (
 	productName   = "cnspec"
@@ -73,6 +82,7 @@ func Stream(r *policy.ReportCollection, w ocsf.Writer, opts Options) error {
 // the target names the asset and there is nothing else to report about it.
 func ConvertVulnReport(target string, data *mvd.VulnReport, version ocsf.Version, out io.Writer) error {
 	c := newConverter(Options{Version: version}, time.Now())
+	c.logName = logNameVulnReport
 	asset := &inventory.Asset{Name: target}
 	events := &ocsf.Events{}
 	c.addVulnerabilityFindings(events, data, &assetContext{
@@ -97,6 +107,7 @@ func newConverter(opts Options, now time.Time) *converter {
 		version:     opts.Version,
 		findings:    opts.Findings,
 		includeData: opts.IncludeData,
+		logName:     logNameScan,
 		now:         now.UnixMilli(),
 	}
 }
@@ -106,6 +117,8 @@ type converter struct {
 	version     ocsf.Version
 	findings    ocsf.FindingClasses
 	includeData bool
+	// logName is the stream these events came from, for metadata.log_name.
+	logName string
 	// now is the scan time in milliseconds since the epoch. It is a field rather
 	// than a call to time.Now so that a conversion is reproducible.
 	now int64
@@ -206,7 +219,12 @@ func (c *converter) metadata(profiles ...string) ocsf.Metadata {
 			Version:    cnspec.GetVersion(),
 			URLString:  productURL,
 		},
-		LoggedTime: c.now,
+		// The provider is the service that logged the event and the name is the
+		// stream within it, which is how the schema's own example splits
+		// Microsoft-Windows-Security-Auditing from the Security log.
+		LogProvider: productName,
+		LogName:     c.logName,
+		LoggedTime:  c.now,
 	}
 	if len(profiles) > 0 {
 		res.Profiles = profiles

--- a/reports/ocsf/convert/convert_test.go
+++ b/reports/ocsf/convert/convert_test.go
@@ -66,6 +66,9 @@ func TestOcsfConverter(t *testing.T) {
 		assert.Equal(t, fixedScanTime.UnixMilli(), finding.Time)
 		assert.Equal(t, string(ocsf.Version130), finding.Metadata.Version)
 		assert.Equal(t, "cnspec", finding.Metadata.Product.Name)
+		assert.Equal(t, "cnspec", finding.Metadata.LogProvider)
+		assert.Equal(t, "cnspec scan", finding.Metadata.LogName,
+			"the events of a scan name the stream they came from")
 		assert.NotEmpty(t, finding.Compliance.Standards, "standards is a required attribute")
 		require.Len(t, finding.Resources, 1)
 		assert.Equal(t, "X1", finding.Resources[0].Name)
@@ -654,4 +657,22 @@ func TestOcsfStreamedParquetAcrossAssets(t *testing.T) {
 	// classes the scan did not produce must not leave empty files behind
 	_, err = os.Stat(filepath.Join(dir, ocsf.ClassDetectionFinding+".parquet"))
 	assert.True(t, os.IsNotExist(err), "no file for a class with no events")
+}
+
+// TestVulnReportLogName covers the other source of OCSF events: cnspec vuln has
+// no scan behind it, and a SIEM filtering on the log name has to be able to tell
+// the two apart.
+func TestVulnReportLogName(t *testing.T) {
+	report := advisoryReportCollection().VulnReports[reportfixture.AssetMrn]
+
+	buf := bytes.Buffer{}
+	require.NoError(t, ConvertVulnReport("X1", report, ocsf.DefaultVersion, &buf))
+
+	var event map[string]any
+	line := strings.Split(strings.TrimSpace(buf.String()), "\n")[0]
+	require.NoError(t, json.Unmarshal([]byte(line), &event))
+
+	metadata := event["metadata"].(map[string]any)
+	assert.Equal(t, "cnspec vuln", metadata["log_name"])
+	assert.Equal(t, "cnspec", metadata["log_provider"])
 }

--- a/reports/ocsf/gen.yaml
+++ b/reports/ocsf/gen.yaml
@@ -125,7 +125,7 @@ classes:
       - cloud
 
 objects:
-  metadata: [version, product, logged_time, profiles, event_code, labels]
+  metadata: [version, product, log_name, log_provider, logged_time, profiles, event_code, labels]
   product: [name, vendor_name, version, url_string]
   finding_info:
     [uid, title, desc, created_time, first_seen_time, modified_time, product_uid, src_url, types,

--- a/reports/ocsf/types.gen.go
+++ b/reports/ocsf/types.gen.go
@@ -1141,6 +1141,18 @@ type Metadata struct {
 	// The product that reported the event.
 	Product Product `json:"product" parquet:"product"`
 
+	// Log Name
+	//
+	// The event log name. For example, syslog file name or Windows logging
+	// subsystem: Security.
+	LogName string `json:"log_name,omitempty" parquet:"log_name,optional"`
+
+	// Log Provider
+	//
+	// The logging provider or logging service that logged the event. For
+	// example, Microsoft-Windows-Security-Auditing.
+	LogProvider string `json:"log_provider,omitempty" parquet:"log_provider,optional"`
+
 	// Logged Time
 	//
 	// The time when the logging system collected and logged the event.This


### PR DESCRIPTION
`metadata.log_name` and `metadata.log_provider` are recommended OCSF attributes that a SIEM uses to route and attribute events. The validator has been reporting both as missing since the export landed.

The schema splits them the way its own example does — `Microsoft-Windows-Security-Auditing` is the provider, `Security` is the log — so:

| | |
|---|---|
| `log_provider` | `cnspec` — the service that logged the event |
| `log_name` | `cnspec scan`, or `cnspec vuln` for a standalone vulnerability report |

The two commands describe different things, and someone filtering a shared index should be able to tell them apart without inspecting the event classes.

Three lines of mapping plus the attributes in `gen.yaml`; the types are regenerated from the schema as usual.

## Verification

- `go test -race ./reports/...` clean
- Live `cnspec scan local` output validates against OCSF 1.3.0 and 1.9.0 with zero errors and zero warnings, and both attributes carry through
- Tests cover the scan and the vulnerability-report paths separately

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
