### PR TITLE
🧹 skills: bump plugin versions so installed users get the updates

### DIFF
--- a/skills/mql/.claude-plugin/plugin.json
+++ b/skills/mql/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mql",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MQL query development with syntax guidance, platform-specific patterns, and MCP tool integration",
   "author": {
     "name": "Mondoo, Inc."

--- a/skills/policy-graph/.claude-plugin/plugin.json
+++ b/skills/policy-graph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-graph",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Navigate cnspec policy bundles using graph commands for LLMs",
   "author": {
     "name": "Mondoo, Inc."


### PR DESCRIPTION
## The problem

Both skills have been pinned at `1.0.0` since they were added in #2607, while their content changed **six times**. `claude plugin update` compares the version in `.claude-plugin/plugin.json` and short-circuits when it hasn't moved, so it never re-copies the files:

```text
$ claude plugin update mql@cnspec-skills
Checking for updates for plugin "mql@cnspec-skills" at user scope…
✔ mql is already at the latest version (1.0.0).
```

Refreshing the marketplace doesn't help either — that updates the clone, not the installed plugin.

**Nobody who installed these skills has received a single update in four months.** That includes #3141, which corrected auditd examples in `mql-reference.md` that were teaching a wrong MQL pattern:

```diff
-auditd.rules.files.where(path == '/etc/localtime' && keyname == 'time-change')
+auditd.rules.files.where(path == '/etc/localtime' && keyname != empty)
```

Installed users are still being served the version on the left.

## The change

Bumped per what actually changed since `1.0.0`:

| Skill | Version | Cumulative diff | What changed |
| --- | --- | --- | --- |
| `mql` | 1.0.0 → **1.1.0** | +55/−20 | gained the "Wiring Policies into Content Validation" section (#3376); corrected auditd (#3141) and azure (#3156) examples; link fixes (#3612) |
| `policy-graph` | 1.0.0 → **1.0.1** | +4/−11 | a cross-reference to the `mql` skill, plus link fixes — no new capability |

## Verification

I checked the mechanism rather than assuming it. Setting the version to `1.1.0` in a local marketplace clone makes the CLI behave correctly:

```text
$ claude plugin update mql@cnspec-skills
✔ Plugin "mql" updated from 1.0.0 to 1.1.0 for scope user. Restart to apply changes.

$ ls ~/.claude/plugins/cache/cnspec-skills/mql/
1.0.0/  1.1.0/     ← new directory, current content
```

The version is read from each skill's own `plugin.json` — `marketplace.json`'s `plugins[]` entries carry only `name`, `source`, `skills`, `description`, with no version field — so these two files are the only lever.

`make skills/generate/check` passes (`agents/AGENTS.md` unaffected).

## Follow-up worth considering

This remains a **manual** step, and forgetting it is exactly what caused the four-month gap. A CI check requiring a version bump whenever a file under `skills/<name>/` changes would make it durable. An alternative is deriving the version from the commit, which is what [`mondoohq/skills`](https://github.com/mondoohq/skills) does — its plugins report a git sha as their version and therefore update on every commit. Happy to open either as a follow-up; left out here to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
