### PR TITLE
📝 skills: use absolute links so they resolve in an installed plugin

### DIFF
--- a/skills/mql/README.md
+++ b/skills/mql/README.md
@@ -22,4 +22,4 @@ The skill automatically activates when working on MQL-related tasks. You can als
 
 ## Installation
 
-See [skills/README.md](../README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.
+See [skills/README.md](https://github.com/mondoohq/cnspec/blob/main/skills/README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.

--- a/skills/mql/SKILL.md
+++ b/skills/mql/SKILL.md
@@ -164,7 +164,7 @@ If the Mondoo MCP server is available, you can use these tools instead of the CL
 
 `cnspec policy lint` proves a policy **compiles**. It does not prove a check reaches the verdict you claim, that an IaC variant ever matches an asset, or that a remediation snippet is well-formed and actually fixes the thing it documents. Those live in a separate suite.
 
-When you are authoring or editing policies **inside the cnspec repository**, every one of those checks lives in `content/validation/`, and [`content/validation/README.md`](../../content/validation/README.md) is the reference for all of it. Authoring rules are in [`content/CLAUDE.md`](../../content/CLAUDE.md).
+When you are authoring or editing policies **inside the cnspec repository**, every one of those checks lives in `content/validation/`, and [`content/validation/README.md`](https://github.com/mondoohq/cnspec/blob/main/content/validation/README.md) is the reference for all of it. Authoring rules are in [`content/CLAUDE.md`](https://github.com/mondoohq/cnspec/blob/main/content/CLAUDE.md).
 
 ```bash
 make test/content              # lint + bundle scans + compliance mappings

--- a/skills/policy-graph/README.md
+++ b/skills/policy-graph/README.md
@@ -24,4 +24,4 @@ Provides structured navigation of `.mql.yaml` policy bundles that replaces manua
 
 ## Installation
 
-See [skills/README.md](../README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.
+See [skills/README.md](https://github.com/mondoohq/cnspec/blob/main/skills/README.md) for installation instructions across Claude Code, Codex, Gemini CLI, and Cursor.


### PR DESCRIPTION
## What

Replaces the four repo-relative links in plugin-shipped skill files with their canonical `github.com` URLs.

## Why

A Claude Code plugin is installed as a **standalone directory containing only the skill's own files** — not a repo checkout. On a machine with `mql@cnspec-skills` installed:

```text
~/.claude/plugins/cache/cnspec-skills/mql/1.0.0/
├── README.md
├── SKILL.md
├── mql-reference.md
└── samples/
```

Nothing above the skill root is present, so any `../` link in a shipped file dangles for everyone who installed the skill rather than cloning the repo. Both broken links land on high-traffic paths:

| File | Link | Reached when |
| --- | --- | --- |
| `skills/mql/SKILL.md` | `../../content/validation/README.md`, `../../content/CLAUDE.md` | a policy author follows the content-validation guidance |
| `skills/mql/README.md` | `../README.md` | a new user looks up install instructions |
| `skills/policy-graph/README.md` | `../README.md` | same |

Absolute URLs resolve in all three contexts the skills are read in — installed plugin, local clone, and browsing the repo on GitHub — so they're the portable choice here. Verified each target returns HTTP 200:

```shell
$ for u in content/validation/README.md content/CLAUDE.md skills/README.md; do
    curl -s -o /dev/null -w "%{http_code} $u\n" "https://github.com/mondoohq/cnspec/blob/main/$u"
  done
200 content/validation/README.md
200 content/CLAUDE.md
200 skills/README.md
```

## Scope

Only files that ship *inside* a plugin are changed.

`skills/README.md` deliberately keeps its relative links to `../agents/AGENTS.md` and `../docs/graph.md`: it is repo-level documentation and is not part of either plugin (`marketplace.json` sources them from `./skills/mql` and `./skills/policy-graph`), so those links resolve fine wherever it is actually read.

## Verification

- `make skills/generate/check` → `agents/AGENTS.md is up to date.` (frontmatter untouched, so no regeneration needed)
- No remaining `](../` links under `skills/mql/` or `skills/policy-graph/`

## Background

Found while consolidating Mondoo's agent skills. The stale `mondoo-mql` mirror in `mondoohq/skills` was removed in [mondoohq/skills#14](https://github.com/mondoohq/skills/pull/14) in favour of this repo's maintained `mql` skill, which made these links the last rough edge for plugin users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
