### PR TITLE
🐛 cnquery-update: handle pre-release tags and unversioned mql

### DIFF
--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -139,7 +139,13 @@ jobs:
           if [[ "${MQL_MODULE}" =~ /v[0-9]+$ ]]; then
             REF="${MQL_VERSION}"
           else
-            REF=$(gh api "/repos/mondoohq/mql/git/refs/tags/${MQL_VERSION}" --jq '.object.sha')
+            # /commits/<ref>, not /git/refs/tags/<tag>: for an ANNOTATED tag
+            # the latter's .object.sha is the tag object, not the commit, and
+            # `go get` on it fails. Every mql tag is lightweight today, but
+            # nothing enforces that -- a tag created through the releases API,
+            # or with `git tag -m`, is annotated. This endpoint resolves either
+            # kind to the commit.
+            REF=$(gh api "/repos/mondoohq/mql/commits/${MQL_VERSION}" --jq '.sha')
             if [ -z "${REF}" ]; then
               echo "Could not resolve ${MQL_VERSION} to a commit SHA on mondoohq/mql"
               exit 1

--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -32,14 +32,21 @@ jobs:
           # Determine which version should be released based on event type
           VERSION: ${{ (github.event_name == 'workflow_dispatch' && inputs.version) || github.event.client_payload.version }}
         run: |
-          # Semantic Versioning regex (with optional 'v' prefix). The capture
-          # group matters: what lands in $GITHUB_OUTPUT below is re-emitted
-          # from BASH_REMATCH, not from $VERSION, so only the matched semver
-          # can ever reach a workflow environment file. Validating and then
-          # echoing the raw value would leave the output one regex bug away
+          # Semantic Versioning regex (with optional 'v' prefix and optional
+          # pre-release segment, so 14.0.0-rc.4 is accepted as well as 13.38.1).
+          #
+          # The capture group matters: what lands in $GITHUB_OUTPUT below is
+          # re-emitted from BASH_REMATCH, not from $VERSION, so only the matched
+          # semver can ever reach a workflow environment file. Validating and
+          # then echoing the raw value would leave the output one regex bug away
           # from an attacker-controlled newline injecting extra step outputs.
-          if [[ ! "$VERSION" =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            echo "Error: Version is not a valid semantic version."
+          #
+          # The pre-release group therefore has to sit INSIDE the outer one.
+          # Written as two sibling groups it still validates, and BASH_REMATCH[1]
+          # silently loses the suffix -- v14.0.0-rc.4 would bump cnspec to
+          # v14.0.0, a tag that does not exist, with no error anywhere.
+          if [[ ! "$VERSION" =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
+            echo "Error: Version is not a valid semantic version: $VERSION"
             exit 1
           fi
           MQL_VERSION="${BASH_REMATCH[1]}"
@@ -110,6 +117,7 @@ jobs:
       - name: Bump mql
         env:
           MQL_VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Take the module path from the branch we are bumping: support
           # branches import go.mondoo.com/mql/v{major}, while main tracks
@@ -120,7 +128,25 @@ jobs:
             echo "Could not find an mql import in go.mod"
             exit 1
           fi
-          go get "${MQL_MODULE}@${MQL_VERSION}"
+          # Two cases:
+          #  - mql module path is versioned (e.g. go.mondoo.com/mql/v13):
+          #    go accepts a v13.x.y semver reference directly.
+          #  - mql module path is unversioned (e.g. go.mondoo.com/mql):
+          #    Go rejects v2+ semver references ("major version must be
+          #    compatible: should be v0 or v1"). Resolve the tag to a
+          #    commit SHA and use a pseudo-version instead. This matches
+          #    what cnspec/main is already doing today.
+          if [[ "${MQL_MODULE}" =~ /v[0-9]+$ ]]; then
+            REF="${MQL_VERSION}"
+          else
+            REF=$(gh api "/repos/mondoohq/mql/git/refs/tags/${MQL_VERSION}" --jq '.object.sha')
+            if [ -z "${REF}" ]; then
+              echo "Could not resolve ${MQL_VERSION} to a commit SHA on mondoohq/mql"
+              exit 1
+            fi
+            echo "Resolved ${MQL_VERSION} -> ${REF} (unversioned mql module path)"
+          fi
+          go get "${MQL_MODULE}@${REF}"
           go mod tidy
           echo "${MQL_VERSION}" > VERSION
 


### PR DESCRIPTION
## Summary

Teaches `cnquery-update.yml` to handle mql **pre-release tags** (`v14.0.0-rc.1`, `v14.0.0-pre.2`, etc.) and the **unversioned mql module path** on cnspec `main`. Together with [mondoohq/mql#`<num>`](https://github.com/mondoohq/mql/pull/`<num>`) (which unblocks the mql-side dispatch on pre-releases), the mql → cnspec bump becomes fully automatic.

## Two things fixed

### 1. Version regex accepts pre-release suffixes

Before: `^v?[0-9]+\.[0-9]+\.[0-9]+$` — rejects `v14.0.0-rc.1`. Confirmed empirically today: `gh workflow run cnquery-update.yml -f version=v14.0.0-rc.1` failed at the `Determine Version and Validate` step with "Error: Version is not a valid semantic version."

After: `^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — matches standard semver pre-release identifiers.

### 2. Bump mql handles unversioned mql module paths

Before: `go get "${MQL_MODULE}@${MQL_VERSION}"` — fails when `MQL_MODULE` is unversioned (`go.mondoo.com/mql`, i.e., cnspec/main today) and `MQL_VERSION` is v2+:

```
go: go.mondoo.com/mql@v14.0.0-rc.1: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v14
```

After: check if the module path has a `/vN` suffix. If yes, use the semver ref directly. If no, resolve the tag to a commit SHA via `gh api` and pass that to `go get` — Go accepts SHAs and produces a pseudo-version, matching cnspec/main's current pin shape (`go.mondoo.com/mql v0.0.0-<ts>-<sha>`).

## Why this is safe for stable v13 too

- Cnspec's `v13` support branch imports `go.mondoo.com/mql/v13` (versioned). The `if [[ … /v[0-9]+$ ]]` check keeps the current semver-ref path for that case — no behavior change.
- Cnspec's `main` imports unversioned mql. New SHA path applies. Same as what a human does today with `go get go.mondoo.com/mql@<sha>` when opening a manual bump PR.

## Test plan

- [ ] Merge this + the companion mql PR.
- [ ] Cut a mql pre-release (`v14.0.0-rc.N`) — verify cnspec bump PR opens automatically against cnspec `main`, and its go.mod update produces a pseudo-version.
- [ ] Cut a mql stable v13 patch (`v13.36.N`) on the mql v13 branch — verify the bump PR opens against cnspec `v13` with a proper semver import.
- [ ] `workflow_dispatch cnquery-update.yml -f version=v14.0.0-rc.1 -f dry-run=true` — verify it accepts the pre-release semver.
