### PR TITLE
🐛 content: rewrite the okta trusted-origin snippet for provider 7.x

### DIFF
--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3680,10 +3680,17 @@ queries:
           desc: |
             ```hcl
             resource "okta_trusted_origin" "example" {
-              active = true
               name   = "Example Origin"
               origin = "https://app.example.com"
-              scopes = ["CORS", "REDIRECT"]
+              status = "ACTIVE"
+
+              scopes {
+                type = "CORS"
+              }
+
+              scopes {
+                type = "REDIRECT"
+              }
             }
             ```
     refs:


### PR DESCRIPTION
#3592 moved the okta provider constraint to `~> 7.0`. okta/okta 7.0.0 renamed two arguments on `okta_trusted_origin`, and the remediation snippet on `mondoo-okta-security-trusted-origins-https` used both older spellings.

| 6.15.0 | 7.0.0 |
| --- | --- |
| `active = true` (bool attribute) | `status = "ACTIVE"` (string attribute) |
| `scopes = ["CORS", "REDIRECT"]` (list of strings) | repeated `scopes { type = ... }` block |

With terraform on PATH, that snippet fails under the merged pin:

```
[FAIL] mondoo-okta-security-trusted-origins-https
       resource "okta_trusted_origin" "example" {
       terraform validate: Unsupported argument: An argument named "active" is not expected here.
       terraform validate: Unsupported argument: An argument named "scopes" is not expected here.
                           Did you mean to define a block of type "scopes"?
```

After this change the whole okta target is clean: **32 snippets, 0 failures** (`python3 content/validation/remediation/code/terraform.py okta`). `cnspec policy lint` valid, `typos` clean.

### Why CI did not catch this

It cannot, today. `validate-terraform` never installs terraform, so the `terraform validate` half of the validator is skipped and only tflint runs — which does not resolve a snippet against the provider schema. That is fixed separately; this PR is the content half.

### Scope

The MQL variants are untouched. They read `origin`, which 7.0 did not change, and mql parses HCL itself rather than resolving it against a provider schema, so no variant could have noticed either rename.

Full schema diff 6.15.0 → 7.0.0: two resources added (`okta_org_captcha`, `okta_user_subscription`), none removed, four resources with renamed or dropped arguments. `okta_trusted_origin` is the only one content touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)