### PR TITLE
🧹 repo: drop duplicated guidance from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-cnspec is an open-source, cloud-native security and policy project that assesses infrastructure security and compliance. It finds vulnerabilities and misconfigurations across cloud environments, Kubernetes, containers, servers, SaaS products, and more.
-
 **cnspec is built on top of mql** (`go.mondoo.com/mql`). mql provides the MQL query engine, provider system, and resource framework; cnspec adds policy evaluation, scoring, compliance frameworks, and security assessments.
 
 ## Where things live
@@ -48,11 +46,6 @@ make test/go             # Go tests only
 make test/go/plain       # With coverage
 make test/lint           # Linter
 make benchmark/go        # Benchmarks
-
-# Single test
-go test -v ./policy -run TestSpecificTest
-go test -v ./policy/...
-go test -race ./...
 ```
 
 ### Content validation
@@ -112,19 +105,8 @@ A check often needs a provider field that does not exist yet. `make prep/repos` 
 
 ### Dependency management
 
-- **Forbidden packages**: do not use `github.com/pkg/errors` (use `github.com/cockroachdb/errors`) or `github.com/mitchellh/mapstructure` (use `github.com/go-viper/mapstructure/v2`).
+- **Forbidden packages**: do not use `github.com/pkg/errors` (use `github.com/cockroachdb/errors`, wrapping with `errors.Wrap`) or `github.com/mitchellh/mapstructure` (use `github.com/go-viper/mapstructure/v2`).
 - When proto files reference mql types, ensure the mql repo is present via `make prep/repos`.
-
-### Error handling
-
-Use `github.com/cockroachdb/errors`:
-
-```go
-import "github.com/cockroachdb/errors"
-
-return errors.Wrap(err, "failed to load policy")
-return errors.New("invalid policy structure")
-```
 
 ### Generated code
 
@@ -183,8 +165,6 @@ So two **bare boolean fields** joined with `&&` pass when neither resolved. This
 ## Resources
 
 - [cnspec Documentation](https://mondoo.com/docs/cnspec)
-- [MQL Documentation](https://mondoo.com/docs/mql) · [Built-in Functions](https://mondoo.com/docs/mql/functions) · [Resources by Provider](https://mondoo.com/docs/mql/resources)
-- [MQL operator precedence](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) — reference for operator precedence during policy reviews
 - [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro)
-- [mql Repository](https://github.com/mondoohq/mql)
-- [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt)
+
+The MQL references (resource lists, built-in functions, operator precedence, `llms-full.txt`) are linked inline in "Verify before you claim" above.


### PR DESCRIPTION
`CLAUDE.md` is loaded into context on every session in this repo, so anything in it that is already stated elsewhere is paid for on every task. This drops four blocks that are duplicated, without losing any guidance.

| Removed | Already available from |
|---|---|
| Overview opener | `README.md` line 6, near-verbatim. The mql relationship sentence stays — the README does not spell that out. |
| `# Single test` snippet | Stock `go test -run` / `-race` usage, not project knowledge. |
| `### Error handling` | Repeats the forbidden-packages rule three lines above it. `errors.Wrap` folded into that bullet. |
| 4 of 6 `## Resources` links | All four already appear inline in "Verify before you claim", which is where a reviewer needs them. Kept the cnspec docs root and the Policy Authoring Guide, which do not appear above, plus a pointer to the rest. |

Verified before removing: `README.md` carries the overview sentence, and each dropped URL resolves to a link target that appears earlier in the file.

853 bytes, ~6% of the file. Small on its own — the larger wins are noted below.

## Not in this PR

- **`content/CLAUDE.md` is 47 KB**, 3.4x this file, and loads on first touch of `content/` — which is most work in this repo. Its `## Formatting requirements` section (6.2 KB) is a hand-run linter: the 130-char `summary:` limit, the em-dash ban, the 75-char `title` limit, the required `desc:`/`audit:`/`remediation:` triple, and the per-platform remediation-method matrix are **not** enforced by any validator today. Moving those into `content/validation/scans/bundles_test.go` would let the prose shrink to a pointer and make the rules stronger than prose can be.
- **`## Reviewing pull requests (for bots & automated reviewers)` is 43% of this file.** It is addressed to PR reviewers rather than to anyone doing development, and its content is deliberately duplicated from `content/CLAUDE.md`. It stays put until we know whether `mondoo-code-review[bot]` actually reads `CLAUDE.md`; if it does not, that section belongs in a `.claude/skills/` entry that `/code-review` loads on demand.
- **`skills/` is not the destination for maintainer guidance.** It is a published plugin marketplace for cnspec users (`/plugin marketplace add mondoohq/cnspec`), which is why #3166 had to move the ambiguous-path gotcha back out of `skills/mql/SKILL.md` and into `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)