### PR TITLE
http-security: show the Server header value in the obfuscate-server evidence

### DIFF
--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.3.1
+    version: 1.3.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -438,7 +438,13 @@ queries:
       compliance/pci-dss-4: pcidss-requirement-3-5-1
       compliance/soc2-2017: soc2-control-cc6-1-10
       compliance/vda-isa-5: vda-isa-5-5-1-1
-    mql: http.get.header.server == empty || http.get.header.server.downcase != /nginx|microsoft|apache|litespeed|lsws|openresty/
+    mql: |
+      if (http.get.header.server != empty) {
+        http.get.header.server
+        http.get.header.server.downcase != /nginx|microsoft|apache|litespeed|lsws|openresty/
+      } else {
+        true
+      }
     docs:
       desc: |
         This check verifies that responses do not advertise which web server software is answering requests.


### PR DESCRIPTION
The obfuscate-server check combined two boolean expressions with `||`, so a failing result rendered its evidence as `[failed] false || false`. The actual Server header value never appeared, even though it is the one thing needed to act on the finding, and the check's own audit section tells users to fetch exactly that value with curl.

Restructured the query as if/else with a data statement (established pattern in this repo, see mondoo-github-best-practices), so a failing check now renders:

```
{
  "http.get.header.server": "nginx/1.24.0",
  "http.get.header.server.downcase != /nginx|microsoft|apache|litespeed|lsws|openresty/": false
}
```

Semantics are unchanged: the check passes when the header is absent and passes when the value does not match the known-server pattern; the data statement is output only and does not affect scoring. Verified in both directions against live hosts: a failing host shows its header value in the evidence, a host without a Server header still passes. Policy version bumped to 1.3.2.