### PR TITLE
🐛 content: rewrite the two workbench snippets for the google 8 provider

### DIFF
--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -36486,22 +36486,11 @@ queries:
             }
             ```
 
-            For the legacy `google_notebooks_instance` resource:
-
-            ```hcl
-            resource "google_notebooks_instance" "default" {
-              name         = "notebook-private"
-              location     = "us-central1-a"
-              machine_type = "e2-medium"
-
-              vm_image {
-                project      = "deeplearning-platform-release"
-                image_family = "tf-latest-cpu"
-              }
-
-              no_public_ip = true
-            }
-            ```
+            The google provider removed `google_notebooks_instance` in 8.0, so a
+            configuration still declaring a legacy Notebooks instance has to move to
+            `google_workbench_instance` before it can be planned at all. The check itself
+            still judges both resource types, because a state file written by an earlier
+            provider version can carry either.
         - id: console
           desc: |
             To disable the public IP on a Vertex AI Workbench instance using the Google Cloud Console:
@@ -43995,6 +43984,7 @@ queries:
         values['network_spec'].all(_['network'] != null && _['network'] != "")
       )
   # No Terraform variants for the runtime resource: google_workbench_instance gen-2 stores its service account in a nested gce_setup.service_accounts block; the Terraform coverage below targets the legacy google_notebooks_instance whose flat service_account argument matches the runtime notebooksService.instances resource this check evaluates.
+  # The google provider removed google_notebooks_instance in 8.0, so these variants now only judge state and plan documents written by an earlier provider. They stay because that is the population the runtime notebooksService.instances resource covers; pointing them at google_workbench_instance instead would have them judge assets their runtime sibling cannot see. The remediation names the Workbench resource because that is the only one a reader can still declare.
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account
     title: Ensure Vertex AI Workbench instances use a non-default service account
     impact: 70
@@ -44045,7 +44035,7 @@ queries:
 
         A purpose-built service account restricts that reach to the APIs and buckets the notebook workflow genuinely needs, which bounds the damage from compromised notebook code. It also makes the audit trail readable: actions taken by a per-workload account identify the workflow that took them, where actions by the shared default account identify nothing.
 
-        The service account is chosen when the instance is created and cannot be changed on a running instance, so remediation means creating a replacement with `gcloud workbench instances create --service-account-email`, or `service_account` on a `google_notebooks_instance` resource in Terraform, then migrating the work and deleting the original.
+        The service account is chosen when the instance is created and cannot be changed on a running instance, so remediation means creating a replacement with `gcloud workbench instances create --service-account-email`, or a `google_workbench_instance` resource carrying a `service_accounts` block in Terraform, then migrating the work and deleting the original.
       audit: |
         ### Audit via Console
 
@@ -44085,22 +44075,25 @@ queries:
             ```
         - id: terraform
           desc: |
-            To assign a dedicated service account to a legacy Notebooks instance in Terraform, set `service_account` on the `google_notebooks_instance` resource:
+            To assign a dedicated service account to a Workbench instance in Terraform, set `email` on a `service_accounts` block inside `gce_setup`:
 
             ```hcl
-            resource "google_notebooks_instance" "example" {
-              name         = "example-instance"
-              location     = "us-central1-a"
-              machine_type = "e2-medium"
+            resource "google_workbench_instance" "example" {
+              name     = "example-instance"
+              location = "us-central1-a"
 
-              vm_image {
-                project      = "deeplearning-platform-release"
-                image_family = "tf-latest-cpu"
+              gce_setup {
+                machine_type = "e2-medium"
+
+                service_accounts {
+                  email = google_service_account.notebook.email
+                }
               }
-
-              service_account = google_service_account.notebook.email
             }
             ```
+
+            The service account is fixed at creation, so an existing instance has to be
+            replaced rather than edited in place.
     refs:
       - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-identity
         title: Manage identity and access for Vertex AI Workbench instances

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -43983,8 +43983,7 @@ queries:
         values['network_spec'] != empty &&
         values['network_spec'].all(_['network'] != null && _['network'] != "")
       )
