### PR TITLE
👷 ci: shard the terraform remediation validation across six runners

### DIFF
--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -183,7 +183,27 @@ jobs:
       - name: Validate remediation commands
         run: python3 content/validation/remediation/commands/validate.py --github-actions
 
+  # The fan-out lives in one place: SHARD_TOTAL below. The matrix indices and
+  # the I/N the validator is called with are both derived from it, so adding a
+  # shard is a one-number change. Splitting them across a literal list and a
+  # literal denominator lets the two drift, and a denominator larger than the
+  # number of jobs silently leaves snippets unvalidated.
+  plan-terraform-shards:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      SHARD_TOTAL: 6
+    outputs:
+      indices: ${{ steps.plan.outputs.indices }}
+      total: ${{ steps.plan.outputs.total }}
+    steps:
+      - id: plan
+        run: |
+          echo "total=$SHARD_TOTAL" >> "$GITHUB_OUTPUT"
+          echo "indices=$(jq -nc --argjson n "$SHARD_TOTAL" '[range($n)]')" >> "$GITHUB_OUTPUT"
+
   validate-terraform:
+    needs: plan-terraform-shards
     runs-on: ubuntu-latest
     # A shard validates ~260 snippets. Each one costs a `terraform init` plus a
     # `terraform validate` against the provider schema, roughly 12 seconds of
