### PR TITLE
🐛 validation: move the bot-bumped tool pins out of the workflow

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -15,10 +15,13 @@ on:
       - "content/validation/remediation/**"
       - "content/validation/data/**"
       # Every linter and CLI version this file installs decides what the
-      # validators accept, so a pull request that changes only a pin here has
-      # to run them -- otherwise the weekly bumps from
+      # validators accept, so a pull request that changes only a pin has to run
+      # them -- otherwise the weekly bumps from
       # validation-dependency-updates.yaml would merge unvalidated, which is
-      # the one thing opening them as pull requests is meant to prevent.
+      # the one thing opening them as pull requests is meant to prevent. The
+      # pins themselves live in tool-pins.env, so both paths are listed: the
+      # data file for a bump, this workflow for a change to how it installs.
+      - "content/validation/upstream/tool-pins.env"
       - ".github/workflows/validate-remediation.yaml"
   workflow_dispatch:
 
@@ -48,6 +51,13 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
 
       - name: Install AWS CLI v2
         # Official AWS installer (https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
@@ -93,15 +103,8 @@ jobs:
           openstack --version
 
       - name: Install doctl
-        # Pinned release tarball from
-        # https://github.com/digitalocean/doctl/releases. Bump DOCTL_VERSION
-        # and DOCTL_SHA256 in lockstep when DigitalOcean ships new commands
-        # or flags — the SHA-256 is published in the per-release
-        # `doctl-<version>-checksums.sha256` file. No auth needed for
-        # `doctl --help` introspection.
-        env:
-          DOCTL_VERSION: "1.166.0"
-          DOCTL_SHA256: "1596424b64091a7939bde561daf2402ca8a141966429928e688d20d17091ec89"
+        # Pinned release tarball; DOCTL_VERSION and DOCTL_SHA256 come from
+        # tool-pins.env. No auth needed for `doctl --help` introspection.
         run: |
           # --fail makes curl exit non-zero on HTTP 4xx/5xx (default -sSL silently
           # writes the error body to disk and trips the sha256 check below).
@@ -124,12 +127,8 @@ jobs:
           gh --version
 
       - name: Install glab
-        # Pinned release tarball from the gitlab-org/cli generic package
-        # registry. Bump GLAB_VERSION and GLAB_SHA256 in lockstep when
-        # GitLab ships new commands or flags.
-        env:
-          GLAB_VERSION: "1.113.0"
-          GLAB_SHA256: "c265589fb2018f310b6a27df9356efee42991f858e7e3a5fa232228a13b47467"
+        # Pinned tarball from the gitlab-org/cli generic package registry;
+        # GLAB_VERSION and GLAB_SHA256 come from tool-pins.env.
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/${GLAB_VERSION}/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
@@ -141,13 +140,8 @@ jobs:
           glab --version
 
       - name: Install hcloud
-        # Pinned release tarball from
-        # https://github.com/hetznercloud/cli/releases. Bump HCLOUD_VERSION
-        # and HCLOUD_SHA256 in lockstep when Hetzner ships new commands or
-        # flags — the SHA-256 is published in the per-release checksums.txt.
-        env:
-          HCLOUD_VERSION: "1.67.0"
-          HCLOUD_SHA256: "7164483e05a1abef492768db429a28c21d579dc70e807558cb140debc2971477"
+        # Pinned release tarball; HCLOUD_VERSION and HCLOUD_SHA256 come from
+        # tool-pins.env.
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz" \
@@ -159,15 +153,9 @@ jobs:
           hcloud version
 
       - name: Install databricks CLI
-        # Pinned release zip from
-        # https://github.com/databricks/cli/releases. Bump DATABRICKS_VERSION
-        # and DATABRICKS_SHA256 in lockstep when Databricks ships new commands
-        # or flags — the SHA-256 is published in the per-release
-        # `databricks_cli_<version>_SHA256SUMS` file. No auth needed for the
-        # `__complete` / `--help` introspection the validator performs.
-        env:
-          DATABRICKS_VERSION: "1.12.1"
-          DATABRICKS_SHA256: "60833feee22caa98f575c4948ccbbc9473fda0dd80c9b79544dc7b079f6a9815"
+        # Pinned release zip; DATABRICKS_VERSION and DATABRICKS_SHA256 come
+        # from tool-pins.env. No auth needed for the `__complete` / `--help`
+        # introspection the validator performs.
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/databricks/cli/releases/download/v${DATABRICKS_VERSION}/databricks_cli_${DATABRICKS_VERSION}_linux_amd64.zip" \
@@ -179,15 +167,9 @@ jobs:
           databricks version
 
       - name: Install STACKIT CLI
-        # Pinned release tarball from
-        # https://github.com/stackitcloud/stackit-cli/releases. Bump
-        # STACKIT_VERSION and STACKIT_SHA256 in lockstep when STACKIT ships new
-        # commands or flags — the SHA-256 is published in the per-release
-        # `stackit-cli_<version>_checksums.txt` file. No auth needed for the
-        # `__complete` / `--help` introspection the validator performs.
-        env:
-          STACKIT_VERSION: "0.71.0"
-          STACKIT_SHA256: "091836594293e3cdf957015caa336f855b103f4ffe14ca07688b01a54dfefb15"
+        # Pinned release tarball; STACKIT_VERSION and STACKIT_SHA256 come
+        # from tool-pins.env. No auth needed for the `__complete` / `--help`
+        # introspection the validator performs.
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/stackitcloud/stackit-cli/releases/download/v${STACKIT_VERSION}/stackit-cli_${STACKIT_VERSION}_linux_amd64.tar.gz" \
@@ -215,13 +197,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
+
       - name: Set up tflint
         uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6.3.0
         with:
