### PR TITLE
👷 ci: restore code generation on the v13 branch

### DIFF
--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Bump mql

--- a/.github/workflows/content-iac-tests.yaml
+++ b/.github/workflows/content-iac-tests.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       # https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Install GoReleaser

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Run golangci-lint

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Check go mod
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Run golangci-lint
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       # https://github.com/actions/cache/blob/main/examples.md#go---modules
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,15 @@ prep: prep/tools
 # or download them from the internet, so we are making sure the repo exists this way.
 # An alternative (especially for local development) is to soft-link a local copy of the repo
 # yourself. We don't pin submodules at this time, but we may want to check if they are up to date here.
+# This branch tracks mql v13, so it needs mql's v13 branch: mql main declares
+# its protos as go_package "go.mondoo.com/mql/...", and generating against
+# those emits imports this branch's go.mod (go.mondoo.com/mql/v13) does not
+# provide.
 prep/repos:
-	test -x mql || git clone https://github.com/mondoohq/mql.git mql
+	test -x mql || git clone -b v13 https://github.com/mondoohq/mql.git mql
 
 prep/repos/update: prep/repos
-	cd mql; git checkout main && git pull; cd -;
+	cd mql; git checkout v13 && git pull; cd -;
 
 prep/tools/windows:
 	go get google.golang.org/protobuf


### PR DESCRIPTION
The [Generated Code Test on #3571](https://github.com/mondoohq/cnspec/actions/runs/32834510465/job/97760274847) fails, and it fails for every PR targeting v13 — two independent drifts, both from main changes that landed after v13 was cut on 2026-08-18.

## 1. `make prep/repos` clones the wrong mql line

It clones mql's default branch, which is now the v14 line, and mql dropped the major suffix there:

| mql ref | `providers-sdk/v1/inventory/inventory.proto` |
|---|---|
| main | `go_package = "go.mondoo.com/mql/providers-sdk/v1/inventory"` |
| v13 | `go_package = "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"` |

So regeneration emits unversioned imports against a go.mod that provides `go.mondoo.com/mql/v13`:

```
../../../policy/cnspec_policy.pb.go:13:2: no required module provides package go.mondoo.com/mql/llx
```

Fixed by cloning and updating mql's `v13` branch. This branch is pinned to that major by definition, so the reference is not a guess.

## 2. `go-version: ">=…"` floats onto Go 1.27

With `check-latest`, `>=1.26` now resolves to **Go 1.27.0**, whose gofmt reflows doc comment lists, so every regenerated file differs from what is checked in:

```diff
-	//  1. Any critical/high issues won't generate a high score (upper limit)
+	// 1. Any critical/high issues won't generate a high score (upper limit)
```

main runs the same job on 1.26.7 and stays green: it dropped the `>=` across these eight workflows in 1e16226e on 2026-08-20, alongside the `.github/env` bump this branch picked up in #3569. Same change applied here, 11 occurrences.

## Verification

The check is `push`-triggered on `**.go`/`**.proto`/`go.mod`, so a CI-only PR never runs it. Verified on a throwaway branch carrying both commits plus a no-op `.go` edit — [run 32836185677](https://github.com/mondoohq/cnspec/actions/runs/32836185677) **passed**, on `go1.26.7` and `git clone -b v13`, with all three `git diff --exit-code` gates clean. Branch deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)