### PR TITLE
🐛 content: rename the auditd restart execute for cookstyle 9.0

### DIFF
--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -7344,13 +7344,16 @@ queries:
 
             ```ruby
             auditd_conf = '/etc/audit/auditd.conf'
+
+            # RHEL-family systems set RefuseManualStop on the auditd unit, so systemd declines
+            # the restart and the legacy action script has to perform it instead.
             restart_command = if platform_family?('rhel', 'fedora', 'amazon')
                                 '/usr/libexec/initscripts/legacy-actions/auditd/restart'
                               else
                                 'systemctl restart auditd'
                               end
 
-            execute 'restart auditd' do
+            execute 'apply auditd configuration' do
               command restart_command
               action :nothing
               not_if "auditctl -s | grep -q '^enabled.*2$'"
@@ -7369,7 +7372,7 @@ queries:
                   ::File.write(auditd_conf, body)
                 end
                 not_if { ::File.read(auditd_conf).match?(/^#{keyword}\s*=\s*#{Regexp.escape(value)}\s*$/) }
-                notifies :run, 'execute[restart auditd]', :delayed
+                notifies :run, 'execute[apply auditd configuration]', :delayed
               end
             end
             ```
@@ -7528,13 +7531,16 @@ queries:
 
             ```ruby
             auditd_conf = '/etc/audit/auditd.conf'
+
+            # RHEL-family systems set RefuseManualStop on the auditd unit, so systemd declines
+            # the restart and the legacy action script has to perform it instead.
             restart_command = if platform_family?('rhel', 'fedora', 'amazon')
                                 '/usr/libexec/initscripts/legacy-actions/auditd/restart'
                               else
                                 'systemctl restart auditd'
                               end
 
-            execute 'restart auditd' do
+            execute 'apply auditd configuration' do
               command restart_command
               action :nothing
               not_if "auditctl -s | grep -q '^enabled.*2$'"
@@ -7553,7 +7559,7 @@ queries:
                   ::File.write(auditd_conf, body)
                 end
                 not_if { ::File.read(auditd_conf).match?(/^#{keyword}\s*=\s*#{Regexp.escape(value)}\s*$/) }
-                notifies :run, 'execute[restart auditd]', :delayed
+                notifies :run, 'execute[apply auditd configuration]', :delayed
               end
             end
             ```
@@ -7739,13 +7745,16 @@ queries:
 
             ```ruby
             auditd_conf = '/etc/audit/auditd.conf'
+
+            # RHEL-family systems set RefuseManualStop on the auditd unit, so systemd declines
+            # the restart and the legacy action script has to perform it instead.
             restart_command = if platform_family?('rhel', 'fedora', 'amazon')
                                 '/usr/libexec/initscripts/legacy-actions/auditd/restart'
                               else
                                 'systemctl restart auditd'
                               end
 
-            execute 'restart auditd' do
+            execute 'apply auditd configuration' do
               command restart_command
               action :nothing
               not_if "auditctl -s | grep -q '^enabled.*2$'"
@@ -7764,7 +7773,7 @@ queries:
                   ::File.write(auditd_conf, body)
                 end
                 not_if { ::File.read(auditd_conf).match?(/^#{keyword}\s*=\s*#{Regexp.escape(value)}\s*$/) }
-                notifies :run, 'execute[restart auditd]', :delayed
+                notifies :run, 'execute[apply auditd configuration]', :delayed
               end
             end
             ```


### PR DESCRIPTION
Unblocks #3590, which bumps the cookstyle pin from 8.6.10 to 9.0.0 and is red on `validate-chef`. The question that pull request leaves for a person is whether the pin is wrong or the content is. Here it is the content.

## What 9.0.0 changed

Cookstyle 9.0.0 rewrote `Chef/Correctness/ServiceResource`. In 8.6.10 it inspected only the `command` property:

```ruby
RESTRICT_ON_SEND = [:command].freeze
```

In 9.0.0 it also reads the resource name of an `execute`, on the reasonable theory that `execute 'systemctl restart httpd'` uses the name as the command:

```ruby
RESTRICT_ON_SEND = %i(command code execute).freeze
```

One of the new `DIRECT_COMMANDS` patterns is the upstart form `/\A(?:start|stop|restart)\s+\S+\z/`, and the two-word label `restart auditd` matches it. That is the whole failure: three auditd recipes in `mondoo-linux-security`, all the same shape.

## Why it is a label and not a command

The resource sets an explicit `command`, which overrides the name:

```ruby
execute 'restart auditd' do
  command restart_command
  action :nothing
  not_if "auditctl -s | grep -q '^enabled.*2$'"
end
```

So the name is documentation, and the command the cop is objecting to is not the one that runs. Confirmed against 9.0.0 by holding the `command` fixed and varying only the name — the identical resource named `apply auditd configuration` passes.

## The change

Rename the resource to what it is for, and update the three `notifies` targets to match. Add a comment recording why the shell-out exists, because that is the part a future reader is most likely to get wrong.

The shell-out stays, and has to. RHEL-family systems set `RefuseManualStop` on the auditd unit, so systemd declines the restart and the `service` resource cannot perform it — which is why the recipe branches to `/usr/libexec/initscripts/legacy-actions/auditd/restart` there. Swapping in `service 'auditd'` to satisfy the cop would silence it and break RHEL.

## Verification

Full `validate_chef_remediation` run over all 277 Chef snippets:

| cookstyle | before | after |
| --- | --- | --- |
| 9.0.0 | 274 passed, 3 failed | **277 passed, 0 failed** |
| 8.6.10 (current pin) | 277 passed, 0 failed | **277 passed, 0 failed** |

Green under the current pin as well as the new one, so this lands on its own and #3590 goes green on a re-run. `cnspec policy lint` and `typos` both clean.