### PR TITLE
🐛 content: fix 13 broken live-AWS checks in mondoo-aws-security

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -9255,7 +9255,7 @@ queries:
       asset.platform == "aws-ebs-volume" &&
       aws.ec2.volume.state != /deleting|deleted|error/ &&
       aws.ec2.volume.encrypted == true
-    mql: aws.ec2.volume.sseType == "sse-kms"
+    mql: aws.ec2.volume.sseType == "sse-kms" || aws.ec2.volume.sseType == empty && aws.ec2.volume.kmsKey != null
   - uid: mondoo-aws-security-ec2-ebs-kms-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == /^aws_(ebs_volume|instance|launch_template)$/)
     mql: |
@@ -10043,7 +10043,7 @@ queries:
   - uid: mondoo-aws-security-elb-ssl-listener-aws
     filters: asset.platform == "aws-elb-loadbalancer"
     mql: |
-      aws.elb.loadbalancer.listenerDescriptions.all(Protocol == "HTTPS" || Protocol == "HTTP" && DefaultActions.any(Type == "redirect" && RedirectConfig["Protocol"] == "HTTPS"))
+      aws.elb.loadbalancer.listeners.all(protocol == "HTTPS" || protocol == "HTTP" && defaultActions.any(_["Type"] == "redirect" && _["RedirectConfig"]["Protocol"] == "HTTPS"))
   - uid: mondoo-aws-security-elb-ssl-listener-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lb_listener")
     mql: |
@@ -13374,7 +13374,8 @@ queries:
   - uid: mondoo-aws-security-api-gw-tls-aws
     filters: asset.platform == "aws-gateway-restapi"
     mql: |
-      aws.apigateway.restapi.securityPolicy == "TLS_1_2"
+      aws.apigateway.restapi.securityPolicy == "TLS_1_2" ||
+      aws.apigateway.restapi.securityPolicy == /^SecurityPolicy_TLS1[23]/
   - uid: mondoo-aws-security-api-gw-tls-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_api_gateway_domain_name")
     mql: |
@@ -15326,8 +15327,8 @@ queries:
   - uid: mondoo-aws-security-eks-cluster-logging-enabled-aws
     filters: asset.platform == "aws-eks-cluster"
     mql: |
-      aws.eks.cluster.logging['clusterLogging'] != null
-      aws.eks.cluster.logging['clusterLogging'].any(_['enabled'] == true)
+      aws.eks.cluster.logging['ClusterLogging'] != null
+      aws.eks.cluster.logging['ClusterLogging'].any(_['Enabled'] == true)
   - uid: mondoo-aws-security-eks-cluster-logging-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_eks_cluster") || asset.platform == "terraform-hcl" && terraform.blocks.contains(type == "module" && arguments["source"] != null && arguments["source"] == /terraform-aws-eks|terraform-aws-modules\/eks\/aws/)
     mql: |
@@ -17829,7 +17830,7 @@ queries:
         title: AWS Documentation - EFS controls
   - uid: mondoo-aws-security-efs-backup-enabled-aws
     filters: asset.platform == "aws-efs-filesystem"
-    mql: aws.efs.filesystem.backupPolicy["Status"] == "ENABLED"
+    mql: aws.efs.filesystem.backupPolicy["BackupPolicy"]["Status"] == "ENABLED"
   - uid: mondoo-aws-security-efs-backup-enabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_efs_file_system")
     mql: |
@@ -18719,7 +18720,7 @@ queries:
         title: AWS Documentation - Security in AWS CodeBuild
   - uid: mondoo-aws-security-codebuild-no-privileged-mode-aws
     filters: asset.platform == "aws-codebuild-project"
-    mql: aws.codebuild.project.environment["privilegedMode"] != true
+    mql: aws.codebuild.project.environment["PrivilegedMode"] != true
   - uid: mondoo-aws-security-codebuild-no-privileged-mode-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -18933,11 +18934,11 @@ queries:
   - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
     filters: asset.platform == "aws-codebuild-project"
     mql: |
-      aws.codebuild.project.environment["environmentVariables"]
+      aws.codebuild.project.environmentVariables
         .where(_["type"] == "PLAINTEXT")
         .none(_["name"] == /(?i)(PASSWORD|SECRET|KEY|TOKEN|CREDENTIAL)/)
-      aws.codebuild.project.environment["imagePullCredentialsType"] == "CODEBUILD" ||
-      aws.codebuild.project.environment["imagePullCredentialsType"] == "SERVICE_ROLE"
+      aws.codebuild.project.environmentImagePullCredentialsType == "CODEBUILD" ||
+      aws.codebuild.project.environmentImagePullCredentialsType == "SERVICE_ROLE"
   - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_codebuild_project")
     mql: |
