### PR TITLE
👷 ci: route mql bumps when main is on the unversioned module path

### DIFF
--- a/.github/scripts/determine-mql-bump-base.sh
+++ b/.github/scripts/determine-mql-bump-base.sh
@@ -4,17 +4,30 @@
 #
 # Determine base branch for cnspec's mql bump PR.
 #
-# When main's mql import major matches the incoming mql release's major,
-# the bump PR opens against main. Otherwise it opens against the v{major}
-# support branch (e.g. v13.35.1 while main is on mql v14 -> v13).
+# Two shapes of main's mql import have to be handled:
+#
+#   1. Major-suffixed path (go.mondoo.com/mql/v13). The major is read
+#      straight off the path: same major as the incoming release -> main,
+#      any other major -> the v{major} support branch.
+#
+#   2. Unversioned path (go.mondoo.com/mql). mql dropped the major suffix
+#      for its v14 development line, which cnspec's main tracks through
+#      pseudo-versions, so the path no longer carries a major. Released
+#      majors still live on their own mql branch, and cnspec mirrors them
+#      with a v{major} support branch — so the incoming release routes to
+#      v{major} when that branch exists, and to main otherwise (the release
+#      belongs to the unversioned development line main is already on).
 #
 # Inputs:
-#   $1 (required)  incoming mql version (e.g. v13.35.1 or 14.0.0-rc.1)
-#   $MAIN_GOMOD    content of main's go.mod. If unset, fetched via `gh api`
-#                  using $GH_REPO (owner/repo) and $GH_TOKEN.
+#   $1 (required)    incoming mql version (e.g. v13.36.0 or 14.0.0-rc.1)
+#   $MAIN_GOMOD      content of main's go.mod. If unset, fetched via `gh api`
+#                    using $GH_REPO (owner/repo) and $GH_TOKEN.
+#   $KNOWN_BRANCHES  space/newline separated branch names to check the
+#                    v{major} support branch against. If unset, existence is
+#                    queried via `gh api` using $GH_REPO and $GH_TOKEN.
 #
 # Output: prints the base branch to stdout ("main" or "v{major}").
-#         Exits non-zero if main's mql import major cannot be determined.
+#         Exits non-zero if main's mql import cannot be found at all.
 set -euo pipefail
 
 MQL_VERSION="${1:?mql version required as first argument}"
@@ -24,24 +37,46 @@ RELEASE_MAJOR="${V%%.*}"
 
 if [ -z "${MAIN_GOMOD+set}" ]; then
   # MAIN_GOMOD not passed in at all — fetch it. An explicit empty value
-  # is respected (and will fail the "Could not extract" check below), so
+  # is respected (and will fail the "Could not find" check below), so
   # tests can exercise failure paths without touching the network.
   : "${GH_REPO:?GH_REPO or MAIN_GOMOD required}"
   MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
 fi
+
+# Does branch $1 exist in the repo?
+branch_exists() {
+  if [ -n "${KNOWN_BRANCHES+set}" ]; then
+    printf '%s' "$KNOWN_BRANCHES" | tr ' ' '\n' | grep -qx -- "$1"
+    return
+  fi
+  : "${GH_REPO:?GH_REPO or KNOWN_BRANCHES required}"
+  gh api "/repos/${GH_REPO}/branches/$1" >/dev/null 2>&1
+}
 
 MAIN_MAJOR=$(printf '%s' "$MAIN_GOMOD" \
   | grep -oE 'go\.mondoo\.com/mql/v[0-9]+' \
   | head -1 \
   | grep -oE '[0-9]+$' || true)
 
-if [ -z "$MAIN_MAJOR" ]; then
-  echo "Could not extract mql major from main's go.mod" >&2
+if [ -n "$MAIN_MAJOR" ]; then
+  if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+    echo main
+  else
+    echo "v${RELEASE_MAJOR}"
+  fi
+  exit 0
+fi
+
+# No major suffix on main. Confirm main imports mql at all before falling
+# back to the support-branch lookup, so a go.mod without mql still fails
+# loudly instead of silently routing somewhere.
+if ! printf '%s' "$MAIN_GOMOD" | grep -qE 'go\.mondoo\.com/mql[[:space:]]+v[0-9]'; then
+  echo "Could not find an mql import in main's go.mod" >&2
   exit 1
 fi
 
