### PR TITLE
🧹 deps: bump mql to v14.0.0-rc.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.19.0
 	go.mondoo.com/mondoo-go v0.0.0-20260909120712-e544d4e81e9c
-	go.mondoo.com/mql v0.0.0-20260911202914-fb4ac718b844
+	go.mondoo.com/mql v0.0.0-20260912163759-b3f038614bd3
 	go.mondoo.com/ranger-rpc v0.8.1
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mondoo.com/mondoo-go v0.0.0-20260909120712-e544d4e81e9c h1:ZEh21Oo0+vqhZd/kOKrBO5yTfNEaf0UZbxfOCGsywbg=
 go.mondoo.com/mondoo-go v0.0.0-20260909120712-e544d4e81e9c/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql v0.0.0-20260911202914-fb4ac718b844 h1:cbSv59gVhybK/y5TgF31n63FwvtgE9K/XTFSaR3ERrc=
-go.mondoo.com/mql v0.0.0-20260911202914-fb4ac718b844/go.mod h1:3Z9IJPdzb2TbO+VT4owC1wX4Wof65S8FOrff8uQ3a+s=
+go.mondoo.com/mql v0.0.0-20260912163759-b3f038614bd3 h1:53PbuSLkPOoUviGoQbOrl/V5cAoFk7iD5SmmUJAd6/0=
+go.mondoo.com/mql v0.0.0-20260912163759-b3f038614bd3/go.mod h1:3Z9IJPdzb2TbO+VT4owC1wX4Wof65S8FOrff8uQ3a+s=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Pins cnspec to the commit mql tagged as `v14.0.0-rc.4`, so the two ship the same code.

```
go.mondoo.com/mql v0.0.0-20260911202914-fb4ac718b844   (v14.0.0-rc.3)
                  v0.0.0-20260912163759-b3f038614bd3   (v14.0.0-rc.4)
```

One commit between them: mondoohq/mql#10419, reporting services on systemd targets that ship no `/sbin/init`.

## By commit, not by tag

`go get go.mondoo.com/mql@v14.0.0-rc.4` cannot work: mql's module path is `module go.mondoo.com/mql` with no `/v14` suffix, so Go will not resolve a `v14.x` tag for it. The pin is a pseudo-version, which is what the release runbook does and what cnspec has carried since v14 work began.

(Worth noting because mondoohq/cnspec#3603 is fixing exactly this in the automated bump path.)

## Next

This is step 3 of the `v14.0.0-rc.4` release. Once merged, cnspec gets tagged `v14.0.0-rc.4` and the rest should be hands-off — which is the point of this release:

- **mondoohq/installer#771** — `published` trigger. Unproven: rc.3 was published to the bucket by `workflow_dispatch`, not by the real event.
- **mondoohq/installer#772** — signed MSI and macOS pkg for a pre-release. Never run.

`go build ./...` and the `cnspec` / `apps/cnspec/cmd` / `apps/cnspec/cmd/config` test packages pass on the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)