### PR TITLE
👷 ci: do not hand a pre-release the GitHub 'latest' pointer

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -43,7 +43,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set release version
-        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+        id: version
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION=$(cat VERSION)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
+          # The channel is derived from the semver pre-release segment, never
+          # declared. Everything after a `-` and before any `+` is that segment;
+          # build metadata (`13.38.1+41`) is not a pre-release and stays stable.
+          # cnquery-update.yml writes the mql version straight into VERSION, so
+          # a pre-release bump reaches this workflow on a normal merge -- without
+          # this, it would publish a v14 rc as a full release and hand it the
+          # `releases/latest` pointer that every v13 client reads.
+          core=${RELEASE_VERSION%%+*}
+          if [ "$core" != "${core#*-}" ]; then
+            echo "${RELEASE_VERSION} is a pre-release"
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "make_latest=false" >> $GITHUB_OUTPUT
+          else
+            echo "${RELEASE_VERSION} is stable"
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "make_latest=true" >> $GITHUB_OUTPUT
+          fi
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
@@ -56,7 +78,8 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           generate_release_notes: true
-          make_latest: true
+          prerelease: ${{ steps.version.outputs.prerelease }}
+          make_latest: ${{ steps.version.outputs.make_latest }}
           token: ${{ steps.generate-token.outputs.token }}
       - name: Release file present?
         id: check_release_file


### PR DESCRIPTION
## The bug

`gh-release.yaml` creates the GitHub release from the `VERSION` file with:

```yaml
generate_release_notes: true
make_latest: true
```

`make_latest` is hardcoded and there is no `prerelease:` field at all. Whatever version is in `VERSION` becomes a **full** release and takes over `releases/latest`.

## Why it is reachable

`cnquery-update.yml:125` writes the mql version straight into `VERSION`:

```
echo "${MQL_VERSION}" > VERSION
```

`gh-release.yaml` triggers on a push to `main` touching `VERSION`. So the first pre-release bump PR that merges publishes a v14 rc as a full release and points `releases/latest` at it — which is the URL every v13 client and every "download the latest" script resolves.

Current state is correct only by accident: `VERSION` has sat at `v13.35.2` since 19 Aug and the v14 rc releases were created by hand.

## The fix

Derive both flags from the semver pre-release segment — the same rule `goreleaser.yml` already applies to pick the release channel. Everything after a `-` and before any `+` is the pre-release segment; build metadata is not one (SemVer §10).

| `VERSION` | `prerelease` | `make_latest` |
|---|---|---|
| `v13.38.1` | false | true |
| `v13.38.1+41` | false | true |
| `v14.0.0` | false | true |
| `v14.0.0-rc.4` | true | false |
| `v14.0.0-rc.4+9` | true | false |
| `8.4.0-snapshot` | true | false |

The last row is the case the old substring tests (`-alpha`/`-beta`/`-rc`/…) missed.

## Verification

Derivation run against all six inputs above; output matches the table. Stable behaviour is unchanged — a release with no pre-release segment still gets `make_latest: true`, exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)