### PR TITLE
✨ use the operating system's proxy settings on Windows

### DIFF
--- a/internal/supportbundle/supportbundle.go
+++ b/internal/supportbundle/supportbundle.go
@@ -46,6 +46,7 @@ import (
 	"go.mondoo.com/cnspec"
 	"go.mondoo.com/cnspec/internal/scandump"
 	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/logger"
 	"go.mondoo.com/mql/providers"
 )
@@ -264,6 +265,13 @@ type Manifest struct {
 	Hostname   string            `json:"hostname,omitempty"`
 	Args       []string          `json:"args,omitempty"`
 	Env        map[string]string `json:"env"`
+	// Proxy is the proxy that platform traffic goes through as this process
+	// resolved it, credentials redacted, and ProxySource where it came from
+	// (api_proxy, environment, system). Both are empty for a direct
+	// connection. On a proxied Windows machine this is the first thing to
+	// look at when the platform is unreachable.
+	Proxy       string `json:"proxy,omitempty"`
+	ProxySource string `json:"proxy_source,omitempty"`
 }
 
 func (b *Bundle) writeManifest() error {
@@ -280,6 +288,7 @@ func (b *Bundle) writeManifest() error {
 		Args:       b.Args,
 		Env:        collectRelevantEnv(),
 	}
+	m.Proxy, m.ProxySource = effectiveProxy()
 
 	raw, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -294,7 +303,24 @@ func (b *Bundle) writeManifest() error {
 var loggedEnvVars = []string{
 	"DEBUG", "TRACE", "MONDOO_CONFIG_PATH", "MONDOO_CONFIG_HOME",
 	"MONDOO_HOME", "MONDOO_AUTO_UPDATE", "NO_COLOR", "HTTP_PROXY",
-	"HTTPS_PROXY", "NO_PROXY", "MEM_DEBUG",
+	"HTTPS_PROXY", "NO_PROXY", "MONDOO_API_PROXY", "MONDOO_SYSTEM_PROXY",
+	"MEM_DEBUG",
+}
+
+// effectiveProxy reports the proxy platform traffic goes through and its
+// source, or empty strings for a direct connection or when the configuration
+// cannot be read. It never fails the bundle: the proxy is context for the
+// bundle, not its subject.
+func effectiveProxy() (proxy, source string) {
+	opts, err := config.Read()
+	if err != nil {
+		return "", ""
+	}
+	p, src, err := opts.EffectiveProxy(opts.UpstreamApiEndpoint())
+	if err != nil || p == nil {
+		return "", ""
+	}
+	return p.Redacted(), string(src)
 }
 
 func collectRelevantEnv() map[string]string {

--- a/policy/hub.go
+++ b/policy/hub.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/logger"
 	"go.mondoo.com/mql/mrn"
-	"go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 )
@@ -366,9 +366,14 @@ func (s *LocalServices) DefaultPolicies(ctx context.Context, req *DefaultPolicie
 		registryEndpoint = defaultRegistryUrl
 	}
 
-	// Note, this does not use the proxy config override from the mondoo.yml since we only get here when
-	// it is used without upstream config
-	client, err := NewPolicyHubClient(registryEndpoint, ranger.DefaultHttpClient())
+	// There is no upstream config on this path, but the registry is still
+	// reached through whatever proxy the CLI resolves: api_proxy, the
+	// environment, or the operating system's settings.
+	httpClient, err := config.NewHttpClient()
+	if err != nil {
+		return nil, err
+	}
+	client, err := NewPolicyHubClient(registryEndpoint, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/scan/local_scanner.go
+++ b/policy/scan/local_scanner.go
@@ -1590,12 +1590,11 @@ func (s *localAssetScanner) UpdateFilters(filters *policy.Mqueries, timeout time
 
 func sendErrorToMondooPlatform(serviceAccount *upstream.ServiceAccountCredentials, event *health.SendErrorReq) {
 	// 3. send error to mondoo platform
-	proxy, err := config.GetAPIProxy()
+	httpClient, err := config.NewHttpClient()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to parse proxy setting")
 		return
 	}
-	httpClient := ranger.NewHttpClient(ranger.WithProxy(proxy))
 
 	plugins := []ranger.ClientPlugin{}
 	certAuth, err := upstream.NewServiceAccountRangerPlugin(serviceAccount)

--- a/policy/services.go
+++ b/policy/services.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/mqlc"
 	"go.mondoo.com/mql/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/providers-sdk/v1/upstream"
 	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/sync/semaphore"
 )
@@ -67,7 +68,9 @@ func NewLocalServices(datalake DataLake, runtime llx.Runtime) *LocalServices {
 // NewRemoteServices initializes a services struct with a remote endpoint
 func NewRemoteServices(addr string, auth []ranger.ClientPlugin, httpClient *http.Client) (*Services, error) {
 	if httpClient == nil {
-		httpClient = ranger.DefaultHttpClient()
+		// environment and operating system proxy settings, like every other
+		// platform client without an explicit api_proxy
+		httpClient = upstream.DefaultHttpClient()
 	}
 
 	// restrict parallel upstream connections to two connections

--- a/upload/findings.go
+++ b/upload/findings.go
@@ -18,7 +18,6 @@ import (
 	cliconfig "go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/fex"
-	ranger "go.mondoo.com/ranger-rpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -76,7 +75,11 @@ func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument,
 		return fmt.Errorf("create auth plugin: %w", err)
 	}
 
-	resolver, err := policy.NewPolicyResolverClient(creds.ApiEndpoint, resolverHTTPClient(opts.HTTPClient), plugin)
+	resolverClient, err := resolverHTTPClient(opts.HTTPClient)
+	if err != nil {
+		return fmt.Errorf("resolve proxy: %w", err)
+	}
+	resolver, err := policy.NewPolicyResolverClient(creds.ApiEndpoint, resolverClient, plugin)
 	if err != nil {
 		return fmt.Errorf("create policy resolver client: %w", err)
 	}
@@ -107,12 +110,13 @@ func UploadFindings(ctx context.Context, opts Opts, docs []*fex.FindingDocument,
 }
 
 // resolverHTTPClient returns the client used for the resolver RPCs: the
-// caller-supplied client when set, otherwise ranger's default.
-func resolverHTTPClient(c *http.Client) *http.Client {
+// caller-supplied client when set, otherwise one with the CLI's proxy
+// selection (api_proxy, environment, operating system).
+func resolverHTTPClient(c *http.Client) (*http.Client, error) {
 	if c != nil {
-		return c
+		return c, nil
 	}
-	return ranger.DefaultHttpClient()
+	return cliconfig.NewHttpClient()
 }
 
 // putHTTPClient returns the client used for the signed-URL PUT, bounded by
@@ -230,7 +234,11 @@ func ValidateCredentials(ctx context.Context, creds *upstream.ServiceAccountCred
 		return err
 	}
 
-	client, err := upstream.NewAgentManagerClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	httpClient, err := cliconfig.NewHttpClient()
+	if err != nil {
+		return err
+	}
+	client, err := upstream.NewAgentManagerClient(creds.ApiEndpoint, httpClient, plugin)
 	if err != nil {
 		return err
 	}

--- a/upload/findings_test.go
+++ b/upload/findings_test.go
@@ -103,11 +103,15 @@ func TestDoUpload(t *testing.T) {
 
 func TestResolverHTTPClient(t *testing.T) {
 	// nil falls back to a non-nil default client.
-	assert.NotNil(t, resolverHTTPClient(nil))
+	c, err := resolverHTTPClient(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 
 	// a supplied client is used as-is.
 	custom := &http.Client{}
-	assert.Same(t, custom, resolverHTTPClient(custom))
+	c, err = resolverHTTPClient(custom)
+	require.NoError(t, err)
+	assert.Same(t, custom, c)
 }
 
 func TestPutHTTPClient(t *testing.T) {

--- a/upload/sbomscan.go
+++ b/upload/sbomscan.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	cliconfig "go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/fex"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/sbomscan"
 	"go.mondoo.com/mql/sbom"
-	ranger "go.mondoo.com/ranger-rpc"
 )
 
 // sbomScanner is the slice of the ExtendedVulnMgmt client that ScanSBOM needs; a
@@ -33,7 +33,11 @@ func ScanSBOM(ctx context.Context, opts Opts, bom *sbom.Sbom) ([]*fex.Vulnerabil
 	if err != nil {
 		return nil, fmt.Errorf("create auth plugin: %w", err)
 	}
-	scanner, err := sbomscan.NewExtendedVulnMgmtClient(creds.ApiEndpoint, ranger.DefaultHttpClient(), plugin)
+	httpClient, err := cliconfig.NewHttpClient()
+	if err != nil {
+		return nil, fmt.Errorf("resolve proxy: %w", err)
+	}
+	scanner, err := sbomscan.NewExtendedVulnMgmtClient(creds.ApiEndpoint, httpClient, plugin)
 	if err != nil {
 		return nil, fmt.Errorf("create vuln scan client: %w", err)
 	}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -47,11 +47,10 @@ func (c *countingReader) Read(p []byte) (int, error) {
 
 // UploadFile uploads a file to a pre-signed URL via HTTP PUT.
 //
-// The request honors the Mondoo CLI's api_proxy setting in addition to the
-// standard HTTPS_PROXY/HTTP_PROXY env vars: config.GetAPIProxy() resolves
-// MONDOO_API_PROXY, viper's api_proxy (mondoo.yml / --api-proxy), and finally
-// HTTPS_PROXY. When no proxy is configured, the default transport's
-// http.ProxyFromEnvironment is used (which also honors NO_PROXY).
+// The request goes through the same proxy the rest of the CLI's platform
+// traffic does: api_proxy (mondoo.yml, --api-proxy, MONDOO_API_PROXY) first,
+// then HTTPS_PROXY/HTTP_PROXY with NO_PROXY, then the operating system's proxy
+// settings on Windows. See config.ProxyFunc for the precedence.
 //
 // It sets the provided headers and Content-Type to application/octet-stream.
 // The caller is responsible for checking the response status code and closing
@@ -101,30 +100,23 @@ func UploadFile(ctx context.Context, url string, headers map[string]string, file
 	return Result{Response: resp, BytesSent: counter.n.Load(), Duration: time.Since(start)}, err
 }
 
-// newHTTPClient builds the HTTP client used by UploadFile. When api_proxy is
-// configured (via mondoo.yml, MONDOO_API_PROXY, --api-proxy, or HTTPS_PROXY)
-// the transport is set to route through that proxy URL; otherwise we return
-// a plain client whose default transport already honors HTTP(S)_PROXY/NO_PROXY
-// via http.ProxyFromEnvironment.
+// newHTTPClient builds the HTTP client used by UploadFile, with the CLI's
+// proxy selection (config.ProxyFunc) installed on a clone of the default
+// transport so TLS settings, timeouts and connection-pool tuning are
+// inherited. The assertion is guarded: callers (or tests) may have replaced
+// http.DefaultTransport with a non-*http.Transport wrapper, in which case a
+// fresh transport is used rather than panicking.
 func newHTTPClient() (*http.Client, error) {
-	proxy, err := config.GetAPIProxy()
+	proxy, err := config.ProxyFunc()
 	if err != nil {
 		return nil, err
 	}
-	if proxy == nil {
-		return &http.Client{}, nil
-	}
-	// Clone the default transport when possible so we inherit TLS settings,
-	// timeouts, and connection-pool tuning. Guard the assertion: callers (or
-	// tests) may have replaced http.DefaultTransport with a non-*http.Transport
-	// wrapper, in which case we fall back to a fresh transport rather than
-	// panicking.
 	var tr *http.Transport
 	if base, ok := http.DefaultTransport.(*http.Transport); ok {
 		tr = base.Clone()
 	} else {
 		tr = &http.Transport{}
 	}
-	tr.Proxy = http.ProxyURL(proxy)
+	tr.Proxy = proxy
 	return &http.Client{Transport: tr}, nil
 }


### PR DESCRIPTION
## Summary

cnspec counterpart of https://github.com/mondoohq/mql/pull/10755: cnspec built a handful of HTTP clients outside the shared upstream client, each reading `api_proxy` or `HTTPS_PROXY` on its own. On a Windows machine whose proxy lives in Internet Settings or the WinHTTP default they went direct and failed. They now take the proxy selector mql resolves for every platform client, so the precedence is the same everywhere: `--api-proxy`/`MONDOO_API_PROXY`, then `api_proxy` in the config file, then `HTTPS_PROXY` with `NO_PROXY`, then the operating system's settings unless `system_proxy: false`, then direct. A proxy in the config file keeps overriding everything else.

## What changes

- `upload/upload.go`: the pre-signed upload PUT uses `config.ProxyFunc` on a clone of the default transport.
- `policy/scan/local_scanner.go`: error reporting uses `config.NewHttpClient`.
- `policy/hub.go`: the registry lookup without an upstream config goes through the resolved proxy too.
- `policy/services.go`: the nil-client fallback in `NewRemoteServices` uses the system-aware `upstream.DefaultHttpClient`.
- `upload/findings.go`, `upload/sbomscan.go`: findings upload, credential validation and SBOM scanning use `config.NewHttpClient`.
- Support bundle: the manifest records the proxy in effect and its source (`proxy`, `proxy_source`) and captures `MONDOO_API_PROXY` and `MONDOO_SYSTEM_PROXY`.
- `cnspec status` shows the proxy through mql's status command.

## Dependency

Draft until https://github.com/mondoohq/mql/pull/10755 merges. Then bump `go.mondoo.com/mql` to the merged commit; this branch was built and tested against the mql branch through a temporary `go.work` (not committed).

## Testing

- `go build ./...`, `go test` for `upload`, `policy`, `policy/scan`, `internal/supportbundle`, `apps/cnspec/cmd`, `internal/datalakes/...` against the mql branch.
- Cross-compiles for windows/amd64.
- Live verification on a Windows Server 2025 EC2 instance behind a Squid proxy, with this branch's `cnspec.exe`: `cnspec status`, the LocalSystem service check-in, the provider subprocess environment and a full `cnspec scan local` with upload all went through the system proxy, and `api_proxy` in the config file kept overriding the environment and the system settings. Results and evidence: https://github.com/mondoohq/mql/pull/10755#issuecomment-5638529813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
