### PR TITLE
🐛 content: scope the zone-wide DNS checks to the zone apex

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.5.1
+    version: 1.6.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -35,6 +35,20 @@ policies:
       # The root cause is upstream (initDns substitutes an empty fqdn for an IP
       # target); this guard is what protects users until they pick that up, since
       # the network provider versions independently of cnspec.
+      #
+      # The four checks carrying `dns.fqdn == dns.zone.fqdn` are zone-wide, and
+      # that filter keeps them on the one name able to answer them. DNSKEY, NS
+      # and SOA records exist at a zone apex and nowhere else inside the zone,
+      # so asking www.example.com whether its zone is signed, or how many
+      # nameservers serve it, reads empty and fails a name that has nothing to
+      # misconfigure. Scanning an apex surfaces the `www` host as an asset of
+      # its own, which is where those failures were reported.
+      #
+      # The apex is established by delegation (`dns.zone`) rather than by the
+      # public suffix list, so a delegated subdomain is audited as the zone it
+      # is: `cs.cmu.edu` has its own nameservers and its own signing state, and
+      # an eTLD+1 test would skip it as a subdomain of `cmu.edu`. This needs
+      # network provider 13.3.1 or newer, which is where `dns.zone` lands.
       - title: Networking
         filters: |
           asset.family.contains('network') && dns.fqdn != empty
@@ -52,7 +66,7 @@ queries:
   - uid: mondoo-dns-security-no-cname-for-root-domain
     title: Ensure no CNAME is used for root domain
     impact: 60
-    filters: domainName.fqdn == domainName.effectiveTLDPlusOne
+    filters: dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
@@ -143,6 +157,7 @@ queries:
   - uid: mondoo-dns-security-no-ip-for-ns-mx-records
     title: Ensure NS and MX records are not pointing to IP addresses
     impact: 75
+    filters: dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
@@ -410,6 +425,7 @@ queries:
   - uid: mondoo-dns-security-dnssec-enabled
     title: Ensure DNSSEC is enabled
     impact: 75
+    filters: dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
@@ -620,6 +636,7 @@ queries:
   - uid: mondoo-dns-security-ns-redundancy
     title: Ensure at least two NS records exist
     impact: 60
+    filters: dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08


### PR DESCRIPTION
## The bug

Four checks in `mondoo-dns-security` ask questions about a **zone**, but evaluate against whatever name is scanned. DNSKEY, NS and SOA records exist at a zone apex and nowhere else inside the zone, so on a non-apex name those checks read an **empty record set** — and an empty list fails `!= empty` and `.length >= 2` while passing `.all()` and `.none()` vacuously.

The result is a confident wrong answer on any name that isn't an apex. Reproduced against live DNS with the policy as it stands, on `www.mondoo.com`:

```
! Error:      Ensure at least two NS records exist
✕ HIGH (75):  Ensure DNSSEC is enabled
✕ HIGH (75):  Ensure NS and MX records are not pointing to IP addresses
```

`mondoo.com` is signed, has four nameservers, and passes all three. `www.mondoo.com` has no DNSKEY and no NS of its own — nothing to misconfigure, and nothing the checks can read.

## The fix

Filter the four zone-wide checks on `dns.fqdn == dns.zone.fqdn`, so each runs once, on the one name able to answer it.

After the change:

| target | zone-wide checks | name-level checks |
|---|---|---|
| `mondoo.com` | 4, all pass | 4, all pass |
| `www.mondoo.com` | **none** | 4, all pass |

## Why not `effectiveTLDPlusOne`

`no-cname-for-root-domain` already carried `domainName.fqdn == domainName.effectiveTLDPlusOne`, and copying that onto the other three is the obvious one-line fix. It answers the wrong question.

The eTLD+1 is the *registrable* domain, from the public suffix list. The name that publishes DNSKEY, NS and SOA is the apex of the *served* zone. They diverge wherever a subdomain is delegated:

| name | `dns.zone.fqdn` | `effectiveTLDPlusOne` |
|---|---|---|
| `www.mondoo.com` | `mondoo.com` | `mondoo.com` |
| `cs.cmu.edu` | `cs.cmu.edu` | `cmu.edu` |
| `www.cs.cmu.edu` | `cs.cmu.edu` | `cmu.edu` |
| `eecs.berkeley.edu` | `eecs.berkeley.edu` | `berkeley.edu` |

`cs.cmu.edu` is a zone with its own nameservers and its own signing state. An eTLD+1 filter skips it as a subdomain of `cmu.edu`, trading the reported false positive for a false negative on exactly the zones most likely to be misconfigured. Scanned with this change it is audited as the zone it is, and reports a **true** finding that would otherwise stay hidden:

```
cs.cmu.edu        ✓ Ensure at least two NS records exist
                  ✕ HIGH (75):  Ensure DNSSEC is enabled
www.cs.cmu.edu    (no zone-wide checks)
```

That is also why `no-cname-for-root-domain` **moves onto the same test**: a zone apex is where a CNAME cannot coexist with SOA and NS, and that is the served zone, not the registrable domain.

## Requires network provider 13.3.1

`dns.zone` landed in mondoohq/mql#10542 (merged). It reports the apex by walking up to the closest enclosing name that answers with NS records of its own, and is null for a name in no zone — including a scan target given as an IP address, which makes it subsume the `dns.fqdn != empty` guard for these four checks. That group filter stays, since it also covers the four name-level checks.

⚠️ **The provider is merged but not yet released** — `providers/network/config/config.go` still reads `13.3.0`. Until 13.3.1 ships, `cnspec policy lint` fails against the older provider:

```
bundle-compile-error  error  ...  cannot find field 'zone' in dns
FTL invalid policy bundle(s)
```

So `make test/content/lint` will be red on this PR until the provider release lands, and green immediately after. That is the intended gate rather than a problem to work around: the PR turns green exactly when it becomes safe to merge. Verified locally against a provider built from mql `main` — lint passes, and the scan results in the tables above are from that build.

## Version

Policy `1.5.1` → `1.6.0`: which assets get scored changes, so it is not a patch. Check UIDs, impacts and compliance tags are untouched.