-          # Keep at the latest release. Note that the `signature` attribute the
-          # validator sets on ruleset plugins needs >= 0.62; v0.61.0 and earlier
-          # silently ignore it.
-          tflint_version: v0.64.0
+          # TFLINT_VERSION comes from tool-pins.env, without the `v` this
+          # action wants.
+          tflint_version: v${{ env.TFLINT_VERSION }}
 
       - name: Validate terraform remediation blocks
         env:
@@ -247,11 +235,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
+
       - name: Install cfn-lint
         # cfn-lint bundles the AWS resource specification, so the pinned
         # version determines which resource types and properties are known.
-        # Bump it to pick up new services and fresh deprecation warnings.
-        run: pipx install cfn-lint==1.55.1
+        # CFN_LINT_VERSION comes from tool-pins.env.
+        run: pipx install "cfn-lint==${CFN_LINT_VERSION}"
 
       - name: Validate cloudformation remediation blocks
         run: python3 content/validation/remediation/code/cloudformation.py --github-actions
@@ -270,18 +265,21 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
+
       - name: Install Bicep CLI
-        # Pinned release binary from https://github.com/Azure/bicep/releases.
-        # Bump BICEP_VERSION and BICEP_SHA256 in lockstep; the pinned version
-        # determines which resource types and apiVersions are known, so a bump
-        # can surface newly deprecated apiVersions in existing snippets.
+        # Pinned release binary; BICEP_VERSION and BICEP_SHA256 come from
+        # tool-pins.env, where the pinned version decides which resource types
+        # and apiVersions are known.
         #
         # Installed directly rather than via `az bicep install`, which puts the
         # binary under the Azure CLI's config directory (AZURE_CONFIG_DIR, not
         # always ~/.azure on a runner) and gives nothing to checksum.
-        env:
-          BICEP_VERSION: "0.46.1"
-          BICEP_SHA256: "3e011d629ea4311b7a7dd8f0040ab2b1a072ea4ff5d02cb75e0e55a9a6703fb9"
         run: |
           curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL \
             "https://github.com/Azure/bicep/releases/download/v${BICEP_VERSION}/bicep-linux-x64" \
@@ -308,8 +306,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
+
       - name: Install ansible-lint
-        run: pipx install ansible-lint==26.8.0
+        run: pipx install "ansible-lint==${ANSIBLE_LINT_VERSION}"
 
       - name: Validate ansible remediation blocks
         run: python3 content/validation/remediation/code/ansible.py --github-actions
@@ -372,10 +377,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Load the pinned tool versions
+        # Bumped by a bot, so declared in a data file rather than here: an
+        # installation token cannot push a change under .github/workflows/,
+        # which made every weekly bump of these pins unlandable. See
+        # content/validation/upstream/tool-pins.env for the full argument.
+        run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
+
       - name: Install cookstyle
         # cookstyle is Chef's RuboCop distribution. The runner image ships a
         # system Ruby, so no separate toolchain setup is needed.
-        run: sudo gem install cookstyle -v 8.6.10 --no-document
+        run: sudo gem install cookstyle -v "${COOKSTYLE_VERSION}" --no-document
 
       - name: Validate chef remediation blocks
         run: python3 content/validation/remediation/code/chef.py --github-actions

--- a/.github/workflows/validation-upstream-drift.yaml
+++ b/.github/workflows/validation-upstream-drift.yaml
@@ -92,7 +92,7 @@ jobs:
             echo "grammar is refreshed by re-running its dump script against the new"
             echo "tool, which that workflow does in its own jobs."
             echo
-            echo "The pins are declared in \`.github/workflows/validate-remediation.yaml\`,"
+            echo "The pins are declared in \`content/validation/upstream/tool-pins.env\`,"
             echo "\`content/validation/remediation/code/terraform.py\`,"
             echo "\`content/validation/remediation/commands/openapi.py\`, and the \`_meta\` block of"
             echo "each \`data/*.json\`. \`content/validation/upstream/pins.py\` is what"

--- a/content/validation/README.md
+++ b/content/validation/README.md
@@ -310,14 +310,16 @@ Every validator above is only as good as the thing it checks against, and each o
 
 | Pin | Declared in |
 |---|---|