-if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
-  echo main
-else
+if branch_exists "v${RELEASE_MAJOR}"; then
   echo "v${RELEASE_MAJOR}"
+else
+  echo main
 fi

--- a/.github/scripts/determine-mql-bump-base.sh
+++ b/.github/scripts/determine-mql-bump-base.sh
@@ -12,25 +12,40 @@
 #
 #   2. Unversioned path (go.mondoo.com/mql). mql dropped the major suffix
 #      for its v14 development line, which cnspec's main tracks through
-#      pseudo-versions, so the path no longer carries a major. Released
-#      majors still live on their own mql branch, and cnspec mirrors them
-#      with a v{major} support branch — so the incoming release routes to
-#      v{major} when that branch exists, and to main otherwise (the release
-#      belongs to the unversioned development line main is already on).
+#      pseudo-versions, so the path carries no major to compare against.
+#      Both repos instead branch a major off when main moves to the next
+#      one (mql and cnspec both cut v13 on 2026-08-18), so the branches
+#      answer the question the path no longer can:
+#
+#        cnspec has v{major}              -> v{major}, the support branch
+#        mql has v{major}, cnspec has not -> error; the release comes from
+#                                            an mql maintenance line whose
+#                                            cnspec branch is missing, and
+#                                            landing it on main would
+#                                            downgrade main's mql
+#        neither has v{major}             -> main, which is the only line
+#                                            this major can belong to
+#
+#      Nothing here is pinned to a specific major, so v15 needs no change:
+#      once mql and cnspec cut v14 and main moves on, v14.x releases route
+#      to v14 and v15.x releases route to main.
 #
 # Inputs:
 #   $1 (required)    incoming mql version (e.g. v13.36.0 or 14.0.0-rc.1)
 #   $MAIN_GOMOD      content of main's go.mod. If unset, fetched via `gh api`
 #                    using $GH_REPO (owner/repo) and $GH_TOKEN.
-#   $KNOWN_BRANCHES  space/newline separated branch names to check the
-#                    v{major} support branch against. If unset, existence is
-#                    queried via `gh api` using $GH_REPO and $GH_TOKEN.
+#   $KNOWN_BRANCHES  space/newline separated cnspec branch names to check the
+#                    support branch against. If unset, existence is queried
+#                    via `gh api` using $GH_REPO and $GH_TOKEN.
+#   $MQL_BRANCHES    same, for mql's branches. If unset, queried via `gh api`
+#                    using $MQL_REPO (default mondoohq/mql).
 #
 # Output: prints the base branch to stdout ("main" or "v{major}").
-#         Exits non-zero if main's mql import cannot be found at all.
+#         Exits non-zero if the base branch cannot be determined.
 set -euo pipefail
 
 MQL_VERSION="${1:?mql version required as first argument}"
+MQL_REPO="${MQL_REPO:-mondoohq/mql}"
 
 V="${MQL_VERSION#v}"
 RELEASE_MAJOR="${V%%.*}"
@@ -43,14 +58,26 @@ if [ -z "${MAIN_GOMOD+set}" ]; then
   MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
 fi
 
