### PR TITLE
🧹 deps: bump golang.org/x/crypto to v0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1175,8 +1175,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
Bumps `golang.org/x/crypto` from v0.55.0 to v0.56.0, clearing two High-severity advisories:

| Advisory | Severity | EPSS |
|---|---|---|
| GO-2026-6355 | High | 0.4% (30th) |
| GO-2026-6354 | High | 0.3% (23rd) |

`x/crypto` is an indirect dependency, so this only raises the module floor — no import changes. `go mod tidy` produced no further churn, and `go.sum` moves by a single hash pair, meaning v0.56.0 did not raise its own requirements on `x/sys` or `x/term`.

### Every other `golang.org/x/*` module is already current

`go list -m -u` over the full set reports no available upgrade for any of them:

```
golang.org/x/sync     v0.22.0
golang.org/x/sys      v0.47.0
golang.org/x/crypto   v0.55.0 [v0.56.0]
golang.org/x/exp      v0.0.0-20260824195058-e88cd73687aa
golang.org/x/mod      v0.40.0
golang.org/x/net      v0.58.0
golang.org/x/oauth2   v0.36.0
golang.org/x/term     v0.45.0
golang.org/x/text     v0.41.0
golang.org/x/time     v0.15.0
golang.org/x/tools    v0.49.0
golang.org/x/xerrors  v0.0.0-20240903120638-7835f813f4da
```

### Verification

- `go build ./...` — clean.
- `govulncheck ./...` — "No vulnerabilities found", 0 called vulnerabilities.

One module-level finding remains, and it is not actionable: `GO-2026-5932`, the standing advisory that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design. It lists `Fixed in: N/A`, so no version of `x/crypto` clears it. cnspec does not call into that package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)