-  # No Terraform variants for the runtime resource: google_workbench_instance gen-2 stores its service account in a nested gce_setup.service_accounts block; the Terraform coverage below targets the legacy google_notebooks_instance whose flat service_account argument matches the runtime notebooksService.instances resource this check evaluates.
-  # The google provider removed google_notebooks_instance in 8.0, so these variants now only judge state and plan documents written by an earlier provider. They stay because that is the population the runtime notebooksService.instances resource covers; pointing them at google_workbench_instance instead would have them judge assets their runtime sibling cannot see. The remediation names the Workbench resource because that is the only one a reader can still declare.
+  # The Terraform variants judge both Workbench resources: google_workbench_instance carries its service account in a nested gce_setup.service_accounts block, while the legacy google_notebooks_instance uses a flat service_account argument. The google provider removed the legacy resource in 8.0, so only the Workbench form can still be written, but plan and state documents from earlier provider versions carry either.
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account
     title: Ensure Vertex AI Workbench instances use a non-default service account
     impact: 70
@@ -44104,22 +44103,55 @@ queries:
         serviceAccount != empty && serviceAccount.contains("-compute@developer.gserviceaccount.com") == false
       )
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl
-    filters: asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_notebooks_instance')
+    filters: |
+      asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_workbench_instance' || nameLabel == 'google_notebooks_instance')
     mql: |
+      terraform.resources('google_workbench_instance').all(
+        blocks.where(type == 'gce_setup') != empty &&
+        blocks.where(type == 'gce_setup').all(
+          blocks.where(type == 'service_accounts') != empty &&
+          blocks.where(type == 'service_accounts').all(
+            arguments['email'] != null && arguments['email'] != "" &&
+            arguments['email'].contains("-compute@developer.gserviceaccount.com") == false
+          )
+        )
+      )
       terraform.resources('google_notebooks_instance').all(
         arguments['service_account'] != null && arguments['service_account'] != "" &&
         arguments['service_account'].contains("-compute@developer.gserviceaccount.com") == false
       )
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-plan
-    filters: asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_notebooks_instance')
+    filters: |
+      asset.platform == 'terraform-plan' && terraform.plan.resourceChanges.contains(type == 'google_workbench_instance' || type == 'google_notebooks_instance')
     mql: |
+      terraform.plan.resourceChanges.where(type == 'google_workbench_instance').all(
+        change.after['gce_setup'] != empty &&
+        change.after['gce_setup'].all(
+          _['service_accounts'] != empty &&
+          _['service_accounts'].all(
+            _['email'] != null && _['email'] != "" &&
+            _['email'].contains("-compute@developer.gserviceaccount.com") == false
+          )
+        )
+      )
       terraform.plan.resourceChanges.where(type == 'google_notebooks_instance').all(
         change.after['service_account'] != null && change.after['service_account'] != "" &&
         change.after['service_account'].contains("-compute@developer.gserviceaccount.com") == false
       )
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-state
-    filters: asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_notebooks_instance')
+    filters: |
+      asset.platform == 'terraform-state' && terraform.state.resources.contains(type == 'google_workbench_instance' || type == 'google_notebooks_instance')
     mql: |
