### PR TITLE
🐛 content: report unreachable endpoints instead of scoring them clean

### DIFF
--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.6.0
+    version: 1.6.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -36,19 +36,34 @@ policies:
       # target); this guard is what protects users until they pick that up, since
       # the network provider versions independently of cnspec.
       #
-      # The four checks carrying `dns.fqdn == dns.zone.fqdn` are zone-wide, and
-      # that filter keeps them on the one name able to answer them. DNSKEY, NS
-      # and SOA records exist at a zone apex and nowhere else inside the zone,
-      # so asking www.example.com whether its zone is signed, or how many
-      # nameservers serve it, reads empty and fails a name that has nothing to
-      # misconfigure. Scanning an apex surfaces the `www` host as an asset of
-      # its own, which is where those failures were reported.
+      # The four zone-wide checks are filtered on `dns.fqdn ==
+      # domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn`, which
+      # keeps them on the names able to answer them. DNSKEY, NS and SOA records
+      # exist at a zone apex and nowhere else inside the zone, so asking
+      # www.example.com whether its zone is signed, or how many nameservers
+      # serve it, reads empty and fails a name that has nothing to misconfigure.
+      # Scanning an apex surfaces the `www` host as an asset of its own, which
+      # is where those failures were reported.
       #
       # The apex is established by delegation (`dns.zone`) rather than by the
       # public suffix list, so a delegated subdomain is audited as the zone it
       # is: `cs.cmu.edu` has its own nameservers and its own signing state, and
-      # an eTLD+1 test would skip it as a subdomain of `cmu.edu`. This needs
-      # network provider 13.3.1 or newer, which is where `dns.zone` lands.
+      # an eTLD+1 test alone would skip it as a subdomain of `cmu.edu`. This
+      # needs network provider 13.3.1 or newer, which is where `dns.zone` lands.
+      #
+      # The registrable-domain test comes first so the common case never makes
+      # the lookup. `dns.zone` walks the delegation over the network, and
+      # dnsshake reports a query failure as an error rather than a null zone —
+      # deliberately, so a resolver outage is not read as "this name has no
+      # zone". A filter that errors is not a filter that is false: the resolver
+      # drops the check from the resolved policy, so a timed-out lookup removes
+      # these four silently, with no failure and no error in the report. For a
+      # name whose zone apex is its registrable domain — every name this policy
+      # is normally pointed at — the first arm is true and `||` short-circuits
+      # before `dns.zone` is ever touched. A delegated apex such as `cs.cmu.edu`
+      # still needs the lookup, and remains exposed to that outage; the ordering
+      # shrinks the window rather than closing it. Closing it means teaching the
+      # resolver to tell a filter that errored from one that was false.
       - title: Networking
         filters: |
           asset.family.contains('network') && dns.fqdn != empty
@@ -66,7 +81,7 @@ queries:
   - uid: mondoo-dns-security-no-cname-for-root-domain
     title: Ensure no CNAME is used for root domain
     impact: 60
-    filters: dns.fqdn == dns.zone.fqdn
+    filters: dns.fqdn == domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
@@ -157,7 +172,7 @@ queries:
   - uid: mondoo-dns-security-no-ip-for-ns-mx-records
     title: Ensure NS and MX records are not pointing to IP addresses
     impact: 75
-    filters: dns.fqdn == dns.zone.fqdn
+    filters: dns.fqdn == domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-log-08
@@ -425,7 +440,7 @@ queries:
   - uid: mondoo-dns-security-dnssec-enabled
     title: Ensure DNSSEC is enabled
     impact: 75
-    filters: dns.fqdn == dns.zone.fqdn
+    filters: dns.fqdn == domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-cek-04
@@ -636,7 +651,7 @@ queries:
   - uid: mondoo-dns-security-ns-redundancy
     title: Ensure at least two NS records exist
     impact: 60
-    filters: dns.fqdn == dns.zone.fqdn
+    filters: dns.fqdn == domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn
     tags:
       compliance/bsi-sys-1-5: false
       compliance/csa-cloud-controls-matrix-4: cloud-controls-matrix-4-bcr-08

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.3.2
+    version: 1.4.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -29,6 +29,29 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # This group's filter is deterministic on purpose. The other groups here
+      # select on `http.get.header != empty` and `tls.certificates != empty`,
+      # both of which reach out over the network to decide whether the group
+      # applies — and when the request cannot be made, the expression errors
+      # rather than returning empty. A filter that errors is not a filter that
+      # is false: the resolver drops the checks behind it from the resolved
+      # policy, so a host with nothing answering on the scanned port came back
+      # with zero checks and a clean score. `asset.platform == 'host'` cannot
+      # fail, so this one check always runs and reports the unreachable endpoint
+      # as the finding it is, while the header groups keep their request filter
+      # and stay quiet rather than failing every header individually.
+      #
+      # That leaves the partial case open: when the host answers but a header
+      # group's own request fails transiently, that group still disappears
+      # without a trace, and this check passes. Observed on a healthy host — one
+      # run of this policy returned the three HSTS checks and the next did not.
+      # Closing it means teaching the resolver to tell a filter that errored
+      # from one that was false, rather than dropping both.
+      - title: HTTP endpoint
+        filters: |
+          asset.platform == 'host'
+        checks:
+          - uid: mondoo-http-security-endpoint-responds
       - title: Headers for HTTP/HTTPS communication
         filters: |
           asset.platform == 'host' && http.get.header != empty
