### PR TITLE
🐛 copy pre-release artifacts to releases.mondoo.com

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -280,3 +280,23 @@ jobs:
           event-type: update
           client-payload: >-
             {"version": ${{ toJSON(github.ref_name) }}}
+
+  # For pre-release tags (-alpha, -beta, -pre, -rc) the trigger-installer-release
+  # job above is skipped (gated on skip-publish != 'true'), so the installer's
+  # pkg_published_trigger_build_release chain never runs and pre-release artifacts
+  # don't end up on releases.mondoo.com. Call releasr's github_copy workflow
+  # explicitly so the deb/rpm/tarball assets from the GH pre-release show up at
+  # releases.mondoo.com/cnspec/<version>/ -- without repointing apt/yum "latest"
+  # to the pre-release (include-prereleases: false in releasr's `idx` step).
+  copy-prerelease-to-releases-mondoo-com:
+    name: Copy pre-release to releases.mondoo.com
+    if: ${{ needs.goreleaser.outputs.skip-publish == 'true' }}
+    needs: goreleaser
+    uses: mondoohq/releasr/.github/workflows/github_copy.yaml@main
+    with:
+      repository: cnspec
+      version: ${{ github.ref_name }}
+      bucket: releases-us.mondoo.io
+      include-prereleases: false
+      update-parent: true
+    secrets: inherit

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -292,6 +292,11 @@ jobs:
     name: Copy pre-release to releases.mondoo.com
     if: ${{ needs.goreleaser.outputs.skip-publish == 'true' }}
     needs: goreleaser
+    # id-token: write lets the called workflow auth to GCP via WIF.
+    # contents: read is required to download the releasr binary.
+    permissions:
+      contents: read
+      id-token: write
     uses: mondoohq/releasr/.github/workflows/github_copy.yaml@main
     with:
       repository: cnspec


### PR DESCRIPTION
## Summary

Symmetric to [mondoohq/mql#<num>](https://github.com/mondoohq/mql/pulls/philipbalinov): adds a `copy-prerelease-to-releases-mondoo-com` job that fires on pre-release tags (`-alpha`/`-beta`/`-pre`/`-rc`) and copies the GH release artifacts to `releases.mondoo.com/cnspec/<version>/` — without repointing apt/yum "latest".

## Why

The `trigger-installer-release` job in this file is gated on `needs.goreleaser.outputs.skip-publish != 'true'`, so for a pre-release tag it never fires. That means installer's `pkg_published_trigger_build_release.yaml` doesn't run either, and no `releasr release cp` happens. Pre-release artifacts (like v14.0.0-pre.1 today) never make it to `releases.mondoo.com`.

This PR closes that gap for pre-releases without touching the stable-release path.

## Change

New `copy-prerelease-to-releases-mondoo-com` job at the bottom of the file: `if: skip-publish == 'true'`, `needs: goreleaser`, calls `mondoohq/releasr/.github/workflows/github_copy.yaml@main` via `uses:` with `include-prereleases: false` and `update-parent: true`. `secrets: inherit` propagates the GCP + mergebot secrets releasr's workflow needs.

The existing `trigger-installer-release` and `mondoo-operator-cnspec` jobs are unchanged; they still handle the stable path.

## Why `uses:` and not `repository_dispatch:`

Explicit call chain — the copy job shows up as a downstream node under the goreleaser run in the Actions view, rather than a fire-and-forget dispatch landing on releasr. Synchronous, easier to debug, one unified log tree.

## Dependency

Needs [mondoohq/releasr#<num>](https://github.com/mondoohq/releasr/pulls/philipbalinov) merged first — that PR adds the `workflow_call:` trigger to `github_copy.yaml`.

## Test plan

- [ ] Land releasr PR first.
- [ ] Tag a `v14.0.0-pre.2` on cnspec main → verify the new job runs and succeeds → verify `curl -sI https://releases.mondoo.com/cnspec/14.0.0-pre.2/cnspec_14.0.0-pre.2_linux_amd64.tar.gz` returns 200.
- [ ] Verify apt `stable` component for cnspec still returns v13.35.2 (no latest demotion).
- [ ] Tag a stable `v13.35.3` (hypothetical) on the v13 branch → verify the new job **does NOT run**, and the existing installer chain still handles the stable copy.