+      terraform.state.resources.where(type == 'google_workbench_instance').all(
+        values['gce_setup'] != empty &&
+        values['gce_setup'].all(
+          _['service_accounts'] != empty &&
+          _['service_accounts'].all(
+            _['email'] != null && _['email'] != "" &&
+            _['email'].contains("-compute@developer.gserviceaccount.com") == false
+          )
+        )
+      )
       terraform.state.resources.where(type == 'google_notebooks_instance').all(
         values['service_account'] != null && values['service_account'] != "" &&
         values['service_account'].contains("-compute@developer.gserviceaccount.com") == false

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/workbench-default-compute-sa/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/workbench-default-compute-sa/main.tf
@@ -1,0 +1,15 @@
+# The default Compute Engine service account holds project-wide Editor by
+# default, so every notebook on it can rewrite the project.
+resource "google_workbench_instance" "research" {
+  project  = var.project_id
+  name     = "research-workbench"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "e2-standard-4"
+
+    service_accounts {
+      email = "123456789012-compute@developer.gserviceaccount.com"
+    }
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/workbench-no-service-accounts/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/fail/workbench-no-service-accounts/main.tf
@@ -1,0 +1,11 @@
+# With the service_accounts block omitted the instance falls back to the default
+# Compute Engine account.
+resource "google_workbench_instance" "research" {
+  project  = var.project_id
+  name     = "research-workbench"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "e2-standard-4"
+  }
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/pass/workbench-dedicated-sa/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-gcp-security/mondoo-gcp-security-workbench-instance-no-default-service-account-terraform-hcl/pass/workbench-dedicated-sa/main.tf
@@ -1,0 +1,14 @@
+resource "google_workbench_instance" "research" {
+  project  = var.project_id
+  name     = "research-workbench"
+  location = "us-central1-a"
+
+  gce_setup {
+    machine_type = "e2-standard-4"
+
+    # Purpose-built account scoped to just what the notebook needs.
+    service_accounts {
+      email = "workbench-research@example-prod.iam.gserviceaccount.com"
+    }
+  }
+}


### PR DESCRIPTION
#3592 moved the google provider constraint to `~> 8.0`. hashicorp/google 8.0.0 **removes 16 resources relative to 7.46.0 and adds none**, and two of the removals reach content: both remediation snippets that declare `google_notebooks_instance`.

```
[FAIL] mondoo-gcp-security-vertex-ai-workbench-no-public-ip
       terraform validate: Invalid resource type: The provider hashicorp/google
       does not support resource type "google_notebooks_instance".
[FAIL] mondoo-gcp-security-workbench-instance-no-default-service-account
       terraform validate: Invalid resource type: The provider hashicorp/google
       does not support resource type "google_notebooks_instance".
```

### What changed

**`vertex-ai-workbench-no-public-ip`** offered the legacy resource as a second fence beside the current `google_workbench_instance` one. The fence is dropped and replaced with what a reader holding a legacy configuration actually has to do, because under 8.0 there is no legacy resource left for them to write. Its variants already judged both resource types, so nothing else moved.

**`workbench-instance-no-default-service-account`** had nothing but the legacy resource. Its remediation moves onto `google_workbench_instance` and the nested `gce_setup.service_accounts` block:

```hcl
resource "google_workbench_instance" "example" {
  name     = "example-instance"
  location = "us-central1-a"

  gce_setup {
    machine_type = "e2-medium"

    service_accounts {
      email = google_service_account.notebook.email
    }
  }
}
```

The prose line that named the old flat `service_account` argument is corrected to match.

### The check had to move with it

Leaving that check's Terraform variants on the legacy resource alone made `TestRemediationSatisfiesCheck` fail, and correctly so:

```
the check did not run against its own remediation snippet
the snippet does not declare a resource this check's filter matches, so
applying it as shown leaves the check unevaluated
```

A reader applying the documented fix got a configuration the check silently ignored. All three Terraform variants now judge **both** resources, which is the shape the `vertex-ai-workbench-no-public-ip` variants beside them already use for the same pair: `google_workbench_instance` through `gce_setup.service_accounts.email`, and the legacy `google_notebooks_instance` through its flat `service_account`. The legacy branch stays because plan and state documents written by an earlier provider still carry that resource, and because it is the population the runtime `notebooksService.instances` sibling reads.

An omitted `service_accounts` block is not neutral — the instance falls back to the default Compute Engine account — so the nested reads are guarded with `!= empty &&` to fail rather than pass vacuously.

The IaC fixtures keep declaring the legacy resource alongside three new Workbench ones, because fixtures are parsed by mql, never by terraform.

### Verification

- `TestRemediationSatisfiesCheck` for every `mondoo-gcp-security` variant: **pass** (this check previously failed).
- `TestTerraformVariants` for the check: all six scenarios pass — `pass/dedicated-sa`, `pass/workbench-dedicated-sa`, `fail/no-service-account`, `fail/default-compute-sa`, `fail/workbench-default-compute-sa`, `fail/workbench-no-service-accounts`.
- `TestTerraformVariantCoverage`: pass.
- The plan and state variants are not fixture-gated, so both were checked by hand against real documents: a `terraform plan -out` and a `terraform show -json` state generated against hashicorp/google 8.x, each carrying a dedicated-SA, a default-compute-SA and a no-block instance. Verdicts pass/fail/fail in both.
- `python3 content/validation/remediation/code/terraform.py gcp` — 276 snippets, 0 failures (2 failures before).
- `cnspec policy lint` valid; `typos` clean.

### Why CI did not catch the snippets

It cannot, today. `validate-terraform` never installs terraform, so the `terraform validate` half of the validator is skipped and only tflint runs — which does not resolve a snippet against the provider schema. That is fixed separately; this PR is the content half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
