### PR TITLE
👷 ci: check the bump scripts out beside the workspace, not into it

### DIFF
--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -42,11 +42,17 @@ jobs:
       # Sparse-checkout the scripts dir before we know the target branch, so
       # we can run determine-mql-bump-base.sh to figure out where to open the
       # bump PR. The full checkout of the target branch happens further down.
+      # It goes in its own directory: dropping it in the workspace root left
+      # the second checkout reusing this repo, and switching a sparse working
+      # tree to another branch fails per file ("not uptodate; will not remove
+      # from working tree") without failing the step, so the base branch was
+      # never materialized and .github/env came up missing.
       - name: Checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: '.github/scripts'
           sparse-checkout-cone-mode: false
+          path: .bump-scripts
       # Route the bump PR to the right branch. When main's go.mod carries a
       # major-suffixed mql import, the incoming major is compared against
       # it: matching -> base=main, otherwise -> base=v{major}. mql dropped
@@ -65,7 +71,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          BASE=$(.github/scripts/determine-mql-bump-base.sh "$MQL_VERSION")
+          BASE=$(.bump-scripts/.github/scripts/determine-mql-bump-base.sh "$MQL_VERSION")
           echo "Release major: ${MQL_VERSION%%.*}, resolved base branch: ${BASE}"
           echo "base=${BASE}" >> "$GITHUB_OUTPUT"
       # Mint a short-lived installation token from the mondoo-mergebot


### PR DESCRIPTION
Follow-up to #3567. With the base branch now resolving correctly, the [v13.36.0 dry run](https://github.com/mondoohq/cnspec/actions/runs/32831498832/job/97750993853) got one step further and stopped at:

```
cat: .github/env: No such file or directory
```

## Cause

`Checkout scripts` sparse-checks-out `.github/scripts` into the workspace root, so `Checkout code` found an existing repo there and reused it. Disabling sparse checkout and switching to the base branch then failed per file:

```
[command]/usr/bin/git sparse-checkout disable
[command]/usr/bin/git checkout --progress --force -B v13 refs/remotes/origin/v13
error: Path '.github/workflows/test-scripts.yml' not uptodate; will not remove from working tree
error: Path 'cli/reporter/hdf_format_test.go' not uptodate; will not remove from working tree
...
```

`git checkout` still exited 0, so actions/checkout reported success and the workspace held nothing but `.github/scripts`. The next step is where it showed up.

Latent since #3533 added the scripts checkout on 2026-08-21 — the last green bump was 2026-08-19, so no run has exercised this path.

## Fix

Give the scripts checkout its own `path: .bump-scripts`, so the base-branch checkout starts from a clean workspace and materializes the whole tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)