-| linter releases (`cfn-lint`, `ansible-lint`, `cookstyle`, `tflint`) | `.github/workflows/validate-remediation.yaml` |
-| CLI release artifacts (`bicep`, `doctl`, `glab`, `hcloud`, `databricks`) — version **and** SHA-256 | `.github/workflows/validate-remediation.yaml` |
+| linter releases (`cfn-lint`, `ansible-lint`, `cookstyle`, `tflint`) | `upstream/tool-pins.env` |
+| CLI release artifacts (`bicep`, `doctl`, `glab`, `hcloud`, `databricks`, `stackit`) — version **and** SHA-256 | `upstream/tool-pins.env` |
 | tflint ruleset plugins, Terraform provider `~>` constraints | `remediation/code/terraform.py` (`TFLINT_PLUGIN_MAP`, `PROVIDER_MAP`) |
 | OpenAPI specs pinned to a commit | `remediation/commands/openapi.py` (`*_OPENAPI_SHA`) |
 | YAML-only OpenAPI specs, converted and checked in | `upstream/dump/api_specs.py` (`OKTA_SPEC_VERSION`, `PORTAINER_SPEC_SHA`) |
 | checked-in CLI grammars | the `_meta` block of each `data/*.json` |
 
-Dependabot watches `gomod` and `github-actions`. It watches none of the above. `upstream/pins.py` is the single registry: it reads each pin out of the file that declares it, so there is no second copy to go stale. Adding an entry to `PROVIDER_MAP` or `TFLINT_PLUGIN_MAP` puts it under watch automatically; a new linter or CLI needs a line in `WORKFLOW_TOOLS` or `WORKFLOW_CHECKSUMMED`.
+Dependabot watches `gomod` and `github-actions`. It watches none of the above. `upstream/pins.py` is the single registry: it reads each pin out of the file that declares it, so there is no second copy to go stale. Adding an entry to `PROVIDER_MAP` or `TFLINT_PLUGIN_MAP` puts it under watch automatically; a new linter or CLI needs a line in `WORKFLOW_TOOLS` or `WORKFLOW_CHECKSUMMED` *and* a `KEY=value` line in `upstream/tool-pins.env`.
+
+`tool-pins.env` is a data file rather than the `env:` block of the step that installs the tool, which is where these pins started. A GitHub App installation token is refused any push whose diff touches `.github/workflows/`, so once the weekly bumper started rewriting them it could never land them: `bump linter` and `bump cli` failed on exactly the weeks a linter or CLI had moved, while every other kind merged. `validate-remediation.yaml` appends the file's `KEY=value` lines to `$GITHUB_ENV` and reads them as environment variables; the download URLs stay in the workflow, and `pins.py` reads them back out of it so the digest it records is of the bytes CI fetches.
 
 ```bash
 python3 content/validation/upstream/check.py                  # what has moved
@@ -388,7 +390,7 @@ The failure mode is loud once you have fixtures (`check did not run against …`
 Which registry depends on how the vendor's interface is reached, and anything that introduces a new binary needs a CI change too:
 
 - **A new REST API** — add an entry to `API_PROVIDERS` in `commands/openapi.py` with the policy file, host, and spec source. A spec pinned to a commit SHA also needs its constant registered in `upstream/pins.py`; a YAML-only spec is converted once by `upstream/dump/api_specs.py` and checked into `data/`.
-- **A new Cobra CLI** — add an entry to `COBRA_CLIS` in `commands/cobra.py` (CLI name, policy list, `include_audit`, install hint). The CLI must also be installed by the `validate-remediation.yaml` commands job, pinned by version **and** SHA-256.
+- **A new Cobra CLI** — add an entry to `COBRA_CLIS` in `commands/cobra.py` (CLI name, policy list, `include_audit`, install hint). The CLI must also be installed by the `validate-remediation.yaml` commands job, pinned by version **and** SHA-256 in `upstream/tool-pins.env`.
 - **A new cloud CLI with its own grammar source** — a module beside `aws.py`/`azure.py`/`gcloud.py` plus an entry in `CLI_VALIDATORS` in `commands/validate.py`, and the same CI install step.
 - **An existing validator gaining a second policy** — some validators name their policies in module constants rather than a registry (`azure.py` validates both `mondoo-azure-security` and `mondoo-m365-security`, because the M365 policy's CLI remediations also use `az`). Add the file there.
 

--- a/content/validation/upstream/bump.py
+++ b/content/validation/upstream/bump.py
@@ -37,7 +37,7 @@ from pins import (  # noqa: E402
     Pin,
     discover,
     sync_dump_script_pins,
-    verify_workflow_checksums,
+    verify_tool_checksums,
 )
 
 
@@ -52,7 +52,7 @@ CAVEATS = {
         "question is whether the content or the pin is wrong."
     ),
     "cli": (
-        "The SHA-256 in the workflow was recomputed from the artifact this bump "
+        "The SHA-256 in `tool-pins.env` was recomputed from the artifact this bump "
         "points at, downloaded from the same URL CI uses. A red run means the "
         "vendor changed a command or flag that remediation or audit steps rely on."
     ),
@@ -224,7 +224,7 @@ def main() -> None:
         return
 
     if args.verify_checksums:
-        results = verify_workflow_checksums()
+        results = verify_tool_checksums()
         for name, ok, detail in results:
             print(f"[{'PASS' if ok else 'FAIL'}] {name:<12} {detail}")
         if any(not ok for _, ok, _ in results):

--- a/content/validation/upstream/pins.py
+++ b/content/validation/upstream/pins.py
@@ -54,6 +54,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # content/validati
 from paths import DATA_DIR, DUMP_DIR, REPO_ROOT, VALIDATION_DIR  # noqa: E402
 
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validate-remediation.yaml"
+# Read for the artifact download URLs only. Never written: an installation
+# token cannot push a change under .github/workflows/, which is why the pins
+# the bumper rewrites live in TOOL_PINS instead.
+TOOL_PINS = VALIDATION_DIR / "upstream" / "tool-pins.env"
 OPENAPI_MODULE = VALIDATION_DIR / "remediation" / "commands" / "openapi.py"
 TERRAFORM_VALIDATOR = VALIDATION_DIR / "remediation" / "code" / "terraform.py"
 API_SPECS_DUMP = VALIDATION_DIR / "upstream" / "dump" / "api_specs.py"
@@ -299,14 +303,19 @@ class Pin:
         return self.apply is not None
 
 
-def _sub_once(text: str, pattern: str, new_value: str, path: Path) -> str:
+def _sub_once(text: str, pattern: str, new_value: str, path: Path, flags: int = 0) -> str:
     """Replace group 1 of the first `pattern` match with `new_value`.
 
     Every rewrite in this module goes through here so that a pattern which
     stopped matching (upstream reformatted the file, someone moved the pin)
     raises instead of writing a file that looks bumped but is not.
+
+    `flags` is for the line-anchored patterns in tool-pins.env, whose `^` means
+    nothing without re.MULTILINE -- and which, read with the same flags they
+    are matched with here, would otherwise find the pin and then fail to write
+    it.
     """
-    m = re.search(pattern, text)
+    m = re.search(pattern, text, flags)
     if not m:
         raise ValueError(f"pin pattern no longer matches in {path}: {pattern}")
     start, end = m.span(1)
@@ -314,22 +323,33 @@ def _sub_once(text: str, pattern: str, new_value: str, path: Path) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Pins declared in the workflow's `run:` steps
+# Tool pins declared in upstream/tool-pins.env
 # ---------------------------------------------------------------------------
+#
+# Read from the data file, not from the workflow that installs them, so that
+# the weekly bumper can push the result: GitHub refuses a GitHub App
+# installation token any push touching `.github/workflows/`, and these are the
+# only pins a bot rewrites that ever lived there. `tool-pins.env` has the whole
+# argument.
+#
+# The download URLs stay in the workflow and are read back out of it, which is
+# what keeps the re-checksum honest -- the bytes hashed are the bytes CI
+# fetches. That is a read of the workflow, never a write.
 
 # Tools installed at a bare version string, with nothing to checksum.
-# (display name, regex capturing the pinned version, resolver)
+# (display name, env var in tool-pins.env, resolver)
 WORKFLOW_TOOLS = [
-    ("cfn-lint", r"pipx install cfn-lint==([0-9][^\s]*)", lambda: latest_pypi("cfn-lint")),
-    ("ansible-lint", r"pipx install ansible-lint==([0-9][^\s]*)", lambda: latest_pypi("ansible-lint")),
-    ("cookstyle", r"gem install cookstyle -v ([0-9][^\s]*)", lambda: latest_rubygem("cookstyle")),
-    ("tflint", r"tflint_version:\s*v?([0-9][^\s]*)", lambda: latest_github_release("terraform-linters/tflint")),
+    ("cfn-lint", "CFN_LINT_VERSION", lambda: latest_pypi("cfn-lint")),
+    ("ansible-lint", "ANSIBLE_LINT_VERSION", lambda: latest_pypi("ansible-lint")),
+    ("cookstyle", "COOKSTYLE_VERSION", lambda: latest_rubygem("cookstyle")),
+    ("tflint", "TFLINT_VERSION", lambda: latest_github_release("terraform-linters/tflint")),
 ]
 
-# Tools downloaded as a release artifact and verified against a checksum. The
-# workflow declares each as an `X_VERSION` / `X_SHA256` env pair; the artifact
-# URL is read out of the same step, so bumping one of these re-downloads
-# exactly what CI will download and recomputes the digest from it.
+# Tools downloaded as a release artifact and verified against a checksum.
+# `tool-pins.env` declares each as an `X_VERSION` / `X_SHA256` pair; the
+# artifact URL is read out of the workflow step that interpolates `X_VERSION`,
+# so bumping one of these re-downloads exactly what CI will download and
+# recomputes the digest from it.
 # (display name, env var prefix, resolver)
 WORKFLOW_CHECKSUMMED = [
     ("bicep", "BICEP", lambda: latest_github_release("Azure/bicep")),
@@ -339,6 +359,21 @@ WORKFLOW_CHECKSUMMED = [
     ("databricks", "DATABRICKS", lambda: latest_github_release("databricks/cli")),
     ("stackit", "STACKIT", lambda: latest_github_release("stackitcloud/stackit-cli")),
 ]
+
+
+def _pin_pattern(var: str) -> str:
+    """Match `VAR=value` on its own line in tool-pins.env.
+
+    Anchored per line so a mention of the name inside a comment cannot be
+    rewritten in place of the pin, and so `BICEP_VERSION` cannot match inside
+    some future `BICEP_VERSION_SUFFIX`.
+    """
+    return rf"^{var}=([^\s#]+)"
+
+
+def _read_pin(text: str, var: str) -> str | None:
+    m = re.search(_pin_pattern(var), text, re.MULTILINE)
+    return m.group(1) if m else None
 
 
 def _workflow_url_for(text: str, version_var: str) -> str | None:
@@ -355,70 +390,72 @@ def _workflow_url_for(text: str, version_var: str) -> str | None:
     return None
 
 
-def check_workflow_tools() -> list[Pin]:
-    if not WORKFLOW.exists():
+def check_tool_pins() -> list[Pin]:
+    if not TOOL_PINS.exists():
         return []
-    text = WORKFLOW.read_text()
+    text = TOOL_PINS.read_text()
+    workflow_text = WORKFLOW.read_text() if WORKFLOW.exists() else ""
     out: list[Pin] = []
 
-    for name, pattern, resolver in WORKFLOW_TOOLS:
-        m = re.search(pattern, text)
-        if not m:
+    for name, var, resolver in WORKFLOW_TOOLS:
+        pinned = _read_pin(text, var)
+        if pinned is None:
             out.append(Pin(name, "linter", "unknown", "unknown",
-                           "no pin found in validate-remediation.yaml"))
+                           f"{var} not found in tool-pins.env"))
             continue
 
-        def make_apply(pat: str) -> Callable[[str], list[Path]]:
+        def make_apply(v: str) -> Callable[[str], list[Path]]:
             def apply(new_version: str) -> list[Path]:
-                WORKFLOW.write_text(_sub_once(WORKFLOW.read_text(), pat, new_version, WORKFLOW))
-                return [WORKFLOW]
+                TOOL_PINS.write_text(
+                    _sub_once(TOOL_PINS.read_text(), _pin_pattern(v), new_version,
+                              TOOL_PINS, re.MULTILINE)
+                )
+                return [TOOL_PINS]
             return apply
 
-        out.append(Pin(name, "linter", m.group(1), resolver(),
-                       apply=make_apply(pattern), files=[WORKFLOW]))
+        out.append(Pin(name, "linter", pinned, resolver(),
+                       apply=make_apply(var), files=[TOOL_PINS]))
 
     for name, prefix, resolver in WORKFLOW_CHECKSUMMED:
         version_var, sha_var = f"{prefix}_VERSION", f"{prefix}_SHA256"
-        version_pat = rf'{version_var}:\s*"?([0-9][^"\s]*)'
-        sha_pat = rf'{sha_var}:\s*"?([0-9a-f]{{64}})'
-        vm = re.search(version_pat, text)
-        if not vm:
+        pinned = _read_pin(text, version_var)
+        if pinned is None:
             out.append(Pin(name, "cli", "unknown", "unknown",
-                           f"{version_var} not found in validate-remediation.yaml"))
+                           f"{version_var} not found in tool-pins.env"))
             continue
-        url_template = _workflow_url_for(text, version_var)
+        url_template = _workflow_url_for(workflow_text, version_var)
         note = "" if url_template else f"no download URL interpolating ${{{version_var}}}"
 
         # Every loop variable the closure needs is passed in explicitly: bound
         # by reference they would all resolve to the last tool in the list, and
         # a bump would then hash the wrong artifact into the right pin.
-        def make_apply(vpat: str, spat: str, template: str, var: str) -> Callable[[str], list[Path]]:
+        def make_apply(vvar: str, svar: str, template: str) -> Callable[[str], list[Path]]:
             def apply(new_version: str) -> list[Path]:
-                url = template.replace("${" + var + "}", new_version)
+                url = template.replace("${" + vvar + "}", new_version)
                 blob = fetch_bytes(url)
                 if not blob:
                     raise ValueError(f"could not download {url} to re-checksum")
                 digest = hashlib.sha256(blob).hexdigest()
-                body = WORKFLOW.read_text()
-                body = _sub_once(body, vpat, new_version, WORKFLOW)
-                body = _sub_once(body, spat, digest, WORKFLOW)
-                WORKFLOW.write_text(body)
-                return [WORKFLOW]
+                body = TOOL_PINS.read_text()
+                body = _sub_once(body, _pin_pattern(vvar), new_version, TOOL_PINS, re.MULTILINE)
+                body = _sub_once(body, _pin_pattern(svar), digest, TOOL_PINS, re.MULTILINE)
+                TOOL_PINS.write_text(body)
+                return [TOOL_PINS]
             return apply
 
         out.append(Pin(
-            name, "cli", vm.group(1), resolver(), note,
-            apply=(make_apply(version_pat, sha_pat, url_template, version_var)
+            name, "cli", pinned, resolver(), note,
+            apply=(make_apply(version_var, sha_var, url_template)
                    if url_template else None),
-            files=[WORKFLOW],
+            files=[TOOL_PINS],
         ))
 
     return out
 
 
-def verify_workflow_checksums() -> list[tuple[str, bool, str]]:
+def verify_tool_checksums() -> list[tuple[str, bool, str]]:
     """Re-derive each checksummed CLI's digest at the version it is *already*
-    pinned to, and compare it against the digest in the workflow.
+    pinned to, and compare it against the digest in tool-pins.env.
 
     This is the one thing about the auto-bump that is not self-evident from a
     diff: everything else rewrites a string that a reviewer can eyeball, but a
@@ -429,33 +466,35 @@ def verify_workflow_checksums() -> list[tuple[str, bool, str]]:
 
     Returns (name, matches, detail) per tool.
     """
-    if not WORKFLOW.exists():
+    if not TOOL_PINS.exists():
         return []
-    text = WORKFLOW.read_text()
+    text = TOOL_PINS.read_text()
+    workflow_text = WORKFLOW.read_text() if WORKFLOW.exists() else ""
     out = []
     for name, prefix, _ in WORKFLOW_CHECKSUMMED:
-        version_var = f"{prefix}_VERSION"
-        vm = re.search(rf'{version_var}:\s*"?([0-9][^"\s]*)', text)
-        sm = re.search(rf'{prefix}_SHA256:\s*"?([0-9a-f]{{64}})', text)
-        if not vm or not sm:
-            out.append((name, False, f"{version_var}/{prefix}_SHA256 not found"))
+        version_var, sha_var = f"{prefix}_VERSION", f"{prefix}_SHA256"
+        pinned = _read_pin(text, version_var)
+        recorded = _read_pin(text, sha_var)
+        if not pinned or not recorded:
+            out.append((name, False, f"{version_var}/{sha_var} not found in tool-pins.env"))
             continue
-        template = _workflow_url_for(text, version_var)
+        template = _workflow_url_for(workflow_text, version_var)
         if not template:
             out.append((name, False, f"no download URL interpolating ${{{version_var}}}"))
             continue
-        url = template.replace("${" + version_var + "}", vm.group(1))
+        url = template.replace("${" + version_var + "}", pinned)
         blob = fetch_bytes(url)
         if blob is None:
             out.append((name, False, f"could not download {url}"))
             continue
         digest = hashlib.sha256(blob).hexdigest()
         out.append((
-            name, digest == sm.group(1),
-            f"v{vm.group(1)} {url}" if digest == sm.group(1)
-            else f"v{vm.group(1)} computed {digest}, pinned {sm.group(1)}",
+            name, digest == recorded,
+            f"v{pinned} {url}" if digest == recorded
+            else f"v{pinned} computed {digest}, pinned {recorded}",
         ))
     return out
+
 
 
 # ---------------------------------------------------------------------------
@@ -764,7 +803,7 @@ def check_spec_dumps() -> list[Pin]:
 def discover() -> list[Pin]:
     """Every watched pin, with its current value and what upstream has."""
     return (
-        check_workflow_tools()
+        check_tool_pins()
         + check_terraform_pins()
         + check_spec_pins()
         + check_spec_dumps()

--- a/content/validation/upstream/pins_test.py
+++ b/content/validation/upstream/pins_test.py
@@ -250,3 +250,76 @@ PROVIDER_MAP = {
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BumpableFileTest(unittest.TestCase):
+    """No automatable pin may live under `.github/workflows/`.
+
+    A GitHub App installation token is refused any push whose diff touches a
+    workflow file unless the App holds the `workflows` permission, which the
+    bumper's token deliberately does not. Declaring a bot-bumped pin in a
+    workflow therefore does not fail at review time -- it fails weeks later,
+    inside `validation-dependency-updates.yaml`, as
+
+        ! [remote rejected] deps/validation/linter -> deps/validation/linter
+          (refusing to allow a GitHub App to create or update workflow
+           `.github/workflows/validate-remediation.yaml` without `workflows`
+           permission)
+
+    and only for the kinds whose pin happened to move that week, so the rest of
+    the run stays green and the gap reads as an ordinary quiet week. That is
+    what the `linter` and `cli` kinds did for every run between the workflow
+    landing and this test: the pins were declared in the workflow that installs
+    them, which is the obvious place for them and the one place they cannot be.
+    """
+
+    WORKFLOW_DIR = pins.REPO_ROOT / ".github" / "workflows"
+
+    def test_no_automatable_pin_writes_into_a_workflow(self):
+        # `files` is what the bumper stages and pushes, so it is the set that
+        # decides whether the push is accepted -- not where the pin is read
+        # from. `check_tool_pins` still *reads* the download URL out of the
+        # workflow to re-checksum against the bytes CI fetches; that is a read,
+        # and it is fine.
+        # Offline like every other test here: with both fetchers dark every
+        # resolver returns "unknown", which changes each pin's `state` but not
+        # its `files` or its `apply` -- the two this is about.
+        with mock.patch.object(pins, "fetch_json", return_value=None), \
+             mock.patch.object(pins, "fetch_bytes", return_value=None):
+            discovered = pins.discover()
+
+        for pin in discovered:
+            if not pin.automatable:
+                continue
+            for path in pin.files:
+                with self.subTest(pin=pin.slug, path=str(path)):
+                    self.assertFalse(
+                        self.WORKFLOW_DIR in Path(path).parents,
+                        f"{pin.slug} bumps {path}; a workflow file cannot be "
+                        f"pushed by the bumper's installation token. Move the "
+                        f"pin into content/validation/upstream/tool-pins.env.",
+                    )
+
+    def test_every_tool_pin_is_still_found(self):
+        """...and the test above is not passing because it examined nothing.
+
+        A pin whose pattern stops matching is not an error in `pins.py`: it
+        degrades to an unstamped Pin with no `apply`, which reports as
+        "unchecked" and opens no pull request. That is the right fail-safe for
+        a resolver and the wrong one here, because a silently unwatched pin and
+        a pin the test skipped look identical. Naming the count pins both down.
+        """
+        with mock.patch.object(pins, "fetch_json", return_value=None), \
+             mock.patch.object(pins, "fetch_bytes", return_value=None):
+            tools = pins.check_tool_pins()
+
+        self.assertEqual(
+            len(pins.WORKFLOW_TOOLS) + len(pins.WORKFLOW_CHECKSUMMED), len(tools)
+        )
+        for pin in tools:
+            with self.subTest(pin=pin.slug):
+                self.assertTrue(
+                    pin.automatable,
+                    f"{pin.slug} lost its bump: {pin.note or 'no apply'}",
+                )
+                self.assertEqual([pins.TOOL_PINS], pin.files)

--- a/content/validation/upstream/tool-pins.env
+++ b/content/validation/upstream/tool-pins.env
@@ -1,0 +1,87 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# The linter and CLI versions `validate-remediation.yaml` installs, and the
+# SHA-256 of every release artifact it downloads.
+#
+# These decide what the remediation validators accept -- cfn-lint bundles the
+# AWS resource specification, bicep decides which apiVersions are known, each
+# CLI grammar decides which subcommands and flags an `id: cli` block may use --
+# so they are validator inputs rather than CI configuration, and they are bumped
+# by a bot rather than by hand.
+#
+# That last part is why they live here and not beside the `run:` steps that
+# consume them, which is otherwise the obvious place for them. GitHub refuses a
+# GitHub App installation token any push whose diff touches `.github/workflows/`
+# unless the App holds the `workflows` permission. The weekly bumper in
+# `validation-dependency-updates.yaml` pushes with such a token and the App does
+# not hold it -- deliberately, since a bot that can rewrite CI can rewrite what
+# CI checks. Declared in the workflow, these ten pins were the only ones the
+# bumper could never land, and it failed on exactly the weeks one of them moved.
+#
+# Read by two consumers, which is the whole contract:
+#
+#   - `validate-remediation.yaml` appends the `KEY=value` lines to $GITHUB_ENV,
+#     so every name below is an environment variable in the steps that follow.
+#   - `upstream/pins.py` reads and rewrites them, and re-derives each SHA-256
+#     from the artifact it just downloaded. The download URLs stay in the
+#     workflow and are read back out of it, so the bytes hashed here are the
+#     bytes CI fetches.
+#
+# Do not add anything but `KEY=value` and comments: the workflow filters to
+# lines matching ^[A-Z0-9_]+= before appending, and $GITHUB_ENV rejects a line
+# it cannot parse. Bump a version and its SHA-256 in lockstep, or let the weekly
+# workflow do it.
+
+# --- Linters, installed at a bare version -----------------------------------
+
+# https://pypi.org/project/cfn-lint/ -- bundles the AWS resource specification,
+# so the pin decides which resource types and properties are known.
+CFN_LINT_VERSION=1.55.1
+
+# https://pypi.org/project/ansible-lint/
+ANSIBLE_LINT_VERSION=26.8.0
+
+# https://rubygems.org/gems/cookstyle -- Chef's RuboCop distribution.
+COOKSTYLE_VERSION=8.6.10
+
+# https://github.com/terraform-linters/tflint/releases -- without the `v`, which
+# the workflow adds back. Keep at the latest release: the `signature` attribute
+# the validator sets on ruleset plugins needs >= 0.62, and v0.61.0 and earlier
+# silently ignore it.
+TFLINT_VERSION=0.64.0
+
+# --- CLIs, downloaded as a checksummed release artifact ---------------------
+
+# https://github.com/Azure/bicep/releases -- the pinned version decides which
+# resource types and apiVersions are known, so a bump can surface newly
+# deprecated apiVersions in existing snippets. The release publishes no
+# checksum file for the bare linux-x64 binary; this digest is re-derived from
+# the artifact itself by `upstream/pins.py`.
+BICEP_VERSION=0.46.1
+BICEP_SHA256=3e011d629ea4311b7a7dd8f0040ab2b1a072ea4ff5d02cb75e0e55a9a6703fb9
+
+# https://github.com/digitalocean/doctl/releases -- SHA-256 published in the
+# per-release `doctl-<version>-checksums.sha256`.
+DOCTL_VERSION=1.166.0
+DOCTL_SHA256=1596424b64091a7939bde561daf2402ca8a141966429928e688d20d17091ec89
+
+# https://gitlab.com/gitlab-org/cli/-/releases -- served from the generic
+# package registry; the GitHub mirror publishes no releases.
+GLAB_VERSION=1.113.0
+GLAB_SHA256=c265589fb2018f310b6a27df9356efee42991f858e7e3a5fa232228a13b47467
+
+# https://github.com/hetznercloud/cli/releases -- SHA-256 published in the
+# per-release `checksums.txt`.
+HCLOUD_VERSION=1.67.0
+HCLOUD_SHA256=7164483e05a1abef492768db429a28c21d579dc70e807558cb140debc2971477
+
+# https://github.com/databricks/cli/releases -- SHA-256 published in the
+# per-release `databricks_cli_<version>_SHA256SUMS`.
+DATABRICKS_VERSION=1.12.1
+DATABRICKS_SHA256=60833feee22caa98f575c4948ccbbc9473fda0dd80c9b79544dc7b079f6a9815
+
+# https://github.com/stackitcloud/stackit-cli/releases -- SHA-256 published in
+# the per-release `stackit-cli_<version>_checksums.txt`.
+STACKIT_VERSION=0.71.0
+STACKIT_SHA256=091836594293e3cdf957015caa336f855b103f4ffe14ca07688b01a54dfefb15


### PR DESCRIPTION
## The failure

[`validation-dependency-updates.yaml`](https://github.com/mondoohq/cnspec/actions/workflows/validation-dependency-updates.yaml) has failed on **every** run since it landed. Same error each time, in the `Create pull request` step:

```
! [remote rejected] deps/validation/linter -> deps/validation/linter
  (refusing to allow a GitHub App to create or update workflow
   `.github/workflows/validate-remediation.yaml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/mondoohq/cnspec'
```

GitHub refuses a GitHub App installation token any push whose diff touches `.github/workflows/` unless the App holds the `workflows` permission. The mondoo-mergebot App does not hold it.

The ten linter and CLI pins the bumper rewrites were declared in the workflow that installs them, so `bump linter` and `bump cli` could never land. Everything else could — the split runs cleanly along *which file the bumper writes*:

| Run | linter / cli | terraform-provider / spec |
|---|---|---|
| [32692752955](https://github.com/mondoohq/cnspec/actions/runs/32692752955) | ❌ both | — |
| [32514347893](https://github.com/mondoohq/cnspec/actions/runs/32514347893) | ❌ both | ✅ `bump spec` |
| [32080503906](https://github.com/mondoohq/cnspec/actions/runs/32080503906) | ❌ linter | — |
| [31997023081](https://github.com/mondoohq/cnspec/actions/runs/31997023081) | ❌ linter | ✅ opened #3434 |
| [31921730669](https://github.com/mondoohq/cnspec/actions/runs/31921730669) | ❌ linter | ✅ |

It is not intermittent. It fires on exactly the weeks a linter or CLI moved, and the rest of the run stays green — so a red workflow with no pull request for `cookstyle` reads as an ordinary quiet week. `cookstyle`, `doctl`, `glab`, `databricks` and `stackit` are all behind right now for this reason.

The `refresh-azure-grammar` failure in the very first dispatch run was separate and one-off; that job has been green for six runs since.

## The fix

Move the pins to **`content/validation/upstream/tool-pins.env`**, a `KEY=value` data file. `validate-remediation.yaml` appends its lines to `$GITHUB_ENV` once per job and reads them as ordinary environment variables:

```yaml
- name: Load the pinned tool versions
  run: grep -E '^[A-Z0-9_]+=' content/validation/upstream/tool-pins.env >> "$GITHUB_ENV"
```

Nothing the bumper writes is a workflow file any more, and it needs no new privilege.

**The pin values and what CI installs are unchanged.** The download URLs stay in the workflow and `pins.py` still reads them back out of it, which is what keeps the re-checksum honest — the bytes hashed are the bytes CI fetches. That is now a read of the workflow and never a write.

The alternative was granting the App `workflows: write`. That is the wrong direction: a bot able to rewrite CI can rewrite what CI checks, and these pins are validator inputs rather than CI logic anyway.

## Verification

- **The regression test fails on the pre-fix code**, naming all ten pins — checked by restoring both `pins.py` and the workflow from `main` and running it. It is not a test that only ever passes.
- A second test asserts every tool pin is still *found* and still bumpable. A pin whose pattern stops matching degrades to an unstamped `Pin` with no `apply`, which is the right fail-safe for a resolver and would let the first test pass by examining nothing.
- `make test/content/upstream/unit` — 33 passed.
- `check.py` reports all ten pins with identical `pinned` values and the same five behind as before.
- **Ran the real bumper** (`bump.py --only doctl,cookstyle`): it rewrote `tool-pins.env`, left the workflow byte-identical, and the digest it recorded for doctl 1.167.0 matches an independent `curl … | shasum -a 256` of the release. Reverted before committing — that bump is the bot's to open.
- `bump.py --verify-checksums` — PASS for all six CLIs against the live artifacts.
- Simulated the `$GITHUB_ENV` load: 16 lines, none the runner would reject, every interpolation resolving to its pre-change value.

While in here, `_sub_once` gained a `flags` parameter. The line-anchored patterns matched with `re.MULTILINE` on read but were rewritten without it, so the first real bump found the pin and then failed to write it — caught by the existing guard, which raised rather than writing a file that looked bumped and was not.

## Follow-up

Once this merges, the next scheduled run should open the `deps/validation/linter` and `deps/validation/cli` pull requests that have been blocked for six weeks. `cookstyle` is a major (8.6.10 → 9.0.0), so expect that one to need content work — which is the signal the workflow exists to surface.