### PR TITLE
✨ auto-tag cnspec after a mql bump PR merges

### DIFF
--- a/.github/workflows/auto-tag-after-mql-bump.yml
+++ b/.github/workflows/auto-tag-after-mql-bump.yml
@@ -1,0 +1,81 @@
+name: Auto-tag after mql bump
+
+# Fires when a "🧹 Bump mql to <version>" PR from cnquery-update.yml
+# merges into main (or a v{major} support branch). Extracts the version
+# from the bump branch name and tags the base branch with the same
+# version, which kicks off goreleaser.yml just like a manual tag push.
+#
+# Skipped when:
+#  - the PR was closed without merging;
+#  - the merged branch doesn't match `version/mql_update_v*`;
+#  - a tag with the same name already exists (idempotent — safe to
+#    reuse the branch, safe to re-run).
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, v13]
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'version/mql_update_')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from bump branch
+        id: version
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # version/mql_update_v14.0.0-rc.1  ->  v14.0.0-rc.1
+          VERSION="${HEAD_REF#version/mql_update_}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Bump branch '${HEAD_REF}' did not yield a valid semver: '${VERSION}'"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Use the mergebot app token so the tag push triggers goreleaser.yml.
+      # GITHUB_TOKEN-authored pushes don't fire further workflow_run/push
+      # events, so we'd tag but goreleaser would never build it.
+      - name: Generate mergebot token
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: cnspec
+
+      - name: Checkout base branch (post-merge)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Skip if tag exists
+        id: check
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+            echo "::notice::Tag ${TAG} already exists — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and push
+        if: ${{ steps.check.outputs.skip != 'true' }}
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git config user.email "tools@mondoo.com"
+          git config user.name "Mondoo Tools"
+          git tag -m "cnspec ${TAG}" "${TAG}"
+          echo "::notice::Tagging ${BASE} as ${TAG}"
+          git push origin "${TAG}"