-# Does branch $1 exist in the repo?
+# Does branch $2 exist in repo $1? $3 names the env var holding a
+# pre-supplied branch list, so tests can answer without the network.
+# Only an HTTP 404 counts as "no such branch" — any other API failure is
+# fatal, so a bad token or a network blip cannot be read as "not a support
+# branch" and quietly route the bump to main.
 branch_exists() {
-  if [ -n "${KNOWN_BRANCHES+set}" ]; then
-    printf '%s' "$KNOWN_BRANCHES" | tr ' ' '\n' | grep -qx -- "$1"
+  local repo="$1" branch="$2" list_var="$3" err
+  if [ -n "${!list_var+set}" ]; then
+    printf '%s' "${!list_var}" | tr ' ' '\n' | grep -qx -- "$branch"
     return
   fi
-  : "${GH_REPO:?GH_REPO or KNOWN_BRANCHES required}"
-  gh api "/repos/${GH_REPO}/branches/$1" >/dev/null 2>&1
+  : "${repo:?repository required to look up branch ${branch}}"
+  if err=$(gh api "/repos/${repo}/branches/${branch}" 2>&1 >/dev/null); then
+    return 0
+  fi
+  if printf '%s' "$err" | grep -q 'HTTP 404'; then
+    return 1
+  fi
+  echo "Could not query ${repo} for branch ${branch}: ${err}" >&2
+  exit 1
 }
 
 MAIN_MAJOR=$(printf '%s' "$MAIN_GOMOD" \
@@ -68,15 +95,29 @@ if [ -n "$MAIN_MAJOR" ]; then
 fi
 
 # No major suffix on main. Confirm main imports mql at all before falling
-# back to the support-branch lookup, so a go.mod without mql still fails
-# loudly instead of silently routing somewhere.
+# back to the branch lookup, so a go.mod without mql still fails loudly
+# instead of silently routing somewhere.
 if ! printf '%s' "$MAIN_GOMOD" | grep -qE 'go\.mondoo\.com/mql[[:space:]]+v[0-9]'; then
   echo "Could not find an mql import in main's go.mod" >&2
   exit 1
 fi
 
-if branch_exists "v${RELEASE_MAJOR}"; then
-  echo "v${RELEASE_MAJOR}"
-else
-  echo main
+GH_REPO="${GH_REPO:-}"
+SUPPORT_BRANCH="v${RELEASE_MAJOR}"
+
+if branch_exists "$GH_REPO" "$SUPPORT_BRANCH" KNOWN_BRANCHES; then
+  echo "$SUPPORT_BRANCH"
+  exit 0
 fi
+
+if branch_exists "$MQL_REPO" "$SUPPORT_BRANCH" MQL_BRANCHES; then
+  cat >&2 <<EOF
+mql ${MQL_VERSION} comes from the ${SUPPORT_BRANCH} maintenance branch of
+${MQL_REPO}, but ${GH_REPO:-cnspec} has no ${SUPPORT_BRANCH} branch to open the bump
+against. Cut ${SUPPORT_BRANCH} in ${GH_REPO:-cnspec} and re-run — landing this on main
+would downgrade the mql main tracks.
+EOF
+  exit 1
+fi
+
+echo main

--- a/.github/scripts/tests/determine-mql-bump-base.bats
+++ b/.github/scripts/tests/determine-mql-bump-base.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 # Tests for .github/scripts/determine-mql-bump-base.sh
 #
-# Each test sets MAIN_GOMOD in the environment so the script runs without
-# calling gh api. See the script's header for the input contract.
+# Each test sets MAIN_GOMOD (and, for the unversioned-path cases,
+# KNOWN_BRANCHES) in the environment so the script runs without calling
+# gh api. See the script's header for the input contract.
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/../determine-mql-bump-base.sh"
@@ -61,7 +62,62 @@ setup() {
   MAIN_GOMOD='require go.mondoo.com/other v1.0.0' \
     run bash "$SCRIPT" v13.35.1
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Could not extract mql major"* ]]
+  [[ "$output" == *"Could not find an mql import"* ]]
+}
+
+# --- main on mql's unversioned (v14+) module path -------------------------
+# mql dropped the major suffix for its v14 line, so main's go.mod pins
+# go.mondoo.com/mql at a pseudo-version and carries no major to compare.
+
+@test "unversioned main: release with a support branch routes there" {
+  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" v13.36.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "unversioned main: release without a support branch routes to main" {
+  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" v14.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "unversioned main: no v-prefix on the incoming version" {
+  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" 13.36.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "unversioned main: pre-release suffix does not change routing" {
+  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" v13.37.0-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "unversioned main: real go.mod shape from main routes v13 to v13" {
+  # Abridged copy of main's go.mod: the commented replace directive must not
+  # be mistaken for the import, and the require line is what decides.
+  MAIN_GOMOD=$'module go.mondoo.com/cnspec\n\n// replace go.mondoo.com/mql => ../mql\n\nrequire (\n\tgo.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7\n\tgo.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f\n)' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" v13.36.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "a major-suffixed import still wins over the unversioned fallback" {
+  # Both shapes present (e.g. mid-migration): the suffixed one decides.
+  MAIN_GOMOD=$'require (\n\tgo.mondoo.com/mql/v13 v13.35.0\n\tgo.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f // indirect\n)' \
+    KNOWN_BRANCHES='main v13' \
+    run bash "$SCRIPT" v13.36.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
 }
 
 @test "missing version argument errors out" {

--- a/.github/scripts/tests/determine-mql-bump-base.bats
+++ b/.github/scripts/tests/determine-mql-bump-base.bats
@@ -2,11 +2,21 @@
 # Tests for .github/scripts/determine-mql-bump-base.sh
 #
 # Each test sets MAIN_GOMOD (and, for the unversioned-path cases,
-# KNOWN_BRANCHES) in the environment so the script runs without calling
-# gh api. See the script's header for the input contract.
+# KNOWN_BRANCHES for cnspec's branches and MQL_BRANCHES for mql's) in the
+# environment so the script runs without calling gh api. See the script's
+# header for the input contract.
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/../determine-mql-bump-base.sh"
+
+  # main's go.mod shape since mql dropped the major suffix.
+  UNVERSIONED='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f'
+  # Branch state today: main is on mql v14, v13 is the maintenance line.
+  TODAY_CNSPEC='main v13'
+  TODAY_MQL='main v13'
+  # Branch state after v14 ships and main moves on to v15.
+  NEXT_CNSPEC='main v13 v14'
+  NEXT_MQL='main v13 v14'
 }
 
 @test "matching major routes to main (v-prefixed tag)" {
@@ -68,34 +78,32 @@ setup() {
 # --- main on mql's unversioned (v14+) module path -------------------------
 # mql dropped the major suffix for its v14 line, so main's go.mod pins
 # go.mondoo.com/mql at a pseudo-version and carries no major to compare.
+# The branch layout of the two repos decides instead; see setup() for the
+# UNVERSIONED / TODAY_* / NEXT_* fixtures used below.
 
-@test "unversioned main: release with a support branch routes there" {
-  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
-    KNOWN_BRANCHES='main v13' \
+@test "unversioned main: maintenance release routes to its support branch" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" v13.36.0
   [ "$status" -eq 0 ]
   [ "$output" = "v13" ]
 }
 
-@test "unversioned main: release without a support branch routes to main" {
-  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
-    KNOWN_BRANCHES='main v13' \
+@test "unversioned main: the line main tracks routes to main" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" v14.0.0
   [ "$status" -eq 0 ]
   [ "$output" = "main" ]
 }
 
-@test "unversioned main: no v-prefix on the incoming version" {
-  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
-    KNOWN_BRANCHES='main v13' \
+@test "unversioned main: no v prefix on the incoming version" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" 13.36.0
   [ "$status" -eq 0 ]
   [ "$output" = "v13" ]
 }
 
 @test "unversioned main: pre-release suffix does not change routing" {
-  MAIN_GOMOD='require go.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f' \
-    KNOWN_BRANCHES='main v13' \
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" v13.37.0-rc.1
   [ "$status" -eq 0 ]
   [ "$output" = "v13" ]
@@ -105,16 +113,47 @@ setup() {
   # Abridged copy of main's go.mod: the commented replace directive must not
   # be mistaken for the import, and the require line is what decides.
   MAIN_GOMOD=$'module go.mondoo.com/cnspec\n\n// replace go.mondoo.com/mql => ../mql\n\nrequire (\n\tgo.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7\n\tgo.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f\n)' \
-    KNOWN_BRANCHES='main v13' \
+    KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" v13.36.0
   [ "$status" -eq 0 ]
   [ "$output" = "v13" ]
 }
 
-@test "a major-suffixed import still wins over the unversioned fallback" {
+# --- the next major needs no change to this script ------------------------
+
+@test "after v14 ships: v14 routes to the new support branch" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$NEXT_CNSPEC" MQL_BRANCHES="$NEXT_MQL" \
+    run bash "$SCRIPT" v14.1.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v14" ]
+}
+
+@test "after v14 ships: v15 routes to main" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$NEXT_CNSPEC" MQL_BRANCHES="$NEXT_MQL" \
+    run bash "$SCRIPT" v15.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "after v14 ships: v13 still routes to v13" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$NEXT_CNSPEC" MQL_BRANCHES="$NEXT_MQL" \
+    run bash "$SCRIPT" v13.40.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "mql cut the branch but cnspec has not: fail instead of landing on main" {
+  MAIN_GOMOD="$UNVERSIONED" KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$NEXT_MQL" \
+    GH_REPO='mondoohq/cnspec' \
+    run bash "$SCRIPT" v14.1.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"has no v14 branch"* ]]
+}
+
+@test "a major-suffixed import still wins over the branch lookup" {
   # Both shapes present (e.g. mid-migration): the suffixed one decides.
   MAIN_GOMOD=$'require (\n\tgo.mondoo.com/mql/v13 v13.35.0\n\tgo.mondoo.com/mql v0.0.0-20260825052922-32d60cce639f // indirect\n)' \
-    KNOWN_BRANCHES='main v13' \
+    KNOWN_BRANCHES="$TODAY_CNSPEC" MQL_BRANCHES="$TODAY_MQL" \
     run bash "$SCRIPT" v13.36.0
   [ "$status" -eq 0 ]
   [ "$output" = "main" ]

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -47,12 +47,15 @@ jobs:
         with:
           sparse-checkout: '.github/scripts'
           sparse-checkout-cone-mode: false
-      # Route the bump PR to the right branch by comparing the incoming mql
-      # major with the mql major currently imported on main. Matching major
-      # -> base=main; any other major -> base=v{major} support branch
-      # (e.g. an mql v13.35.1 tag while main is on mql v14 -> base=v13).
-      # Logic lives in .github/scripts/determine-mql-bump-base.sh and is
-      # unit-tested via .github/scripts/tests/determine-mql-bump-base.bats.
+      # Route the bump PR to the right branch. When main's go.mod still
+      # carries a major-suffixed mql import, the incoming major is compared
+      # against it: matching -> base=main, otherwise -> base=v{major}. mql
+      # dropped the suffix for its v14 line, so when main pins the
+      # unversioned go.mondoo.com/mql there is no major to compare and the
+      # release routes to the v{major} support branch when cnspec has one
+      # (an mql v13.36.0 tag while main tracks v14 -> base=v13), and to main
+      # otherwise. Logic lives in .github/scripts/determine-mql-bump-base.sh
+      # and is unit-tested via .github/scripts/tests/determine-mql-bump-base.bats.
       - name: Determine base branch
         id: base
         env:
@@ -94,8 +97,16 @@ jobs:
         env:
           MQL_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          MAJOR=$(echo "${MQL_VERSION}" | cut -d. -f1)
-          go get go.mondoo.com/mql/${MAJOR}@${MQL_VERSION}
+          # Take the module path from the branch we are bumping: support
+          # branches import go.mondoo.com/mql/v{major}, while main tracks
+          # mql's unversioned path. Matching a version after the path skips
+          # the commented-out replace directive at the top of go.mod.
+          MQL_MODULE=$(grep -oE 'go\.mondoo\.com/mql(/v[0-9]+)?[[:space:]]+v[0-9]' go.mod | head -1 | awk '{print $1}')
+          if [ -z "${MQL_MODULE}" ]; then
+            echo "Could not find an mql import in go.mod"
+            exit 1
+          fi
+          go get "${MQL_MODULE}@${MQL_VERSION}"
           go mod tidy
           echo "${MQL_VERSION}" > VERSION
 

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -47,14 +47,16 @@ jobs:
         with:
           sparse-checkout: '.github/scripts'
           sparse-checkout-cone-mode: false
-      # Route the bump PR to the right branch. When main's go.mod still
-      # carries a major-suffixed mql import, the incoming major is compared
-      # against it: matching -> base=main, otherwise -> base=v{major}. mql
-      # dropped the suffix for its v14 line, so when main pins the
-      # unversioned go.mondoo.com/mql there is no major to compare and the
-      # release routes to the v{major} support branch when cnspec has one
-      # (an mql v13.36.0 tag while main tracks v14 -> base=v13), and to main
-      # otherwise. Logic lives in .github/scripts/determine-mql-bump-base.sh
+      # Route the bump PR to the right branch. When main's go.mod carries a
+      # major-suffixed mql import, the incoming major is compared against
+      # it: matching -> base=main, otherwise -> base=v{major}. mql dropped
+      # the suffix for its v14 line, so when main pins the unversioned
+      # go.mondoo.com/mql there is no major to compare and the v{major}
+      # branches of the two repos decide instead: cnspec has v{major} ->
+      # base=v{major} (an mql v13.36.0 tag while main tracks v14 -> v13);
+      # only mql has it -> error, because the release comes from an mql
+      # maintenance line cnspec has not branched off; neither has it ->
+      # base=main. Logic lives in .github/scripts/determine-mql-bump-base.sh
       # and is unit-tested via .github/scripts/tests/determine-mql-bump-base.bats.
       - name: Determine base branch
         id: base


### PR DESCRIPTION
## Problem

The [v13.36.0 bump](https://github.com/mondoohq/cnspec/actions/runs/32822932166/job/97724745047) failed at *Determine base branch*:

```
Could not extract mql major from main's go.mod
```

mql moved its v14 line to a non-versioned module path (mondoohq/mql#10234), so cnspec's main no longer imports `go.mondoo.com/mql/v14` — it pins the unversioned `go.mondoo.com/mql` at a pseudo-version. `determine-mql-bump-base.sh` only ever read the major off the `/vN` path suffix, found nothing to compare against, and exited 1 before the bump could be routed to `v13`.

## Fix

A major-suffixed import still decides on its own, so existing routing is unchanged. When the path carries no major, the `v{major}` branches of the two repos answer the question the path no longer can — mql and cnspec branch a major off at the same moment main moves to the next one (both cut `v13` on 2026-08-18):

| state | base |
|---|---|
| cnspec has `v{major}` | `v{major}` |
| mql has `v{major}`, cnspec has not | error naming the branch to cut — the release comes from an mql maintenance line whose cnspec branch is missing, and landing it on main would downgrade main's mql |
| neither has `v{major}` | `main` — the only line that major can belong to |

Nothing is pinned to a specific major, so **v15 needs no change**: once v14 is branched in both repos, v14.x routes to `v14` and v15.x routes to `main`.

Branch lookups treat only HTTP 404 as "no such branch"; any other API failure is fatal, so a bad token or a network blip cannot read as "not a support branch" and route the bump to main.

The *Bump mql* step also no longer hardcodes `go.mondoo.com/mql/${MAJOR}` — it takes the module path from the go.mod of the branch being bumped (suffixed on support branches, unversioned on main).

## Verification

20 bats cases, including the branch state today and after v14 ships. Run against the live branch state of both repos with main's real go.mod:

| incoming | base |
|---|---|
| v13.36.0 | `v13` |
| v14.0.0 | `main` |
| v15.0.0 | `main` |

Once this lands, the v13.36.0 bump can be re-run via workflow_dispatch (`dry-run` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)