### PR TITLE
👷 ci: pin the v13 branch to Go 1.26

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-golang-version=1.25.6
+golang-version=1.26
 protoc-version=33.x


### PR DESCRIPTION
`go.mod` on this branch requires `go 1.26.5`, but `.github/env` still pins `golang-version=1.25.6`, so every job that installs Go from that file gets a toolchain its own go.mod rejects:

```
go: go.mod requires go >= 1.26.5 (running go 1.25.6; GOTOOLCHAIN=local)
```

That is where the mql v13.36.0 bump [stopped](https://github.com/mondoohq/cnspec/actions/runs/32832511616) once #3567 and #3568 got it routing to this branch and checking the branch out correctly.

main carried the same mismatch and fixed it in 1e16226e on 2026-08-20 — two days after v13 was cut on 2026-08-18 — so the fix never reached here. This applies the same one-line change.

| branch | `.github/env` | `go.mod` |
|---|---|---|
| main | `golang-version=1.26` | `go 1.26.6` |
| v13 (before) | `golang-version=1.25.6` | `go 1.26.5` |
| v13 (after) | `golang-version=1.26` | `go 1.26.5` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)