### PR TITLE
✨ update: add --channel for a one-off binary update

### DIFF
--- a/apps/cnspec/cmd/update.go
+++ b/apps/cnspec/cmd/update.go
@@ -17,6 +17,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
+	updateCmd.Flags().String("channel", "", "Release channel to update from: stable or preview (default: the configured update_channel, or the channel this build belongs to)")
 }
 
 // envUpdateReexec marks the process that selfupdate exec'd into after installing
@@ -35,18 +36,55 @@ var updateCmd = &cobra.Command{
 This downloads the release for this platform, verifies it, and re-executes the
 new binary. It is the same mechanism cnspec uses to update itself in the
 background; running this command performs the check immediately instead of
-waiting for the next refresh interval.`,
+waiting for the next refresh interval.
+
+--channel updates from a different release channel for this one command,
+without changing any configuration. On a stable install that is how you move to
+a release candidate without putting the machine on the pre-release track
+permanently.
+
+It cannot move you backwards: cnspec only ever updates to a higher version, so
+--channel stable on a pre-release build reports that there is nothing newer
+rather than rolling back. Reinstall to return to the stable line.
+
+Examples:
+  cnspec update                     # the configured channel
+  cnspec update --channel preview   # one-off, from the pre-release track`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// we need silence usage here, otherwise we get the usage printed in case of error
 		// see https://github.com/spf13/cobra/issues/340
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
-		return runUpdate()
+		return runUpdate(cmd)
 	},
 }
 
