### PR TITLE
⭐ UploadResourcesData: resource recording rides the scan upload only

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -446,15 +446,18 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		Parallelism:   viper.GetInt("parallelism"),
 	}
 
-	// FIXME: DEPRECATED, remove in v12.0 and make this the default for all
-	// use-cases where we have upstream recording enabled vv
-	// Instead of depending on the feature-flag, we look at the config
-	if conf.Features.IsActive(mql.StoreResourcesData) {
+	// Resource recording rides the uploaded scan database: the server
+	// advertises UploadResourcesData per scope (ScanParameters), and the
+	// recorded data is delivered only inside the UploadResultsV2 scandb —
+	// recording without v2 would be pure cost with no delivery path, so
+	// both features gate it. StoreResourcesData (the predecessor) is
+	// retired: it needed a resolved-policy second key and sent resources
+	// through the legacy StoreResults RPC.
+	if conf.Features.IsActive(mql.UploadResourcesData) && conf.Features.IsActive(mql.UploadResultsV2) {
 		if err = runtime.EnableResourcesRecording(); err != nil {
 			log.Fatal().Err(err).Msg("failed to enable resources recording")
 		}
 	}
-	// ^^
 
 	// if users want to get more information on available output options,
 	// print them before executing the scan

--- a/cli/reporter/cli_reporter.go
+++ b/cli/reporter/cli_reporter.go
@@ -114,14 +114,12 @@ func (r *Reporter) WithOutput(out io.Writer) *Reporter {
 }
 
 func (r *Reporter) WriteReport(ctx context.Context, data *policy.ReportCollection) error {
-	features := mql.GetFeatures(ctx)
 	switch r.Conf.format {
 	case FormatCompact, FormatSummary, FormatFull:
 		rr := &defaultReporter{
-			Reporter:                r,
-			output:                  r.out,
-			data:                    data,
-			isStoreResourcesEnabled: features.IsActive(mql.StoreResourcesData),
+			Reporter: r,
+			output:   r.out,
+			data:     data,
 		}
 		return rr.print()
 	case FormatReport:

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -36,9 +36,6 @@ type defaultReporter struct {
 	output io.Writer
 	data   *policy.ReportCollection
 
-	// indicates if the StoreResourcesData MQL feature is enabled
-	isStoreResourcesEnabled bool
-
 	// tracks whether any section of the current asset's body (controls,
 	// queries, checks, risks, vulnerabilities) has already printed content
 	// since the asset header. It is used to emit exactly one blank line
@@ -249,7 +246,13 @@ func (r *defaultReporter) printSummary(orderedAssets []assetMrnName) {
 			r.out("See more scan results and asset relationships on the Mondoo App: ")
 			r.out(url + NewLineCharacter)
 
-			if len(orderedAssets) == 1 && orderedAssets[0].Mrn != "" && r.isStoreResourcesEnabled {
+			// The MRN is the handle for follow-up queries against the
+			// platform (resources, findings, exports) — worth printing for
+			// any single-asset upstream scan, not just resource-recording
+			// ones. This used to be gated on the StoreResourcesData
+			// feature, which threaded a flag through the reporter for one
+			// line of output.
+			if len(orderedAssets) == 1 && orderedAssets[0].Mrn != "" {
 				r.out("Asset MRN: " + orderedAssets[0].Mrn + NewLineCharacter)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7
-	go.mondoo.com/mql v0.0.0-20260825090451-0161b9d5a678
+	go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0
@@ -334,7 +334,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
-	go.mondoo.com/mql/v13 v13.36.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.45.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1096,10 +1096,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6kp6p8QjIHBGeAQ0cNKv/BfUCP0=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260825090451-0161b9d5a678 h1:ISmg/8JctSL7yf03hTnt71rqikaT6/neCGB7gpupcmY=
-go.mondoo.com/mql v0.0.0-20260825090451-0161b9d5a678/go.mod h1:jYzJl6OsYEp5Dmg4wNtqCVlfNSu0odz1FX0fofCSiVg=
-go.mondoo.com/mql/v13 v13.36.0 h1:2quYTSMNvERkZyZNzOeAeGEGl8JHM92JskW0etgniyo=
-go.mondoo.com/mql/v13 v13.36.0/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
+go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66 h1:hE5MsVxNUbViaimVHtUABKdQwxeHRo/zkHzc+4nUWOk=
+go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66/go.mod h1:jYzJl6OsYEp5Dmg4wNtqCVlfNSu0odz1FX0fofCSiVg=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1196,7 +1196,16 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 		return nil, err
 	}
 
-	if mql.GetFeatures(s.job.Ctx).IsActive(mql.StoreResourcesData) && resolvedPolicy.HasFeature(policy.ServerFeature_STORE_RESOURCES_DATA) {
+	// UploadResourcesData delivers resource recordings inside the uploaded
+	// scan database only: under UploadResultsV2, s.services is the local
+	// sqlite-backed service (WithServices below), so this StoreResults
+	// writes into the scandb that gets uploaded — never an upstream RPC.
+	// Without v2 there is no delivery path, so nothing is stored. The old
+	// StoreResourcesData two-key gate (client feature + a
+	// ServerFeature_STORE_RESOURCES_DATA stamp on the resolved policy) and
+	// its legacy upstream StoreResults send are retired with it.
+	feats := mql.GetFeatures(s.job.Ctx)
+	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) {
 		log.Info().Str("mrn", s.job.Asset.Mrn).Msg("store resources for asset")
 		recording := s.Runtime.Recording()
 		data, ok := recording.GetAssetData(s.job.Asset.Mrn)


### PR DESCRIPTION
Consumes mql's `UploadResourcesData` feature (mondoohq/mql#10406, merged) and retires the `StoreResourcesData` mechanism. 
**One key instead of two**: recording (`EnableResourcesRecording`) and storing now gate on `UploadResourcesData` + `UploadResultsV2` from `ScanParameters.enabled_features` alone. The `ServerFeature_STORE_RESOURCES_DATA` resolved-policy second key — which no environment ever stamped, so the old feature never actually ran anywhere — is no longer consulted.

**Bucket upload only**: under `UploadResultsV2`, `WithServices` binds the local sqlite-backed services, so the `StoreResults` call writes resource rows straight into the scan database that gets uploaded. Without v2 there is no delivery path and nothing is recorded — the legacy upstream `StoreResults` RPC send is gone. Old deployed clients are unaffected by design: they gate on the old feature name, which new servers stop emitting, and unknown names are dropped with a warning.

**Reporter cleanup** (from review discussion): the `isStoreResourcesEnabled` bool threaded a feature flag through the reporter to gate a single `Asset MRN:` line. Both the bool and the gate are removed — the line now prints for every single-asset upstream scan, since the MRN is the follow-up-query handle regardless of resource recording.

**Pin**: `go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66` (mql main head containing the merged feature, on the v14 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)