@@ -57,6 +80,29 @@ policies:
           - uid: mondoo-http-security-hsts-preload
     scoring_system: highest impact
 queries:
+  - uid: mondoo-http-security-endpoint-responds
+    title: Ensure the host answers an HTTP request
+    impact: 70
+    mql: http.get.header != empty
+    docs:
+      desc: |
+        This check verifies that the scanned host answers an HTTP request with response headers, which is the precondition for every header check in this policy.
+
+        A failure means no HTTP response was obtained at all: nothing is listening on the scanned port, the port is filtered, or the connection was reset before headers were returned. Confirm with `curl -sSI https://<host>/`, which prints the status line and headers when the endpoint answers and the transport error when it does not.
+
+        **Why this matters**
+
+        This check exists because its absence scored the wrong answer. The header groups in this policy select assets with `http.get.header != empty`, an expression that performs the request; when the request cannot be made the expression errors, and a check whose filter errors is dropped from the resolved policy rather than failed. A host that answered nothing therefore reported zero checks and a passing score — indistinguishable, in the report, from a host that returned every security header this policy asks for.
+
+        Treating "no answer" as "nothing to report" also hides the ordinary causes of an unreachable endpoint, which are worth knowing: a service that is down, a listener bound to the wrong interface, or a firewall rule that is broader than intended.
+      audit: |
+        Run `curl -sSI https://<HOST>/` and confirm that a status line and response headers are returned.
+      remediation: |
+        Serve HTTP on the scanned port, or scan the port that is served.
+
+        - Confirm the service is listening on the expected interface: `ss -lntp | grep -E ':(80|443)'`.
+        - Confirm no firewall drops the port: `sudo iptables -L -n | grep -E '(80|443)'`, or the equivalent cloud security-group rule.
+        - If the site is fronted by a load balancer, reverse proxy, or CDN, scan that endpoint — it is where the response headers this policy assesses are set.
   - uid: mondoo-http-security-x-content-type-options-nosniff
     title: Set X-Content-Type-Options HTTP header to 'nosniff'
     impact: 60

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security
-    version: 1.8.0
+    version: 1.9.0
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -28,6 +28,29 @@ policies:
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:
+      # This group's filter is deterministic on purpose. Every other group here
+      # selects on `tls.params != empty`, which opens a TLS connection to decide
+      # whether the group applies — and when that connection cannot be made, the
+      # expression errors rather than returning empty. A filter that errors is
+      # not a filter that is false: the resolver drops the checks behind it from
+      # the resolved policy, so a host with nothing listening on the scanned port
+      # came back with zero checks and a clean score, which is the worst possible
+      # answer from a TLS policy. `asset.platform == 'host'` cannot fail, so this
+      # one check always runs and reports the unreachable endpoint as the finding
+      # it is. The detail groups keep their connection filter, so a host that
+      # legitimately serves no TLS still gets one row here rather than a wall of
+      # failures for ciphers and certificates that were never negotiated.
+      #
+      # That leaves the partial case open: when the host answers but the
+      # handshake behind a detail group's filter fails transiently, that group
+      # still disappears without a trace, and this check passes. Closing that
+      # means teaching the resolver to tell a filter that errored from one that
+      # was false, rather than dropping both.
+      - title: TLS/SSL endpoint
+        filters: |
+          asset.platform == 'host'
+        checks:
+          - uid: mondoo-tls-security-endpoint-negotiates-tls
       - title: Secure TLS/SSL connection
         filters: |
           asset.platform == 'host' && tls.params != empty
@@ -61,6 +84,29 @@ policies:
           - uid: mondoo-tls-security-cert-ocsp-configured
     scoring_system: highest impact
 queries:
+  - uid: mondoo-tls-security-endpoint-negotiates-tls
+    title: Ensure the host negotiates a TLS connection
+    impact: 70
+    mql: tls.params != empty
+    docs:
+      desc: |
+        This check verifies that the scanned host completes a TLS handshake on the scanned port, which is the precondition for every other check in this policy.
+
+        A failure means no TLS session could be established at all: nothing is listening on the port, the port is filtered, the service speaks a non-TLS protocol on it, or the handshake was rejected outright. Confirm which by connecting directly — `openssl s_client -connect <host>:443` reports whether the port answers and, if it does, what it answered with. If the host is not intended to serve TLS on the scanned port, scan the port that does (`cnspec scan host <host>:<port>`) rather than suppressing the check, and if it is not intended to serve TLS at all, this policy is not the one to point at it.
+
+        **Why this matters**
+
+        This check exists because its absence scored the wrong answer. The other groups in this policy select assets with `tls.params != empty`, an expression that opens a TLS connection; when that connection cannot be made the expression errors, and a check whose filter errors is dropped from the resolved policy rather than failed. A host with no TLS listener therefore reported zero checks and a passing score — indistinguishable, in the report, from a host whose TLS is configured correctly.
+
+        Unencrypted transport is also the condition every one of those checks is meant to prevent. A service reached over plaintext exposes credentials, session tokens, and payloads to anyone on the path, and offers no way for a client to detect tampering — which is a stronger finding than any individual cipher or certificate weakness this policy reports, not a reason to stay silent.
+      audit: |
+        Run `openssl s_client -connect <HOST>:443 -servername <HOST> </dev/null` and confirm that a certificate chain and a negotiated protocol version are returned.
+      remediation: |
+        Serve TLS on the scanned port, or scan the port where TLS is served.
+
+        - Confirm the service is listening: `ss -lntp | grep ':443'` on the host.
+        - Confirm no firewall drops the port: `sudo iptables -L -n | grep 443`, or the equivalent cloud security-group rule.
+        - If TLS terminates elsewhere (a load balancer, a reverse proxy, a CDN), scan that endpoint instead — it is where the TLS configuration this policy assesses actually lives.
   - uid: mondoo-tls-security-cert-domain-name-match
     title: Certificate's domain name must match
     impact: 90


### PR DESCRIPTION
## The bug

A group filter that performs network I/O decides which checks apply by reaching out over the network. When that call fails, the expression **errors** rather than returning empty — and a filter that errors is not a filter that is false. The resolver drops the checks behind it from the resolved policy, so the failure leaves no trace: no checks, no errors, and a passing score.

Verified against a host with nothing listening on the scanned port:

```
cnspec scan host dnssec-failed.org -f content/mondoo-tls-security.mql.yaml
  → 0 checks, LOW (0)

cnspec scan host dnssec-failed.org -f content/mondoo-http-security.mql.yaml
  → 0 checks, LOW (0)
```

A TLS policy answering "clean" for a host that speaks no TLS is the worst available answer, and in the report it is indistinguishable from a host that passed every check. Control: `ftp.gnu.org`, which does listen on 443, gets all 22 TLS checks — the mechanism is the failed connection, not the host being uninteresting.

## The fix

One check per policy, in a group whose filter is `asset.platform == 'host'` and therefore cannot fail, asserting the endpoint answers at all:

| policy | new check | version |
|---|---|---|
| `mondoo-tls-security` | Ensure the host negotiates a TLS connection | 1.8.0 → 1.9.0 |
| `mondoo-http-security` | Ensure the host answers an HTTP request | 1.3.2 → 1.4.0 |

The detail groups keep their connection filters on purpose, so a host that legitimately serves no TLS gets a single row rather than a wall of failures for ciphers and certificates that were never negotiated.

## `mondoo-dns-security`

The same shape reached the four zone-wide checks added in #3579, filtered on `dns.fqdn == dns.zone.fqdn`. `dns.zone` walks the delegation over the network, and dnsshake reports a query failure as an error rather than a null zone — deliberately, so a resolver outage is not read as *this name has no zone*. A timed-out lookup therefore removes those four silently.

The filter now tests the registrable domain first:

```
dns.fqdn == domainName.effectiveTLDPlusOne || dns.fqdn == dns.zone.fqdn
```

For a name whose apex is its registrable domain — every name this policy is normally pointed at — the first arm is true and `||` short-circuits before `dns.zone` is touched. This follows the reasoning already recorded on the HSTS group filter in `mondoo-http-security`, which was joined with `&&` for the same short-circuit reason. A delegated apex such as `cs.cmu.edu` still needs the lookup and stays exposed, so this **shrinks the window rather than closing it**; 1.6.0 → 1.6.1, since nothing changes when lookups succeed.

## Verification

Scan counts before (`main`) and after, per host:

| host | DNS | TLS | HTTP |
|---|---|---|---|
| `mondoo.com` | 8 → 8 | 22 → 23 | 13 → 14 |
| `www.mondoo.com` | 4 → 4 | 22 → 23 | 13 → 14 |
| `cs.cmu.edu` | 8 → 8 | 22 → 23 | 13 → 14 |
| `dnssec-failed.org` | 8 → 8 | **0 → 1** | **0 → 1** |

DNS is unchanged everywhere, which is the intent — the reorder only matters when a lookup fails. The `+1` on reachable hosts is the new check passing. `#3579`'s own results still hold: `www.mondoo.com` scores no zone-wide checks, `cs.cmu.edu` is audited as the zone it is.

Green locally: `cnspec policy lint ./content`, `remediation/code/bash.py` (3600 PASS, 0 FAIL), `go test ./content/validation/compliance/...`, `typos`.

## What this does not fix

The partial case. If a host answers but a detail group's own network call fails transiently, that group still disappears silently and the new check passes — observed once on a healthy host, where one run returned the three HSTS checks and the next did not.

Closing that means teaching the resolver to tell a filter that **errored** from one that was **false**, rather than dropping both. That is an engine change rather than a content change, and it is not attempted here; each policy carries a comment recording the limit at the filter it affects.