--- a/.github/workflows/auto-tag-after-mql-bump.yml
+++ b/.github/workflows/auto-tag-after-mql-bump.yml
@@ -33,11 +33,17 @@ jobs:
         run: |
           # version/mql_update_v14.0.0-rc.1  ->  v14.0.0-rc.1
           VERSION="${HEAD_REF#version/mql_update_}"
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          # `v?`, matching cnquery-update.yml, which is what builds this branch
+          # name. Requiring the prefix here while the producer treats it as
+          # optional would let a bump PR open, pass review and merge, and only
+          # then fail -- after the fact, with the version already in VERSION.
+          if [[ ! "$VERSION" =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
             echo "::error::Bump branch '${HEAD_REF}' did not yield a valid semver: '${VERSION}'"
             exit 1
           fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Normalise: every cnspec tag is v-prefixed, and goreleaser's version
+          # derivation expects it.
+          echo "version=v${BASH_REMATCH[1]#v}" >> "$GITHUB_OUTPUT"
 
       # Use the mergebot app token so the tag push triggers goreleaser.yml.
       # GITHUB_TOKEN-authored pushes don't fire further workflow_run/push
@@ -51,10 +57,16 @@ jobs:
           owner: mondoohq
           repositories: cnspec
 
-      - name: Checkout base branch (post-merge)
+      # merge_commit_sha, not base.ref. base.ref resolves to wherever the branch
+      # points when this job runs, which is after a token mint and a full clone
+      # -- anything merged in that window would be swept into the release
+      # silently: the tag exists, goreleaser builds, and the release just
+      # carries work nobody meant to ship. merge_commit_sha is the commit this
+      # PR actually produced on the base branch.
+      - name: Checkout the merge commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
 
@@ -73,9 +85,15 @@ jobs:
         env:
           TAG: ${{ steps.version.outputs.version }}
           BASE: ${{ github.event.pull_request.base.ref }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           git config user.email "tools@mondoo.com"
           git config user.name "Mondoo Tools"
-          git tag -m "cnspec ${TAG}" "${TAG}"
-          echo "::notice::Tagging ${BASE} as ${TAG}"
+          # Lightweight, like every cnspec tag to date. `-m` implies `-a`, and an
+          # annotated tag's ref resolves to a tag object rather than a commit --
+          # which quietly breaks anything reading `.object.sha` to get the commit
+          # (the bug fixed on the mql side in #3603). No reason to change the
+          # shape of this repo's tags as a side effect of automating them.
+          git tag "${TAG}"
+          echo "::notice::Tagging ${SHA} (merged into ${BASE}) as ${TAG}"
           git push origin "${TAG}"

--- a/.github/workflows/auto-tag-after-mql-bump.yml
+++ b/.github/workflows/auto-tag-after-mql-bump.yml
@@ -14,7 +14,12 @@ name: Auto-tag after mql bump
 on:
   pull_request:
     types: [closed]
-    branches: [main, v13]
+    # v* rather than a list: a new support branch should not also require
+    # editing this filter. Note the file still has to exist ON that branch --
+    # a pull_request workflow resolves from the merge commit, and a bump PR
+    # branches off its base -- so this widens the filter, it does not remove
+    # the cherry-pick.
+    branches: [main, "v*"]
 
 permissions:
   contents: read
@@ -75,7 +80,13 @@ jobs:
         env:
           TAG: ${{ steps.version.outputs.version }}
         run: |
-          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+          # ls-remote, not rev-parse against the clone. Whether the clone has
+          # tags at all depends on an actions/checkout implementation detail:
+          # with fetch-depth: 0 it fetches +refs/tags/*, but a targeted fetch
+          # does not, so trimming the clone later would turn this guard into a
+          # no-op that always reports "no such tag" and re-tags every time.
+          # Asking the remote is the thing we actually mean.
+          if [ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]; then
             echo "::notice::Tag ${TAG} already exists — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Closes the last manual step in the mql → cnspec release chain. Adds a new workflow `.github/workflows/auto-tag-after-mql-bump.yml` that, when a mql-bump PR from `cnquery-update.yml` merges into `main` (or `v13`), automatically tags the merged base with the same version. The tag push then triggers `goreleaser.yml` — same as if a human had run `git tag && git push`.

## Where this fits in the chain

Prereqs already open / merging:
- [mondoohq/mql#`<num>`](https://github.com/mondoohq/mql/pull/`<num>`) — dispatch cnspec bump on pre-releases
- [mondoohq/cnspec#3579](https://github.com/mondoohq/cnspec/pull/3579) — cnquery-update.yml handles pre-releases + unversioned mql
- [mondoohq/releasr#114](https://github.com/mondoohq/releasr/pull/114) — WIF for github_copy.yaml so `secrets: inherit` works
- [mondoohq/mql#10405](https://github.com/mondoohq/mql/pull/10405) + [mondoohq/cnspec#3570](https://github.com/mondoohq/cnspec/pull/3570) — copy pre-release artifacts to releases.mondoo.com

**Merge this LAST** — it's the one that turns a merged bump PR into a real release. If the earlier PRs are broken, land those first, verify one end-to-end run, then flip this on.

## Trigger + gates

`on: pull_request: types: [closed], branches: [main, v13]`

Fires when:
- `pull_request.merged == true` (not just closed)
- `head.ref` starts with `version/mql_update_` (the branch name cnquery-update.yml uses)
- The extracted version matches semver
- No tag with that name already exists (idempotent — safe to re-merge)

Skipped for: closed-not-merged PRs, PRs from humans with unrelated branch names, retriggers on an already-tagged version.

## Auth

Uses the `mondoo-mergebot` GH App token (same one cnquery-update.yml uses), because pushes authenticated by `GITHUB_TOKEN` don't trigger further workflow runs — we'd tag but `goreleaser.yml` wouldn't fire.

## Trust model

Trusts the reviewer to only merge green PRs. If the bump PR has failing checks and someone bypasses branch protection to merge anyway, this workflow will still tag. In that case `goreleaser.yml` will fail on the same broken code and surface it again — no worse than the human-driven flow today.

## Test plan

- [ ] Merge after everything else.
- [ ] Dispatch mql `goreleaser.yml` on a test tag `v14.0.0-rc.99` (or wait for the next real pre-release).
- [ ] Verify cnspec bump PR opens against `main` (via #3579).
- [ ] Merge that PR.
- [ ] Verify `auto-tag-after-mql-bump.yml` fires, verify cnspec `v14.0.0-rc.99` tag exists, verify `goreleaser.yml` starts building from it.
- [ ] Verify the tag is on the merged base (not the PR's head branch).
