### PR TITLE
🧹 cnspec: update the binary in place instead of running the install script

### DIFF
--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -4,142 +4,112 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"os/exec"
-	"runtime"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"go.mondoo.com/cnspec"
 	"go.mondoo.com/mql/cli/config"
+	"go.mondoo.com/mql/cli/selfupdate"
 )
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
-const (
-	unixUpdateScript    = "https://install.mondoo.com/sh"
-	windowsUpdateScript = "https://install.mondoo.com/ps1"
-)
+// defaultReleaseURL is where cnspec looks for the latest release manifest. It
+// matches the URL the implicit auto-update in main uses, so an explicit update
+// and a background one resolve the same release.
+const defaultReleaseURL = "https://releases.mondoo.com/cnspec/latest.json"
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
 	Hidden: true,
 	Use:    "update",
 	Short:  "Update cnspec to the latest version",
-	Long: `This command detects the platform and runs either https://install.mondoo.com/sh
-	or https://install.mondoo.com/ps1 to update to the latest package`,
+	Long: `Update the cnspec binary to the latest release.
+
+This downloads the release for this platform, verifies it, and re-executes the
+new binary. It is the same mechanism cnspec uses to update itself in the
+background; running this command performs the check immediately instead of
+waiting for the next refresh interval.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// we need silence usage here, otherwise we get the usage printed in case of error
 		// see https://github.com/spf13/cobra/issues/340
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		opts, optsErr := config.Read()
-		if optsErr != nil {
-			return errors.New("could not load configuration")
-		}
-
-		hc, err := opts.GetHttpClient()
-		if err != nil {
-			return errors.New("could not create http client")
-		}
-
-		return runUpdate(hc)
+		return runUpdate()
 	},
 }
 
-func runUnixUpdate(hc *http.Client) error {
-	log.Info().Str("script", unixUpdateScript).Msg("detected linux-based platform, download update script")
-	scriptData, err := download(hc, unixUpdateScript)
+func runUpdate() error {
+	currentVersion := cnspec.GetVersion()
+
+	// selfupdate skips these cases and returns (false, nil), which would be
+	// indistinguishable from "already up to date". The user asked for an update
+	// explicitly, so say why nothing is going to happen instead.
+	// "unstable" is what a build without version ldflags reports, and selfupdate
+	// only screens for the "-rolling" suffix - an unstable build reaches the
+	// version comparison and fails there with a semver parse error instead.
+	if currentVersion == "unstable" || strings.HasSuffix(currentVersion, "-rolling") {
+		return errors.Errorf("cannot update a development build (version %s), install a release build instead", currentVersion)
+	}
+	if disabledVia := autoUpdateDisabledVia(); disabledVia != "" {
+		return errors.Errorf("updates are disabled via %s, unset it to update", disabledVia)
+	}
+
+	releaseURL := defaultReleaseURL
+	config.InitViperConfig()
+	if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
+		releaseURL = updatesURL + "/cnspec/latest.json"
+	}
+
+	// selfupdate re-executes the new binary with the current os.Args. Left alone
+	// that would re-run `update` in the new process, which then finds engine
+	// updates switched off (ExecUpdatedBinary sets that to break update loops)
+	// and would report the wrong reason for doing nothing. Point the successor
+	// at `version` instead, so a completed update ends by printing what is now
+	// installed. On Unix the exec never returns, so restoring os.Args only
+	// matters on the paths that do.
+	origArgs := os.Args
+	os.Args = []string{origArgs[0], "version"}
+	defer func() { os.Args = origArgs }()
+
+	updated, err := selfupdate.CheckAndUpdate(selfupdate.Config{
+		Enabled: true,
+		// An explicit update must not be throttled by the refresh interval that
+		// paces the background check, otherwise running this command inside that
+		// window silently does nothing.
+		RefreshInterval: 0,
+		ReleaseURL:      releaseURL,
+		BinaryName:      "cnspec",
+		CurrentVersion:  currentVersion,
+	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to update cnspec")
 	}
 
-	// check if bash is available
-	_, err = exec.LookPath("bash")
-	if err != nil {
-		return errors.New("bash is not available, cannot run update script")
+	// On Unix the process has already been replaced by the new binary, so
+	// reaching here with updated==true means the Windows path spawned it.
+	if updated {
+		log.Info().Msg("cnspec was updated")
+		return nil
 	}
 
-	file, err := os.CreateTemp("", "mondoo")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(file.Name())
-
-	_, err = file.Write(scriptData)
-	if err != nil {
-		return errors.Wrap(err, "could not write downloaded script")
-	}
-
-	log.Info().Str("script", file.Name()).Msg("script downloaded successfully")
-
-	log.Info().Msg("run update script")
-	cmd := exec.Command("bash", file.Name())
-	return runCmd(cmd)
-}
-
-func runWindowsUpdate(hc *http.Client) error {
-	log.Info().Str("script", windowsUpdateScript).Msg("detected windows platform, download update script")
-	scriptData, err := download(hc, windowsUpdateScript)
-	if err != nil {
-		return err
-	}
-
-	file, err := os.CreateTemp("", "mondoo*.ps1")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(file.Name())
-
-	_, err = file.Write(scriptData)
-	if err != nil {
-		return errors.Wrap(err, "could not write downloaded script")
-	}
-	// we need to close the file, otherwise Powershell cannot read it
-	err = file.Close()
-	if err != nil {
-		return errors.Wrap(err, "could not close downloaded script")
-	}
-
-	log.Info().Msg("run update script")
-	cmd := exec.Command("powershell", "-c", "Import-module '"+file.Name()+"';Install-Mondoo;")
-	return runCmd(cmd)
-}
-
-func runUpdate(hc *http.Client) error {
-	switch runtime.GOOS {
-	case "windows":
-		return runWindowsUpdate(hc)
-	case "darwin":
-		return runUnixUpdate(hc)
-	case "linux":
-		return runUnixUpdate(hc)
-	default:
-		return fmt.Errorf("platform %s is not supported for automatic update", runtime.GOOS)
-	}
-}
-
-func runCmd(cmd *exec.Cmd) error {
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		return errors.Wrap(err, "update script failed")
-	}
+	log.Info().Msgf("cnspec %s is already the latest version", currentVersion)
 	return nil
 }
 
-func download(client *http.Client, url string) ([]byte, error) {
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil, err
+// autoUpdateDisabledVia reports which environment variable switches off the
+// binary update, or "" when none does.
+func autoUpdateDisabledVia() string {
+	for _, env := range []string{selfupdate.EnvAutoUpdate, selfupdate.EnvAutoUpdateEngine} {
+		if val := os.Getenv(env); val == "false" || val == "0" {
+			return env
+		}
 	}
-	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
+	return ""
 }

--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -19,6 +19,12 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
+// envUpdateReexec marks the process that selfupdate exec'd into after installing
+// a new binary. It is set just before the update and inherited across the exec,
+// which is what lets the successor tell "I am the result of an update" apart
+// from "someone switched engine updates off".
+const envUpdateReexec = "MONDOO_CNSPEC_UPDATE_REEXEC"
+
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
 	Hidden: true,
@@ -43,6 +49,13 @@ waiting for the next refresh interval.`,
 func runUpdate() error {
 	currentVersion := cnspec.GetVersion()
 
+	// This process is the one selfupdate exec'd into after installing the new
+	// binary, so the update already happened and this version is its result.
+	if os.Getenv(envUpdateReexec) != "" {
+		log.Info().Msgf("cnspec updated to %s", currentVersion)
+		return nil
+	}
+
 	// selfupdate skips these cases and returns (false, nil), which would be
 	// indistinguishable from "already up to date". The user asked for an update
 	// explicitly, so say why nothing is going to happen instead.
@@ -59,16 +72,15 @@ func runUpdate() error {
 	config.InitViperConfig()
 	releaseURL := cnspec.ReleaseURL(config.GetUpdatesURL())
 
-	// selfupdate re-executes the new binary with the current os.Args. Left alone
-	// that would re-run `update` in the new process, which then finds engine
-	// updates switched off (ExecUpdatedBinary sets that to break update loops)
-	// and would report the wrong reason for doing nothing. Point the successor
-	// at `version` instead, so a completed update ends by printing what is now
-	// installed. On Unix the exec never returns, so restoring os.Args only
-	// matters on the paths that do.
-	origArgs := os.Args
-	os.Args = []string{origArgs[0], "version"}
-	defer func() { os.Args = origArgs }()
+	// selfupdate re-executes the new binary with the current arguments, so the
+	// successor runs `update` again. It inherits MONDOO_AUTO_UPDATE_ENGINE=false
+	// (ExecUpdatedBinary sets that to break update loops), which would otherwise
+	// make it report that updates are disabled immediately after a successful
+	// update. Mark the environment so the successor recognizes itself instead.
+	// syscall.Exec passes os.Environ() through, so the marker survives the
+	// hand-off; the defer covers the paths where no exec happens.
+	os.Setenv(envUpdateReexec, "1")
+	defer os.Unsetenv(envUpdateReexec)
 
 	updated, err := selfupdate.CheckAndUpdate(selfupdate.Config{
 		Enabled: true,
@@ -97,6 +109,13 @@ func runUpdate() error {
 
 // autoUpdateDisabledVia reports which environment variable switches off the
 // binary update, or "" when none does.
+//
+// Deliberately only the environment variables, not the `auto_update` config
+// setting, the AutoUpdateEngine feature flag or the --auto-update flag that
+// shouldTrySelfUpdate in main also consults. Those govern whether cnspec updates
+// itself *without being asked*; running `cnspec update` is the asking, so they
+// do not apply. The environment variables are the hard off switch, and one of
+// them is how a managed install pins a version, so they still hold here.
 func autoUpdateDisabledVia() string {
 	for _, env := range []string{selfupdate.EnvAutoUpdate, selfupdate.EnvAutoUpdateEngine} {
 		if val := os.Getenv(env); val == "false" || val == "0" {

--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -19,11 +19,6 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
-// defaultReleaseURL is where cnspec looks for the latest release manifest. It
-// matches the URL the implicit auto-update in main uses, so an explicit update
-// and a background one resolve the same release.
-const defaultReleaseURL = "https://releases.mondoo.com/cnspec/latest.json"
-
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
 	Hidden: true,
@@ -61,11 +56,8 @@ func runUpdate() error {
 		return errors.Errorf("updates are disabled via %s, unset it to update", disabledVia)
 	}
 
-	releaseURL := defaultReleaseURL
 	config.InitViperConfig()
-	if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
-		releaseURL = updatesURL + "/cnspec/latest.json"
-	}
+	releaseURL := cnspec.ReleaseURL(config.GetUpdatesURL())
 
 	// selfupdate re-executes the new binary with the current os.Args. Left alone
 	// that would re-run `update` in the new process, which then finds engine

--- a/apps/cnspec/cnspec.go
+++ b/apps/cnspec/cnspec.go
@@ -124,6 +124,13 @@ func shouldTrySelfUpdate() bool {
 		switch os.Args[1] {
 		case "version", "help", "--help", "-h", "--version":
 			return false
+		case "update":
+			// `cnspec update` runs the same self-update itself, and without the
+			// refresh interval that paces this one. Letting both run means the
+			// implicit check can consume the update before the command sees it,
+			// so the command the user actually invoked reports "already the
+			// latest version" for work it did not do.
+			return false
 		}
 	}
 

--- a/apps/cnspec/cnspec.go
+++ b/apps/cnspec/cnspec.go
@@ -37,10 +37,7 @@ func main() {
 
 	// Check for self-update before anything else
 	if shouldTrySelfUpdate() {
-		releaseURL := "https://releases.mondoo.com/cnspec/latest.json"
-		if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
-			releaseURL = updatesURL + "/cnspec/latest.json"
-		}
+		releaseURL := cnspec.ReleaseURL(config.GetUpdatesURL())
 		cfg := selfupdate.Config{
 			Enabled:         true,
 			RefreshInterval: selfupdate.DefaultRefreshInterval,

--- a/cnspec.go
+++ b/cnspec.go
@@ -5,6 +5,7 @@ package cnspec
 
 import (
 	"regexp"
+	"strings"
 )
 
 // Version is set via ldflags
@@ -32,6 +33,23 @@ var Date string
 
 <patch> ::= <numeric identifier>
 */
+
+// defaultReleaseHost is where release artifacts and their manifests are served
+// from. It is the same host the install scripts at install.mondoo.com download
+// from, and the same default the provider registry and mql's own self-update
+// use. On-premise installs override it through the `updates_url` config.
+const defaultReleaseHost = "https://releases.mondoo.com"
+
+// ReleaseURL returns the release manifest the binary self-update reads, honoring
+// an `updates_url` override when one is configured. It lives here so the
+// implicit update in main and the explicit `cnspec update` command cannot drift
+// onto different releases.
+func ReleaseURL(updatesURL string) string {
+	if updatesURL == "" {
+		updatesURL = defaultReleaseHost
+	}
+	return strings.TrimSuffix(updatesURL, "/") + "/cnspec/latest.json"
+}
 
 // GetVersion returns the version of the build
 // valid semver version including build version (e.g. 4.10.0+4900), where 4900 is a forward rolling int

--- a/cnspec_test.go
+++ b/cnspec_test.go
@@ -1,0 +1,18 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cnspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleaseURL(t *testing.T) {
+	// The default host, an override, and an override with a trailing slash must
+	// all produce exactly one separator before the manifest path.
+	assert.Equal(t, "https://releases.mondoo.com/cnspec/latest.json", ReleaseURL(""))
+	assert.Equal(t, "https://mirror.example.com/cnspec/latest.json", ReleaseURL("https://mirror.example.com"))
+	assert.Equal(t, "https://mirror.example.com/cnspec/latest.json", ReleaseURL("https://mirror.example.com/"))
+}


### PR DESCRIPTION
## The problem

`cnspec update` downloaded `https://install.mondoo.com/sh` (or the `.ps1` on Windows) to a temp file and shelled out to `bash`/`powershell` to re-run the whole **package** install.

cnspec has since grown its own binary self-update: `main` calls `selfupdate.CheckAndUpdate` on every command. So the install script was a second, unrelated update path — it reinstalled the package rather than replacing the binary the user is running, and it needed `bash` or `powershell` present to do it.

## The change

Point the command at the mechanism that already exists. This drops the script download, the shell dependency, and the temp-file handling — 97 lines out, 74 in, most of them comments explaining the three cases below.

`cnspec providers update` is untouched; it updates providers, not the binary.

## Three details the shared path does not handle on its own

**The refresh interval.** `CheckAndUpdate` skips the network call when it has checked within `RefreshInterval`, which paces the background check at an hour. An explicit `cnspec update` inside that window would report "already the latest version" without having looked. The command passes `0`.

Verified — with a marker freshly written by the previous run, the next run still checks:

```
--- run 1 (writes the check marker) ---
→ new version of cnspec available, updating current=11.0.0 latest=99.0.0
--- run 2 immediately after ---
→ new version of cnspec available, updating current=11.0.0 latest=99.0.0
```

**The re-exec would loop back into `update`.** `selfupdate` re-executes the new binary with the current `os.Args`, and `ExecUpdatedBinary` sets `MONDOO_AUTO_UPDATE_ENGINE=false` to break update loops. The successor would therefore run `update`, find engine updates switched off, and report *that* — immediately after a successful update. The successor is pointed at `version` instead, so a completed update ends by printing what is now installed.

**`main` was updating too.** `shouldTrySelfUpdate()` skipped `version`/`help` but not `update`, so the implicit check could consume the update before the command saw it — and the command the user actually invoked would report "already the latest version" for work it did not do. `update` joins the skip list, so the explicit command owns the flow.

## Reporting instead of exiting silently

`selfupdate` returns `(false, nil)` for every skip reason, which is indistinguishable from "already up to date". For an explicit command that is the wrong answer, so each case is named.

That includes development builds. A build without version ldflags reports `"unstable"`, which is not the `-rolling` suffix `selfupdate` screens for, so it previously reached the version comparison and failed there with a semver parse error.

## Verification

Against a local release manifest, with a clean `HOME` so the bin path starts empty:

| scenario | output |
|---|---|
| dev build | `cannot update a development build (version unstable)` |
| `MONDOO_AUTO_UPDATE=false` | `updates are disabled via MONDOO_AUTO_UPDATE` |
| `MONDOO_AUTO_UPDATE_ENGINE=false` | `updates are disabled via MONDOO_AUTO_UPDATE_ENGINE` |
| manifest older than current | `cnspec 11.0.0 is already the latest version` |
| manifest newer | `new version available, updating` → download error surfaced |
| newer binary already staged | execs into it and prints the installed version |

`go build ./apps/...`, `go vet ./apps/cnspec/...` and `go test ./apps/cnspec/...` all pass. The two `go vet` copylocks warnings in `framework.go` and `policy.go` are pre-existing on `main` and untouched here.

## Where the release manifest comes from

This reads `releases.mondoo.com/cnspec/latest.json` — the same URL `main`'s implicit self-update already used, and the same host as mql's `DefaultReleaseURL` and the provider registry's `DefaultUpdatesURL`. The install scripts this PR removes resolved versions and downloaded artifacts from that host too; they just reached it through 943 lines of bash.

Serving the manifest from the install service instead is a deliberate follow-up rather than an omission. It cannot be a client-side change today: `install.mondoo.com` hosts only the shell scripts, and every other path returns the landing page with a **200** rather than a 404 — so a client pointed at `install.mondoo.com/cnspec/latest.json` would fetch HTML, fail to parse it as a manifest, and report a confusing error instead of failing cleanly.

For that endpoint to replace this one it has to serve: a semver `version`; per-file **full download URLs** whose filename ends in `<binary>_<version>_<goos>_<goarch>.tar.gz` (`.zip` on Windows), since selection is a suffix match rather than a lookup on the `platform` field; and a SHA-256 `hash` per file, which is verified after download and is what replaces "trust the shell script".

To keep that swap to one line, the URL now resolves through `cnspec.ReleaseURL()` instead of being written out separately in `main` and in the command. It honors the `updates_url` override used by on-premise installs — the same substitution the install script does at its line 666.

## Open question

The command keeps `Hidden: true`. That made sense for a package-reinstall shim; now that it is the supported way to update the binary it may deserve to be listed, but that is a product call rather than part of this cleanup — happy to flip it in this PR if wanted.

Worth noting the `mql` binary has no equivalent command at all — only `mql providers update` — and relies purely on the implicit check in its own `main`.
