### PR TITLE
🐛 edge: authenticate with cnspec's WIF, not mql's service account key

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       # Add "contents" to write release
       contents: "write"
+      # Add "id-token" for google-github-actions/auth
+      id-token: "write"
 
     runs-on:
       group: arc-runners
@@ -118,17 +120,15 @@ jobs:
       # the install service resolved a bucket path that has never existed for
       # cnspec. These are the same archives goreleaser already built for the
       # images; they were simply discarded.
-      # A service account key, not workload identity federation. The WIF
-      # binding cannot be impersonated from a branch push -- goreleaser.yml
-      # uses it and runs only on tags, while mql's providers.yaml writes this
-      # same bucket from a push to a branch and uses this key to do it.
-      # Getting that backwards fails with `iam.serviceAccounts.getAccessToken
-      # denied`, which reads like a broken grant rather than the wrong
-      # credential. Confirmed on mondoohq/mql#10763.
+      # Workload identity federation, the same credentials goreleaser.yml uses.
+      # Not mql's GCP_RELEASE_SERVICE_ACCOUNT: that secret does not exist in
+      # this repository, so `credentials_json` resolved to empty and the auth
+      # action rejected the run for specifying neither credential.
       - name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
-          credentials_json: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WIP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1


### PR DESCRIPTION
The first cnspec edge build after #3640 merged failed at authentication:

```
google-github-actions/auth failed with: the GitHub Action workflow must specify
exactly one of "workload_identity_provider" or "credentials_json"
```

[run 34640589478](https://github.com/mondoohq/cnspec/actions/runs/34640589478)

## Cause

`credentials_json` resolved to **empty**. `GCP_RELEASE_SERVICE_ACCOUNT` is an **mql** secret — used by mql's `providers.yaml` — and it does not exist in this repository. The only GCP credentials here are the WIF pair `goreleaser.yml` uses:

```
$ git grep -ho "secrets\.[A-Z_]*GCP[A-Z_]*" -- .github/workflows | sort | uniq -c
   1 secrets.GCP_WIP
   1 secrets.GCP_SERVICE_ACCOUNT
   1 secrets.GCP_RELEASE_SERVICE_ACCOUNT   <- only referenced by the line this PR removes
```

I carried mql's fix across without checking its inputs existed here. That is the same mistake twice: mql's own failure was diagnosed as a missing `environment` before it turned out to be the credential, and this one was a credential that isn't there.

## Change

`workload_identity_provider` + `service_account`, byte-identical to `goreleaser.yml`'s auth block. `id-token: write` comes back with it, since WIF needs it and a service account key does not. `environment: prod` stays.

## What the next run establishes

**mql's WIF binding refused a branch push** — that is why mql's edge workflow uses a key. Whether this repository's binding admits one is a fact about the GCP configuration that only a real run answers.

If it is refused the same way, the binding needs widening to cover pushes to `main` from this workflow; swapping credentials again would not help, because there is no key secret here to swap to.

## Not affected

Everything else in the edge pipeline is confirmed working on mql, which runs the identical workflow: version folding (`v14.0.0-rc.2+10039` → `14.0.0-rc.2.10039`), the upload name check, the `edge-published` dispatch, and installer's index job writing `edge/mql/latest.json`. This is purely the credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)