@@ -193,12 +213,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # The validator hands blocks out round-robin against a counter that runs
-      # across every target file, so `shards` must equal the number of entries
-      # here. Too few and some snippets are never validated; too many and the
-      # extra shards do nothing but pay the mirror cost.
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: ${{ fromJSON(needs.plan-terraform-shards.outputs.indices) }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -242,11 +258,13 @@ jobs:
           # plugin init and fails the google/azurerm rulesets. The token
           # raises the limit to 5000/hour.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # matrix.shard is a fixed enum from the matrix above, so no untrusted
-        # input reaches the shell.
+        # Both values come from plan-terraform-shards, which produces them
+        # from integers, so no untrusted input reaches the shell. The validator
+        # rejects an index outside [0, total) rather than validating nothing.
         run: |
           python3 content/validation/remediation/code/terraform.py \
-            --github-actions --shard ${{ matrix.shard }}/6
+            --github-actions \
+            --shard ${{ matrix.shard }}/${{ needs.plan-terraform-shards.outputs.total }}
 
   validate-cloudformation:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-remediation.yaml
+++ b/.github/workflows/validate-remediation.yaml
@@ -185,7 +185,20 @@ jobs:
 
   validate-terraform:
     runs-on: ubuntu-latest
+    # A shard validates ~260 snippets. Each one costs a `terraform init` plus a
+    # `terraform validate` against the provider schema, roughly 12 seconds of
+    # wall time, and the script runs 8 of them at a time: about 7 minutes of
+    # work per shard. Twenty minutes leaves room for the provider mirror and a
+    # slow runner without letting a stuck shard hold the run open.
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      # The validator hands blocks out round-robin against a counter that runs
+      # across every target file, so `shards` must equal the number of entries
+      # here. Too few and some snippets are never validated; too many and the
+      # extra shards do nothing but pay the mirror cost.
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -221,7 +234,7 @@ jobs:
           # would break every diagnostic it is here to collect.
           terraform_wrapper: false
 
-      - name: Validate terraform remediation blocks
+      - name: Validate terraform remediation blocks (shard ${{ matrix.shard }})
         env:
           # `tflint --init` downloads ruleset plugins from GitHub releases.
           # Without an authenticated token it uses the 60-request/hour
@@ -229,7 +242,11 @@ jobs:
           # plugin init and fails the google/azurerm rulesets. The token
           # raises the limit to 5000/hour.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 content/validation/remediation/code/terraform.py --github-actions
+        # matrix.shard is a fixed enum from the matrix above, so no untrusted
+        # input reaches the shell.
+        run: |
+          python3 content/validation/remediation/code/terraform.py \
+            --github-actions --shard ${{ matrix.shard }}/6
 
   validate-cloudformation:
     runs-on: ubuntu-latest

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -1122,8 +1122,29 @@ def main():
             workers = int(args[i + 1])
             i += 1
         elif args[i] == "--shard" and i + 1 < len(args):
-            index_str, _, total_str = args[i + 1].partition("/")
-            shard = (int(index_str), int(total_str or 1))
+            # A malformed or out-of-range shard has to be loud. Every failure
+            # mode here ends with the script validating nothing and exiting 0,
+            # which reads as a green run that checked the whole corpus.
+            spec = args[i + 1]
+            index_str, _, total_str = spec.partition("/")
+            try:
+                shard = (int(index_str), int(total_str or 1))
+            except ValueError:
+                print(
+                    f"Error: --shard wants I/N with whole numbers, got {spec!r}",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            shard_index, shard_total = shard
+            if shard_total < 1 or not 0 <= shard_index < shard_total:
+                print(
+                    f"Error: --shard index must be within [0, {shard_total}), "
+                    f"got {shard_index}/{shard_total}. Out of range, no block "
+                    f"matches and the run would pass without validating "
+                    f"anything.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
             i += 1
         else:
             positional.append(args[i])

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -989,15 +989,33 @@ def build_provider_mirror(
 
 
 def validate_policy_file(
-    filepath: Path, plugin_cache: Path, workers: int
+    filepath: Path, plugin_cache: Path, workers: int,
+    shard: tuple[int, int] = (0, 1), seen: list[int] | None = None,
 ) -> tuple[int, int]:
-    """Validate all terraform blocks in a policy file."""
+    """Validate all terraform blocks in a policy file.
+
+    `shard` is (index, total). Blocks are handed out round-robin against a
+    counter that runs across every target file, so each shard gets an even
+    slice no matter how the blocks are distributed over the files. Every shard
+    walks the same targets in the same order, which makes the split identical
+    in each job without them having to agree on anything at run time.
+    """
     if not filepath.exists():
         print(f"Warning: Policy file not found: {filepath}", file=sys.stderr)
         return 0, 0
 
     content = filepath.read_text()
     blocks = extract_hcl_blocks(content, filepath)
+
+    shard_index, shard_total = shard
+    if shard_total > 1:
+        counter = seen if seen is not None else [0]
+        selected = []
+        for b in blocks:
+            if counter[0] % shard_total == shard_index:
+                selected.append(b)
+            counter[0] += 1
+        blocks = selected
 
     if not blocks:
         return 0, 0
@@ -1093,6 +1111,7 @@ def main():
     github_actions = False
     workers = 8
     target = "all"
+    shard = (0, 1)
 
     positional = []
     i = 0
@@ -1101,6 +1120,10 @@ def main():
             github_actions = True
         elif args[i] == "--workers" and i + 1 < len(args):
             workers = int(args[i + 1])
+            i += 1
+        elif args[i] == "--shard" and i + 1 < len(args):
+            index_str, _, total_str = args[i + 1].partition("/")
+            shard = (int(index_str), int(total_str or 1))
             i += 1
         else:
             positional.append(args[i])
@@ -1114,7 +1137,7 @@ def main():
         print(
             f"Unknown target: {target}\n"
             f"Usage: {sys.argv[0]} [{'|'.join(valid_targets)}] "
-            f"[--github-actions] [--workers N]",
+            f"[--github-actions] [--workers N] [--shard I/N]",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -1137,9 +1160,14 @@ def main():
             TARGETS.keys() if target == "all" else [target]
         )
 
+        # One counter for the whole run: the round-robin split has to continue
+        # across file boundaries, or a shard would re-take block 0 of every file.
+        seen = [0]
         for t in targets_to_run:
             for filepath in TARGETS[t]:
-                p, f = validate_policy_file(filepath, plugin_cache, workers)
+                p, f = validate_policy_file(
+                    filepath, plugin_cache, workers, shard, seen
+                )
                 total_pass += p
                 total_fail += f
 

--- a/content/validation/remediation/code/terraform.py
+++ b/content/validation/remediation/code/terraform.py
@@ -824,7 +824,15 @@ def validate_block(
         # tflint has already seen the snippet as written. terraform validate
         # gets a copy with dangling references neutralized, in its own
         # directory so the tflint run is not affected by the substitution.
-        if terraform_available():
+        #
+        # The mirror only carries PROVIDER_MAP, and init reads it through
+        # -plugin-dir, which never reaches the network. A snippet that needs a
+        # provider outside the map -- a community provider a resource is only
+        # available from, say -- can therefore never be initialized, and the
+        # schema pass would report that as a fault in the snippet. Such a
+        # snippet keeps its tflint coverage and skips the schema check, which
+        # is the same deal every provider had before PROVIDER_MAP existed.
+        if terraform_available() and all(p in PROVIDER_MAP for p in providers):
             tf_dir = tmp_path / "tfvalidate"
             tf_dir.mkdir()
             (tf_dir / "main.tf").write_text(


### PR DESCRIPTION
Since #3597 installed terraform in this job, the validator no longer skips its schema pass -- `build_provider_mirror` returns early when terraform is absent, so before that PR the job only ran tflint. The full pass does not fit in the job's 20 minutes and every run has been cancelled at the cap since that merge, on every branch. The verifying PR's own run (ci/install-terraform-for-schema- validation) already timed out the same way.

Measured on a warm checkout: `terraform init -plugin-dir` plus `terraform validate` costs ~12.4s per snippet, and there are 1570 snippets across the target files. At the script's 8 workers that is ~40 minutes of wall time. Mirroring a provider is cheap by comparison (~7s, 176MB for aws), so a provider cache alone would not have closed the gap.

Adds `--shard I/N` to the validator and fans the job out over six runners. Blocks are handed out round-robin against a counter that runs across every target file, so the split stays even no matter how blocks are distributed over the files, and every shard walks the same targets in the same order, which makes the partition identical in each job without coordination. Six shards give 262/262/262/262/261/261 blocks, about 7 minutes each.

Verified end to end with tflint 0.64.0 and terraform 1.15.5: the `dns` target validates 8 blocks unsharded and 3+3+2 across `--shard 0..2/3`, so the shards cover every block exactly once. Without `--shard` the behaviour is unchanged, which keeps local runs and the other callers working as before.