### PR TITLE
👷 ci: sanitize the mql bump version before writing it to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/cnquery-update.yml
+++ b/.github/workflows/cnquery-update.yml
@@ -32,13 +32,19 @@ jobs:
           # Determine which version should be released based on event type
           VERSION: ${{ (github.event_name == 'workflow_dispatch' && inputs.version) || github.event.client_payload.version }}
         run: |
-          # Semantic Versioning regex (with optional 'v' prefix)
-          if [[ ! "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # Semantic Versioning regex (with optional 'v' prefix). The capture
+          # group matters: what lands in $GITHUB_OUTPUT below is re-emitted
+          # from BASH_REMATCH, not from $VERSION, so only the matched semver
+          # can ever reach a workflow environment file. Validating and then
+          # echoing the raw value would leave the output one regex bug away
+          # from an attacker-controlled newline injecting extra step outputs.
+          if [[ ! "$VERSION" =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "Error: Version is not a valid semantic version."
             exit 1
           fi
-          echo "Version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          MQL_VERSION="${BASH_REMATCH[1]}"
+          echo "Version: $MQL_VERSION"
+          echo "version=$MQL_VERSION" >> "$GITHUB_OUTPUT"
       # Sparse-checkout the scripts dir before we know the target branch, so
       # we can run determine-mql-bump-base.sh to figure out where to open the
       # bump PR. The full checkout of the target branch happens further down.
@@ -94,7 +100,7 @@ jobs:
           ref: ${{ steps.base.outputs.base }}
 
       - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
+        run: cat ".github/env" >> "$GITHUB_ENV"
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -125,8 +131,8 @@ jobs:
         run: |
           BRANCH_NAME="version/mql_update_${MQL_VERSION}"
           COMMIT_MSG="🧹 Bump mql to ${MQL_VERSION}"
-          echo "COMMIT_TITLE=${COMMIT_MSG}" >> $GITHUB_OUTPUT
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "COMMIT_TITLE=${COMMIT_MSG}" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
 
       # Dry-run: print what the PR WOULD have looked like, and stop.
       # Everything above (base decision, go get, VERSION write) still runs


### PR DESCRIPTION
Closes the xgrep `actions-env-laundered-injection` finding — [code scanning alert 1092](https://github.com/mondoohq/cnspec/security/code-scanning/1092), HIGH — on `.github/workflows/cnquery-update.yml`.

## The finding

The **Determine Version and Validate** step takes its version from `inputs.version` or `github.event.client_payload.version`, validates it against an anchored semver regex, and then echoed the raw `$VERSION` into `$GITHUB_OUTPUT`. A newline in a value written to a workflow environment file injects additional step outputs that later steps consume, so the safety of that write rested entirely on the regex holding.

## It is hardening, not an exploitable bug

The existing guard does hold. Bash compiles `[[ =~ ]]` patterns as POSIX ERE without `REG_NEWLINE`, so `^...$` anchor to the whole string rather than to a line:

```
$ VERSION=$(printf 'v1.2.3\nEVIL=1')
$ [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo accept || echo reject
reject
```

The `repository_dispatch` path is additionally gated on the sender being `mondoo-tools`. Nothing is currently getting through.

## The change

What changes is where the output value comes from. The regex now captures the version, and the step re-emits `${BASH_REMATCH[1]}` instead of `$VERSION`:

```bash
if [[ ! "$VERSION" =~ ^(v?[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
  echo "Error: Version is not a valid semantic version."
  exit 1
fi
MQL_VERSION="${BASH_REMATCH[1]}"
echo "version=$MQL_VERSION" >> "$GITHUB_OUTPUT"
```

The value written to `$GITHUB_OUTPUT` is now *constructed from the match* rather than merely blessed by it, so a future loosening of the pattern cannot carry an unmatched suffix through. `BASH_REMATCH` is populated whenever the regex engine runs and the leading `!` negates only the exit status, so it is still set on the fall-through path.

Also quotes the three unquoted `$GITHUB_OUTPUT` / `$GITHUB_ENV` redirections in this file, which makes it clean under actionlint (SC2086).

## Verification

Run with xgrep **0.58.0**, the same version that raised the alert — a locally installed 0.37.0 does not carry this rule at all and reports the file clean either way.

| | before | after |
|---|---|---|
| `xgrep scan` on the file | `actions-env-laundered-injection` (HIGH, confidence HIGH) at line 41 | no findings |
| `actionlint` on the file | SC2086 at line 103 | no issues |

Accept/reject behaviour of the step is unchanged:

| input | verdict |
|---|---|
| `v1.2.3`, `13.36.0`, `v14.0.0` | accepted, `version=` set to the same value as before |
| `1.2`, `abc` | rejected |
| `v1.2.3; rm -rf /` | rejected |
| `v1.2.3\nEVIL=1` | rejected |

This was the only instance of the rule in the repository.