### PR TITLE
👷 ci: name the mql branch code generation reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,19 @@ prep: prep/tools
 # or download them from the internet, so we are making sure the repo exists this way.
 # An alternative (especially for local development) is to soft-link a local copy of the repo
 # yourself. We don't pin submodules at this time, but we may want to check if they are up to date here.
+# Which mql line code generation reads. cnspec's *.pb.go bake in the
+# go_package of mql's protos, so this has to be the mql branch this cnspec
+# branch imports, or generation emits imports go.mod does not provide.
+# main tracks mql main. A support branch cut from here has to set this to
+# its own major's mql branch: mql no longer carries the major in its module
+# path (mondoohq/mql#10234), so nothing in the tree can infer it.
+MQL_BRANCH ?= main
+
 prep/repos:
-	test -x mql || git clone https://github.com/mondoohq/mql.git mql
+	test -x mql || git clone -b $(MQL_BRANCH) https://github.com/mondoohq/mql.git mql
 
 prep/repos/update: prep/repos
-	cd mql; git checkout main && git pull; cd -;
+	cd mql; git checkout $(MQL_BRANCH) && git pull; cd -;
 
 prep/tools/windows:
 	go get google.golang.org/protobuf


### PR DESCRIPTION
Follow-up to #3572, which fixed this on v13 by naming its branch. **The first version of this PR derived the branch from the mql import path in go.mod. That was wrong — see below — and it has been replaced.**

## The problem

`make prep/repos` clones mql's default branch. mql's protos carry their major in `go_package`, so generating against the wrong line emits imports the branch's go.mod does not provide:

```
../../../policy/cnspec_policy.pb.go:13:2: no required module provides package go.mondoo.com/mql/llx
```

That broke every PR to v13 after the split, including the [v13.36.0 bump](https://github.com/mondoohq/cnspec/actions/runs/32834510465/job/97760274847). A support branch cut from main would inherit the same bug from here.

## Why it cannot be derived

mql removed the major from its module path permanently — mondoohq/mql#10234: *"we decided that this version indicator doesn't really provide much value anymore… we can avoid one annoying (potentially erroneous) update step every 6 months"*. cnspec followed in 1e16226e.

v13 carries `module go.mondoo.com/mql/v13` only because it was branched on 2026-08-18, two days before that change landed on 2026-08-20; its go.mod has not been touched since 2026-08-16. Nothing restores a suffix when a major is frozen.

So reading the major off the import path resolves correctly for v13 and falls back to `main` for v14 and everything after — cloning the next development line into a frozen branch, silently. That is the original bug with a fix's face on it.

## What this does instead

Names it, in one greppable place to change when a major is cut, and overridable for local work against another line:

```make
MQL_BRANCH ?= main
```

```
make prep/repos MQL_BRANCH=v13
```

This does not make the next branch cut correct by itself — it makes the thing that has to change visible, and gives the branch a knob instead of an assumption. The Generated Code Test remains the backstop that catches it if it is missed.

## Verification

`make -n prep/repos` resolves to `git clone -b main …` — byte-identical to the command [run 32837378535](https://github.com/mondoohq/cnspec/actions/runs/32837378535) already exercised green (that run tested this same resolved clone, from the earlier revision of this PR). With `MQL_BRANCH=v13` it resolves to `git clone -b v13 …`.

v13 keeps its hardcode from #3572; it is correct and frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)