### PR TITLE
🧹 go: bump go directive to 1.26.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/cnspec
 
-go 1.26.6
+go 1.26.8
 
 // replace go.mondoo.com/mql => ../mql
 


### PR DESCRIPTION
Raises the `go` directive in `go.mod` from 1.26.6 to 1.26.8.

No workflow change is needed: `.github/env` pins `golang-version=1.26`, which `setup-go` already resolves to the newest 1.26 patch release.

### Verification

- `go mod tidy` is a no-op beyond the one-line directive change.
- `GOTOOLCHAIN=go1.26.8 go build ./...` succeeds.