### PR TITLE
🧹 repo: cut the prose in the CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,89 +1,87 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Notes for Claude Code working in this repo. Terse on purpose.
 
 ## Overview
 
-**cnspec is built on top of mql** (`go.mondoo.com/mql`). mql provides the MQL query engine, provider system, and resource framework; cnspec adds policy evaluation, scoring, compliance frameworks, and security assessments.
+cnspec is built on mql (`go.mondoo.com/mql`). mql gives us the MQL query engine, the provider system, and the resource framework. cnspec adds policy evaluation, scoring, compliance frameworks, and security assessments.
 
 ## Where things live
 
-- **`apps/cnspec/cmd/`** — CLI entry point and commands (scan, shell, bundle, etc.).
-- **`policy/`** — policy engine core (resolution, execution, scoring). See `policy/CLAUDE.md` for engine internals, scanning flow, and protobuf/gRPC patterns.
-- **`content/`** — default security policies (`*.mql.yaml`) and, under `querypacks/`, data-collection bundles that do not score. `content/CLAUDE.md` holds the authoring rules (variants, compliance tags, MQL semantics); `content/README.md` is the user-facing catalog.
-- **`content/validation/`** — every test and validator that runs against those policies, plus its fixtures. `content/validation/README.md` is the definitive reference for content validation.
-- **`cli/`** — terminal-facing components, and the output formats still coupled to the CLI (compact, SARIF, JUnit, JSON, CSV). `cli/reporter` also owns `PrintConfig`, the format registry and the output handlers for every format.
-- **`reports/`** — the report standards, none of which is terminal-facing. `reports/ocsf` is the OCSF schema and **imports no cnspec package**, deliberately, so it stays extractable as `go.mondoo.com/ocsf` (see `docs/adr/0005-ocsf-type-generation.md`); cnspec's mapping onto it lives in `reports/ocsf/convert`. `reports/hdf` is OHDF, and `reports/reportdoc` is what every format reads a check's documentation and outcome from.
-- **`internal/bundle/`, `internal/datalakes/`, `internal/lsp/`** — bundle loading, storage, LSP support.
-- **`examples/`, `test/`, `docs/`** — examples, integration tests, docs.
+- `apps/cnspec/cmd/` — CLI entry point and commands (scan, shell, bundle, ...).
+- `policy/` — policy engine: resolution, execution, scoring. Engine internals, scanning flow, and protobuf/gRPC patterns are in `policy/CLAUDE.md`.
+- `content/` — the shipped security policies (`*.mql.yaml`). `querypacks/` holds data-collection bundles that don't score. Authoring rules: `content/CLAUDE.md`. User-facing catalog: `content/README.md`.
+- `content/validation/` — every test and validator that runs against those policies, plus fixtures. Reference: `content/validation/README.md`.
+- `cli/` — terminal components, plus the output formats still coupled to the CLI (compact, SARIF, JUnit, JSON, CSV). `cli/reporter` also owns `PrintConfig`, the format registry, and every format's output handler.
+- `reports/` — report standards, none terminal-facing. `reports/ocsf` is the OCSF schema and imports no cnspec package on purpose, so it stays extractable as `go.mondoo.com/ocsf` (`docs/adr/0005-ocsf-type-generation.md`); the cnspec mapping onto it is in `reports/ocsf/convert`. `reports/hdf` is OHDF. `reports/reportdoc` is where every format reads a check's docs and outcome.
+- `internal/bundle/`, `internal/datalakes/`, `internal/lsp/` — bundle loading, storage, LSP.
+- `examples/`, `test/`, `docs/`.
 
-## Essential commands
+## Commands
 
-### Build & install
+### Build
 
 ```bash
-make cnspec/build              # Build the cnspec binary
-make cnspec/install            # Install to $GOBIN
-make cnspec/build/linux        # Cross-compile (also: /linux/arm, /windows)
+make cnspec/build              # build the binary
+make cnspec/install            # install to $GOBIN
+make cnspec/build/linux        # cross-compile (also /linux/arm, /windows)
 ```
 
-### Code generation
+### Codegen
 
-Run after modifying `.proto` files, policy bundle structures, or reporter configurations.
+Run after changing `.proto` files, policy bundle structures, or reporter configs.
 
 ```bash
-make prep                # Install required tools (first time only)
-make prep/repos          # Clone/verify mql dependency (required for proto compilation)
-make prep/repos/update   # Update mql dependency
-make cnspec/generate     # Regenerate all generated code (proto, policy, reporter)
+make prep                # install tools (first time only)
+make prep/repos          # clone/verify mql (needed for proto compilation)
+make prep/repos/update   # update mql
+make cnspec/generate     # regenerate proto, policy, reporter code
 ```
 
-### Testing
+### Tests
 
 ```bash
-make test                # Run all tests
-make test/go             # Go tests only
-make test/go/plain       # With coverage
-make test/lint           # Linter
-make benchmark/go        # Benchmarks
+make test                # everything
+make test/go             # Go only
+make test/go/plain       # with coverage
+make test/lint           # linter
+make benchmark/go        # benchmarks
 ```
 
 ### Content validation
 
-Everything that checks the policies in `content/` lives in `content/validation/`, and
-**[`content/validation/README.md`](content/validation/README.md) is the definitive
-reference** for it: what each check proves, when CI runs it, and how to run it manually.
+Lives in `content/validation/`. What each check proves, when CI runs it, how to run it manually: [`content/validation/README.md`](content/validation/README.md).
 
 ```bash
 make test/content        # lint + bundle scans + compliance mappings
 make test/content/lint   # cnspec policy lint over content/ and content/querypacks
-make test/content/iac    # the IaC fixture suites (slow; run when you touch a variant)
+make test/content/iac    # IaC fixture suites (slow; run when you touch a variant)
 ```
 
-Most of those validators are **allowlist-driven**, so a new policy is covered only once it is registered with them. Adding a `*.mql.yaml` without wiring it into the variant suites and the remediation validators ships the whole bundle unexamined with every gate green — see [Adding a policy: what to register](content/validation/README.md#adding-a-policy-what-to-register).
+Most validators are allowlist-driven: a new policy is covered only once it's registered with them. Add a `*.mql.yaml` without wiring it into the variant suites and the remediation validators and the whole bundle ships unexamined, every gate green. See [Adding a policy: what to register](content/validation/README.md#adding-a-policy-what-to-register).
 
-### Scanning & policy linting
+### Scanning and linting
 
 ```bash
-cnspec scan local                      # Local system
-cnspec scan docker image ubuntu:22.04  # Docker
-cnspec scan aws                        # AWS (uses local AWS CLI config)
+cnspec scan local                      # local system
+cnspec scan docker image ubuntu:22.04  # docker
+cnspec scan aws                        # AWS (local AWS CLI config)
 cnspec scan k8s                        # Kubernetes
 cnspec scan ssh user@host              # SSH
 
-cnspec policy lint ./content                                    # Lint all policies
-cnspec policy lint ./content/mondoo-linux-security.mql.yaml     # Lint one policy
+cnspec policy lint ./content                                    # all policies
+cnspec policy lint ./content/mondoo-linux-security.mql.yaml     # one policy
 ```
 
 ## Working in this repo
 
-### Commits and pull requests
+### Commits and PRs
 
-Commit titles are `<emoji> <scope>: <lowercase description>`, and the emoji is part of the convention rather than decoration. Across the last 200 commits on `main`: **✨** new capability or coverage (57), **🧹** cleanup, refactor, or maintenance (47), **🐛** bug fix (40), **👷** CI and automation (8), **📝** documentation (3). The scope is the area, not the file — `validation`, `content`, `ci`, or a provider name such as `aws` or `alibaba`.
+Titles are `<emoji> <scope>: <lowercase description>`. The emoji is part of the convention, not decoration. Counts over the last 200 commits on `main`: ✨ new capability or coverage (57), 🧹 cleanup/refactor/maintenance (47), 🐛 bug fix (40), 👷 CI and automation (8), 📝 docs (3). Scope is the area, not the file: `validation`, `content`, `ci`, or a provider name like `aws` or `alibaba`.
 
-### Stacked pull requests
+### Stacked PRs
 
-Squash-merging a base branch does **not** retarget the PRs stacked on it. The squash lands a new SHA on `main` and leaves the original branch commit orphaned but alive, so GitHub keeps the stacked PR pointed at a dead branch and will happily merge into it. The PR then reports `MERGED` while none of its work is on `main`.
+Squash-merging a base branch does not retarget the PRs stacked on it. The squash lands a new SHA on `main` and leaves the original branch commit orphaned but alive, so GitHub keeps the stacked PR pointed at a dead branch and will merge into it. The PR then reports `MERGED` with none of its work on `main`.
 
 After a base branch merges, check every PR stacked on it:
 
@@ -91,80 +89,82 @@ After a base branch merges, check every PR stacked on it:
 git merge-base --is-ancestor <pr-merge-commit> origin/main && echo on-main || echo ORPHANED
 ```
 
-To recover, branch from `origin/main` and `git cherry-pick <pr-merge-commit>` — a squash commit has a single parent, so it applies cleanly — then confirm `git diff <pr-merge-commit> HEAD` is empty before opening the replacement. Also diff the recovered tree against the merged one: a base branch amended after its own squash merge strands those fixes too.
+Recover it: branch from `origin/main`, `git cherry-pick <pr-merge-commit>` (a squash commit has one parent, so it applies cleanly), confirm `git diff <pr-merge-commit> HEAD` is empty, open the replacement. Also diff the recovered tree against the merged one, since a base branch amended after its own squash merge strands those fixes too.
 
 ### Worktrees
 
-Feature work happens in worktrees, and many branches are already checked out in one. `git checkout <branch>` fails when it is, so operate on the branch in place with `git -C <worktree>` (find it with `git worktree list`) rather than trying to check it out again.
+Feature work happens in worktrees, and many branches are already checked out in one, which makes `git checkout <branch>` fail. Find the worktree with `git worktree list` and work on the branch in place with `git -C <worktree>`.
 
 ### Local mql development
 
-A check often needs a provider field that does not exist yet. `make prep/repos` clones mql into `./mql`, and `go.mod` carries a commented `replace go.mondoo.com/mql => ../mql` for building against a sibling checkout. After changing a provider's `.lr` schema, regenerate and rebuild that provider, then copy it into `~/.config/mondoo/providers/<name>/` — that installed copy, not the source, is what `cnspec policy lint` resolves against.
+A check often needs a provider field that doesn't exist yet. `make prep/repos` clones mql into `./mql`; `go.mod` has a commented `replace go.mondoo.com/mql => ../mql` for building against a sibling checkout. After changing a provider's `.lr` schema: regenerate, rebuild that provider, copy it into `~/.config/mondoo/providers/<name>/`. That installed copy, not the source, is what `cnspec policy lint` resolves against.
 
 ## Development rules
 
-### Dependency management
+### Dependencies
 
-- **Forbidden packages**: do not use `github.com/pkg/errors` (use `github.com/cockroachdb/errors`, wrapping with `errors.Wrap`) or `github.com/mitchellh/mapstructure` (use `github.com/go-viper/mapstructure/v2`).
-- When proto files reference mql types, ensure the mql repo is present via `make prep/repos`.
+- Banned: `github.com/pkg/errors` (use `github.com/cockroachdb/errors` and `errors.Wrap`) and `github.com/mitchellh/mapstructure` (use `github.com/go-viper/mapstructure/v2`).
+- Proto files referencing mql types need the mql repo present: `make prep/repos`.
 
 ### Generated code
 
-Never edit these files manually. Regenerate with `make cnspec/generate`:
+Never hand-edit. Regenerate with `make cnspec/generate`:
 
-- `*.pb.go` — Generated from proto files.
-- `*.ranger.go` — Generated ranger-rpc code.
-- `*.vtproto.pb.go` — Optimized vtproto marshaling.
-- `*_gen.go` — Generated via `go generate`.
+- `*.pb.go` — from proto files
+- `*.ranger.go` — ranger-rpc
+- `*.vtproto.pb.go` — vtproto marshaling
+- `*_gen.go` — `go generate`
 
-## Reviewing pull requests (for bots & automated reviewers)
+## Reviewing PRs (bots and automated reviewers)
 
-This section is for any automated reviewer (mondoo-code-review, Claude, etc.) commenting on PRs in this repo. **Most false positives come from guessing how MQL behaves instead of verifying it.** Before asserting that a query is wrong, that a field doesn't exist, or that precedence/grouping is off, confirm it against the references below. If you cannot verify a claim, frame it as a question ("Does `x` exist on this resource?"), not a defect.
+For automated reviewers (mondoo-code-review, Claude) commenting on PRs here. Most false positives come from guessing how MQL behaves instead of verifying it. Before claiming a query is wrong, a field is missing, or precedence is off, check the references below. Can't verify it? Ask a question ("Does `x` exist on this resource?") instead of filing a defect.
 
-### Verify before you claim
+### Verify first
 
-- **Resource & field existence** — Do not assume a resource or field is missing. Check what the provider actually exposes:
-  - [Resources by Provider](https://mondoo.com/docs/mql/resources) — canonical list of resources and their fields, grouped by provider (aws-pack, azure-pack, gcp-pack, core-pack, …).
-  - [Built-in Functions](https://mondoo.com/docs/mql/functions) — `parse.json`, `parse.date`, `regex`, list ops (`all`, `any`, `where`, `contains`, `none`, `map`), etc.
-  - [Full Mondoo Docs (LLM-friendly text)](https://mondoo.com/docs/llms-full.txt) — single raw-text dump of all docs; grep it when you need to confirm a field or function quickly.
-  - Locally, the *installed* provider schema is authoritative for what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. The source of truth in code is `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql).
-  - To check a real query end to end: `cnquery run <provider> -c '<mql>'` (no TTY needed) or `cnspec policy lint ./content/<file>.mql.yaml`. **Run the query before claiming it returns the wrong thing.**
-- **Operator precedence** — MQL precedence is fixed; consult [`mqlc/parser/operators.go`](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11) before flagging precedence. Notably `&&` binds tighter than `||`, so `a || b && c` already parses as `a || (b && c)` — that is usually intentional, not a bug.
+Resource and field existence — don't assume something is missing, check what the provider exposes:
 