-func runUpdate() error {
+// resolveUpdateChannel returns the channel this run should update from: the
+// --channel flag if given, otherwise whatever the configuration and the running
+// build resolve to.
+//
+// An unknown value is an error rather than the fallback it gets in config. In a
+// config file the value may be sitting somewhere nobody is looking at, so
+// following the build is the safer reading; typed on the command line it is
+// worth saying so. Same reasoning as `providers update --channel`.
+func resolveUpdateChannel(cmd *cobra.Command) (string, error) {
+	flag, _ := cmd.Flags().GetString("channel")
+	if flag == "" {
+		return config.GetUpdateChannel(), nil
+	}
+
+	channel := strings.ToLower(strings.TrimSpace(flag))
+	switch channel {
+	case config.ChannelStable, config.ChannelPreview:
+		return channel, nil
+	default:
+		return "", errors.Errorf("unknown channel %q, expected %s or %s",
+			flag, config.ChannelStable, config.ChannelPreview)
+	}
+}
+
+func runUpdate(cmd *cobra.Command) error {
 	currentVersion := cnspec.GetVersion()
 
 	// This process is the one selfupdate exec'd into after installing the new
@@ -70,7 +108,11 @@ func runUpdate() error {
 	}
 
 	config.InitViperConfig()
-	channel := config.GetUpdateChannel()
+
+	channel, err := resolveUpdateChannel(cmd)
+	if err != nil {
+		return err
+	}
 	releaseURL := cnspec.ReleaseURL(config.GetUpdatesURL(), channel)
 
 	// selfupdate re-executes the new binary with the current arguments, so the
@@ -104,6 +146,14 @@ func runUpdate() error {
 		return nil
 	}
 
+	// Asking a pre-release build for stable finds nothing, because cnspec only
+	// ever updates to a higher version. Silence there reads like the channel was
+	// ignored, when in fact it was honoured and there is no way down.
+	if channel == config.ChannelStable && isPrereleaseVersion(currentVersion) {
+		log.Info().Msgf("cnspec %s is a pre-release; the stable channel has nothing newer, and cnspec does not downgrade. Reinstall to return to the stable line.", currentVersion)
+		return nil
+	}
+
 	// Name the channel when it is not the default. On preview "already the
 	// latest version" is true of that track only, and a user who set the channel
 	// to get a release candidate needs to be able to tell the difference between
@@ -115,6 +165,16 @@ func runUpdate() error {
 
 	log.Info().Msgf("cnspec %s is already the latest version", currentVersion)
 	return nil
+}
+
+// isPrereleaseVersion reports whether a version carries a semver pre-release
+// segment. Build metadata is stripped first: it is not a pre-release under
+// SemVer 10. Mirrors the check in cli/config, deliberately as a string split
+// rather than a parse, so "unstable" and -rolling builds answer cleanly.
+func isPrereleaseVersion(version string) bool {
+	core, _, _ := strings.Cut(version, "+")
+	_, prerelease, found := strings.Cut(strings.TrimPrefix(core, "v"), "-")
+	return found && prerelease != ""
 }
 
 // autoUpdateDisabledVia reports which environment variable switches off the

--- a/apps/cnspec/cmd/update_channel_test.go
+++ b/apps/cnspec/cmd/update_channel_test.go
@@ -1,0 +1,108 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/cli/config"
+)
+
+func updateFlagCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("channel", "", "")
+	require.NoError(t, cmd.ParseFlags(args))
+	return cmd
+}
+
+func resetUpdateChannelState(t *testing.T) {
+	t.Helper()
+	viper.Set(config.KeyUpdateChannel, "")
+	config.SetRunningVersion("")
+	t.Cleanup(func() {
+		viper.Set(config.KeyUpdateChannel, "")
+		config.SetRunningVersion("")
+	})
+}
+
+// TestResolveUpdateChannel covers the one-off override on `cnspec update`:
+// moving a stable install to a release candidate without putting the machine on
+// the pre-release track permanently.
+func TestResolveUpdateChannel(t *testing.T) {
+	t.Run("no flag uses the configured channel", func(t *testing.T) {
+		resetUpdateChannelState(t)
+		viper.Set(config.KeyUpdateChannel, config.ChannelPreview)
+
+		channel, err := resolveUpdateChannel(updateFlagCmd(t))
+		require.NoError(t, err)
+		assert.Equal(t, config.ChannelPreview, channel)
+	})
+
+	t.Run("no flag on a stable build is stable", func(t *testing.T) {
+		resetUpdateChannelState(t)
+		config.SetRunningVersion("13.38.1")
+
+		channel, err := resolveUpdateChannel(updateFlagCmd(t))
+		require.NoError(t, err)
+		assert.Equal(t, config.ChannelStable, channel)
+	})
+
+	t.Run("the flag overrides a stable build", func(t *testing.T) {
+		resetUpdateChannelState(t)
+		config.SetRunningVersion("13.38.1")
+
+		channel, err := resolveUpdateChannel(updateFlagCmd(t, "--channel", "preview"))
+		require.NoError(t, err)
+		assert.Equal(t, config.ChannelPreview, channel)
+	})
+
+	t.Run("the flag overrides configuration", func(t *testing.T) {
+		resetUpdateChannelState(t)
+		viper.Set(config.KeyUpdateChannel, config.ChannelPreview)
+
+		channel, err := resolveUpdateChannel(updateFlagCmd(t, "--channel", "stable"))
+		require.NoError(t, err)
+		assert.Equal(t, config.ChannelStable, channel)
+	})
+
+	t.Run("case and spacing are normalized", func(t *testing.T) {
+		resetUpdateChannelState(t)
+
+		channel, err := resolveUpdateChannel(updateFlagCmd(t, "--channel", "  PREVIEW "))
+		require.NoError(t, err)
+		assert.Equal(t, config.ChannelPreview, channel)
+	})
+
+	t.Run("an unknown channel is an error, not a fallback", func(t *testing.T) {
+		resetUpdateChannelState(t)
+
+		_, err := resolveUpdateChannel(updateFlagCmd(t, "--channel", "beta"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "beta")
+		assert.Contains(t, err.Error(), config.ChannelPreview)
+	})
+}
+
+// TestIsPrereleaseVersion pins the check behind the "cnspec does not downgrade"
+// message, including the shapes a development build reports.
+func TestIsPrereleaseVersion(t *testing.T) {
+	for version, want := range map[string]bool{
+		"14.0.0-rc.2":      true,
+		"14.0.0-rc.2.3509": true,
+		"v14.0.0-pre.1":    true,
+		"14.0.0-rolling":   true,
+		"13.38.1":          false,
+		"14.0.0":           false,
+		"8.4.0+41":         false, // build metadata is not a pre-release
+		"unstable":         false,
+		"":                 false,
+	} {
+		assert.Equal(t, want, isPrereleaseVersion(version), "version: %q", version)
+	}
+}

--- a/docs/cnspec-adv-install/update.mdx
+++ b/docs/cnspec-adv-install/update.mdx
@@ -84,6 +84,16 @@ pre-releases by anything but an explicit setting.
 Run `cnspec status` to see which channel a machine is on; the Channel row
 appears whenever it is not the default.
 
+To move to a release candidate once, without putting the machine on the
+pre-release track permanently:
+
+```bash
+cnspec update --channel preview
+```
+
+The same flag works on `cnspec providers update`, for trying a single
+pre-release provider.
+
 <Callout type="warning">
   Pre-releases are for testing an upcoming release before it ships. There is no
   automatic way back to `stable`: cnspec never downgrades itself, so returning to


### PR DESCRIPTION
```
cnspec update --channel preview
```

moves a stable install to a release candidate without putting the machine on the pre-release track permanently.

`cnspec providers update` already had this flag (mondoohq/mql#10764); `cnspec update` did not. Same use case, so having one and not the other was just an inconsistency.

## Scope

The explicit command only. The implicit background check has no invocation to attach a one-off flag to, and would be the wrong place for one anyway — a flag that only applies when a human types it is exactly what this is.

`update_channel` in config, and the build-derived default, are unchanged and still apply when no flag is given.

## An unknown channel is an error here

Same reasoning as the providers flag: in a config file the value may be sitting somewhere nobody is looking at, so following the build is the safer reading. Typed on the command line it is worth saying so.

```
$ cnspec update --channel beta
x unknown channel "beta", expected stable or preview
```

## It cannot move you backwards, and now says so

cnspec only ever updates to a higher version (`CheckAndUpdate` refuses `cmp <= 0`), so `--channel stable` on a pre-release build finds nothing. Silence there reads like the flag was ignored, when in fact it was honoured and there is no way down:

```
$ cnspec update --channel stable        # on a 14.0.0-rc.2 build
→ cnspec 14.0.0-rc.2 is a pre-release; the stable channel has nothing newer,
  and cnspec does not downgrade. Reinstall to return to the stable line.
```

That is a known gap in the channel design; this flag inherits it rather than introducing it, and surfaces it where someone would hit it.

## Verified against the live service

Built with a version stamp and run for real, deliberately avoiding the one combination that would have downloaded and exec'd a binary:

| invocation | result |
|---|---|
| `--channel beta` | typed error, no network reached |
| `--channel stable` on `14.0.0-rc.2` | the no-downgrade message above |
| no flag on `14.0.0-rc.2` | follows the build → preview |

Plus unit tests over the flag/config/build precedence, and the pre-release check including `unstable`, `-rolling` and `8.4.0+41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