@@ -23786,8 +23787,8 @@ queries:
   - uid: mondoo-aws-security-redshift-cluster-require-ssl-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: |
-      aws.redshift.cluster.parameters.where(_['ParameterName'] == "require_ssl").all(
-        _['ParameterValue'] == "true"
+      aws.redshift.cluster.parameters.one(
+        _['ParameterName'] == "require_ssl" && _['ParameterValue'] == "true"
       )
   - uid: mondoo-aws-security-redshift-cluster-require-ssl-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_redshift_parameter_group")
@@ -24355,7 +24356,7 @@ queries:
       aws.guardduty.detectors.length > 0 &&
       aws.guardduty.detectors.all(
         featureConfigurations.where(
-          name == /S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING/
+          name == /^(S3_DATA_EVENTS|EKS_AUDIT_LOGS|EBS_MALWARE_PROTECTION|RDS_LOGIN_EVENTS|LAMBDA_NETWORK_LOGS|RUNTIME_MONITORING)$/
         ).all(status == "ENABLED")
       )
   - uid: mondoo-aws-security-guardduty-all-features-enabled-terraform-hcl
@@ -38490,7 +38491,7 @@ queries:
         title: AWS Security Hub Controls Reference
   - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-aws
     filters: asset.platform == "aws-redshift-cluster"
-    mql: aws.redshift.cluster.maintenanceTrackName == "Current"
+    mql: aws.redshift.cluster.maintenanceTrackName.downcase == "current"
   - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-cloudformation
     filters: asset.platform == "cloudformation" && cloudformation.template.resources.contains(type == "AWS::Redshift::Cluster")
     mql: |
@@ -43757,7 +43758,7 @@ queries:
   - uid: mondoo-aws-security-mq-audit-logging-aws
     filters: |
       asset.platform == "aws-mq-broker" &&
-      aws.mq.broker.engineType == "ACTIVEMQ"
+      aws.mq.broker.engineType == /(?i)^activemq$/
     mql: |
       aws.mq.broker.auditLogsEnabled == true
   - uid: mondoo-aws-security-mq-audit-logging-terraform-hcl
@@ -50179,8 +50180,8 @@ queries:
     filters: asset.platform == "aws-lambda-function"
     mql: |
       aws.lambda.function.policy == empty ||
-      aws.lambda.function.policy.Statement.where(Effect == "Allow" && Principal['Service'] != empty).all(
-        Condition.string.contains("SourceArn") || Condition.string.contains("SourceAccount")
+      aws.lambda.function.policyStatements.where(effect == "Allow" && principals["Service"] != empty).all(
+        conditions.values.any(_.keys.any(_ == /SourceArn|SourceAccount/))
       )
   - uid: mondoo-aws-security-lambda-source-arn-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_lambda_permission")
@@ -60133,8 +60134,9 @@ queries:
   - uid: mondoo-aws-security-vpc-dhcp-custom-dns-aws
     filters: asset.platform == "aws-vpc"
     mql: |
-      aws.vpc.dhcpOptions.configurations.where(key == "domain-name-servers").all(
-        values.none(_ == "AmazonProvidedDNS")
+      aws.vpc.dhcpOptions.configurations.one(_["Key"] == "domain-name-servers")
+      aws.vpc.dhcpOptions.configurations.where(_["Key"] == "domain-name-servers").all(
+        _["Values"].none(_["Value"] == "AmazonProvidedDNS")
       )
   - uid: mondoo-aws-security-vpc-dhcp-custom-dns-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_vpc_dhcp_options")

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -38327,7 +38327,9 @@ queries:
         title: AWS KMS Customer Managed Keys
   - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-aws
     filters: asset.platform == "aws-redshift-cluster"
-    mql: aws.redshift.cluster.kmsKey { metadata.KeyManager == "CUSTOMER" }
+    mql: |
+      aws.redshift.cluster.kmsKey != null
+      aws.redshift.cluster.kmsKey.metadata.KeyManager == "CUSTOMER"
   - uid: mondoo-aws-security-redshift-cluster-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "aws_redshift_cluster")
     mql: |


### PR DESCRIPTION
## Summary

While building a full positive/negative test environment for this policy (one passing and one failing AWS resource per check, 531 checks, 853 Terraform resources), we found a set of live-AWS check variants that can never fail, can never pass, or never score. This PR fixes the 13 that are pure MQL issues.

**Verification method for every fix:** query the AWS API directly (`aws` CLI / boto3), evaluate the current and the fixed MQL with `cnquery run` against the same live resources, and confirm the fixed expression evaluates **true on the correctly-configured resource and false on the deliberately-misconfigured one**. `cnspec policy lint` passes.

## Checks that could never FAIL (false negatives — the security-relevant class)

| Check | Root cause → fix |
|---|---|
| `lambda-source-arn` | statement selector over the raw policy dict matched no statements, so a permission **without** SourceArn passed → rewritten on typed `policyStatements` (`effect`, `principals`, `conditions`) |
| `elb-ssl-listener` | block over raw `listenerDescriptions` evaluated over an empty list (the `.lr` schema itself says "use the listeners field") → rewritten on typed `listeners` |
| `vpc-dhcp-custom-dns` | dict keys are `Key`/`Values` (values object-wrapped as `{Value: ...}`), MQL used `key`/`values` → fixed + existence guard so an empty configurations list can't vacuously pass |
| `codebuild-no-privileged-mode` | raw `environment` dict key is `PrivilegedMode` — a privileged project with plaintext credentials scored **pass** |

## Checks that could never PASS

| Check | Root cause → fix |
|---|---|
| `efs-backup-enabled` | `backupPolicy` holds the raw DescribeBackupPolicy response → `backupPolicy["BackupPolicy"]["Status"]` |
| `eks-cluster-logging-enabled` | keys are `ClusterLogging`/`Enabled` (as documented in `aws.lr`) |
| `codebuild-no-plaintext-credentials` | use the flattened typed `environmentVariables` / `environmentImagePullCredentialsType` fields |
| `redshift-cluster-current-maintenance-track` | API returns `current`, MQL compared `== "Current"` → `.downcase` |
| `guardduty-all-features-enabled` | unanchored `/RUNTIME_MONITORING/` also matches legacy `EKS_RUNTIME_MONITORING`, which AWS keeps DISABLED while the successor is enabled → anchored regex |
| `api-gw-tls` | REGIONAL REST APIs reject the literal `TLS_1_2` security policy and only accept the new `SecurityPolicy_TLS1*` names → accept those too |
| `ec2-ebs-kms-encryption` | DescribeVolumes returns no `SseType` in some regions/accounts → fall back to the typed `kmsKey` when `sseType` is empty |

## Checks that never scored

| Check | Root cause → fix |
|---|---|
| `mq-audit-logging` | check filter compared `engineType == "ACTIVEMQ"` but the API returns `ActiveMQ` → case-insensitive match |

## Hardening

- `redshift-cluster-require-ssl`: `.one(...)` instead of `.where(...).all(...)` so an empty parameter list cannot vacuously pass. (Note: AWS's engine default for `require_ssl` is now `true`.)

## Known issues NOT addressed here (provider-side, cnquery/mql repo)

- All 11 `opensearch-*` checks never run: `DiscoveryESDomains` enumerates via the legacy ES ListDomainNames API (which returns **both** engines) and claims every domain as `aws-es-domain`.
- The 4 `rds-snapshot-*` checks filter on a platform (`aws-rds-snapshot`) that discovery never emits.
- `ecs-logging-enabled`: cnquery instantiates a `logConfiguration` sub-resource for every container, so `!= empty` is always true (a policy-side workaround would be `logConfiguration.logDriver != empty`).
- `efs-encrypted-check` / `redshift-cluster-cmk-encryption`: the unencrypted resource produces a per-asset scan **error** instead of a fail.
- `emr-cluster-restrict-visibility`: AWS has deprecated `VisibleToAllUsers` (SetVisibleToAllUsers returns 200 and is ignored) — the check can never pass on new clusters and probably should be retired.
- Several checks have no live-AWS variant at all (IaC-only): `api-gw-require-authentication`, `iot-domain-configuration-tls-1-2-minimum` (whose IaC pass-regex `IoTSecurityPolicy_TLS_1_2_*` matches no real AWS policy name), `codeartifact-domain-cmk-encryption`, `kinesis-video-stream-cmk-encryption`, `datasync-task-cloudwatch-logging-encryption`, `ec2-user-data-no-secrets`.

Suggestion for mqlc: five of these bugs share one mechanism — a bare identifier or unknown dict key inside an iteration block silently evaluates to null, turning `.where()` into "match nothing" and `.all()` into vacuous truth. A compile-time warning for unresolvable identifiers in dict-iteration blocks would have caught all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)