-### Do not flag these — they are correct MQL
+- [Resources by Provider](https://mondoo.com/docs/mql/resources) — resources and fields, grouped by provider (aws-pack, azure-pack, gcp-pack, core-pack, ...).
+- [Built-in Functions](https://mondoo.com/docs/mql/functions) — `parse.json`, `parse.date`, `regex`, list ops (`all`, `any`, `where`, `contains`, `none`, `map`).
+- [llms-full.txt](https://mondoo.com/docs/llms-full.txt) — raw dump of all docs; grep it to confirm a field or function fast.
+- Locally, the *installed* schema is what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. Source of truth in code: `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql).
+- End to end: `cnquery run <provider> -c '<mql>'` (no TTY needed) or `cnspec policy lint ./content/<file>.mql.yaml`. Run the query before claiming it returns the wrong thing.
 
-Each is verified against the compiler and explained in full in [`content/CLAUDE.md`](content/CLAUDE.md). The one-liners here exist so a reviewer that never opens that file still does not raise the false positive.
+Operator precedence is fixed; see [`mqlc/parser/operators.go`](https://github.com/mondoohq/mql/blob/main/mqlc/parser/operators.go#L11). `&&` binds tighter than `||`, so `a || b && c` already parses as `a || (b && c)`. That's usually intentional.
 
-| Pattern | Why it is not a bug |
+### Don't flag these, they're correct MQL
+
+All verified against the compiler and explained in full in [`content/CLAUDE.md`](content/CLAUDE.md). Repeated here so a reviewer that never opens that file still doesn't file the false positive.
+
+| Pattern | Why it's not a bug |
 |---|---|
-| `a == 1 \|\| b > 0 && b <= 5`, unparenthesized | MQL has no parenthesized grouping anywhere; `(` is rejected as an operand. `&&` binds tighter than `\|\|`, so the grouping already is what the author meant. Never suggest adding parens "for clarity". |
-| `guard \|\| guard \|\| D && E` described as "skipped", "short-circuited past", or "silently passes" | This is the **guard chain**, the dominant shape in `content/`. Short-circuiting decides what is *evaluated*, never the *verdict*: if `D` is false, `D && E` is false, the disjunction is false, and the check **fails**. Before filing, build the truth table and name the row where the current form passes and a parenthesized form fails. There is no such row — this is the most-filed false positive on this repo. |
-| A literal flagged on character count from the diff (ARN colons, a missing path segment) | Rendered diffs distort spacing; do not count characters in one. Resolve the literal against its oracle and quote the output (`aws iam get-policy`, `cfn-lint`, the provider schema). AWS-managed policy ARNs have an empty account field, so `arn:aws:iam::aws:policy/…` with two colons is canonical. |
-| `blocks.where(type == 'x').all(y)` where `values['x'].all(y)` looks simpler | Not equivalent. `.all()` passes vacuously on an empty list and fails outright on `null`, and an absent key is `null`. The rewrite flips the absent-block verdict. |
-| `field != empty` rather than `field != ""` | `null != ""` is true, so `!= ""` is not a non-empty test. `!= empty` is the null-safe form. |
-| A predicate in `mql:` that "could" live in `filters:` | `filters:` is asset selection. Moving a predicate there drops assets from scoring rather than failing them. |
-| Several lines in one `mql:` block | Newline is an implicit AND. A later line is not ignoring an earlier one. |
-| A `-terraform-hcl` variant stricter than its `-plan`/`-state` sibling | Usually deliberate: HCL sees author intent, plan/state see resolved values. Do not recommend unifying them by copying one body into another. |
-| A `compliance/*` tag unlike a neighbouring check's | Neighbours map different control objectives. Verify against the framework text before flagging *or* endorsing. |
+| `a == 1 \|\| b > 0 && b <= 5`, unparenthesized | MQL has no parenthesized grouping at all; `(` is rejected as an operand. `&&` binds tighter than `\|\|`, so the grouping is already what the author meant. Never suggest parens "for clarity". |
+| `guard \|\| guard \|\| D && E` called "skipped", "short-circuited past", or "silently passes" | This is the guard chain, the dominant shape in `content/`. Short-circuiting decides what is *evaluated*, never the *verdict*: if `D` is false, `D && E` is false, the disjunction is false, the check fails. Build the truth table and name the row where the current form passes and a parenthesized form fails. There isn't one. Most-filed false positive on this repo. |
+| A literal flagged on character count from the diff (ARN colons, missing path segment) | Rendered diffs distort spacing; don't count characters in one. Resolve the literal against its oracle and quote the output (`aws iam get-policy`, `cfn-lint`, the provider schema). AWS-managed policy ARNs have an empty account field, so `arn:aws:iam::aws:policy/...` with two colons is canonical. |
+| `blocks.where(type == 'x').all(y)` where `values['x'].all(y)` looks simpler | Not equivalent. `.all()` passes vacuously on an empty list and fails on `null`, and an absent key is `null`. The rewrite flips the absent-block verdict. |
+| `field != empty` rather than `field != ""` | `null != ""` is true, so `!= ""` isn't a non-empty test. `!= empty` is the null-safe form. |
+| A predicate in `mql:` that "could" live in `filters:` | `filters:` is asset selection. Moving a predicate there drops assets from scoring instead of failing them. |
+| Several lines in one `mql:` block | Newline is an implicit AND. A later line isn't ignoring an earlier one. |
+| A `-terraform-hcl` variant stricter than its `-plan`/`-state` sibling | Usually deliberate: HCL sees author intent, plan/state see resolved values. Don't unify them by copying one body into another. |
+| A `compliance/*` tag unlike a neighbouring check's | Neighbours map different control objectives. Check the framework text before flagging *or* endorsing. |
 
-### Two that are real bugs, and are easy to miss
+### Two real bugs that are easy to miss
 
-**`null && null` is `true`** — and it is the only null combination that is. Verified:
+`null && null` is `true`, and it's the only null combination that is:
 
 ```
-m["absent"] && m["also_absent"]   → [ok] true
-m["absent"] && true               → [failed]
-m["absent"] && false              → [failed]
-m["absent"] || false              → [failed]
+m["absent"] && m["also_absent"]   -> [ok] true
+m["absent"] && true               -> [failed]
+m["absent"] && false              -> [failed]
+m["absent"] || false              -> [failed]
 ```
 
-So two **bare boolean fields** joined with `&&` pass when neither resolved. This does **not** extend to comparisons: `null == "x"` is `false`, not null, so `field_a == "x" && field_b == "y"` fails when both are absent. Flag the bare-field form; leave the comparison form alone. The comparison form has its own asymmetry — `field != "insecure"` passes when the field is absent — which `content/CLAUDE.md` covers.
+Two bare boolean fields joined with `&&` therefore pass when neither resolved. Doesn't extend to comparisons: `null == "x"` is `false`, not null, so `field_a == "x" && field_b == "y"` fails when both are absent. Flag the bare-field form, leave the comparison form alone. The comparison form has its own asymmetry (`field != "insecure"` passes when the field is absent), covered in `content/CLAUDE.md`.
 
-**A dotted path that is also a resource name is not a field read.** The compiler extends the resource path greedily, so `azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel` builds a bare `…cluster.autoUpgradeProfile` resource whose accessor never runs; every field reads `null` and the check answers confidently wrong. Suspect it when the value is a sub-object and the full path appears as a resource in `cnspec providers resources <provider> --json`; confirm by running the query and looking for `provider returned no data and no error for a field … id=` with an **empty** `id=`. Not Azure-specific — Cloudflare, GCP, AWS, vSphere and Arista all have resources shaped this way. `content/CLAUDE.md` has the full treatment and the fix.
+A dotted path that is also a resource name is not a field read. The compiler extends the resource path greedily, so `azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel` builds a bare `...cluster.autoUpgradeProfile` resource whose accessor never runs; every field reads `null` and the check answers confidently wrong. Suspect it when the value is a sub-object and the full path appears as a resource in `cnspec providers resources <provider> --json`. Confirm by running the query and looking for `provider returned no data and no error for a field ... id=` with an empty `id=`. Not Azure-specific: Cloudflare, GCP, AWS, vSphere, and Arista all have resources shaped this way. Full treatment and fix in `content/CLAUDE.md`.
 
-## Resources
+## Links
 
-- [cnspec Documentation](https://mondoo.com/docs/cnspec)
-- [Policy Authoring Guide](https://mondoo.com/docs/cnspec/write-policies/write-intro)
+- [cnspec docs](https://mondoo.com/docs/cnspec)
+- [Policy authoring guide](https://mondoo.com/docs/cnspec/write-policies/write-intro)
 
-The MQL references (resource lists, built-in functions, operator precedence, `llms-full.txt`) are linked inline in "Verify before you claim" above.
+MQL references (resource lists, functions, precedence, `llms-full.txt`) are linked in "Verify first" above.

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -1,6 +1,6 @@
 # content/CLAUDE.md
 
-Policy authoring guidance for `*.mql.yaml` files in this directory. Loaded automatically when working under `content/`.
+Authoring rules for the `*.mql.yaml` policies in this directory. Loads automatically when working under `content/`. Terse on purpose.
 
 ## Bundle structure
 
@@ -23,97 +23,98 @@ policies:
               }
 ```
 
-The parts whose behavior is not obvious from reading a policy file:
+The parts you can't infer from reading a policy file:
 
-- **`checks:` score, `queries:` do not.** A `queries:` entry collects data and never passes or fails.
-- **`filters:` is asset selection, not logic.** A filter decides *which assets a check applies to* (`asset.platform == "aws"`). Predicate logic — `field != empty`, `flag == true`, a threshold — belongs in `mql:`. Lifting a predicate into `filters:` does not make the check stricter; it silently drops the failing assets from scoring, so the policy reports compliant on assets it never evaluated. Multi-line `filters:` join with an explicit `&&`; multi-line `mql:` uses newline-as-AND. **One exception, and it is a trap:** a filter is compiled as a single MQL snippet, so its lines join with newline-as-AND the same way `mql:` does. When a later line is itself an `||` chain — `platform == "terraform-hcl"` on one line, `resources.contains(a) || resources.contains(b)` on the next — adding the `&&` regroups it, because `&&` binds tighter: `platform && a || b` means `(platform && a) || b`, which matches assets of any platform. MQL has no parentheses to restore the grouping, so leave those filters on separate lines.
-- **Multi-statement check `mql:`.** A check's `mql:` block can contain multiple top-level statements. Each is scored as a separate datapoint and the check passes only if every datapoint passes — it is *not* "last expression wins". Use this when you want each assertion to surface independently in scan output; collapse to a single `&&`-joined expression only if you want one combined datapoint.
-- **`summary:`** is required, ≤130 chars. See Formatting requirements.
+- **`checks:` score, `queries:` don't.** A `queries:` entry collects data. It never passes or fails.
+- **`filters:` is asset selection, not logic.** A filter picks *which assets a check applies to* (`asset.platform == "aws"`). Predicates (`field != empty`, `flag == true`, a threshold) belong in `mql:`. Lifting a predicate into `filters:` doesn't make the check stricter, it drops the failing assets from scoring, so the policy reports compliant on assets it never evaluated.
+- **Multi-line `filters:` join with an explicit `&&`.** Multi-line `mql:` uses newline-as-AND. One exception, and it's a trap: a filter compiles as a single MQL snippet, so its lines also join with newline-as-AND. When a later line is itself an `||` chain (`platform == "terraform-hcl"` on one line, `resources.contains(a) || resources.contains(b)` on the next), adding the `&&` regroups it, because `&&` binds tighter: `platform && a || b` means `(platform && a) || b`, which matches any platform. MQL has no parens to restore the grouping, so leave those filters on separate lines.
+- **A check's `mql:` can hold several top-level statements.** Each is scored as its own datapoint and the check passes only if all of them pass. It is *not* "last expression wins". Use it when you want each assertion to surface separately in scan output; collapse to one `&&`-joined expression if you want a single datapoint.
+- **`summary:` is required, 130 chars max.** See below.
 
 ## Formatting requirements
 
-- Every policy must have a `summary:` field — the one-line description shown in policy listings and the marketplace. It is **required** and must be **130 characters or fewer**. Write it verb-first (`Secure`, `Enforce`, `Validate`, `Detect`, `Harden`) followed by the concrete scope, matching the existing policies. Do **not** use em-dashes (`—`, `–`) or `--` in the summary; restructure the sentence instead.
-- All `desc` and `remediation` fields must be valid Markdown (rendered in the UI). Use proper headings, lists, code blocks, links.
-- **The em-dash ban is not only for `summary:`.** No `—`, `–`, or `--` anywhere in policy prose — `desc`, `audit`, `remediation`. The same goes for parenthetical asides: do not bolt a clarification onto a sentence with `(...)`. In both cases restructure the sentence or drop the aside; do not trade one for the other.
-- **Write about the check, not about the bundle.** Policy prose is read next to a single finding, so it must not name variant UIDs or the `variants:` mechanism. Say "the Terraform version of this check", never "the `-terraform-hcl` variant". Do not reference "this policy", the MQL query, or Mondoo tooling.
-- **Containers are not patched.** Images are rebuilt and redeployed. Remediation prose for container checks says so, rather than describing an in-place package upgrade that would be lost on the next deploy.
-- **No inline linter suppressions in remediation snippets.** A shipped snippet is example code an operator will paste. If shellcheck, cfn-lint, or PSScriptAnalyzer flags it, fix the snippet or add the rule to the validator's exclude list — never `# shellcheck disable=...` inside the fence.
+- **`summary:`** is required on every policy, 130 chars or fewer. It's the one-liner shown in policy listings and the marketplace. Verb-first (`Secure`, `Enforce`, `Validate`, `Detect`, `Harden`) plus the concrete scope, matching existing policies.
+- **No `—`, `–`, or `--` anywhere in policy prose.** Not in `summary`, `desc`, `audit`, or `remediation`. Same for parenthetical asides: don't bolt a clarification onto a sentence with `(...)`. Restructure the sentence or drop the aside. Don't trade one for the other.
+- **`desc` and `remediation` must be valid Markdown** (they render in the UI): headings, lists, code blocks, links.
+- **Write about the check, not the bundle.** Policy prose sits next to a single finding, so it must not name variant UIDs or the `variants:` mechanism. Say "the Terraform version of this check", never "the `-terraform-hcl` variant". Don't reference "this policy", the MQL query, or Mondoo tooling.
+- **Containers aren't patched.** Images get rebuilt and redeployed. Container remediation says that, rather than describing an in-place package upgrade that the next deploy wipes.
+- **No inline linter suppressions in remediation snippets.** A shipped snippet is example code someone will paste. If shellcheck, cfn-lint, or PSScriptAnalyzer flags it, fix the snippet or add the rule to the validator's exclude list. Never `# shellcheck disable=...` inside the fence.
 - **Spelling exceptions go in `typos.toml`** under `[default.extend-words]`, which is case-insensitive, so one lowercase entry covers every casing. There is no `expect.txt`. If the flagged word is a deliberate misspelling in an example, reword the example instead of allowlisting it.
-- Check `title` must match the action enforced by the `mql` query and described in `desc`. If the title says "Ensure X is enabled" the query must assert X is enabled and the description must explain X — don't let titles drift from what the check actually does (e.g., a title about "encryption at rest" paired with a query that inspects TLS settings).
-- Every check's `docs:` block must include all three sections: `desc:`, `audit:`, and `remediation:`. None of these are optional — `desc` explains *what and why*, `audit` explains *how to verify manually*, and `remediation` explains *how to fix*.
-- `audit:` instructions must use the **vendor's own tooling** — the cloud console or the vendor CLI (`aws`, `az`, `gcloud`, `oci`, `doctl`, `kubectl`, `gh`, …). **Never** reference Mondoo tools (`cnspec`, `mql`, the Mondoo console) in audit steps. Prefer the vendor CLI for an automated path; fall back to console click-through when no CLI exists. The point of `audit:` is to give an auditor a vendor-native way to reproduce the finding without trusting Mondoo's output.
-- `remediation:` must include **every remediation method the target platform supports** — not just one or two. Use `- id: <method>` entries in the list. Required coverage by platform:
+- **`title` must match what the `mql` asserts and what `desc` explains.** "Ensure X is enabled" means the query asserts X is enabled. Titles drift: a title about encryption at rest paired with a query inspecting TLS is the classic case.
+- **Every check's `docs:` needs all three of `desc:`, `audit:`, `remediation:`.** None optional. `desc` = what and why, `audit` = how to verify by hand, `remediation` = how to fix.
+- **`audit:` uses the vendor's own tooling**, the cloud console or vendor CLI (`aws`, `az`, `gcloud`, `oci`, `doctl`, `kubectl`, `gh`, ...). Never `cnspec`, `mql`, or the Mondoo console. Prefer the CLI; fall back to console click-through where no CLI exists. The point is to let an auditor reproduce the finding without trusting Mondoo's output.
+- **`remediation:` covers every method the platform supports**, not one or two. Use `- id: <method>` entries:
   - **AWS**: `console`, `cli`, `terraform`, `cloudformation`
-  - **Azure**: `portal`, `cli`, `terraform`, `bicep` (Azure uses `portal` — the product name for the Azure web UI — instead of the generic `console` used by other clouds)
+  - **Azure**: `portal`, `cli`, `terraform`, `bicep` (Azure's web UI is called the portal, so `portal`, not `console`)
   - **GCP / OCI / DigitalOcean / Cloudflare / Hetzner / other clouds**: `console`, `cli`, `terraform`
-  - **Windows / macOS**: `gui`, `cli`, `ansible`, and `script` (PowerShell on Windows, bash on macOS). In `mondoo-windows-security` also `chef`.
-  - **Linux / FreeBSD**: `cli`, `script` (bash or sh), `ansible`. In `mondoo-linux-security` and `mondoo-freebsd-security` also `chef`.
-
-  A `chef` entry is a Chef Infra recipe, matching the `chef` entries in the two Chef Infra policies. Add one wherever Chef Infra Client runs on the asset and the fix is a change to state on that host. Prefer a purpose-built resource over a shell-out: `registry_key`, `windows_security_policy`, `windows_audit_policy`, and `windows_user_privilege` cover almost all of the Windows policy; `sysctl`, `kernel_module`, `systemd_unit`, `user_ulimit`, and `sudo` cover most of the Linux one. On FreeBSD the `sysctl` resource writes `/etc/sysctl.d`, which the base system does not read, so kernel parameters go into `/etc/sysctl.conf` instead; the `service` provider there edits `/etc/rc.conf` directly, making `action :disable` the `sysrc` equivalent.
-  - **Kubernetes**: `kubectl`, `manifest` (YAML), and where applicable `helm`
+  - **Windows / macOS**: `gui`, `cli`, `ansible`, `script` (PowerShell on Windows, bash on macOS). Plus `chef` in `mondoo-windows-security`.
+  - **Linux / FreeBSD**: `cli`, `script` (bash or sh), `ansible`. Plus `chef` in `mondoo-linux-security` and `mondoo-freebsd-security`.
+  - **Kubernetes**: `kubectl`, `manifest` (YAML), and `helm` where applicable
   - **Microsoft 365** (`mondoo-m365-security`): `console`, `powershell`, and `terraform` where a real resource exists.
-    - `console` — the relevant Microsoft admin center (Microsoft Entra, Microsoft 365, Microsoft Defender, Exchange, SharePoint, or Intune). Always applies.
-    - `powershell` — Microsoft Graph PowerShell for Entra/identity checks, Exchange Online PowerShell for Exchange checks, SharePoint Online Management Shell for SharePoint checks. Always applies, except where the control is a DNS record (SPF), which uses `cli` (`az network dns …`) instead.
-    - `terraform` — **only** where the `azuread` provider (or, for DNS-record checks, a DNS provider such as `azurerm`) exposes a genuine resource for the setting. The Conditional Access checks (`azuread_conditional_access_policy`) and role assignments (`azuread_directory_role_assignment`) qualify. Exchange Online, SharePoint Online, Intune device configuration, the tenant authorization policy, the security-defaults toggle, and per-domain password validity have **no** Terraform resource — use a `# No Terraform remediation:` comment, never a `null_resource` + `local-exec` shell-out or an `azapi` block faking one.
+    - `console` is the relevant Microsoft admin center (Entra, Microsoft 365, Defender, Exchange, SharePoint, Intune). Always applies.
+    - `powershell` is Microsoft Graph PowerShell for Entra/identity, Exchange Online PowerShell for Exchange, SharePoint Online Management Shell for SharePoint. Always applies, except DNS-record controls (SPF), which use `cli` (`az network dns ...`).
+    - `terraform` only where the `azuread` provider (or a DNS provider such as `azurerm` for DNS records) has a genuine resource. Conditional Access (`azuread_conditional_access_policy`) and role assignments (`azuread_directory_role_assignment`) qualify. Exchange Online, SharePoint Online, Intune device config, the tenant authorization policy, the security-defaults toggle, and per-domain password validity have none: use a `# No Terraform remediation:` comment, never a `null_resource` + `local-exec` shell-out or an `azapi` block faking one.
 
-  Omit a method only when it genuinely doesn't apply, and leave a YAML comment above the check explaining why (same pattern as the "No Terraform variants" comment above).
-- Verify CLI commands in remediation steps with the validator (see below) before committing.
+  A `chef` entry is a Chef Infra recipe, matching the ones in the two Chef Infra policies. Add one wherever Chef Infra Client runs on the asset and the fix changes state on that host. Prefer a purpose-built resource over a shell-out: `registry_key`, `windows_security_policy`, `windows_audit_policy`, and `windows_user_privilege` cover most of the Windows policy; `sysctl`, `kernel_module`, `systemd_unit`, `user_ulimit`, and `sudo` cover most of the Linux one. On FreeBSD the `sysctl` resource writes `/etc/sysctl.d`, which the base system doesn't read, so kernel parameters go in `/etc/sysctl.conf`; the `service` provider there edits `/etc/rc.conf` directly, making `action :disable` the `sysrc` equivalent.
+
+  Omit a method only when it genuinely doesn't apply, with a YAML comment above the check saying why.
+- **Verify CLI commands in remediation with the validator** before committing (see Validation).
 
 ## Impact scoring
 
-`impact:` drives prioritization in scan output and dashboards. The rows below are **bands** — ranges of values, not single numbers. Pick the band that matches the check's risk, then choose a value within that range; any value inside the band is valid (`75`, for example, sits within the 70–79 band).
+`impact:` drives prioritization in scan output and dashboards. The rows are **bands**, not single values. Pick the band that matches the risk, then any value inside it (`75` is a fine 70-79).
 
 | Impact | When to use |
 |--------|-------------|
-| 90–100 | Direct path to data loss, account compromise, or full takeover. Public exposure of customer data, unauthenticated admin endpoints, plaintext secrets in shared storage, disabled audit logging on production. |
-| 80–89 | High-confidence misconfiguration with realistic exploit chain. Encryption disabled on sensitive resources, overly permissive IAM, network-wide ingress on management ports, missing MFA on privileged identities. |
-| 70–79 | Important hardening that meaningfully reduces blast radius. CMK encryption instead of vendor-managed keys, private endpoints over public, log retention/aggregation, disabling remote management shells and consoles left reachable by vendor defaults. |
-| 60–69 | Recommended hardening with moderate risk reduction. Tag/label hygiene that gates other controls, non-default versions of managed services, password complexity above vendor defaults. |
-| 30–59 | Best practices and informational. Defense-in-depth that rarely changes outcomes on its own (resource labeling, optional telemetry, naming conventions). |
+| 90-100 | Direct path to data loss, account compromise, or full takeover. Public exposure of customer data, unauthenticated admin endpoints, plaintext secrets in shared storage, disabled audit logging on production. |
+| 80-89 | High-confidence misconfiguration with a realistic exploit chain. Encryption disabled on sensitive resources, overly permissive IAM, network-wide ingress on management ports, missing MFA on privileged identities. |
+| 70-79 | Hardening that meaningfully reduces blast radius. CMK instead of vendor-managed keys, private endpoints over public, log retention/aggregation, disabling remote management shells left reachable by vendor defaults. |
+| 60-69 | Recommended hardening, moderate risk reduction. Tag/label hygiene that gates other controls, non-default versions of managed services, password complexity above vendor defaults. |
+| 30-59 | Best practices and informational. Defense in depth that rarely changes outcomes alone: resource labeling, optional telemetry, naming conventions. |
 
-Anchor to a sibling check in the same policy whenever possible — if you're adding an encryption-at-rest check next to five others at `impact: 70`, use 70 unless you can justify why this one differs. Cite a sibling UID in the PR description.
+Anchor to a sibling check in the same policy where you can. Adding an encryption-at-rest check next to five others at `impact: 70`? Use 70 unless you can say why this one differs, and cite the sibling UID in the PR description.
 
-## UID and naming conventions
+## UID and naming
 
-**Pattern**: `mondoo-<provider>-security-<resource>-<rule>`
+Pattern: `mondoo-<provider>-security-<resource>-<rule>`
 
-- `<provider>` is the policy's cloud/platform — `aws`, `azure`, `gcp`, `oci`, `digitalocean`, `hetzner`, `linux`, `windows`, `macos`, `kubernetes`, `github`, `gitlab`, etc.
-- `<resource>` is the service or object being checked — `eks-cluster`, `s3-bucket`, `cloud-sql-mysql`, `network-security-group`. Use the vendor's own naming where it exists; don't invent new terminology.
-- `<rule>` describes the assertion in active voice — `cmks-in-kms`, `private-controlplane`, `logging-enabled`, `restrict-public-access`. Keep it short and concrete; avoid generic suffixes like `-misconfigured` or `-check`.
+- `<provider>` is the policy's cloud or platform: `aws`, `azure`, `gcp`, `oci`, `digitalocean`, `hetzner`, `linux`, `windows`, `macos`, `kubernetes`, `github`, `gitlab`, ...
+- `<resource>` is the service or object: `eks-cluster`, `s3-bucket`, `cloud-sql-mysql`, `network-security-group`. Use the vendor's naming, don't invent terminology.
+- `<rule>` describes the assertion in active voice: `cmks-in-kms`, `private-controlplane`, `logging-enabled`, `restrict-public-access`. Short and concrete, no `-misconfigured` or `-check` suffixes.
 
-**Variant suffixes** (parent UID + suffix; see the Terraform variants section for context):
+Variant suffixes (parent UID + suffix, see Terraform variants below):
 
-- `-<cloud>` — runtime variant (e.g., `-aws`, `-azure`, `-gcp`). Match the parent's cloud.
-- `-terraform-hcl` / `-terraform-plan` / `-terraform-state` — Terraform asset variants.
-- `-cloudformation` / `-bicep` — IaC variants for AWS / Azure where applicable.
+- `-<cloud>` for the runtime variant (`-aws`, `-azure`, `-gcp`), matching the parent's cloud
+- `-terraform-hcl` / `-terraform-plan` / `-terraform-state`
+- `-cloudformation` / `-bicep` for AWS / Azure where applicable
 
-The parent check carries `title`, `impact`, `tags`, and `docs:`; variants carry the platform-specific `mql:` and a `mondoo.com/filter-title` + `mondoo.com/filter-icon` tag pair. Don't repeat compliance tags on variants.
+The parent carries `title`, `impact`, `tags`, and `docs:`. Variants carry the platform-specific `mql:` plus a `mondoo.com/filter-title` and `mondoo.com/filter-icon` tag pair. Don't repeat compliance tags on variants.
 
-**Before adding a new UID**: grep the existing policy for the resource name to confirm there isn't already a check on the same control objective (`grep -i "<resource>-<rule>" content/mondoo-<provider>-security.mql.yaml`). Duplicate checks fragment compliance mappings and confuse scan output.
+Before adding a UID, grep for an existing check on the same control objective: `grep -i "<resource>-<rule>" content/mondoo-<provider>-security.mql.yaml`. Duplicates fragment compliance mappings and confuse scan output.
 
 ## `docs:` body structure
 
-The three required sections follow a consistent shape across the repo. Match it so new checks are visually and structurally indistinguishable from the surrounding policy.
+Match the existing shape so new checks are indistinguishable from their neighbours.
 
-**`desc:`** — what the check verifies, then why it matters.
+**`desc:`** is what the check verifies, then why it matters.
 
 ```markdown
 This check verifies that <capability> is <required state>.
 
-<What that capability is and what it does, in a sentence or two.> <Where the reader administers it, and the value the check requires.>
+<What that capability is and what it does, a sentence or two.> <Where the reader administers it, and the value the check requires.>
 
 **Why this matters**
 
 <What an attacker concretely does without it, or what concretely breaks. Two to four short paragraphs.>
 
-<When this legitimately should not be applied, or what to pair it with.>
+<When this legitimately shouldn't be applied, or what to pair it with.>
 ```
 
 Four rules, in priority order.
 
-**1. The first sentence says what is being verified.** It begins with the literal string `This check`, and it names the capability the reader would recognize as a security property — not the resource, not the config key, not a paraphrase of the title. A reader who stops after one sentence should know what was assessed.
+**1. The first sentence says what is being verified.** It starts with the literal string `This check` and names the capability a reader would recognize as a security property, not the resource, the config key, or a paraphrase of the title. Someone who stops after one sentence should know what was assessed.
 
-**2. The capability leads; the setting is how it is measured.** The setting is the instrument, never the subject:
+**2. The capability leads; the setting is how it's measured.** The setting is the instrument, never the subject:
 
 ```markdown
 This check verifies that Address Space Layout Randomization is fully enabled.
@@ -121,9 +122,9 @@ This check verifies that Address Space Layout Randomization is fully enabled.
 ASLR places a program's stack, heap, shared libraries, and executable at different memory addresses every time it runs, so an attacker cannot know in advance where anything is. The check reads the kernel parameter `kernel.randomize_va_space`, which must be `2`. A value of `1` randomizes everything except the `brk` heap, and `0` turns randomization off entirely.
 ```
 
-Not "This check verifies that `kernel.randomize_va_space` is set to 2", which tells a reader what the scanner did rather than what is true about their system.
+Not "This check verifies that `kernel.randomize_va_space` is set to 2", which says what the scanner did rather than what's true about the system.
 
-**3. Name the setting where the reader administers it, not where the scanner reads it.** On an OS these coincide: `kernel.randomize_va_space` *is* the sysctl, `/etc/ssh/sshd_config` *is* the file. On SaaS, cloud, and API-driven policies they diverge completely, and naming the MQL accessor is useless to the reader:
+**3. Name the setting where the reader administers it, not where the scanner reads it.** On an OS these are the same: `kernel.randomize_va_space` *is* the sysctl, `/etc/ssh/sshd_config` *is* the file. On SaaS, cloud, and API-driven policies they diverge, and naming the MQL accessor is useless to the reader:
 
 | Wrong | Right |
 |---|---|
@@ -131,19 +132,19 @@ Not "This check verifies that `kernel.randomize_va_space` is set to 2", which te
 | `github.organization.defaultRepositoryPermission` must be `read` | GitHub calls this **Base permissions**, under Organization Settings, Member privileges. It offers None, Read, Write, and Admin |
 | the response header names from a GET request | the server must send `X-Content-Type-Options: nosniff` |
 
-Backticks stay correct for anything the reader types or sees: a filename, an HTTP header, a Terraform argument, a manifest field such as `securityContext.readOnlyRootFilesystem`, a literal value. What never appears is the provider path the query walks.
+Backticks are still right for anything the reader types or sees: a filename, an HTTP header, a Terraform argument, a manifest field like `securityContext.readOnlyRootFilesystem`, a literal value. What never appears is the provider path the query walks.
 
-**4. Say what an attacker does, not that risk is reduced.** "Reduces the attack surface", "improves the security posture", and "adheres to the principle of least functionality" are true of every check in the repo and therefore tell the reader nothing. Name the mechanism, and name a real technique or advisory where you are confident it is accurate.
+**4. Say what an attacker does, not that risk is reduced.** "Reduces the attack surface", "improves the security posture", and "adheres to the principle of least functionality" are true of every check in the repo, so they tell the reader nothing. Name the mechanism, and name a real technique or advisory where you're confident it's accurate.
 
-Also: do not close with a paragraph restating the opener. Do not write "compliance with security standards may be compromised" unless you name the control. Do not reference the MQL query, variant UIDs, or "this policy" — the reader sees the check in isolation.
+Also: don't close with a paragraph restating the opener. Don't write "compliance with security standards may be compromised" without naming the control. Don't reference the MQL query, variant UIDs, or "this policy", because the reader sees the check in isolation.
 
-Use exactly one `**Why this matters**` heading. Older policies carry a second `**Risk mitigation**` heading; do not add it to new checks, and drop it when you rewrite one. Around 2,000 descriptions still have it and will converge as policies are revisited.
+Use exactly one `**Why this matters**` heading. Older policies carry a second `**Risk mitigation**` heading. Don't add it to new checks, and drop it when you rewrite one. Roughly 2,000 descriptions still have it and will converge as policies are revisited.
 
-**`audit:`** — vendor-native verification steps. Use H3 headers (`### Audit via Console`, `### Audit via CLI`) when both a console path and a CLI path exist. Each path is a short numbered list ending with what a passing vs. failing result looks like. Never reference `cnspec`, `mql`, or the Mondoo console (see the formatting rule above).
+**`audit:`** is vendor-native verification steps. Use H3 headers (`### Audit via Console`, `### Audit via CLI`) when both a console and a CLI path exist. Each path is a short numbered list ending with what pass and fail look like. Never reference `cnspec`, `mql`, or the Mondoo console.
 
-**The audit command must observe what the query observes.** A vendor command that reports the *effective* configuration will contradict a check that reads a *file*, and the auditor will conclude the scanner is wrong. The worked example is `sshd -T`: `sshd.config.params`, `.ciphers`, `.macs`, and `.kexs` parse `/etc/ssh/sshd_config` and its `Include` files and never shell out, so for a directive whose OpenSSH default is already secure (`X11Forwarding`, `IgnoreRhosts`, `HostbasedAuthentication`, `PermitRootLogin`, `PermitEmptyPasswords`, `PermitUserEnvironment`, `LogLevel`) `sshd -T` prints the passing value on a host where the directive is absent and the check fails. Grep the configuration file instead, and say in the audit text that an absent directive fails.
+The audit command must observe what the query observes. A vendor command that reports the *effective* config contradicts a check that reads a *file*, and the auditor concludes the scanner is wrong. Worked example, `sshd -T`: `sshd.config.params`, `.ciphers`, `.macs`, and `.kexs` parse `/etc/ssh/sshd_config` and its `Include` files and never shell out. So for a directive whose OpenSSH default is already secure (`X11Forwarding`, `IgnoreRhosts`, `HostbasedAuthentication`, `PermitRootLogin`, `PermitEmptyPasswords`, `PermitUserEnvironment`, `LogLevel`), `sshd -T` prints the passing value on a host where the directive is absent and the check fails. Grep the config file instead, and say in the audit text that an absent directive fails.
 
-**`remediation:`** — a list of `- id: <method>` entries, one per supported management surface (see the remediation-coverage rule above). Each entry's `desc:` follows the same shape:
+**`remediation:`** is a list of `- id: <method>` entries, one per supported management surface. Each entry's `desc:` follows this shape:
 
 ```markdown
 To <restate the fix in active voice> using <method>:
@@ -157,41 +158,41 @@ To <restate the fix in active voice> using <method>:
 ```
 ```
 
-Order the list consistently: `console`/`portal` → `cli` → `terraform` → `cloudformation`/`bicep` for clouds; `gui` → `cli` → `script` → `ansible` for OS targets. Reviewers scan in this order — keep it predictable.
+Order the list the same way every time: `console`/`portal` -> `cli` -> `terraform` -> `cloudformation`/`bicep` for clouds; `gui` -> `cli` -> `script` -> `ansible` for OS targets. Reviewers read in that order.
 
 ## Compliance tags (`compliance/<framework>: <control-uid>`)
 
-**Never copy compliance tags from a neighboring check.** The nearby check was mapped for a different control objective; reusing its tags propagates a wrong mapping and misleads auditors. Two checks that both "relate to identity" can map to different controls.
+**Never copy compliance tags from a neighbouring check.** That check was mapped for a different control objective; reusing its tags propagates a wrong mapping and misleads auditors. Two checks that both "relate to identity" can map to different controls.
 
-**A new check is not done until it carries compliance tags.** Any check added to a policy whose existing checks have `compliance/*` tags must ship with its own verified tags (completing the process below) — or with the user's explicit approval to skip them. Do **not** open a PR that adds untagged checks next to tagged siblings and merely note the omission in the PR body; that ships an inconsistent, half-finished policy. An empty `find` for the `cnspec-enterprise-policies` repo means **ask the user where the clone lives** — it does not authorize proceeding without tags.
+**A new check isn't done until it carries compliance tags.** A check added to a policy whose existing checks have `compliance/*` tags ships with its own verified tags, or with the user's explicit approval to skip them. Don't open a PR that adds untagged checks next to tagged siblings and note the omission in the PR body; that ships a half-finished policy. An empty `find` for the `cnspec-enterprise-policies` repo means **ask the user where the clone lives**, it does not authorize proceeding without tags.
 
-When adding or changing compliance tags, follow this process for **each** framework the policy already tags:
+For **each** framework the policy already tags:
 
-1. **Read the authoritative control text.** Open the framework definition in `cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (e.g., `iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where their clone lives if you don't already know; if the files aren't available, stop and tell the user — do not guess.
-2. **State in one sentence what the check actually enforces.** If the check is about identity proofing, say so; if it's about encryption-at-rest, say so. Do not let the check's *title* mislead you — read the MQL.
-3. **Find the single best-matching control** by scanning control titles and descriptions for language that covers the enforced behavior. Strict fit only: MFA, password policy, and session-timeout controls are *not* acceptable stand-ins for identity-proofing, encryption, network-isolation, etc.
-4. **If no control fits, tag it with the YAML boolean `false`** — unquoted, like `compliance/soc2-2017: false`. **Not** `"false"` (the string), not `false-fit`, not `n/a`, not omitting the key. The unquoted boolean is the established repo convention (`grep -rho 'compliance/[a-z0-9-]*: false' content/*.mql.yaml | wc -l` counts over 5,000) and is what downstream tooling expects. A missing mapping is strictly better than a wrong one — wrong mappings get caught in compliance audits and create trust debt.
-5. **Cite the control you chose.** When you present tags to the user, include the control title and a short quote from the control description so the user can verify.
+1. **Read the control text.** Open `cnspec-enterprise-policies/frameworks/<framework>.mql.yaml` (`iso-27001-2022.mql.yaml`, `soc2-2017.mql.yaml`, `nist-sp-800-53-rev5.mql.yaml`, ...). Each control has a `uid`, `title`, and usually `docs.desc`. Ask the user where their clone is if you don't know. If the files aren't available, stop and say so. Don't guess.
+2. **Say in one sentence what the check actually enforces.** Identity proofing? Encryption at rest? Read the MQL; don't let the title mislead you.
+3. **Find the single best-matching control** by scanning control titles and descriptions. Strict fit only: MFA, password policy, and session-timeout controls are not stand-ins for identity proofing, encryption, network isolation, etc.
+4. **If no control fits, tag the YAML boolean `false`**, unquoted: `compliance/soc2-2017: false`. Not `"false"`, not `false-fit`, not `n/a`, not omitting the key. The unquoted boolean is the repo convention (`grep -rho 'compliance/[a-z0-9-]*: false' content/*.mql.yaml | wc -l` counts over 5,000) and is what downstream tooling expects. A missing mapping beats a wrong one; wrong mappings surface in compliance audits and create trust debt.
+5. **Cite the control you picked.** Include the control title and a short quote from its description so the user can verify.
 
-**The `<framework>` in the key must exactly match the framework's `uid:` field** — the value declared inside the framework YAML, *not* the file name. They are not always the same: `cnspec-enterprise-policies/frameworks/bsi-grundschutz-sys15.mql.yaml` declares `uid: bsi-sys-1-5`, so the tag is `compliance/bsi-sys-1-5`. A key that matches no real framework `uid` generates a framework map with a dangling `framework_owner`, which fails bundle migration in `cnspec-enterprise-policies` with `cannot find framework owner`. Likewise the `<control-uid>` value must be a `uid` that exists under that framework's `controls:`.
+**The `<framework>` key must match the framework's `uid:` field**, the value declared inside the framework YAML, not the file name. They differ: `frameworks/bsi-grundschutz-sys15.mql.yaml` declares `uid: bsi-sys-1-5`, so the tag is `compliance/bsi-sys-1-5`. A key matching no real framework `uid` generates a framework map with a dangling `framework_owner`, which fails bundle migration in `cnspec-enterprise-policies` with `cannot find framework owner`. The `<control-uid>` likewise has to exist under that framework's `controls:`.
 
 ### Which frameworks a check has to resolve
 
-Step 1 says "each framework the policy already tags", and in practice that is the same list nearly everywhere. Fourteen frameworks are applied to essentially every tagged check in `content/`, so a new check resolves all fourteen — to a control uid, or to `false`:
+In practice the list is the same nearly everywhere. Fourteen frameworks are applied to essentially every tagged check in `content/`, so a new check resolves all fourteen, to a control uid or to `false`:
 
 `bsi-sys-1-5`, `csa-cloud-controls-matrix-4`, `dora`, `hipaa`, `iso-27001-2022`, `nis-2`, `nist-csf-1`, `nist-csf-2`, `nist-sp-800-171`, `nist-sp-800-53-rev5`, `owasp-top-10-2025`, `pci-dss-4`, `soc2-2017`, `vda-isa-5`
 
-Four more are **subject-scoped** and are added only when the check's subject matter is genuinely in scope, not as part of the standard sweep: `owasp-llm-top-10-2025` and `nist-ai-100-1` (AI/LLM checks), `owasp-asvs-5` (application security verification), `mitre-attack` (checks that map to a specific adversary technique).
+Four more are subject-scoped and only added when the subject matter is genuinely in scope, not as part of the standard sweep: `owasp-llm-top-10-2025` and `nist-ai-100-1` (AI/LLM), `owasp-asvs-5` (appsec verification), `mitre-attack` (checks mapping to a specific adversary technique).
 
-Confirm the current list rather than trusting this one, since it moves as frameworks are added:
+The list moves as frameworks are added, so confirm it rather than trusting this one:
 
 ```bash
 grep -rho "compliance/[a-z0-9-]*:" content/*.mql.yaml | sort | uniq -c | sort -rn
 ```
 
-The frameworks in the standard set appear on nearly every tagged check; the subject-scoped ones appear on a few dozen to a few hundred. **A policy missing one of the standard fourteen entirely is drift, not a decision.** The fourteen currently report an identical count, so a framework whose count falls out of line with the other thirteen is the signal to go looking for the policy that skipped it.
+The standard set appears on nearly every tagged check; subject-scoped ones on a few dozen to a few hundred. A policy missing one of the standard fourteen entirely is drift, not a decision. The fourteen currently report identical counts, so a framework whose count falls out of line with the other thirteen points at the policy that skipped it.
 
-**The control uid is not derived from the framework key.** Several frameworks name their controls with a prefix that does not match the key you tag them under, so a constructed uid compiles and maps to nothing:
+**The control uid is not derived from the framework key.** Several frameworks prefix their controls differently from the key you tag them under, so a constructed uid compiles and maps to nothing:
 
 | Tag key | A real control uid under it |
 |---|---|
@@ -201,44 +202,44 @@ The frameworks in the standard set appear on nearly every tagged check; the subj
 | `compliance/nist-sp-800-171` | `nist-sp-800-171--3-4-8` (**double** hyphen) |
 | `compliance/hipaa` | `hipaa-security-ss164-312-b-audit-controls` |
 
-Read the control uid out of the framework YAML. Do not construct it from the framework name.
+Read the control uid out of the framework YAML. Don't construct it from the framework name.
 
-### OWASP Top 10 mapping parity (enforced by test)
+### OWASP Top 10 parity (enforced by test)
 
-The security policies are mapped to the OWASP Top 10:2025 (application) and, for AI/LLM assets, the OWASP Top 10:2025 for LLM Applications. The offline test in `content/validation/compliance/owasp_mapping_test.go` enforces a **parity invariant**: any check that carries a `compliance/pci-dss-4:` tag (the marker for a framework-mapped check) **must** also carry a `compliance/owasp-top-10-2025:` tag, and vice versa. A policy is either fully mapped or not mapped at all.
+The security policies map to OWASP Top 10:2025 (application) and, for AI/LLM assets, OWASP Top 10:2025 for LLM Applications. `content/validation/compliance/owasp_mapping_test.go` enforces a parity invariant: a check carrying `compliance/pci-dss-4:` (the marker for a framework-mapped check) must also carry `compliance/owasp-top-10-2025:`, and vice versa. A policy is fully mapped or not mapped.
 
-**Practical consequence for contributors:** if you add a check to a policy whose sibling checks are framework-mapped, add its `compliance/owasp-top-10-2025:` tag **in the same PR**. Omitting it turns `main` red on the next run, because the new check inherits a `pci-dss-4` tag from the mapping convention but lacks its OWASP partner. Pick the category from the check's actual enforced behavior:
+So if you add a check to a policy whose siblings are framework-mapped, add its `compliance/owasp-top-10-2025:` tag in the same PR. Omit it and `main` goes red on the next run, because the new check inherits a `pci-dss-4` tag from the mapping convention without its OWASP partner. Pick the category from what the check enforces:
 
 - `a01` broken access control (anonymous/bypass, exposure, least privilege)
 - `a02` security misconfiguration (surface area, dangerous defaults)
 - `a04` cryptographic failures (encryption in transit and at rest, password storage)
 - `a07` authentication failures (login/identity, password policy, MFA)
 - `a08` software/data integrity
-- `a09` security logging and monitoring failures
+- `a09` logging and monitoring failures
 
-`a03` (supply chain) applies to build-time checks. **`a05` (injection), `a06` (insecure design), and `a10` (mishandling exceptional conditions) are the domain of source-level SAST tooling, not posture scanning — never map a cnspec posture check to them** (the test rejects these three). Tag `false` (unquoted) only where no framework control fits; the OWASP tag is not optional for a mapped check.
+`a03` (supply chain) applies to build-time checks. `a05` (injection), `a06` (insecure design), and `a10` (mishandling exceptional conditions) belong to source-level SAST, not posture scanning: never map a cnspec posture check to them, and the test rejects all three. Tag `false` (unquoted) only where no framework control fits. The OWASP tag isn't optional for a mapped check.
 
 ## Terraform variants and remediation for cloud policies
 
-When you add or modify a check in a cloud policy (`mondoo-aws-security`, `mondoo-azure-security`, `mondoo-gcp-security`, `mondoo-oci-security`, `mondoo-hetzner-security`, `mondoo-digitalocean-security`, etc.), **two things** must ship together:
+Add or modify a check in a cloud policy (`mondoo-aws-security`, `mondoo-azure-security`, `mondoo-gcp-security`, `mondoo-oci-security`, `mondoo-hetzner-security`, `mondoo-digitalocean-security`, ...) and two things ship together:
 
-1. A **variants:** block so the check runs against the live cloud runtime *and* Terraform HCL/plan/state assets.
-2. A **`- id: terraform`** entry in the `remediation:` list with HCL example code that fixes the underlying issue.
+1. A `variants:` block so the check runs against the live cloud runtime *and* Terraform HCL/plan/state assets.
+2. A `- id: terraform` entry in `remediation:` with HCL that fixes the issue.
 
-Both ride along with every new or modified check — don't ship one without the other.
+Don't ship one without the other.
 
 ### Variants
 
-Convert single-platform checks to a `variants:` block with up to four children:
+Up to four children:
 
-- `<uid>-<cloud>` — runtime check (`asset.platform == 'aws'`, `'azure'`, `'gcp-project'`, `'oci'`, …)
+- `<uid>-<cloud>` — runtime (`asset.platform == 'aws'`, `'azure'`, `'gcp-project'`, `'oci'`, ...)
 - `<uid>-terraform-hcl` — `terraform.resources(...)` against HCL source
 - `<uid>-terraform-plan` — `terraform.plan.resourceChanges` against `terraform plan` JSON
 - `<uid>-terraform-state` — `terraform.state.resources` against `terraform.tfstate`
 
-**The runtime platform name must come from the provider's catalog, not from the cloud's short name.** A filter naming a platform the provider never emits compiles, lints, and passes CI — it just never matches an asset, so the check silently never runs. Check the name against `providers/<cloud>/connection/platforms.go` (or `providers/<cloud>/resources/platforms.go`) in the mql repo, or the `Platforms` array in the installed `~/.config/mondoo/providers/<cloud>/<cloud>.json`. AWS, Azure, and OCI do have an account-level platform named for the cloud (`aws`, `azure`, `oci`); **GCP does not** — use `gcp-project`, `gcp-org`, `gcp-folder`, or a per-resource platform such as `gcp-storage-bucket`.
+**The runtime platform name comes from the provider's catalog, not the cloud's short name.** A filter naming a platform the provider never emits compiles, lints, and passes CI. It just never matches an asset, so the check silently never runs. Check the name against `providers/<cloud>/connection/platforms.go` (or `providers/<cloud>/resources/platforms.go`) in the mql repo, or the `Platforms` array in the installed `~/.config/mondoo/providers/<cloud>/<cloud>.json`. AWS, Azure, and OCI have an account-level platform named for the cloud (`aws`, `azure`, `oci`). **GCP does not**: use `gcp-project`, `gcp-org`, `gcp-folder`, or a per-resource platform such as `gcp-storage-bucket`.
 
-Reference patterns in this repo:
+Reference patterns here:
 
 - GCP: `mondoo-gcp-security-memorystore-iam-auth-enabled` in `mondoo-gcp-security.mql.yaml`
 - HCL nested-block fanout: `mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-terraform-*` (database_flags)
@@ -246,9 +247,9 @@ Reference patterns in this repo:
 
 ### Fixtures for new IaC variants
 
-Every `-terraform-hcl`, `-cloudformation`, and `-bicep` variant ships with pass **and** fail fixtures under `content/validation/scans/fixtures/iac-variants/<policy>/<variant-uid>/{pass,fail}/<scenario>/`.
+Every `-terraform-hcl`, `-cloudformation`, and `-bicep` variant ships pass **and** fail fixtures under `content/validation/scans/fixtures/iac-variants/<policy>/<variant-uid>/{pass,fail}/<scenario>/`.
 
-**Coverage is 100% and the coverage gate holds it there** — a variant added without fixtures fails CI. There is no debt budget to grow. Where a variant asserts exactly what its own `filters:` require, no failing input exists; record that with a `fail/IMPOSSIBLE.md` marker explaining why, and it counts as covered. That marker is the only sanctioned way to ship a variant without a real fail fixture.
+Coverage is 100% and the gate holds it there: a variant without fixtures fails CI, and there's no debt budget to grow. Where a variant asserts exactly what its own `filters:` require, no failing input exists; record that with a `fail/IMPOSSIBLE.md` marker explaining why and it counts as covered. That marker is the only sanctioned way to ship a variant without a real fail fixture.
 
 ```bash
 make test/content/iac/coverage
@@ -256,41 +257,41 @@ make test/content/iac/coverage
 
 ### The remediation has to satisfy the check
 
-The closed-loop suite scans each IaC variant's **own remediation snippet** and requires the check that recommends it to pass. This is the question the linters cannot answer: cfn-lint, tflint and `bicep build` prove a snippet is well-formed, not that it is right. A snippet can name every property correctly and still demonstrate the exact misconfiguration the check forbids.
+The closed-loop suite scans each IaC variant's own remediation snippet and requires the check that recommends it to pass. Linters can't answer that: cfn-lint, tflint, and `bicep build` prove a snippet is well-formed, not that it's right. A snippet can name every property correctly and still demonstrate the exact misconfiguration the check forbids.
 
 ```bash
 make test/content/iac/remediation
 ```
 
-Every variant in the corpus satisfies its own remediation, so this is a flat assertion with no debt list to add to. A snippet that stops closing its check fails here.
+Every variant in the corpus satisfies its own remediation, so this is a flat assertion with no debt list. A snippet that stops closing its check fails here.
 
-Two shapes account for nearly every failure. A snippet that documents only the fixing resource never triggers a check whose `filters:` select on the resource being protected, so it has to declare that resource too. And a value the HCL parser cannot resolve statically, such as a `jsonencode` body containing a resource reference or a policy supplied through an `aws_iam_policy_document` data source, reads as absent rather than as the value it will become at apply time.
+Two shapes cause nearly every failure. A snippet documenting only the fixing resource never triggers a check whose `filters:` select on the resource being protected, so it has to declare that resource too. And a value the HCL parser can't resolve statically (a `jsonencode` body containing a resource reference, or a policy supplied through an `aws_iam_policy_document` data source) reads as absent rather than as what it becomes at apply time.
 
-See [validation/README.md](validation/README.md) for how the snippet is materialized and what each of the three failure modes means.
+[validation/README.md](validation/README.md) covers how the snippet is materialized and what each of the three failure modes means.
 
 ### Terraform remediation
 
-Every parent check that has Terraform variants must also document how to fix the issue in Terraform. Add an `- id: terraform` entry to the `remediation:` list alongside the existing `id: console`, `id: cli`, `id: cloudformation`, `id: bicep` entries. The block holds a short Markdown intro and a fenced ```hcl``` example that resolves the violation.
+Every parent check with Terraform variants documents the Terraform fix too. Add `- id: terraform` to `remediation:` alongside `id: console`, `id: cli`, `id: cloudformation`, `id: bicep`. The block holds a short Markdown intro and a fenced ```hcl``` example that resolves the violation.
 
-Reference: `mondoo-aws-security-eks-cluster-cmks-in-kms` in `mondoo-aws-security.mql.yaml` shows the canonical structure (variants block + remediation list with `id: terraform` HCL alongside CLI/console/CloudFormation).
+Canonical structure: `mondoo-aws-security-eks-cluster-cmks-in-kms` in `mondoo-aws-security.mql.yaml`.
 
 ### When you can't write a variant or remediation, leave a YAML comment
 
-If the runtime check has no Terraform analog, **leave a YAML comment above the parent check explaining why** so future passes don't re-investigate. Common reasons:
+So the next pass doesn't re-investigate. Common reasons:
 
-- The runtime check evaluates operational telemetry (job state, latest execution status, observed traffic) that has no configuration analog.
-- The cloud resource is managed only via SDK / CLI / console and has no Terraform resource (e.g., short-lived imperative API calls like Vertex AI custom jobs).
-- The runtime check depends on cross-resource correlation (e.g., "every cluster has a backup plan that points at it") that the runtime check itself does not yet implement correctly — in which case fix the runtime first.
-- The runtime check inspects a field whose Terraform analog is a different feature (don't paper over the mismatch with a vacuous variant).
+- The runtime check reads operational telemetry (job state, latest execution status, observed traffic) with no configuration analog.
+- The resource is managed only via SDK/CLI/console and has no Terraform resource (short-lived imperative API calls like Vertex AI custom jobs).
+- The runtime check depends on cross-resource correlation ("every cluster has a backup plan pointing at it") that the runtime check itself doesn't implement correctly yet. Fix the runtime first.
+- The runtime check inspects a field whose Terraform analog is a different feature. Don't paper over that with a vacuous variant.
 
-The `# No Terraform variants:` comment goes on the line before `- uid:`:
+`# No Terraform variants:` goes on the line before `- uid:`:
 
 ```yaml
 # No Terraform variants: <one-sentence reason>. <Optional: when this could be revisited>.
 - uid: mondoo-<cloud>-security-...
 ```
 
-The `# No Terraform remediation:` comment goes **inside the `remediation:` list**, as its last line, indented at the same level as the `- id:` entries — where an `- id: terraform` entry would otherwise sit:
+`# No Terraform remediation:` goes inside the `remediation:` list as its last line, indented level with the `- id:` entries, where an `- id: terraform` would sit:
 
 ```yaml
 remediation:
@@ -299,91 +300,89 @@ remediation:
   # No Terraform remediation: <one-sentence reason>. <Optional: when this could be revisited>.
 ```
 
-When neither variants nor remediation are possible (the usual case — if you can't write a variant, you usually can't write Terraform remediation either), include both comments. Each comment must explain the technical limitation, not just say "skip".
+When neither is possible (the usual case, since no variant usually means no Terraform remediation either), include both comments. Each explains the technical limitation, not just "skip".
 
 ### Terraform variants read a different shape than the runtime check
 
-The HCL, plan, and state variants of one check are **not** interchangeable, and the usual bug is assuming they are:
+HCL, plan, and state variants of one check are not interchangeable. The usual bug is assuming they are:
 
-- **A default-true attribute must be asserted as `!= false`, not `== true`.** An attribute the author omitted is `null`, and `null == true` fails, so `== true` flags every correct config that relied on the default.
-- **An absent block is not neutral.** Whether a missing Terraform block means pass or fail depends on the vendor's API default for that setting, which you have to look up. Two attributes in the same block can go opposite ways.
+- **A default-true attribute is asserted as `!= false`, not `== true`.** An omitted attribute is `null`, and `null == true` fails, so `== true` flags every correct config that relied on the default.
+- **An absent block is not neutral.** Whether a missing block means pass or fail depends on the vendor's API default for that setting, which you have to look up. Two attributes in the same block can go opposite ways.
 - **In plan and state JSON, nested blocks serialize as arrays**, and an omitted optional block is `[]`, not `null`. A missing block usually means the insecure default, so guard with `!= empty &&` rather than letting the empty list pass vacuously.
-- **The HCL variant is often stricter than its plan/state siblings**, legitimately — HCL sees the author's intent, plan/state see a resolved value. Do not "unify" variants by copying one body into another; that silently weakens the strict one.
-- Verify every attribute name against the provider's real schema (`terraform providers schema -json`) rather than from memory.
+- **The HCL variant is often legitimately stricter than plan/state**, because HCL sees author intent and plan/state see a resolved value. Don't "unify" variants by copying one body into another; that silently weakens the strict one.
+- **Verify every attribute name against the provider's real schema** (`terraform providers schema -json`), not from memory.
 
 ## MQL traps that produce a confidently wrong verdict
 
-Most of these do not fail lint and do not error at scan time. They return a **verdict**, and the verdict is wrong — worse than a broken check, because nothing signals it. Read this section before writing a query, not after a reviewer questions one.
+Most of these don't fail lint and don't error at scan time. They return a verdict and the verdict is wrong, which is worse than a broken check because nothing signals it. Read this before writing a query.
 
-**Check the field exists before you write the query.** The installed provider schema is what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. The source of truth is `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql). Prove the query end to end with `cnquery run <provider> -c '<mql>'`, and read the verdict as `[ok]` / `[failed]` — a check asserting `x == false` prints `[ok] value: false` when it passes, so "value: false" in the output is not a failure.
+Check the field exists first. The installed provider schema is what lint resolves against: `~/.config/mondoo/providers/<name>/<name>.resources.json`. Source of truth: `providers/<name>/resources/<name>.lr` in the [mql repo](https://github.com/mondoohq/mql). Prove the query end to end with `cnquery run <provider> -c '<mql>'` and read the verdict as `[ok]` / `[failed]`. A check asserting `x == false` prints `[ok] value: false` when it passes, so "value: false" in the output is not a failure.
 
 ### There is no parenthesized grouping
 
-`(` is not a valid operand anywhere in MQL. This one *is* a compile error, but it is listed here because the usual response to it is wrong:
+`(` is not a valid operand anywhere in MQL. This one *is* a compile error, listed here because the usual response to it is wrong:
 
 ```
-(a == 1) || (a == 2)          → expected operand, got token "("
-[1,2].all((_ == 1) || _ == 2) → expected closing ')', got '('
-[1,2].all(_ == 1 || (_ == 2)) → expected operand, got token "("
+(a == 1) || (a == 2)          -> expected operand, got token "("
+[1,2].all((_ == 1) || _ == 2) -> expected closing ')', got '('
+[1,2].all(_ == 1 || (_ == 2)) -> expected operand, got token "("
 ```
 
-Rely on `&&` binding tighter than `||`, so `a || b && c` already parses as `a || (b && c)`, or split the assertion into separate `.any()` / `.all()` calls. Never add parentheses "for clarity" — and decline review suggestions that ask for them.
+Rely on `&&` binding tighter than `||`, so `a || b && c` already parses as `a || (b && c)`, or split the assertion into separate `.any()` / `.all()` calls. Never add parens "for clarity", and decline review suggestions asking for them.
 
 ### A guard chain is not a skipped check
 
-The dominant shape in this directory is a **guard chain**: some `||`-joined guards that exempt an asset, then the assertion as the final `&&` conjunct.
+The dominant shape in this directory: `||`-joined guards that exempt an asset, then the assertion as the final `&&` conjunct.
 
 ```coffee
 aws.batch.jobDefinition.status != "ACTIVE" ||            # guard: not in scope
 aws.batch.jobDefinition.container == null ||             # guard: nothing to check
 aws.batch.jobDefinition.container.jobRole == null ||     # guard: no role attached
 aws.batch.jobDefinition.container.jobRole.inlinePolicyDetails.length == 0 &&
-aws.batch.jobDefinition.container.jobRole.attachedPolicies.all(…)
+aws.batch.jobDefinition.container.jobRole.attachedPolicies.all(...)
 ```
 
-Because `&&` binds tighter, that parses as `guard || guard || guard || (D && E)`, which is the intended semantics. Reviewers — human and automated — repeatedly misread the `D && E` tail as "E only runs when D is true, so the check is skipped and silently passes." **That inference is wrong, and it is the single most-filed false positive on this repo.**
-
-Short-circuit evaluation decides *what gets evaluated*, never *what the verdict is*. In a disjunction, a false conjunct makes the whole expression false, so the check **fails**:
+`&&` binds tighter, so that parses as `guard || guard || guard || (D && E)`, which is the intended semantics. Reviewers, human and automated, keep misreading the `D && E` tail as "E only runs when D is true, so the check is skipped and silently passes". That's wrong, and it's the most-filed false positive on this repo: short-circuiting decides what gets evaluated, never what the verdict is. In a disjunction a false conjunct makes the whole expression false, so the check fails:
 
 | `jobRole` present | inline policies exist (`D`) | attached clean (`E`) | verdict |
 |---|---|---|---|
-| yes | **yes** (`D` false) | yes | **`[failed]`** — the inline policy *is* the violation |
+| yes | **yes** (`D` false) | yes | **`[failed]`**, the inline policy *is* the violation |
 | yes | no | no (`E` false) | `[failed]` |
 | yes | no | yes | `[ok]` |
-| no | — | — | `[ok]` via the guard |
+| no | - | - | `[ok]` via the guard |
 
-There is no input for which the guard-chain form passes and a "fully parenthesized" form would fail. Before claiming a precedence bug, build that table and name the row that differs. If no row differs, there is no bug.
+No input makes the guard-chain form pass where a "fully parenthesized" form would fail. Before claiming a precedence bug, build that table and name the differing row. No differing row, no bug.
 
 Two corollaries:
 
-- The suggested fix is usually **not expressible** — MQL rejects `(`, so the grouping has to come from precedence (see the section above).
-- A guard chain and a pure `&&` chain differ in what an **absent** field means, not in precedence. `role == null ||` *passes* an asset with no role; a pure `&&` chain *fails* it. That is a deliberate authoring decision about absent data, so do not "unify" the two shapes.
+- The suggested fix usually isn't expressible, since MQL rejects `(` and the grouping has to come from precedence.
+- A guard chain and a pure `&&` chain differ in what an **absent** field means, not in precedence. `role == null ||` *passes* an asset with no role; a pure `&&` chain *fails* it. That's a deliberate decision about absent data, so don't unify the two shapes.
 
-### Do not verify a literal by eye in a rendered diff
+### Don't verify a literal by eye in a rendered diff
 
-Character-level claims about string literals — a colon count in an ARN, a missing path segment, a truncated prefix — are not reliable from diff output, where proportional rendering and syntax highlighting distort spacing. One PR collected five findings against `arn:aws:iam::aws:policy/ReadOnlyAccess`, each proposing a different "correct" form and three retracting themselves mid-comment. The ARN was canonical throughout.
+Character-level claims about string literals (a colon count in an ARN, a missing path segment, a truncated prefix) aren't reliable from diff output, where proportional rendering and syntax highlighting distort spacing. One PR filed five findings against `arn:aws:iam::aws:policy/ReadOnlyAccess`, each proposing a different "correct" form, three retracting themselves mid-comment. The ARN was canonical throughout.
 
-Resolve the literal against the system that owns it, and quote the result:
+Resolve the literal against the system that owns it and quote the result:
 
 ```bash
 aws iam get-policy --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess --query 'Policy.Arn' --output text
 # arn:aws:iam::aws:policy/ReadOnlyAccess
 ```
 
-AWS-managed policy ARNs have an **empty account field**, so `iam` is followed by exactly two colons. Same rule for any literal with an authoritative oracle: `cfn-lint` for CloudFormation resource types and property names, `az`/`gcloud`/`aws` for CLI grammar, the provider schema for field paths.
+AWS-managed policy ARNs have an empty account field, so `iam` is followed by exactly two colons. Same rule for any literal with an authoritative oracle: `cfn-lint` for CloudFormation resource types and property names, `az`/`gcloud`/`aws` for CLI grammar, the provider schema for field paths.
 
 ### Comparison against an unresolved field is asymmetric
 
-A field the provider never populated is `null`, and null does not compare like a value. Against a missing map key (`m = {"a": 1}`):
+A field the provider never populated is `null`, and null doesn't compare like a value. Against a missing map key (`m = {"a": 1}`):
 
 | Written as | Verdict when the field is absent |
 |---|---|
 | `m["b"] == "x"` | **fails** |
 | `m["b"] != "x"` | **passes** |
-| `m["b"] != ""` | **passes** — `!= ""` is not a non-empty test |
-| `m["b"] != empty` | **fails** — this is the null-safe guard |
+| `m["b"] != ""` | **passes**, so `!= ""` is not a non-empty test |
+| `m["b"] != empty` | **fails**, this is the null-safe guard |
 
-The trap is the second row. A check phrased in the negative — `setting != "insecure"`, `mode != "off"` — **passes on every asset where the field never resolved**. It should be inconclusive; it reports compliant. Assert presence first:
+The trap is the second row. A check phrased in the negative (`setting != "insecure"`, `mode != "off"`) passes on every asset where the field never resolved. It should be inconclusive; it reports compliant. Assert presence first:
 
 ```coffee
 setting != empty && setting != "insecure"
@@ -393,21 +392,21 @@ Prefer `!= empty` over `!= ""` for the same reason: `"" == empty` is true, but s
 
 ### `.all()` and `.none()` treat null and empty differently
 
-An absent HCL or map key is `null`, **not** an empty list, and the two go opposite ways:
+An absent HCL or map key is `null`, not an empty list, and the two go opposite ways:
 
 ```coffee
-[1,2].where(_ > 5).all(_ == 99)   # empty list  → [ok] value: true   (vacuous pass)
-m["missing"].all(_ == 1)          # null        → [failed] actual: _
+[1,2].where(_ > 5).all(_ == 99)   # empty list  -> [ok] value: true   (vacuous pass)
+m["missing"].all(_ == 1)          # null        -> [failed] actual: _
 m["missing"] == empty || m["missing"].all(_ == 1)   # [ok] true      (null-safe form)
 ```
 
-So `blocks.where(type == 'x').all(y)` and `values['x'].all(y)` are **not** equivalent rewrites: the first is vacuously true when nothing matches, the second fails outright. Do not swap one for the other — the vacuous pass and the hard fail are both wrong answers for "the block is absent", and which one you want depends on the vendor default (see the Terraform section above).
+So `blocks.where(type == 'x').all(y)` and `values['x'].all(y)` are not equivalent rewrites: the first is vacuously true when nothing matches, the second fails outright. Don't swap them. The vacuous pass and the hard fail are both wrong answers for "the block is absent", and which one you want depends on the vendor default (see Terraform variants above).
 
 ### A dotted path that is also a resource name is not a field read
 
-The compiler extends the resource path greedily, and the longest matching resource name wins unconditionally over a field on a shorter one — even when the longer resource cannot stand on its own. `azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel` builds a bare `…cluster.autoUpgradeProfile` resource with no id and no fields; the cluster's accessor never runs and every field reads `null`. Combined with the asymmetry above, the check returns a confident wrong answer rather than an error.
+The compiler extends the resource path greedily, and the longest matching resource name wins unconditionally over a field on a shorter one, even when the longer resource can't stand on its own. `azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel` builds a bare `...cluster.autoUpgradeProfile` resource with no id and no fields; the cluster's accessor never runs and every field reads `null`. With the asymmetry above, the check returns a confident wrong answer instead of an error.
 
-Suspect it when the value is a sub-object (a profile, config, or settings block) **and** the full path appears as a resource in its own right in `cnspec providers resources <provider> --json`. Confirm by running the query: the log line is `provider returned no data and no error for a field … id=` with an **empty `id=`**. Fix by reaching the value through an accessor whose path is not a resource name (`azure.subscription.aks.cluster.…`) or by binding a block to the parent:
+Suspect it when the value is a sub-object (a profile, config, or settings block) **and** the full path appears as a resource in its own right in `cnspec providers resources <provider> --json`. Confirm by running the query: the log line is `provider returned no data and no error for a field ... id=` with an empty `id=`. Fix by reaching the value through an accessor whose path isn't a resource name (`azure.subscription.aks.cluster....`) or by binding a block to the parent:
 
 ```coffee
 azure.subscription.aks.cluster {
@@ -415,44 +414,44 @@ azure.subscription.aks.cluster {
 }
 ```
 
-Not Azure-specific: Cloudflare (`cloudflare.zone.settings.*`), GCP (`gcp.project.gkeService.cluster.networkPolicy.*`), AWS (`aws.emr.cluster.encryptionConfiguration.*`), vSphere, and Arista all have resources shaped this way. Cloudflare adds a second failure mode — a 401/403 degrades to an empty list rather than an error, so an unauthorized scan passes vacuously.
+Not Azure-specific: Cloudflare (`cloudflare.zone.settings.*`), GCP (`gcp.project.gkeService.cluster.networkPolicy.*`), AWS (`aws.emr.cluster.encryptionConfiguration.*`), vSphere, and Arista all have resources shaped this way. Cloudflare adds a second failure mode: a 401/403 degrades to an empty list rather than an error, so an unauthorized scan passes vacuously.
 
 ### Smaller ones that still flip a verdict
 
-- **`files.find` regex matches the whole path**, not the basename. A pattern without a leading `.*` matches nothing, and the `.all()` wrapped around it then passes vacuously. There are 17 `files.find` regex usages in `content/` today; check yours against a real path before trusting it.
-- **Flatten with `.flat`, not `.flatten`** — and guard the nested key first.
-- **`map[string][]string` is filtered, never indexed.** Use `keys` / `values` / `where(key …)` / `flat`. Indexing a missing key returns `null`, which collides with a legitimately empty list.
-- **`terraform.resources()` takes a positional type argument** — `terraform.resources("aws_s3_bucket")`. The named form does not compile.
-- **`parse.int` fails inside variant queries.** Use date arithmetic or a string match instead. For port ranges there is no string→int conversion at all, so match with an anchored regex.
-- **GCP dict fields omit defaults.** `protoToDict` drops `false`, `0`, and `""` and camelCases the keys, so assert presence rather than `== false`.
-- **`.one()` means exactly one, and is almost never what a presence check wants.** `files.one(name.in(["dependabot.yaml", "dependabot.yml"]))` fails a repository holding both. Use `.any()` for "at least one exists" and reserve `.one()` for genuine uniqueness assertions.
-- **`.any()` fails on an empty list, which is usually the verdict you want.** It is the correct operation for "something must exist", precisely because `.all()` and `.none()` pass vacuously there. Verified: `[1,2,3].where(_ > 99).any(_ > 0)` fails, while the same filter with `.all()` returns `[ok] value: true`.
+- **`files.find` regex matches the whole path**, not the basename. A pattern without a leading `.*` matches nothing, and the `.all()` around it then passes vacuously. There are 17 `files.find` regex usages in `content/` today; check yours against a real path.
+- **Flatten with `.flat`, not `.flatten`**, and guard the nested key first.
+- **`map[string][]string` is filtered, never indexed.** Use `keys` / `values` / `where(key ...)` / `flat`. Indexing a missing key returns `null`, which collides with a legitimately empty list.
+- **`terraform.resources()` takes a positional type argument**: `terraform.resources("aws_s3_bucket")`. The named form doesn't compile.
+- **`parse.int` fails inside variant queries.** Use date arithmetic or a string match. Port ranges have no string-to-int conversion at all, so match with an anchored regex.
+- **GCP dict fields omit defaults.** `protoToDict` drops `false`, `0`, and `""` and camelCases keys, so assert presence rather than `== false`.
+- **`.one()` means exactly one** and is almost never what a presence check wants. `files.one(name.in(["dependabot.yaml", "dependabot.yml"]))` fails a repo holding both. Use `.any()` for "at least one exists"; reserve `.one()` for genuine uniqueness.
+- **`.any()` fails on an empty list**, which is usually the verdict you want. It's the right operation for "something must exist", precisely because `.all()` and `.none()` pass vacuously there. Verified: `[1,2,3].where(_ > 99).any(_ > 0)` fails, while the same filter with `.all()` returns `[ok] value: true`.
 
 ## Validation and testing
 
-**[`validation/README.md`](validation/README.md) is the definitive reference** for every check that runs against this directory: what each one proves, when CI runs it, how to scope a run down to a single check, and what a new policy or check has to be registered with. This file owns the authoring rules; that one owns the gates.
+[`validation/README.md`](validation/README.md) is the reference for every gate that runs against this directory: what each proves, when CI runs it, how to scope a run to a single check, what a new policy or check has to be registered with. This file owns the authoring rules; that one owns the gates.
 
 ```bash
 make test/content              # lint + bundle scans + compliance mappings
-make test/content/lint         # cnspec policy lint (run this first, and fix it first)
-make test/content/iac          # every IaC fixture suite — slow; scope it, see the README
-make test/content/remediation  # the remediation code-block linters
-make test/content/commands     # the remediation CLI and API validators
+make test/content/lint         # cnspec policy lint (run first, fix first)
+make test/content/iac          # every IaC fixture suite, slow; scope it, see the README
+make test/content/remediation  # remediation code-block linters
+make test/content/commands     # remediation CLI and API validators
 ```
 
-`cnspec policy lint` must pass before committing any policy change. To lint or scan one policy:
+`cnspec policy lint` has to pass before committing a policy change. One policy at a time:
 
 ```bash
 cnspec policy lint content/mondoo-aws-security.mql.yaml
 cnspec scan local -f content/your-policy.mql.yaml
 ```
 
-Two consequences of how those gates are wired are worth carrying into authoring, because both are invisible while they are wrong:
+Three consequences of how the gates are wired, all invisible while they're wrong:
 
-- **A skipped check is a fixture bug, not a pass.** A variant whose filter never matches anything is indistinguishable from one that passes, in every report, forever. A group filter is evaluated before the check's own filter, so a policy with variants leaves its groups unfiltered — see [Group filters and variants do not mix](validation/README.md#group-filters-and-variants-do-not-mix).
-- **A new policy is visited by nothing until it is registered.** Most validators are allowlist-driven, so an unregistered `*.mql.yaml` ships with its variants untested and its remediation unverified, with every gate green. Wire it up in the same change that adds it: [Adding a policy: what to register](validation/README.md#adding-a-policy-what-to-register).
+- **A skipped check is a fixture bug, not a pass.** A variant whose filter never matches anything is indistinguishable from one that passes, in every report, forever. Group filters are evaluated before the check's own filter, so a policy with variants leaves its groups unfiltered. See [Group filters and variants do not mix](validation/README.md#group-filters-and-variants-do-not-mix).
+- **A new policy is visited by nothing until it's registered.** Most validators are allowlist-driven, so an unregistered `*.mql.yaml` ships with its variants untested and its remediation unverified, every gate green. Wire it up in the same change: [Adding a policy: what to register](validation/README.md#adding-a-policy-what-to-register).
 - **A stale `KNOWN_BUG.md` marker fails the build.** Fixing a check means deleting its markers in the same change.
 
-**Never hand-edit** the checked-in CLI grammars and OpenAPI specs in `validation/data/`; re-run the relevant script in `validation/upstream/dump/` instead.
+Never hand-edit the checked-in CLI grammars and OpenAPI specs in `validation/data/`. Re-run the relevant script in `validation/upstream/dump/`.
 
-Reference links for MQL resources, built-in functions, and the authoring guide are in the repository-root [`CLAUDE.md`](../CLAUDE.md), which loads alongside this file.
+MQL resource links, built-in functions, and the authoring guide are in the repo-root [`CLAUDE.md`](../CLAUDE.md), which loads alongside this file.


### PR DESCRIPTION
The root `CLAUDE.md` and `content/CLAUDE.md` are prompt payload, not documentation. Every sentence of narrative framing is paid on every turn of every session that touches this repo, and both files had accumulated a lot of connective writing around the facts they carry.

This rewords them to state the facts plainly. Nothing is dropped: every command, path, table, count, framework uid, and MQL gotcha is preserved, and the structure is identical (same 49 headings, same 50 code fences across the two files). I diffed all inline code spans, numbers, and URLs between the old and new versions to confirm it — the only deltas were `…` normalized to `...` and one repo path shortened.

Combined the two files go from ~8,970 to ~7,360 words, about 18%.

Representative changes:

| Before | After |
|---|---|
| "This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository." | "Notes for Claude Code working in this repo. Terse on purpose." |
| "Everything that checks the policies in `content/` lives in `content/validation/`, and **[README] is the definitive reference** for it: what each check proves, when CI runs it, and how to run it manually." | "Lives in `content/validation/`. What each check proves, when CI runs it, how to run it manually: [README]." |
| "Reviewers — human and automated — repeatedly misread the `D && E` tail as … **That inference is wrong, and it is the single most-filed false positive on this repo.**<br><br>Short-circuit evaluation decides *what gets evaluated*, never *what the verdict is*." | one sentence: "… That's wrong, and it's the most-filed false positive on this repo: short-circuiting decides what gets evaluated, never what the verdict is." |

18% is about the honest ceiling without cutting content. Both files are mostly reference material — command blocks, the impact bands, the fourteen framework uids, the control-uid prefix table — which is already at its compressed form. Only the prose between it was compressible.

One redundancy left alone deliberately: the root file's "Don't flag these" table and its two-real-bugs section (~600 words) restate `content/CLAUDE.md`'s MQL-traps section. That's on purpose per the note in the root file, so a review bot that never opens `content/` still avoids the false positive. Collapsing it would change what the bot sees, not just how it reads, so it seemed worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)