### PR TITLE
👷 ci: install terraform so the remediation validator resolves schemas

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -211,6 +211,16 @@ jobs:
           # action wants.
           tflint_version: v${{ env.TFLINT_VERSION }}
 
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          # The wrapper replaces `terraform` with a shell script that re-emits
+          # the run's stdout and stderr as step outputs. The validator reads
+          # `terraform validate -json` back and parses it, so the extra framing
+          # would break every diagnostic it is here to collect.
+          terraform_wrapper: false
+
       - name: Validate terraform remediation blocks
         env:
           # `tflint --init` downloads ruleset plugins from GitHub releases.

--- a/content/validation/upstream/pins.py
+++ b/content/validation/upstream/pins.py
@@ -343,6 +343,7 @@ WORKFLOW_TOOLS = [
     ("ansible-lint", "ANSIBLE_LINT_VERSION", lambda: latest_pypi("ansible-lint")),
     ("cookstyle", "COOKSTYLE_VERSION", lambda: latest_rubygem("cookstyle")),
     ("tflint", "TFLINT_VERSION", lambda: latest_github_release("terraform-linters/tflint")),
+    ("terraform", "TERRAFORM_VERSION", lambda: latest_github_release("hashicorp/terraform")),
 ]
 
 # Tools downloaded as a release artifact and verified against a checksum.

--- a/content/validation/upstream/tool-pins.env
+++ b/content/validation/upstream/tool-pins.env
@@ -51,6 +51,13 @@ COOKSTYLE_VERSION=9.0.0
 # silently ignore it.
 TFLINT_VERSION=0.64.0
 
+# https://github.com/hashicorp/terraform/releases -- without the `v`. tflint
+# checks style and its rulesets' own rules; `terraform validate` is what
+# resolves a snippet against the provider schema, and it only runs when the
+# binary is on PATH. The runner image does not ship it, so until this pin
+# existed `validate-terraform` silently degraded to the tflint half alone.
+TERRAFORM_VERSION=1.16.0
+
 # --- CLIs, downloaded as a checksummed release artifact ---------------------
 
 # https://github.com/Azure/bicep/releases -- the pinned version decides which


### PR DESCRIPTION
> **Draft: this needs #3595 and #3596 first.** Its first CI run is expected to be red, with exactly the three failures those two PRs fix. That red run is the demonstration that this change works.

`content/validation/remediation/code/terraform.py` runs two passes over every snippet: tflint, and `terraform validate` against the provider schema. The second is gated on `shutil.which("terraform")` and returns silently when the binary is absent:

```python
def terraform_available() -> bool:
    """Whether the terraform binary is on PATH."""
    return shutil.which("terraform") is not None
```

`validate-terraform` installs tflint and nothing else, and the ubuntu-24.04 runner image ships Packer but not Terraform. **So that second pass has never run in CI.** `git log -S setup-terraform -- .github/workflows/` is empty; #3367 added the pass without adding the install.

### How it shows

| | |
| --- | --- |
| CI job runtime | 1570 snippets in **1m32s** |
| Local run, warm provider mirror | tens of minutes for `gcp` alone |

Ninety seconds is tflint-only speed — no provider mirror is being built, so no schema is being resolved.

Everything the schema pass exists to catch was going uncaught: an argument the resource does not accept, a required argument left out, a value assigned to a computed attribute, a resource type the provider removed. #3592 is the demonstration — it moved google to 8.x and okta to 7.x, went green, and left three snippets on `main` that fail outright with terraform present.

### The change

- `hashicorp/setup-terraform` pinned by SHA, at `TERRAFORM_VERSION` from `tool-pins.env`.
- `terraform_wrapper: false`. The wrapper replaces the binary with a shell script that re-emits stdout and stderr as step outputs, and the validator reads `terraform validate -json` back and parses it.
- The pin lives in `tool-pins.env` rather than beside the `uses:` line, for the reason that file records: the weekly bumper pushes with an installation token, and GitHub refuses such a token any push touching `.github/workflows/`. Registering it in `WORKFLOW_TOOLS` puts it under the bumper and under `test_every_tool_pin_is_still_found`, which counts the pins so an unwatched one cannot pass as unchecked.

### Verification

`python3 -m unittest pins_test data_format_test` — 33 tests, all pass. A full local run of `terraform.py` against `main` plus #3595 and #3596 is the gate for taking this out of draft.

### Expect follow-up work

This is the first time the schema pass will actually run in CI, so it may surface a backlog beyond the three known failures. Anything it finds is a snippet that has been wrong for some time, not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)