### PR TITLE
🐛 arm resources recording where the feature set is final

### DIFF
--- a/apps/cnspec/cmd/scan.go
+++ b/apps/cnspec/cmd/scan.go
@@ -446,18 +446,11 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		Parallelism:   viper.GetInt("parallelism"),
 	}
 
-	// Resource recording rides the uploaded scan database: the server
-	// advertises UploadResourcesData per scope (ScanParameters), and the
-	// recorded data is delivered only inside the UploadResultsV2 scandb —
-	// recording without v2 would be pure cost with no delivery path, so
-	// both features gate it. StoreResourcesData (the predecessor) is
-	// retired: it needed a resolved-policy second key and sent resources
-	// through the legacy StoreResults RPC.
-	if conf.Features.IsActive(mql.UploadResourcesData) && conf.Features.IsActive(mql.UploadResultsV2) {
-		if err = runtime.EnableResourcesRecording(); err != nil {
-			log.Fatal().Err(err).Msg("failed to enable resources recording")
-		}
-	}
+	// Resource recording (UploadResourcesData) is NOT armed here: the
+	// feature usually arrives server-driven via ScanParameters, which this
+	// CLI setup never sees. The per-asset scanner arms it against the final
+	// feature set instead (localAssetScanner.run) — the recorded rows are
+	// delivered inside the uploaded scan database (UploadResultsV2 only).
 
 	// if users want to get more information on available output options,
 	// print them before executing the scan

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7
-	go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72
+	go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7
-	go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66
+	go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7
-	go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48
+	go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7
-	go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4
+	go.mondoo.com/mql v0.0.0-20260826072927-48896753de9b
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1096,10 +1096,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6kp6p8QjIHBGeAQ0cNKv/BfUCP0=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48 h1:QWNNrrkBcFawRfVzY/ZbxlaqXG1RyCS2l1R+B4ND0S8=
-go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
-go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4 h1:oaLTFBdvsH7GQXUaG2TK2Kitu91RzIoHRsDk+fQPaSg=
-go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
+go.mondoo.com/mql v0.0.0-20260826072927-48896753de9b h1:xyx/wszeFIQlXpjl5pNQNd+M2SuHy0TI4wSHgI/SEvw=
+go.mondoo.com/mql v0.0.0-20260826072927-48896753de9b/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -1096,8 +1096,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6kp6p8QjIHBGeAQ0cNKv/BfUCP0=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66 h1:hE5MsVxNUbViaimVHtUABKdQwxeHRo/zkHzc+4nUWOk=
-go.mondoo.com/mql v0.0.0-20260825153339-973e11b0ff66/go.mod h1:jYzJl6OsYEp5Dmg4wNtqCVlfNSu0odz1FX0fofCSiVg=
+go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72 h1:QatN7z+gAbBThIgBkqzDGT6LePZehIQ92wdUqmU4PD8=
+go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -1098,6 +1098,8 @@ go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6k
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48 h1:QWNNrrkBcFawRfVzY/ZbxlaqXG1RyCS2l1R+B4ND0S8=
 go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
+go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4 h1:oaLTFBdvsH7GQXUaG2TK2Kitu91RzIoHRsDk+fQPaSg=
+go.mondoo.com/mql v0.0.0-20260826064404-12d6f1067aa4/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -1096,8 +1096,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6kp6p8QjIHBGeAQ0cNKv/BfUCP0=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72 h1:QatN7z+gAbBThIgBkqzDGT6LePZehIQ92wdUqmU4PD8=
-go.mondoo.com/mql v0.0.0-20260826062202-df7086cb6e72/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
+go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48 h1:QWNNrrkBcFawRfVzY/ZbxlaqXG1RyCS2l1R+B4ND0S8=
+go.mondoo.com/mql v0.0.0-20260826064114-202d9236ee48/go.mod h1:82159K/f8SrtGGN9dOsKslXLZSz23ODcdu2Nx9kHFb0=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1196,34 +1196,17 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 	// (Null by default) before this point. This is the one site that sees
 	// both the final feature set and the final runtime.
 	feats := mql.GetFeatures(s.job.Ctx)
-	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) &&
-		s.job.Asset != nil && len(s.job.Asset.Connections) > 0 {
-		// Mount an in-memory recording if none is mounted — the same
-		// Null-only swap EnableResourcesRecording performs, done through
-		// the llx.Runtime interface so a recording the user mounted (e.g.
-		// --record) is never clobbered.
-		if _, isNull := s.Runtime.Recording().(recording.Null); isNull {
-			rec, err := recording.NewWithFile("", recording.RecordingOptions{
-				DoRecord:  true,
-				DoNotSave: true,
-			})
-			if err != nil {
-				log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not enable resources recording")
-			} else if err := s.Runtime.SetRecording(rec); err != nil {
-				log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not set resources recording")
-			}
+	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) && s.job.runtime != nil {
+		// EnsureResourcesRecording mounts an in-memory recording (Null-only
+		// swap — a --record recording is never clobbered) AND registers the
+		// job asset with it, which is what makes enabling after connect
+		// work: the recording machinery's invariants live behind that one
+		// call. The job asset is passed because it carries the
+		// platform-assigned MRN the store step reads back by. job.runtime
+		// is the same runtime as s.Runtime, just concretely typed.
+		if err := s.job.runtime.EnsureResourcesRecording(s.job.Asset); err != nil {
+			log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not enable resources recording")
 		}
-		// The runtime connected BEFORE this recording existed, so its asset
-		// was registered with the previous (Null) recording: EnsureAsset
-		// normally runs at connect time, AddData silently drops rows for
-		// connections the recording does not know, and GetAssetData at the
-		// store step looks up by the platform-assigned asset MRN — which
-		// only the JOB asset carries (the connection asset predates MRN
-		// assignment). Register the job asset so the recording is indexed
-		// by both the connection id (conf.Id) writes use and the MRN the
-		// store reads back. The providerID/connectionID arguments are
-		// connection metadata only — EnsureAsset indexes by conf.Id.
-		s.Runtime.Recording().EnsureAsset(s.job.Asset, "", 0, s.job.Asset.Connections[0])
 	}
 
 	if err := s.prepareAsset(); err != nil {

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1187,6 +1187,38 @@ type localAssetScanner struct {
 // case of an error, the results may contain partial results. The error is only returned if the scan failed to run not
 // when individual policies failed.
 func (s *localAssetScanner) run() (*AssetReport, error) {
+	// Resource recording must be armed BEFORE any query executes — the
+	// recording captures resource data as the policy run touches it. Armed
+	// here rather than at CLI setup because UploadResourcesData usually
+	// arrives server-driven (ScanParameters → withServerFeatures) on the
+	// job ctx, which does not exist when the CLI parses its local config —
+	// and the sync batcher stamps runtimes with the scanner-level recording
+	// (Null by default) before this point. This is the one site that sees
+	// both the final feature set and the final runtime.
+	feats := mql.GetFeatures(s.job.Ctx)
+	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) {
+		if rt, ok := s.Runtime.(*providers.Runtime); ok {
+			if err := rt.EnableResourcesRecording(); err != nil {
+				log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not enable resources recording")
+			} else if rt.Provider != nil && rt.Provider.Connection != nil &&
+				s.job.Asset != nil && len(s.job.Asset.Connections) > 0 {
+				// The runtime connected BEFORE the recording was armed, so
+				// its asset was registered with the old Null recording:
+				// EnsureAsset runs at connect time, AddData silently drops
+				// rows for connections the recording does not know, and
+				// GetAssetData at the store step looks up by the
+				// platform-assigned asset MRN — which only the JOB asset
+				// carries (the connection asset predates MRN assignment).
+				// Register the job asset, so the recording is indexed by
+				// both the connection id and the MRN the store reads back.
+				rt.Recording().EnsureAsset(s.job.Asset, rt.Provider.Instance.ID,
+					rt.Provider.Connection.Id, s.job.Asset.Connections[0])
+			}
+		} else {
+			log.Warn().Str("asset", s.job.Asset.Mrn).Msg("cannot enable resources recording on this runtime type")
+		}
+	}
+
 	if err := s.prepareAsset(); err != nil {
 		return nil, err
 	}
@@ -1204,7 +1236,6 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 	// StoreResourcesData two-key gate (client feature + a
 	// ServerFeature_STORE_RESOURCES_DATA stamp on the resolved policy) and
 	// its legacy upstream StoreResults send are retired with it.
-	feats := mql.GetFeatures(s.job.Ctx)
 	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) {
 		log.Info().Str("mrn", s.job.Asset.Mrn).Msg("store resources for asset")
 		recording := s.Runtime.Recording()

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1196,27 +1196,34 @@ func (s *localAssetScanner) run() (*AssetReport, error) {
 	// (Null by default) before this point. This is the one site that sees
 	// both the final feature set and the final runtime.
 	feats := mql.GetFeatures(s.job.Ctx)
-	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) {
-		if rt, ok := s.Runtime.(*providers.Runtime); ok {
-			if err := rt.EnableResourcesRecording(); err != nil {
+	if feats.IsActive(mql.UploadResourcesData) && feats.IsActive(mql.UploadResultsV2) &&
+		s.job.Asset != nil && len(s.job.Asset.Connections) > 0 {
+		// Mount an in-memory recording if none is mounted — the same
+		// Null-only swap EnableResourcesRecording performs, done through
+		// the llx.Runtime interface so a recording the user mounted (e.g.
+		// --record) is never clobbered.
+		if _, isNull := s.Runtime.Recording().(recording.Null); isNull {
+			rec, err := recording.NewWithFile("", recording.RecordingOptions{
+				DoRecord:  true,
+				DoNotSave: true,
+			})
+			if err != nil {
 				log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not enable resources recording")
-			} else if rt.Provider != nil && rt.Provider.Connection != nil &&
-				s.job.Asset != nil && len(s.job.Asset.Connections) > 0 {
-				// The runtime connected BEFORE the recording was armed, so
-				// its asset was registered with the old Null recording:
-				// EnsureAsset runs at connect time, AddData silently drops
-				// rows for connections the recording does not know, and
-				// GetAssetData at the store step looks up by the
-				// platform-assigned asset MRN — which only the JOB asset
-				// carries (the connection asset predates MRN assignment).
-				// Register the job asset, so the recording is indexed by
-				// both the connection id and the MRN the store reads back.
-				rt.Recording().EnsureAsset(s.job.Asset, rt.Provider.Instance.ID,
-					rt.Provider.Connection.Id, s.job.Asset.Connections[0])
+			} else if err := s.Runtime.SetRecording(rec); err != nil {
+				log.Warn().Err(err).Str("asset", s.job.Asset.Mrn).Msg("could not set resources recording")
 			}
-		} else {
-			log.Warn().Str("asset", s.job.Asset.Mrn).Msg("cannot enable resources recording on this runtime type")
 		}
+		// The runtime connected BEFORE this recording existed, so its asset
+		// was registered with the previous (Null) recording: EnsureAsset
+		// normally runs at connect time, AddData silently drops rows for
+		// connections the recording does not know, and GetAssetData at the
+		// store step looks up by the platform-assigned asset MRN — which
+		// only the JOB asset carries (the connection asset predates MRN
+		// assignment). Register the job asset so the recording is indexed
+		// by both the connection id (conf.Id) writes use and the MRN the
+		// store reads back. The providerID/connectionID arguments are
+		// connection metadata only — EnsureAsset indexes by conf.Id.
+		s.Runtime.Recording().EnsureAsset(s.job.Asset, "", 0, s.job.Asset.Connections[0])
 	}
 
 	if err := s.prepareAsset(); err != nil {


### PR DESCRIPTION
Follow-up to #3574: `UploadResourcesData` never actually recorded anything. Found debugging a live scan against a server advertising the feature — the store gate passed and logged, yet every uploaded scandb carried `resources=0`.

**Three stacked causes**, each verified live:

1. **Arming happened too early.** `EnableResourcesRecording` ran at CLI setup against local `conf.Features` — but the feature usually arrives server-driven (`ScanParameters` → `withServerFeatures`) onto the scan context, which doesn't exist at CLI setup. So the runtime kept its `Null` recording for the whole scan. (Latent in the old `StoreResourcesData` flow too — consistent with it never having worked server-driven.)
2. **Arming late needs re-registration.** The runtime connects before the recording exists, registering its connection with the old Null recording — and `recording.AddData` silently drops rows for connections it doesn't know.
3. **The MRN index was missing.** `GetAssetData` at the store step looks up by the platform-assigned asset MRN, which only the *job* asset carries — the connection asset predates MRN assignment.

**Fix**: the enable moves into `localAssetScanner.run()` — the one site that sees both the final feature set (local + server-activated) and the final runtime — and calls mql's new `Runtime.EnsureResourcesRecording(asset)` (mondoohq/mql#10470), which mounts the recording (Null-only swap, `--record` never clobbered) and registers the identity-bearing asset in one call, keeping the recording machinery's invariants behind mql's API. No concrete-type cast and no capability interface on this side: `AssetJob.runtime` already holds the concretely-typed runtime the scanner was built from. The CLI-setup block is replaced with a comment pointing here.

**Depends on**: mondoohq/mql#10470 (pinned at its branch head; repin to the merge sha once it lands).

**Verified**: live scan against edge — `checksummedRows` went `resources=0` → `resources=3175`, real recorded resource rows in the uploaded scandb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)