### PR TITLE
🧹 content: fix link rot across every shipped policy

### DIFF
--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -194,7 +194,7 @@ queries:
     refs:
       - url: https://support.atlassian.com/user-management/docs/verify-a-domain-to-manage-accounts/
         title: Verify a domain to manage accounts
-      - url: https://support.atlassian.com/organization-administration/docs/manage-an-organization-with-atlassian-administration/
+      - url: https://support.atlassian.com/organization-administration/docs/get-started-with-an-atlassian-organization/
         title: Manage an Atlassian organization
   - uid: mondoo-atlassian-security-admin-no-stale-api-tokens
     title: Ensure no managed-account API tokens are stale
@@ -365,9 +365,9 @@ queries:
             5. For accounts that are no longer needed, open the account, choose **Deactivate account**, and confirm.
             6. For accounts that must remain, document the business justification and schedule a follow-up review.
     refs:
-      - url: https://support.atlassian.com/organization-administration/docs/deactivate-a-managed-account/
+      - url: https://support.atlassian.com/user-management/docs/deactivate-a-managed-account/
         title: Deactivate a managed account
-      - url: https://support.atlassian.com/organization-administration/docs/manage-an-organization-with-atlassian-administration/
+      - url: https://support.atlassian.com/organization-administration/docs/get-started-with-an-atlassian-organization/
         title: Manage an Atlassian organization
   - uid: mondoo-atlassian-security-jira-no-anonymous-permission-grants
     title: Ensure no Jira project permission scheme grants permission to anyone

--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -195,7 +195,7 @@ queries:
       - url: https://support.atlassian.com/user-management/docs/verify-a-domain-to-manage-accounts/
         title: Verify a domain to manage accounts
       - url: https://support.atlassian.com/organization-administration/docs/get-started-with-an-atlassian-organization/
-        title: Manage an Atlassian organization
+        title: Create an Atlassian organization
   - uid: mondoo-atlassian-security-admin-no-stale-api-tokens
     title: Ensure no managed-account API tokens are stale
     impact: 80
@@ -368,7 +368,7 @@ queries:
       - url: https://support.atlassian.com/user-management/docs/deactivate-a-managed-account/
         title: Deactivate a managed account
       - url: https://support.atlassian.com/organization-administration/docs/get-started-with-an-atlassian-organization/
-        title: Manage an Atlassian organization
+        title: Create an Atlassian organization
   - uid: mondoo-atlassian-security-jira-no-anonymous-permission-grants
     title: Ensure no Jira project permission scheme grants permission to anyone
     impact: 90
@@ -439,7 +439,7 @@ queries:
             6. Confirm the change and re-run the audit to verify no anonymous grants remain.
     refs:
       - url: https://support.atlassian.com/jira-cloud-administration/docs/what-are-permission-schemes-in-jira/
-        title: Manage project permissions
+        title: What are permission schemes in Jira?
       - url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/
         title: Jira Cloud permission schemes REST API
   - uid: mondoo-atlassian-security-confluence-no-anonymous-space-access
@@ -511,7 +511,7 @@ queries:
             7. If the space must remain publicly readable, document the business justification and move the content to a dedicated public documentation site instead of leaving it inside an internal Confluence instance.
     refs:
       - url: https://support.atlassian.com/confluence-cloud/docs/add-change-or-remove-peoples-access-from-your-space/
-        title: Assign space permissions in Confluence
+        title: Add, change, or remove people's access from your space
       - url: https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-space/
         title: Confluence Cloud spaces REST API
   - uid: mondoo-atlassian-security-confluence-no-unlicensed-space-access
@@ -582,6 +582,6 @@ queries:
             6. If portal customers genuinely need documentation, link a dedicated customer-facing space whose content is reviewed and published as external collateral rather than relaxing access on internal spaces.
     refs:
       - url: https://support.atlassian.com/confluence-cloud/docs/add-change-or-remove-peoples-access-from-your-space/
-        title: Assign space permissions in Confluence
+        title: Add, change, or remove people's access from your space
       - url: https://support.atlassian.com/confluence-cloud/docs/give-access-to-unlicensed-users-from-jira-service-management/
         title: Give access to unlicensed users from Jira Service Management

--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-atlassian-security
     name: Mondoo Atlassian Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-atlassian-security.mql.yaml
+++ b/content/mondoo-atlassian-security.mql.yaml
@@ -438,7 +438,7 @@ queries:
             5. Select **Grant permission** and re-grant the same permission to an authenticated audience such as **Any logged in user**, a specific group, or a project role.
             6. Confirm the change and re-run the audit to verify no anonymous grants remain.
     refs:
-      - url: https://support.atlassian.com/jira-cloud-administration/docs/manage-project-permissions/
+      - url: https://support.atlassian.com/jira-cloud-administration/docs/what-are-permission-schemes-in-jira/
         title: Manage project permissions
       - url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/
         title: Jira Cloud permission schemes REST API
@@ -510,7 +510,7 @@ queries:
             6. To stop space administrators from re-enabling public access, sign in as a Confluence administrator and turn off the global setting that allows spaces to turn on anonymous access.
             7. If the space must remain publicly readable, document the business justification and move the content to a dedicated public documentation site instead of leaving it inside an internal Confluence instance.
     refs:
-      - url: https://support.atlassian.com/confluence-cloud/docs/assign-space-permissions/
+      - url: https://support.atlassian.com/confluence-cloud/docs/add-change-or-remove-peoples-access-from-your-space/
         title: Assign space permissions in Confluence
       - url: https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-space/
         title: Confluence Cloud spaces REST API
@@ -581,7 +581,7 @@ queries:
             5. If no service project on the site should expose Confluence content to unlicensed users, a Confluence administrator can additionally open **Confluence settings**, select the **JSM Access** tab, and clear **Use Confluence**. This disables the knowledge base integration for the whole site, so confirm no team depends on it first.
             6. If portal customers genuinely need documentation, link a dedicated customer-facing space whose content is reviewed and published as external collateral rather than relaxing access on internal spaces.
     refs:
-      - url: https://support.atlassian.com/confluence-cloud/docs/assign-space-permissions/
+      - url: https://support.atlassian.com/confluence-cloud/docs/add-change-or-remove-peoples-access-from-your-space/
         title: Assign space permissions in Confluence
       - url: https://support.atlassian.com/confluence-cloud/docs/give-access-to-unlicensed-users-from-jira-service-management/
         title: Give access to unlicensed users from Jira Service Management

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -974,7 +974,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/eks/latest/best-practices/security.html
         title: Amazon EKS Security Best Practices
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
     filters: asset.platform == "aws-eks-cluster"
@@ -1144,7 +1144,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/security-lake/latest/userguide/data-protection.html
         title: Data protection in Amazon Security Lake
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-securitylake-data-lake-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -1631,9 +1631,9 @@ queries:
             ```
         # No CloudFormation remediation: AWS::NetworkFirewall::Firewall does not expose an encryption configuration property, so the customer-managed KMS setting cannot be expressed in a CloudFormation template.
     refs:
-      - url: https://docs.aws.amazon.com/network-firewall/latest/developerguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/network-firewall/latest/developerguide/kms-encryption-at-rest.html
         title: Encryption at rest for AWS Network Firewall
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-networkfirewall-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -1782,7 +1782,7 @@ queries:
                     TlsPolicy: REQUIRE
             ```
     refs:
-      - url: https://docs.aws.amazon.com/ses/latest/dg/configuring-tls-required.html
+      - url: https://docs.aws.amazon.com/ses/latest/dg/security-protocols.html
         title: Requiring TLS for email sent with Amazon SES
   - uid: mondoo-aws-security-ses-configuration-set-require-tls-aws
     filters: asset.platform == "aws"
@@ -1988,7 +1988,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/appflow/latest/userguide/data-protection.html
         title: Data protection in Amazon AppFlow
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-appflow-flow-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -2325,7 +2325,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
         title: Encrypting data in transit for Amazon EFS
-      - url: https://docs.aws.amazon.com/efs/latest/ug/using-fs-policies.html
+      - url: https://docs.aws.amazon.com/efs/latest/ug/create-file-system-policy.html
         title: Using file system policies with Amazon EFS
   - uid: mondoo-aws-security-efs-enforce-transit-encryption-aws
     filters: asset.platform == "aws-efs-filesystem"
@@ -2415,7 +2415,7 @@ queries:
       refs:
         - url: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
           title: Amazon EKS - Pod networking
-        - url: https://docs.aws.amazon.com/eks/latest/userguide/networking-vpc.html
+        - url: https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html
           title: Amazon EKS - Networking in Amazon VPC
       desc: |
         This check verifies that Amazon EKS clusters have `endpointPrivateAccess` enabled and `endpointPublicAccess` disabled, so the Kubernetes API server is reachable only from within the VPC. EKS clusters are accessible over the public internet by default.
@@ -5986,7 +5986,7 @@ queries:
                   ReservedConcurrentExecutions: 10
             ```
     refs:
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-security.html
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
         title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
         title: AWS Lambda Reserved Concurrency
@@ -6186,7 +6186,7 @@ queries:
                   SourceArn: 'arn:aws:s3:::example-bucket'
             ```
     refs:
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-security.html
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
         title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html
         title: AWS Lambda Resource-Based Policies
@@ -10636,7 +10636,7 @@ queries:
                     - !Ref LoadBalancerSecurityGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-internal.html
+      - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html
         title: AWS Documentation - Internal Application Load Balancers
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html
         title: AWS Documentation - How Elastic Load Balancing works
@@ -11118,7 +11118,7 @@ queries:
                   EnableKeyRotation: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
         title: AWS KMS Best Practices
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html
         title: Rotating AWS KMS Keys
@@ -13695,7 +13695,7 @@ queries:
           desc: |
             Do not embed secrets such as AWS access keys, passwords, or API tokens in the `UserData` property of `AWS::EC2::Instance`. Instead, use IAM instance profiles and retrieve secrets at boot time from Secrets Manager or SSM Parameter Store.
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html
+      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
         title: AWS Documentation - Work with instance user data
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
         title: AWS Documentation - Run commands on your Linux instance at launch
@@ -18938,7 +18938,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
         title: AWS Documentation - Build specification reference for CodeBuild
-      - url: https://docs.aws.amazon.com/codebuild/latest/userguide/change-project-console.html
+      - url: https://docs.aws.amazon.com/codebuild/latest/userguide/change-project.html
         title: AWS Documentation - Change a build project's settings in CodeBuild
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
         title: AWS Documentation - What is AWS Secrets Manager
@@ -25375,7 +25375,7 @@ queries:
                   KmsKeyId: !Ref ElastiCacheKMSKey
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/serverless-overview.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.html
         title: AWS Documentation - ElastiCache Serverless
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
         title: AWS Documentation - ElastiCache encryption at rest
@@ -25897,7 +25897,7 @@ queries:
             aws ssm put-parameter --name <parameter-name> --value <value> --type SecureString --key-id <kms-key-id>
             ```
     refs:
-      - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-securestring.html
+      - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/secure-string-parameter-kms-encryption.html
         title: AWS SSM SecureString parameters
   - uid: mondoo-aws-security-ssm-parameter-encryption-aws
     filters: asset.platform == "aws"
@@ -26654,7 +26654,7 @@ queries:
                     - !Ref PrivateSubnet
             ```
     refs:
-      - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-influxdb.html
+      - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html
         title: Amazon Timestream for InfluxDB
   - uid: mondoo-aws-security-timestream-influxdb-not-public-aws
     filters: asset.platform == "aws"
@@ -26821,7 +26821,7 @@ queries:
                       Enabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-influxdb.html
+      - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html
         title: Amazon Timestream for InfluxDB
   - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-aws
     filters: asset.platform == "aws"
@@ -28786,7 +28786,7 @@ queries:
                       FargateEphemeralStorageKmsKeyId: !GetAtt MyKMSKey.Arn
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-storage.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html
         title: Fargate task storage
   - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-aws
     filters: asset.platform == "aws"
@@ -28938,7 +28938,7 @@ queries:
                   KeyAlgorithm: RSA_2048
             ```
     refs:
-      - url: https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html
+      - url: https://docs.aws.amazon.com/acm/latest/userguide/certificate-types.html
         title: AWS Certificate Manager certificates
   # Allowlist of strong key algorithms; the regex accepts both the "RSA-2048" form the aws provider returns (seen in live scan output) and the "RSA_2048" form the AWS SDK uses, so it is robust to either separator. Weak RSA-1024 is rejected.
   - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
@@ -30549,7 +30549,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/encrypt.html
         title: AWS Documentation - Encrypting Neptune resources
-      - url: https://docs.aws.amazon.com/neptune/latest/userguide/backup-restore-overview.html
+      - url: https://docs.aws.amazon.com/neptune/latest/userguide/backup-restore.html
         title: AWS Documentation - Neptune DB cluster snapshots
   - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-aws
     filters: asset.platform == "aws-neptune-cluster"
@@ -31005,7 +31005,7 @@ queries:
                   InstanceType: t3.micro  # Modern instance types only support HVM
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html
+      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ComponentsAMIs.html
         title: Amazon EC2 virtualization types
   - uid: mondoo-aws-security-ec2-no-paravirtual-instances-aws
     filters: asset.platform == "aws"
@@ -31483,7 +31483,7 @@ queries:
       refs:
         - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec.html
           title: Configuring DNSSEC signing in Amazon Route 53
-        - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dnssec-troubleshoot.html
+        - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-troubleshoot.html
           title: Troubleshooting DNSSEC signing in Amazon Route 53
   # No Terraform variants: hosted zone records are frequently managed outside the
   # configuration that creates the zone, so a Terraform variant would report a
@@ -32577,7 +32577,7 @@ queries:
                   MaxUserDurationInSeconds: 36000
             ```
     refs:
-      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/fleets-and-stacks.html
+      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/managing-stacks-fleets.html
         title: Amazon AppStream 2.0 fleets and stacks
   - uid: mondoo-aws-security-appstream-fleet-max-session-duration-aws
     filters: asset.platform == "aws-appstream-fleet"
@@ -32734,7 +32734,7 @@ queries:
                   DisconnectTimeoutInSeconds: 300
             ```
     refs:
-      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/fleets-and-stacks.html
+      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/managing-stacks-fleets.html
         title: Amazon AppStream 2.0 fleets and stacks
   - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-aws
     filters: asset.platform == "aws-appstream-fleet"
@@ -32887,7 +32887,7 @@ queries:
 
             Alternatively, manage the fleet with CloudFormation and set `DisableIMDSV1: true`.
     refs:
-      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/appstream2-instance-metadata-service.html
+      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/customize-fleets-user-instance-metadata-fleets.html
         title: Amazon AppStream 2.0 instance metadata service
       - url: https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html
         title: Amazon AppStream 2.0 CreateFleet API reference
@@ -33207,7 +33207,7 @@ queries:
 
             Note: OS version updates may not be supported via CloudFormation update. Use the AWS CLI for in-place upgrades.
     refs:
-      - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_directory_maintenance.html
+      - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_microsoft_ad.html
         title: AWS Managed Microsoft AD directory maintenance
   - uid: mondoo-aws-security-directoryservice-os-version-aws
     filters: asset.platform == "aws-directoryservice-directory"
@@ -34127,7 +34127,7 @@ queries:
                   DBSubnetGroupName: !Ref DocDBSubnetGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.networking.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/connect-from-outside-a-vpc.html
         title: Amazon DocumentDB - Network security
       - url: https://docs.aws.amazon.com/cli/latest/reference/docdb/modify-db-instance.html
         title: AWS CLI Command Reference - docdb modify-db-instance
@@ -34293,9 +34293,9 @@ queries:
                     - !Ref DocDBSecurityGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.networking.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/connect-from-outside-a-vpc.html
         title: Amazon DocumentDB - Network security
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security-groups.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/document-db-subnet-groups.html
         title: Amazon DocumentDB - Security groups
   - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced
     title: Ensure Cognito user pools enforce multi-factor authentication
@@ -37190,7 +37190,7 @@ queries:
           desc: |
             To ensure WorkSpaces directories deny web access by default in CloudFormation, note that CloudFormation does not natively support configuring WorkSpaces directory access properties. Use the AWS CLI or Terraform to manage web access settings.
     refs:
-      - url: https://docs.aws.amazon.com/workspaces/latest/adminguide/update-directory-details.html
+      - url: https://docs.aws.amazon.com/workspaces/latest/adminguide/update-directory-pools-details.html
         title: Update directory details for your WorkSpaces
   - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-aws
     filters: asset.platform == "aws"
@@ -38484,7 +38484,7 @@ queries:
                   MaintenanceTrackName: current
             ```
     refs:
-      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-maintenance.html
+      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
         title: Amazon Redshift Cluster Maintenance
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Security Hub Controls Reference
@@ -39401,7 +39401,7 @@ queries:
                       ReturnConnectionPasswordEncrypted: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/glue/latest/dg/encrypt-data-catalog.html
+      - url: https://docs.aws.amazon.com/glue/latest/dg/encrypt-glue-data-catalog.html
         title: AWS Documentation - Encrypting your Data Catalog
       - url: https://docs.aws.amazon.com/glue/latest/dg/encryption-at-rest.html
         title: AWS Documentation - Encryption at rest in AWS Glue
@@ -40479,7 +40479,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
         title: AWS Documentation - Using Amazon RDS Proxy
-      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-security.html
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
         title: AWS Documentation - Security with Amazon RDS Proxy
   - uid: mondoo-aws-security-rds-proxy-tls-required-aws
     filters: asset.platform == "aws"
@@ -40804,7 +40804,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/backup_restore-dump_restore_docdb.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/docdb-migration.html
         title: Amazon DocumentDB Migrating Data
   - uid: mondoo-aws-security-documentdb-snapshot-encrypted-aws
     filters: asset.platform == "aws"
@@ -42759,7 +42759,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry-approve.html
         title: Amazon SageMaker - Update the Approval Status of a Model
-      - url: https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry-model-validation.html
+      - url: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-mkt-create-model-package.html
         title: Amazon SageMaker - Validate a Model Package
   - uid: mondoo-aws-security-sagemaker-model-package-approval-validated-aws
     filters: asset.platform == "aws"
@@ -44111,7 +44111,7 @@ queries:
                     - !Ref PrivateSubnet
             ```
     refs:
-      - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/accessing-web-console-of-a-broker.html
+      - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/managing-amazon-mq-broker.html
         title: Amazon MQ - Accessing the Web Console
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
@@ -45248,9 +45248,9 @@ queries:
                     PointInTimeRecoveryEnabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html
+      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html
         title: Amazon DynamoDB - Point-in-Time Recovery
-      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
+      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Backup-and-Restore.html
         title: Amazon DynamoDB - On-Demand Backup and Restore
   - uid: mondoo-aws-security-dynamodb-pitr-enabled-aws
     filters: asset.platform == "aws-dynamodb-table"
@@ -57153,7 +57153,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
         title: AWS Documentation - Managing clusters using the console
-      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-passwords.html
+      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-secrets-manager-integration.html
         title: AWS Documentation - Managing cluster master passwords
   - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
     filters: asset.platform == "aws-redshift-cluster"
@@ -58704,7 +58704,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
         title: AWS Documentation - Configuring a Lambda function to access resources in a VPC
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/security.html
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
         title: AWS Documentation - Security in AWS Lambda
   - uid: mondoo-aws-security-lambda-in-vpc-aws
     filters: asset.platform == "aws-lambda-function"
@@ -59950,7 +59950,7 @@ queries:
             ```
         # No Terraform remediation: The `HOST_TO_CLIENT_URL_REDIRECTION` action is not a supported value in the `aws_appstream_stack` `user_settings` block in the hashicorp/aws provider; URL-redirection policy must be set through the console or CLI.
     refs:
-      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/url-redirection.html
+      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/feature-support-url-redirection.html
         title: Amazon AppStream 2.0 - URL Redirection
   - uid: mondoo-aws-security-appstream-stack-url-redirection-disabled-aws
     filters: asset.platform == "aws"
@@ -60400,7 +60400,7 @@ queries:
                     - !Ref EndpointSecurityGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-security-groups.html
+      - url: https://docs.aws.amazon.com/vpc/latest/privatelink/interface-endpoints.html
         title: AWS Documentation - Security groups for VPC endpoints
   - uid: mondoo-aws-security-vpc-endpoint-security-groups-aws
     filters: asset.platform == "aws-vpc"
@@ -61095,7 +61095,7 @@ queries:
                     Enabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-security-groups.html
+      - url: https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working.html
         title: AWS Documentation - Security groups for Client VPN
   - uid: mondoo-aws-security-client-vpn-security-groups-aws
     filters: asset.platform == "aws"
@@ -63010,7 +63010,7 @@ queries:
                     - FTPS
             ```
     refs:
-      - url: https://docs.aws.amazon.com/transfer/latest/userguide/create-server.html
+      - url: https://docs.aws.amazon.com/transfer/latest/userguide/tf-server-endpoint.html
         title: AWS Documentation - Creating a Transfer Family server
   - uid: mondoo-aws-security-transfer-no-ftp-aws
     filters: asset.platform == "aws-transfer-server"
@@ -63651,7 +63651,7 @@ queries:
                     DirectoryId: !Ref DirectoryId
             ```
     refs:
-      - url: https://docs.aws.amazon.com/transfer/latest/userguide/custom-identity-provider-users.html
+      - url: https://docs.aws.amazon.com/transfer/latest/userguide/custom-idp-intro.html
         title: AWS Documentation - Using custom identity providers
   - uid: mondoo-aws-security-transfer-identity-provider-aws
     filters: asset.platform == "aws-transfer-server"
@@ -66085,7 +66085,7 @@ queries:
                   AutoMinorVersionUpgrade: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/neptune/latest/userguide/manage-console-maintaining.html
+      - url: https://docs.aws.amazon.com/neptune/latest/userguide/manage-console-modify.html
         title: AWS Documentation - Maintaining an Amazon Neptune DB cluster
   - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-aws
     filters: asset.platform == "aws-neptune-cluster"
@@ -67477,7 +67477,7 @@ queries:
                       SourceSecurityGroupId: !Ref AppSecurityGroup
             ```
     refs:
-      - url: https://www.cisa.gov/news-events/alerts/2018/02/27/memcached-distributed-denial-service-attacks
+      - url: https://www.cisa.gov/news-events/alerts/2014/01/17/udp-based-amplification-attacks
         title: CISA - Memcached-based DDoS attacks
   - uid: mondoo-aws-security-secgroup-restricted-memcached-aws
     filters: asset.platform == "aws-security-group"
@@ -67658,7 +67658,7 @@ queries:
                       SourceSecurityGroupId: !Ref AppSecurityGroup
             ```
     refs:
-      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html
+      - url: https://www.elastic.co/docs/deploy-manage/security
         title: Elasticsearch Security Documentation
   - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-aws
     filters: asset.platform == "aws-security-group"
@@ -69942,7 +69942,7 @@ queries:
             ```
         # No Terraform remediation: There is no `aws_appstream_image` resource in the hashicorp/aws provider; customer-built AppStream images and their visibility settings are managed through the console or CLI, not Terraform.
     refs:
-      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/share-image-with-other-accounts.html
+      - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/share-image-with-another-account.html
         title: Amazon AppStream 2.0 - Share an image with other AWS accounts
   - uid: mondoo-aws-security-appstream-image-no-public-visibility-aws
     filters: asset.platform == "aws"
@@ -70219,7 +70219,7 @@ queries:
                       Description: Corporate egress
             ```
     refs:
-      - url: https://docs.aws.amazon.com/workspaces-web/latest/adminguide/ip-access-settings.html
+      - url: https://docs.aws.amazon.com/workspaces-web/latest/adminguide/ip-access-controls.html
         title: Amazon WorkSpaces Web - IP access settings
   - uid: mondoo-aws-security-workspaces-web-ip-access-no-public-aws
     filters: asset.platform == "aws"
@@ -70354,7 +70354,7 @@ queries:
             Re-importing to the same certificate ARN replaces the certificate in place, so the CloudFront origin configuration does not need to change. If you issue a certificate under a new ARN instead, update the distribution origin to reference it with `aws cloudfront update-distribution`.
         # No Terraform remediation: Certificate expiry is operational state, not configuration; Terraform cannot enforce that a certificate has not expired — rotate the certificate and re-import it.
     refs:
-      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
+      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls-authentication.html
         title: Amazon CloudFront - Origin mutual TLS
   - uid: mondoo-aws-security-cloudfront-origin-mtls-cert-not-expired-aws
     filters: asset.platform == "aws-cloudfront-distribution"
@@ -70487,7 +70487,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mutual-tls-authentication.html
+      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html
         title: Amazon CloudFront - Configuring mutual TLS authentication
   - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-aws
     filters: asset.platform == "aws"
@@ -70606,7 +70606,7 @@ queries:
             ```
         # No Terraform remediation: Origin mTLS (`CustomOriginConfig.OriginMtlsConfig`) is not exposed as an argument in the `aws_cloudfront_distribution` origin block in the hashicorp/aws provider; configure origin mTLS through the console or CLI.
     refs:
-      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls.html
+      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls-authentication.html
         title: Amazon CloudFront - Origin mutual TLS
   - uid: mondoo-aws-security-cloudfront-private-origin-mtls-aws
     filters: asset.platform == "aws-cloudfront-distribution"
@@ -70698,7 +70698,7 @@ queries:
             The `--ca-certificates-bundle-source` value is the JSON shape described in the CloudFront API reference (S3 location of the current PEM bundle).
         # No Terraform remediation: The freshness of a trust store CA bundle is operational telemetry, not static configuration; Terraform cannot assert that the bundle was refreshed within the last year — update the bundle and re-apply.
     refs:
-      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mutual-tls-authentication.html
+      - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html
         title: Amazon CloudFront - Configuring mutual TLS authentication
   - uid: mondoo-aws-security-cloudfront-trust-store-recently-updated-aws
     filters: asset.platform == "aws"
@@ -71010,7 +71010,7 @@ queries:
                     UserSecretId: !Ref ConnectorSecretArn
             ```
     refs:
-      - url: https://docs.aws.amazon.com/transfer/latest/userguide/monitoring.html
+      - url: https://docs.aws.amazon.com/transfer/latest/userguide/security_iam_service-with-iam.html
         title: AWS Transfer Family - Monitoring with CloudWatch
   - uid: mondoo-aws-security-transfer-connector-logging-role-aws
     filters: asset.platform == "aws"
@@ -71176,7 +71176,7 @@ queries:
                   AccessEndpoint: https://internal.example.com
             ```
     refs:
-      - url: https://docs.aws.amazon.com/transfer/latest/userguide/web-apps.html
+      - url: https://docs.aws.amazon.com/transfer/latest/userguide/web-app.html
         title: AWS Transfer Family - Web Apps
   - uid: mondoo-aws-security-transfer-web-app-not-public-aws
     filters: asset.platform == "aws"
@@ -71504,7 +71504,7 @@ queries:
         # customModelKmsKeyId cannot be set from a template. Terraform reaches the customization job through
         # an API-backed resource; use the console or CLI instead.
     refs:
-      - url: https://docs.aws.amazon.com/bedrock/latest/userguide/custom-models-encryption.html
+      - url: https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-custom-job.html
         title: Encryption of custom models
   - uid: mondoo-aws-security-bedrock-custom-model-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -72852,7 +72852,7 @@ queries:
                     CommonName: example-root
             ```
     refs:
-      - url: https://docs.aws.amazon.com/privateca/latest/userguide/PcaApiCertificateAuthority.html
+      - url: https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html
         title: AWS Private CA API reference
   - uid: mondoo-aws-security-privateca-strong-signing-algorithm-aws
     filters: asset.platform == "aws"
@@ -73385,7 +73385,7 @@ queries:
                   PubliclyAccessible: false
             ```
     refs:
-      - url: https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-managing-database-public-mode.html
+      - url: https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-configuring-database-public-mode.html
         title: Managing Lightsail database public mode
   - uid: mondoo-aws-security-lightsail-database-not-public-aws
     filters: asset.platform == "aws"
@@ -75836,7 +75836,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html
         title: DynamoDB encryption at rest
-      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html
+      - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html
         title: DynamoDB point-in-time recovery
   - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-aws
     filters: asset.platform == "aws-dynamodb-table"
@@ -78270,7 +78270,7 @@ queries:
                     AutomaticallyAfterDays: 30
             ```
     refs:
-      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-network-rqmts.html
+      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotation-function-network-access.html
         title: Network requirements for rotation Lambda functions
   - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
     filters: asset.platform == "aws-secretsmanager-secret" && aws.secretsmanager.secret.rotationEnabled == true
@@ -78558,7 +78558,7 @@ queries:
         # No CloudFormation remediation: AWS::Route53Resolver::FirewallRule does not support the
         # advanced threat-protection properties; use the console or CLI above.
     refs:
-      - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall-advanced.html
+      - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/firewall-advanced.html
         title: DNS Firewall Advanced threat protection
 
   # ── New checks (batch 1: public/anonymous exposure) ──────────────────────────
@@ -78819,7 +78819,7 @@ queries:
         # No CloudFormation remediation: AWS::NeptuneGraph::Graph public connectivity cannot be changed after
         # creation; recreate via the console or CLI above.
     refs:
-      - url: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vpc.html
+      - url: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/what-is-neptune-analytics.html
         title: AWS Documentation - Neptune Analytics VPC connectivity
 
   # No Terraform variants: Neptune Analytics graph public connectivity is fixed at creation and evaluated from
@@ -78942,7 +78942,7 @@ queries:
         # No CloudFormation remediation: AWS::Backup::BackupVault embeds the access policy inline; scope its
         # AccessPolicy principals using the console, CLI, or Terraform examples above.
     refs:
-      - url: https://docs.aws.amazon.com/aws-backup/latest/devguide/creating-a-vault-access-policy.html
+      - url: https://docs.aws.amazon.com/aws-backup/latest/devguide/create-a-vault-access-policy.html
         title: AWS Documentation - Setting access policies on backup vaults
 
   - uid: mondoo-aws-security-backup-vault-no-public-access-aws
@@ -79860,7 +79860,7 @@ queries:
         # No CloudFormation remediation: there is no CloudFormation resource for AgentCore gateways; use the
         # console or CLI above.
     refs:
-      - url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-authentication.html
+      - url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html
         title: AWS Documentation - AgentCore Gateway authentication
 
   # No Terraform variants: Bedrock AgentCore gateways have no stable Terraform resource; runtime state only.
@@ -80291,7 +80291,7 @@ queries:
                   PreventUserExistenceErrors: ENABLED
             ```
     refs:
-      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-managing-errors.html
+      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-managing-errors.html
         title: AWS Documentation - Managing error responses for user existence
 
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-aws
@@ -80720,7 +80720,7 @@ queries:
         # No CloudFormation remediation: the resolved encryption type is evaluated at runtime; set the
         # KmsEncryptionKey at creation and use the console or CLI above to migrate existing clusters.
     refs:
-      - url: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html
         title: AWS Documentation - Encryption at rest for Aurora DSQL
 
   # No Terraform variants: Aurora DSQL cluster encryption is fixed at creation and read from live state.
@@ -81055,7 +81055,7 @@ queries:
                   Mode: enforce
             ```
     refs:
-      - url: https://docs.aws.amazon.com/vpc/latest/userguide/encryption-in-transit.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-encryption-controls.html
         title: AWS Documentation - Encryption in transit for your VPC
   - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-aws
     filters: asset.platform == "aws-vpc"
@@ -84610,7 +84610,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html
         title: Monitoring Amazon RDS log files
-      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/publishing_cloudwatchlogs.html
+      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Procedural.UploadtoCloudWatch.html
         title: Publishing database logs to Amazon CloudWatch Logs
 
   - uid: mondoo-aws-security-rds-instance-log-exports-enabled-aws
@@ -85298,7 +85298,7 @@ queries:
                         KmsKey: !GetAtt KMSKey.Arn
             ```
     refs:
-      - url: https://docs.aws.amazon.com/athena/latest/ug/manage-queries-control-costs-with-workgroups.html
+      - url: https://docs.aws.amazon.com/athena/latest/ug/workgroups-manage-queries-control-costs.html
         title: Using workgroups to control query access and costs
   - uid: mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-aws
     filters: asset.platform == "aws-athena-workgroup"
@@ -86503,7 +86503,7 @@ queries:
                   VisibleToAllUsers: false
             ```
     refs:
-      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-access-cluster.html
+      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html
         title: Understanding EMR cluster visibility and access
   # No Terraform variants: enhanced-scanning frequency is set at the registry level (aws_ecr_registry_scanning_configuration rules), not on the repository resource, so a faithful per-repository IaC variant is not possible. The fix is documented in the Terraform remediation.
   - uid: mondoo-aws-security-ecr-repository-continuous-scanning

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-aws-security
     name: Mondoo AWS Security
-    version: 12.14.0
+    version: 12.14.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -974,7 +974,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/eks/latest/best-practices/security.html
         title: Amazon EKS Security Best Practices
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
+      - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-eks-cluster-cmks-in-kms-aws
     filters: asset.platform == "aws-eks-cluster"
@@ -1144,7 +1144,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/security-lake/latest/userguide/data-protection.html
         title: Data protection in Amazon Security Lake
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
+      - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-securitylake-data-lake-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -1633,7 +1633,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/network-firewall/latest/developerguide/kms-encryption-at-rest.html
         title: Encryption at rest for AWS Network Firewall
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
+      - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-networkfirewall-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -1783,7 +1783,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/ses/latest/dg/security-protocols.html
-        title: Requiring TLS for email sent with Amazon SES
+        title: Amazon SES and security protocols
   - uid: mondoo-aws-security-ses-configuration-set-require-tls-aws
     filters: asset.platform == "aws"
     mql: |
@@ -1988,7 +1988,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/appflow/latest/userguide/data-protection.html
         title: Data protection in Amazon AppFlow
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
+      - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-appflow-flow-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -5986,8 +5986,6 @@ queries:
                   ReservedConcurrentExecutions: 10
             ```
     refs:
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
-        title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
         title: AWS Lambda Reserved Concurrency
   - uid: mondoo-aws-security-lambda-concurrency-check-aws
@@ -6186,8 +6184,6 @@ queries:
                   SourceArn: 'arn:aws:s3:::example-bucket'
             ```
     refs:
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
-        title: AWS Lambda Security
       - url: https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html
         title: AWS Lambda Resource-Based Policies
   - uid: mondoo-aws-security-lambda-function-public-access-prohibited-aws
@@ -11118,7 +11114,7 @@ queries:
                   EnableKeyRotation: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/kms-security.html
+      - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html
         title: Rotating AWS KMS Keys
@@ -44112,7 +44108,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/managing-amazon-mq-broker.html
-        title: Amazon MQ - Accessing the Web Console
+        title: Amazon MQ - Managing a broker
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
   - uid: mondoo-aws-security-mq-no-public-access-aws
@@ -57152,7 +57148,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
-        title: AWS Documentation - Managing clusters using the console
+        title: AWS Documentation - Amazon Redshift cluster operations
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-secrets-manager-integration.html
         title: AWS Documentation - Managing cluster master passwords
   - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
@@ -58704,8 +58700,8 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
         title: AWS Documentation - Configuring a Lambda function to access resources in a VPC
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/security-iam.html
-        title: AWS Documentation - Security in AWS Lambda
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
+        title: AWS Documentation - Giving Lambda functions access to resources in an Amazon VPC
   - uid: mondoo-aws-security-lambda-in-vpc-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |
@@ -60401,7 +60397,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/privatelink/interface-endpoints.html
-        title: AWS Documentation - Security groups for VPC endpoints
+        title: AWS Documentation - Configure an interface endpoint
   - uid: mondoo-aws-security-vpc-endpoint-security-groups-aws
     filters: asset.platform == "aws-vpc"
     mql: |
@@ -79861,7 +79857,7 @@ queries:
         # console or CLI above.
     refs:
       - url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html
-        title: AWS Documentation - AgentCore Gateway authentication
+        title: AWS Documentation - Amazon Bedrock AgentCore Gateway
 
   # No Terraform variants: Bedrock AgentCore gateways have no stable Terraform resource; runtime state only.
   - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated-aws
@@ -86503,8 +86499,8 @@ queries:
                   VisibleToAllUsers: false
             ```
     refs:
-      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html
-        title: Understanding EMR cluster visibility and access
+      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-access-iam.html
+        title: IAM with Amazon EMR
   # No Terraform variants: enhanced-scanning frequency is set at the registry level (aws_ecr_registry_scanning_configuration rules), not on the repository resource, so a faithful per-repository IaC variant is not possible. The fix is documented in the Terraform remediation.
   - uid: mondoo-aws-security-ecr-repository-continuous-scanning
     title: Ensure ECR repositories use continuous vulnerability scanning

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -1632,7 +1632,7 @@ queries:
         # No CloudFormation remediation: AWS::NetworkFirewall::Firewall does not expose an encryption configuration property, so the customer-managed KMS setting cannot be expressed in a CloudFormation template.
     refs:
       - url: https://docs.aws.amazon.com/network-firewall/latest/developerguide/kms-encryption-at-rest.html
-        title: Encryption at rest for AWS Network Firewall
+        title: Encryption at rest with AWS Key Management Service
       - url: https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html
         title: AWS KMS Best Practices
   - uid: mondoo-aws-security-networkfirewall-cmk-encryption-aws
@@ -2142,7 +2142,7 @@ queries:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
         title: Lambda runtimes
       - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy
-        title: Runtime support policy for AWS Lambda
+        title: Lambda runtimes
   - uid: mondoo-aws-security-lambda-no-deprecated-runtime-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |
@@ -2326,7 +2326,7 @@ queries:
       - url: https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
         title: Encrypting data in transit for Amazon EFS
       - url: https://docs.aws.amazon.com/efs/latest/ug/create-file-system-policy.html
-        title: Using file system policies with Amazon EFS
+        title: Creating file system policies
   - uid: mondoo-aws-security-efs-enforce-transit-encryption-aws
     filters: asset.platform == "aws-efs-filesystem"
     mql: |
@@ -2414,9 +2414,9 @@ queries:
     docs:
       refs:
         - url: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-          title: Amazon EKS - Pod networking
+          title: Amazon EKS - Assign IPs to Pods with the Amazon VPC CNI
         - url: https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html
-          title: Amazon EKS - Networking in Amazon VPC
+          title: Configure networking for Amazon EKS clusters
       desc: |
         This check verifies that Amazon EKS clusters have `endpointPrivateAccess` enabled and `endpointPublicAccess` disabled, so the Kubernetes API server is reachable only from within the VPC. EKS clusters are accessible over the public internet by default.
 
@@ -4257,7 +4257,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
-        title: AWS Documentation - AWS CLI Reference - EC2
+        title: AWS Documentation - ec2
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
   - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
@@ -4425,7 +4425,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/ebs/latest/userguide/encryption-by-default.html
-        title: AWS Documentation - Encryption by default
+        title: AWS Documentation - Enable Amazon EBS encryption by default
   - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-aws
     filters: asset.platform == "aws"
     mql: aws.ec2.ebsEncryptionByDefault.values.all(_ == true)
@@ -5579,9 +5579,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/logs/
-        title: AWS Documentation - AWS CLI Command Reference - logs
+        title: AWS Documentation - logs
       - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
-        title: AWS Documentation - AWS CLI Command Reference - ec2
+        title: AWS Documentation - ec2
       - url: https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs
         title: Terraform registry - Cloud Posse AWS Utils Provider
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
@@ -5796,7 +5796,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/dynamodb/
-        title: AWS Documentation - AWS CLI Command Reference - DynamoDB
+        title: AWS Documentation - dynamodb
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
@@ -8184,7 +8184,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/redshift/
-        title: AWS Documentation - AWS CLI Command Reference - Redshift
+        title: AWS Documentation - redshift
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
   - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
@@ -10633,7 +10633,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html
-        title: AWS Documentation - Internal Application Load Balancers
+        title: AWS Documentation - Application Load Balancers
       - url: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html
         title: AWS Documentation - How Elastic Load Balancing works
   - uid: mondoo-aws-security-elasticsearch-encrypted-at-rest
@@ -13692,9 +13692,9 @@ queries:
             Do not embed secrets such as AWS access keys, passwords, or API tokens in the `UserData` property of `AWS::EC2::Instance`. Instead, use IAM instance profiles and retrieve secrets at boot time from Secrets Manager or SSM Parameter Store.
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
-        title: AWS Documentation - Work with instance user data
+        title: AWS Documentation - Run commands when you launch an EC2 instance with user data input
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
-        title: AWS Documentation - Run commands on your Linux instance at launch
+        title: AWS Documentation - Run commands when you launch an EC2 instance with user data input
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
         title: Terraform Documentation - aws_instance Resource
   - uid: mondoo-aws-security-ec2-user-data-no-secrets-terraform-hcl
@@ -17284,7 +17284,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
-        title: AWS Documentation - Runtime security for Amazon ECS
+        title: AWS Documentation - Identify unauthorized behavior using Runtime Monitoring
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-no-privileged-containers-aws
@@ -17469,7 +17469,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
-        title: AWS Documentation - Runtime security for Amazon ECS
+        title: AWS Documentation - Identify unauthorized behavior using Runtime Monitoring
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
   - uid: mondoo-aws-security-ecs-readonly-root-filesystem-aws
@@ -18935,7 +18935,7 @@ queries:
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
         title: AWS Documentation - Build specification reference for CodeBuild
       - url: https://docs.aws.amazon.com/codebuild/latest/userguide/change-project.html
-        title: AWS Documentation - Change a build project's settings in CodeBuild
+        title: AWS Documentation - Change build project settings in AWS CodeBuild
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
         title: AWS Documentation - What is AWS Secrets Manager
   - uid: mondoo-aws-security-codebuild-no-plaintext-credentials-aws
@@ -20510,7 +20510,7 @@ queries:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html
         title: AWS Documentation - IAM Access Analyzer findings
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-concepts.html
-        title: AWS Documentation - Working with findings
+        title: AWS Documentation - Understand how IAM Access Analyzer findings work
   - uid: mondoo-aws-security-sns-topic-encrypted
     title: Ensure SNS topics are encrypted with KMS
     impact: 70
@@ -23237,7 +23237,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
-        title: AWS Documentation - Runtime security for Amazon ECS
+        title: AWS Documentation - Identify unauthorized behavior using Runtime Monitoring
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
   - uid: mondoo-aws-security-ecs-container-non-root-user-aws
@@ -24683,7 +24683,7 @@ queries:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
-        title: AWS Documentation - Managing grants
+        title: AWS Documentation - Grants in AWS KMS
   - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: aws.kms.key.grants.none(operations.contains("CreateGrant"))
@@ -24835,7 +24835,7 @@ queries:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
-        title: AWS Documentation - Managing grants
+        title: AWS Documentation - Grants in AWS KMS
   - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: aws.kms.key.grants.none(granteePrincipal == "*")
@@ -25372,7 +25372,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.html
-        title: AWS Documentation - ElastiCache Serverless
+        title: AWS Documentation - What is Amazon ElastiCache?
       - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
         title: AWS Documentation - ElastiCache encryption at rest
   - uid: mondoo-aws-security-elasticache-serverless-cmk-encryption-aws
@@ -25894,7 +25894,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/secure-string-parameter-kms-encryption.html
-        title: AWS SSM SecureString parameters
+        title: AWS KMS encryption for AWS Systems Manager Parameter Store SecureString parameters
   - uid: mondoo-aws-security-ssm-parameter-encryption-aws
     filters: asset.platform == "aws"
     mql: |
@@ -26651,7 +26651,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html
-        title: Amazon Timestream for InfluxDB
+        title: What is Timestream for InfluxDB?
   - uid: mondoo-aws-security-timestream-influxdb-not-public-aws
     filters: asset.platform == "aws"
     mql: |
@@ -26818,7 +26818,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html
-        title: Amazon Timestream for InfluxDB
+        title: What is Timestream for InfluxDB?
   - uid: mondoo-aws-security-timestream-influxdb-logging-enabled-aws
     filters: asset.platform == "aws"
     mql: |
@@ -28075,7 +28075,7 @@ queries:
       - url: https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
         title: AWS Documentation - Amazon EKS networking requirements
       - url: https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html
-        title: AWS Documentation - Amazon EKS cluster networking
+        title: AWS Documentation - Configure networking for Amazon EKS clusters
   - uid: mondoo-aws-security-eks-access-entry-no-system-masters
     title: Ensure EKS access entries do not grant the system:masters group
     impact: 85
@@ -28783,7 +28783,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html
-        title: Fargate task storage
+        title: Fargate task ephemeral storage for Amazon ECS
   - uid: mondoo-aws-security-ecs-cluster-fargate-encryption-aws
     filters: asset.platform == "aws"
     mql: |
@@ -28935,7 +28935,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/acm/latest/userguide/certificate-types.html
-        title: AWS Certificate Manager certificates
+        title: Types of certificates in AWS Certificate Manager
   # Allowlist of strong key algorithms; the regex accepts both the "RSA-2048" form the aws provider returns (seen in live scan output) and the "RSA_2048" form the AWS SDK uses, so it is robust to either separator. Weak RSA-1024 is rejected.
   - uid: mondoo-aws-security-acm-certificate-key-algorithm-aws
     filters: asset.platform == "aws"
@@ -30546,7 +30546,7 @@ queries:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/encrypt.html
         title: AWS Documentation - Encrypting Neptune resources
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/backup-restore.html
-        title: AWS Documentation - Neptune DB cluster snapshots
+        title: AWS Documentation - Backing up and restoring an Amazon Neptune DB cluster
   - uid: mondoo-aws-security-neptune-cluster-snapshot-encrypted-aws
     filters: asset.platform == "aws-neptune-cluster"
     mql: |
@@ -31002,7 +31002,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ComponentsAMIs.html
-        title: Amazon EC2 virtualization types
+        title: AMI types and characteristics in Amazon EC2
   - uid: mondoo-aws-security-ec2-no-paravirtual-instances-aws
     filters: asset.platform == "aws"
     mql: |
@@ -31480,7 +31480,7 @@ queries:
         - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec.html
           title: Configuring DNSSEC signing in Amazon Route 53
         - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring-dnssec-troubleshoot.html
-          title: Troubleshooting DNSSEC signing in Amazon Route 53
+          title: Troubleshooting DNSSEC signing
   # No Terraform variants: hosted zone records are frequently managed outside the
   # configuration that creates the zone, so a Terraform variant would report a
   # missing CAA record for zones whose records are correct in Route 53.
@@ -32574,7 +32574,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/managing-stacks-fleets.html
-        title: Amazon AppStream 2.0 fleets and stacks
+        title: Fleets and Stacks in Fleet Type in Amazon WorkSpaces Applications
   - uid: mondoo-aws-security-appstream-fleet-max-session-duration-aws
     filters: asset.platform == "aws-appstream-fleet"
     mql: |
@@ -32731,7 +32731,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/managing-stacks-fleets.html
-        title: Amazon AppStream 2.0 fleets and stacks
+        title: Fleets and Stacks in Fleet Type in Amazon WorkSpaces Applications
   - uid: mondoo-aws-security-appstream-fleet-idle-disconnect-aws
     filters: asset.platform == "aws-appstream-fleet"
     mql: |
@@ -32884,7 +32884,7 @@ queries:
             Alternatively, manage the fleet with CloudFormation and set `DisableIMDSV1: true`.
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/customize-fleets-user-instance-metadata-fleets.html
-        title: Amazon AppStream 2.0 instance metadata service
+        title: User and Instance Metadata for Amazon WorkSpaces Applications Fleets
       - url: https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html
         title: Amazon AppStream 2.0 CreateFleet API reference
   - uid: mondoo-aws-security-appstream-fleet-imdsv2-aws
@@ -33204,7 +33204,7 @@ queries:
             Note: OS version updates may not be supported via CloudFormation update. Use the AWS CLI for in-place upgrades.
     refs:
       - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_microsoft_ad.html
-        title: AWS Managed Microsoft AD directory maintenance
+        title: AWS Managed Microsoft AD
   - uid: mondoo-aws-security-directoryservice-os-version-aws
     filters: asset.platform == "aws-directoryservice-directory"
     mql: |
@@ -34124,7 +34124,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/connect-from-outside-a-vpc.html
-        title: Amazon DocumentDB - Network security
+        title: Connecting to an Amazon DocumentDB cluster from outside an Amazon VPC
       - url: https://docs.aws.amazon.com/cli/latest/reference/docdb/modify-db-instance.html
         title: AWS CLI Command Reference - docdb modify-db-instance
   - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
@@ -34290,9 +34290,9 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/connect-from-outside-a-vpc.html
-        title: Amazon DocumentDB - Network security
+        title: Connecting to an Amazon DocumentDB cluster from outside an Amazon VPC
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/document-db-subnet-groups.html
-        title: Amazon DocumentDB - Security groups
+        title: Managing Amazon DocumentDB subnet groups
   - uid: mondoo-aws-security-cognito-user-pool-mfa-enforced
     title: Ensure Cognito user pools enforce multi-factor authentication
     impact: 90
@@ -34607,7 +34607,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html
-        title: Adding advanced security to a user pool
+        title: Advanced security with threat protection
   - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-aws
     filters: asset.platform == "aws-cognito-userpool"
     mql: aws.cognito.userPool.advancedSecurityMode == "ENFORCED"
@@ -37187,7 +37187,7 @@ queries:
             To ensure WorkSpaces directories deny web access by default in CloudFormation, note that CloudFormation does not natively support configuring WorkSpaces directory access properties. Use the AWS CLI or Terraform to manage web access settings.
     refs:
       - url: https://docs.aws.amazon.com/workspaces/latest/adminguide/update-directory-pools-details.html
-        title: Update directory details for your WorkSpaces
+        title: Update directory details for your WorkSpaces Pools
   - uid: mondoo-aws-security-workspaces-directory-web-access-disabled-aws
     filters: asset.platform == "aws"
     mql: |
@@ -38481,7 +38481,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
-        title: Amazon Redshift Cluster Maintenance
+        title: Cluster operations
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Security Hub Controls Reference
   - uid: mondoo-aws-security-redshift-cluster-current-maintenance-track-aws
@@ -40474,9 +40474,9 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
-        title: AWS Documentation - Using Amazon RDS Proxy
+        title: AWS Documentation - Amazon RDS Proxy
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
-        title: AWS Documentation - Security with Amazon RDS Proxy
+        title: AWS Documentation - Amazon RDS Proxy
   - uid: mondoo-aws-security-rds-proxy-tls-required-aws
     filters: asset.platform == "aws"
     mql: aws.rds.proxies.all(requireTLS == true)
@@ -40641,7 +40641,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
-        title: AWS Documentation - Using Amazon RDS Proxy
+        title: AWS Documentation - Amazon RDS Proxy
   - uid: mondoo-aws-security-rds-proxy-no-debug-logging-aws
     filters: asset.platform == "aws"
     mql: aws.rds.proxies.all(debugLogging == false)
@@ -40801,7 +40801,7 @@ queries:
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
       - url: https://docs.aws.amazon.com/documentdb/latest/devguide/docdb-migration.html
-        title: Amazon DocumentDB Migrating Data
+        title: Migrating and upgrading Amazon DocumentDB
   - uid: mondoo-aws-security-documentdb-snapshot-encrypted-aws
     filters: asset.platform == "aws"
     mql: aws.documentdb.snapshots.all(storageEncrypted == true)
@@ -42756,7 +42756,7 @@ queries:
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry-approve.html
         title: Amazon SageMaker - Update the Approval Status of a Model
       - url: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-mkt-create-model-package.html
-        title: Amazon SageMaker - Validate a Model Package
+        title: Amazon SageMaker - Create a Model Package Resource
   - uid: mondoo-aws-security-sagemaker-model-package-approval-validated-aws
     filters: asset.platform == "aws"
     mql: |
@@ -44108,7 +44108,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/managing-amazon-mq-broker.html
-        title: Amazon MQ - Managing a broker
+        title: Managing an Amazon MQ broker
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
   - uid: mondoo-aws-security-mq-no-public-access-aws
@@ -45245,9 +45245,9 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html
-        title: Amazon DynamoDB - Point-in-Time Recovery
+        title: Point-in-time backups for DynamoDB
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Backup-and-Restore.html
-        title: Amazon DynamoDB - On-Demand Backup and Restore
+        title: Backup and restore for DynamoDB
   - uid: mondoo-aws-security-dynamodb-pitr-enabled-aws
     filters: asset.platform == "aws-dynamodb-table"
     mql: |
@@ -49796,7 +49796,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
-        title: How to use an external ID when granting access to your AWS resources to a third party
+        title: Access to AWS accounts owned by third parties
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid
         title: AWS global condition context keys - aws:PrincipalOrgID
 
@@ -50478,7 +50478,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/data-protection.html
-        title: Amazon Elasticsearch Service - Data Protection
+        title: Data protection in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html
         title: AWS Security Hub - Elasticsearch controls reference
   - uid: mondoo-aws-security-elasticsearch-enforce-https-aws
@@ -50645,7 +50645,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/data-protection.html
-        title: Amazon Elasticsearch Service - Data Protection
+        title: Data protection in Amazon OpenSearch Service
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html
         title: AWS Security Hub - Elasticsearch controls reference
   - uid: mondoo-aws-security-elasticsearch-tls-policy-aws
@@ -57148,9 +57148,9 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
-        title: AWS Documentation - Amazon Redshift cluster operations
+        title: AWS Documentation - Cluster operations
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-secrets-manager-integration.html
-        title: AWS Documentation - Managing cluster master passwords
+        title: AWS Documentation - Managing Amazon Redshift admin passwords using AWS Secrets Manager
   - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
     filters: asset.platform == "aws-redshift-cluster"
     mql: |
@@ -58046,7 +58046,7 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html
         title: AWS Documentation - Fargate task networking
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html
-        title: AWS Documentation - ECS networking best practices
+        title: AWS Documentation - Amazon ECS networking best practices
   # No Terraform variants: this check evaluates the exposure computed for a live
   # `aws.ecs.service` (the task's resolved ENI combined with its attached security
   # groups), which has no Terraform/CloudFormation representation. Terraform
@@ -58186,7 +58186,7 @@ queries:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html
         title: AWS Documentation - Fargate task networking
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html
-        title: AWS Documentation - ECS networking best practices
+        title: AWS Documentation - Amazon ECS networking best practices
   # No Terraform variants: this check evaluates the image string resolved on the live
   # `aws.ecs.container` runtime asset, which has no Terraform/CloudFormation representation.
   # Terraform remediation is still provided because the fix lives in the task definition.
@@ -58548,9 +58548,9 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
-        title: AWS Documentation - AWS Fargate platform versions
+        title: AWS Documentation - Fargate platform versions for Amazon ECS
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
-        title: AWS Documentation - Fargate Linux platform versions
+        title: AWS Documentation - Fargate platform versions for Amazon ECS
   - uid: mondoo-aws-security-lambda-in-vpc
     title: Ensure Lambda functions are deployed within a VPC
     impact: 70
@@ -59947,7 +59947,7 @@ queries:
         # No Terraform remediation: The `HOST_TO_CLIENT_URL_REDIRECTION` action is not a supported value in the `aws_appstream_stack` `user_settings` block in the hashicorp/aws provider; URL-redirection policy must be set through the console or CLI.
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/feature-support-url-redirection.html
-        title: Amazon AppStream 2.0 - URL Redirection
+        title: Host-to-client URL redirection
   - uid: mondoo-aws-security-appstream-stack-url-redirection-disabled-aws
     filters: asset.platform == "aws"
     mql: |
@@ -61092,7 +61092,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working.html
-        title: AWS Documentation - Security groups for Client VPN
+        title: AWS Documentation - Work with AWS Client VPN
   - uid: mondoo-aws-security-client-vpn-security-groups-aws
     filters: asset.platform == "aws"
     mql: |
@@ -61451,7 +61451,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-syntax-data-elements-parameters.html
-        title: AWS Documentation - SSM Document sharing
+        title: AWS Documentation - Data elements and parameters
   - uid: mondoo-aws-security-ssm-document-not-public-aws
     filters: asset.platform == "aws"
     mql: |
@@ -63007,7 +63007,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/tf-server-endpoint.html
-        title: AWS Documentation - Creating a Transfer Family server
+        title: AWS Documentation - Configuring an SFTP, FTPS, or FTP server endpoint
   - uid: mondoo-aws-security-transfer-no-ftp-aws
     filters: asset.platform == "aws-transfer-server"
     mql: |
@@ -63648,7 +63648,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/custom-idp-intro.html
-        title: AWS Documentation - Using custom identity providers
+        title: AWS Documentation - Working with custom identity providers
   - uid: mondoo-aws-security-transfer-identity-provider-aws
     filters: asset.platform == "aws-transfer-server"
     mql: |
@@ -64502,7 +64502,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-policies.html
-        title: AWS Documentation - Resource-based policies for Secrets Manager
+        title: AWS Documentation - Resource-based policies
   # Passes when there is no resource policy; otherwise requires the policy not grant Allow to a wildcard principal.
   # MQL has no grouping parentheses, so this relies on && binding tighter than ||:
   #   empty || empty || (not-public-star && not-public-aws-star)
@@ -65439,7 +65439,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/standards-view-manage.html
-        title: Security standards in AWS Security Hub
+        title: Understanding security standards in Security Hub CSPM
   - uid: mondoo-aws-security-securityhub-standards-enabled-aws
     filters: asset.platform == "aws"
     mql: |
@@ -66082,7 +66082,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/neptune/latest/userguide/manage-console-modify.html
-        title: AWS Documentation - Maintaining an Amazon Neptune DB cluster
+        title: AWS Documentation - Modifying a Neptune DB Cluster Using the Console
   - uid: mondoo-aws-security-neptune-cluster-auto-minor-version-upgrade-aws
     filters: asset.platform == "aws-neptune-cluster"
     mql: |
@@ -67474,7 +67474,7 @@ queries:
             ```
     refs:
       - url: https://www.cisa.gov/news-events/alerts/2014/01/17/udp-based-amplification-attacks
-        title: CISA - Memcached-based DDoS attacks
+        title: UDP-Based Amplification Attacks
   - uid: mondoo-aws-security-secgroup-restricted-memcached-aws
     filters: asset.platform == "aws-security-group"
     mql: |
@@ -67655,7 +67655,7 @@ queries:
             ```
     refs:
       - url: https://www.elastic.co/docs/deploy-manage/security
-        title: Elasticsearch Security Documentation
+        title: Security
   - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-aws
     filters: asset.platform == "aws-security-group"
     mql: |
@@ -69939,7 +69939,7 @@ queries:
         # No Terraform remediation: There is no `aws_appstream_image` resource in the hashicorp/aws provider; customer-built AppStream images and their visibility settings are managed through the console or CLI, not Terraform.
     refs:
       - url: https://docs.aws.amazon.com/appstream2/latest/developerguide/share-image-with-another-account.html
-        title: Amazon AppStream 2.0 - Share an image with other AWS accounts
+        title: Share an Image That You Own With Another AWS Account in Amazon WorkSpaces Applications
   - uid: mondoo-aws-security-appstream-image-no-public-visibility-aws
     filters: asset.platform == "aws"
     mql: |
@@ -70216,7 +70216,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/workspaces-web/latest/adminguide/ip-access-controls.html
-        title: Amazon WorkSpaces Web - IP access settings
+        title: Amazon WorkSpaces Web - Managing IP access controls in Amazon WorkSpaces Secure Browser
   - uid: mondoo-aws-security-workspaces-web-ip-access-no-public-aws
     filters: asset.platform == "aws"
     mql: |
@@ -70351,7 +70351,7 @@ queries:
         # No Terraform remediation: Certificate expiry is operational state, not configuration; Terraform cannot enforce that a certificate has not expired — rotate the certificate and re-import it.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls-authentication.html
-        title: Amazon CloudFront - Origin mutual TLS
+        title: Origin mutual TLS with CloudFront
   - uid: mondoo-aws-security-cloudfront-origin-mtls-cert-not-expired-aws
     filters: asset.platform == "aws-cloudfront-distribution"
     mql: |
@@ -70484,7 +70484,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html
-        title: Amazon CloudFront - Configuring mutual TLS authentication
+        title: Mutual TLS authentication with CloudFront (Viewer mTLS)
   - uid: mondoo-aws-security-cloudfront-trust-store-not-empty-aws
     filters: asset.platform == "aws"
     mql: |
@@ -70603,7 +70603,7 @@ queries:
         # No Terraform remediation: Origin mTLS (`CustomOriginConfig.OriginMtlsConfig`) is not exposed as an argument in the `aws_cloudfront_distribution` origin block in the hashicorp/aws provider; configure origin mTLS through the console or CLI.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls-authentication.html
-        title: Amazon CloudFront - Origin mutual TLS
+        title: Origin mutual TLS with CloudFront
   - uid: mondoo-aws-security-cloudfront-private-origin-mtls-aws
     filters: asset.platform == "aws-cloudfront-distribution"
     mql: |
@@ -70695,7 +70695,7 @@ queries:
         # No Terraform remediation: The freshness of a trust store CA bundle is operational telemetry, not static configuration; Terraform cannot assert that the bundle was refreshed within the last year — update the bundle and re-apply.
     refs:
       - url: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html
-        title: Amazon CloudFront - Configuring mutual TLS authentication
+        title: Mutual TLS authentication with CloudFront (Viewer mTLS)
   - uid: mondoo-aws-security-cloudfront-trust-store-recently-updated-aws
     filters: asset.platform == "aws"
     mql: |
@@ -71007,7 +71007,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/security_iam_service-with-iam.html
-        title: AWS Transfer Family - Monitoring with CloudWatch
+        title: How AWS Transfer Family works with IAM
   - uid: mondoo-aws-security-transfer-connector-logging-role-aws
     filters: asset.platform == "aws"
     mql: |
@@ -71173,7 +71173,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/transfer/latest/userguide/web-app.html
-        title: AWS Transfer Family - Web Apps
+        title: Transfer Family web apps
   - uid: mondoo-aws-security-transfer-web-app-not-public-aws
     filters: asset.platform == "aws"
     mql: |
@@ -72697,7 +72697,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html
-        title: IAM and Step Functions
+        title: What is Step Functions?
   - uid: mondoo-aws-security-sfn-role-no-wildcard-resource-aws
     filters: asset.platform == "aws"
     mql: |
@@ -72849,7 +72849,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html
-        title: AWS Private CA API reference
+        title: Create a private CA in AWS Private CA
   - uid: mondoo-aws-security-privateca-strong-signing-algorithm-aws
     filters: asset.platform == "aws"
     mql: |
@@ -73382,7 +73382,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-configuring-database-public-mode.html
-        title: Managing Lightsail database public mode
+        title: Configure public access for your Lightsail database
   - uid: mondoo-aws-security-lightsail-database-not-public-aws
     filters: asset.platform == "aws"
     mql: |
@@ -73869,7 +73869,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/glue/latest/dg/encrypt-glue-data-catalog.html
-        title: Encrypting your AWS Glue Data Catalog
+        title: Encrypting your Data Catalog
   - uid: mondoo-aws-security-glue-catalog-encryption-cmk-aws
     filters: asset.platform == "aws"
     mql: |
@@ -75833,7 +75833,7 @@ queries:
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.howitworks.html
         title: DynamoDB encryption at rest
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html
-        title: DynamoDB point-in-time recovery
+        title: Point-in-time backups for DynamoDB
   - uid: mondoo-aws-security-dynamodb-pitr-cmk-encryption-aws
     filters: asset.platform == "aws-dynamodb-table"
     mql: |
@@ -76337,7 +76337,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/how-emr-studio-works.html#emr-studio-access-control
-        title: EMR Studio security and encryption
+        title: How Amazon EMR Studio works
   - uid: mondoo-aws-security-emr-studio-cmk-encryption-aws
     filters: asset.platform == "aws"
     mql: |
@@ -78267,7 +78267,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotation-function-network-access.html
-        title: Network requirements for rotation Lambda functions
+        title: Network access for AWS Lambda rotation function
   - uid: mondoo-aws-security-secretsmanager-rotation-lambda-in-vpc-aws
     filters: asset.platform == "aws-secretsmanager-secret" && aws.secretsmanager.secret.rotationEnabled == true
     mql: |
@@ -78555,7 +78555,7 @@ queries:
         # advanced threat-protection properties; use the console or CLI above.
     refs:
       - url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/firewall-advanced.html
-        title: DNS Firewall Advanced threat protection
+        title: DNS Firewall Advanced Rules
 
   # ── New checks (batch 1: public/anonymous exposure) ──────────────────────────
   - uid: mondoo-aws-security-rds-snapshot-not-public
@@ -78816,7 +78816,7 @@ queries:
         # creation; recreate via the console or CLI above.
     refs:
       - url: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/what-is-neptune-analytics.html
-        title: AWS Documentation - Neptune Analytics VPC connectivity
+        title: AWS Documentation - What is Neptune Analytics?
 
   # No Terraform variants: Neptune Analytics graph public connectivity is fixed at creation and evaluated from
   # live graph state; the runtime check reads the resolved connectivity flag.
@@ -78939,7 +78939,7 @@ queries:
         # AccessPolicy principals using the console, CLI, or Terraform examples above.
     refs:
       - url: https://docs.aws.amazon.com/aws-backup/latest/devguide/create-a-vault-access-policy.html
-        title: AWS Documentation - Setting access policies on backup vaults
+        title: AWS Documentation - Vault access policies
 
   - uid: mondoo-aws-security-backup-vault-no-public-access-aws
     filters: asset.platform == "aws"
@@ -79857,7 +79857,7 @@ queries:
         # console or CLI above.
     refs:
       - url: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html
-        title: AWS Documentation - Amazon Bedrock AgentCore Gateway
+        title: 'AWS Documentation - Amazon Bedrock AgentCore Gateway: A secure AI gateway for agents, tools, and models'
 
   # No Terraform variants: Bedrock AgentCore gateways have no stable Terraform resource; runtime state only.
   - uid: mondoo-aws-security-bedrock-agentcore-gateway-authenticated-aws
@@ -80288,7 +80288,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-managing-errors.html
-        title: AWS Documentation - Managing error responses for user existence
+        title: AWS Documentation - Managing user existence error responses
 
   - uid: mondoo-aws-security-cognito-client-prevent-user-existence-errors-aws
     filters: asset.platform == "aws-cognito-userpool"
@@ -80717,7 +80717,7 @@ queries:
         # KmsEncryptionKey at creation and use the console or CLI above to migrate existing clusters.
     refs:
       - url: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html
-        title: AWS Documentation - Encryption at rest for Aurora DSQL
+        title: AWS Documentation - What is Amazon Aurora DSQL?
 
   # No Terraform variants: Aurora DSQL cluster encryption is fixed at creation and read from live state.
   - uid: mondoo-aws-security-dsql-cluster-cmk-encryption-aws
@@ -81052,7 +81052,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-encryption-controls.html
-        title: AWS Documentation - Encryption in transit for your VPC
+        title: AWS Documentation - Enforce VPC encryption in transit
   - uid: mondoo-aws-security-vpc-encryption-in-transit-enforced-aws
     filters: asset.platform == "aws-vpc"
     mql: |
@@ -85295,7 +85295,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/athena/latest/ug/workgroups-manage-queries-control-costs.html
-        title: Using workgroups to control query access and costs
+        title: Use workgroups to control query access and costs
   - uid: mondoo-aws-security-athena-workgroup-minimum-encryption-enforced-aws
     filters: asset.platform == "aws-athena-workgroup"
     mql: |
@@ -85892,7 +85892,7 @@ queries:
             ```
     refs:
       - url: https://docs.aws.amazon.com/cognito/latest/developerguide/managing-users-passwords.html
-        title: Amazon Cognito user pool password policies
+        title: Passwords, account recovery, and password policies
   # No Terraform variants: isPublic is a runtime rollup over the queue's resource policy that accounts for policy conditions; public exposure in Terraform source is already covered by mondoo-aws-security-sqs-no-wildcard-policy.
   - uid: mondoo-aws-security-sqs-queue-not-public
     title: Ensure SQS queues are not publicly accessible

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2141,7 +2141,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
         title: Lambda runtimes
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
+      - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy
         title: Runtime support policy for AWS Lambda
   - uid: mondoo-aws-security-lambda-no-deprecated-runtime-aws
     filters: asset.platform == "aws-lambda-function"
@@ -2413,7 +2413,7 @@ queries:
           mondoo.com/filter-icon: cloudformation
     docs:
       refs:
-        - url: https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html
+        - url: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
           title: Amazon EKS - Pod networking
         - url: https://docs.aws.amazon.com/eks/latest/userguide/networking-vpc.html
           title: Amazon EKS - Networking in Amazon VPC
@@ -3666,7 +3666,7 @@ queries:
                     - !Ref AdminUser
             ```
     refs:
-      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage.html
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html
         title: AWS Documentation - IAM user groups
   - uid: mondoo-aws-security-iam-group-has-users-check-aws
     filters: asset.platform == "aws-iam-group"
@@ -4256,7 +4256,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
         title: AWS Documentation - AWS CLI Reference - EC2
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
@@ -4424,7 +4424,7 @@ queries:
             aws ec2 modify-ebs-default-kms-key-id --kms-key-id <kms-key-arn>
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default
+      - url: https://docs.aws.amazon.com/ebs/latest/userguide/encryption-by-default.html
         title: AWS Documentation - Encryption by default
   - uid: mondoo-aws-security-ec2-ebs-encryption-by-default-aws
     filters: asset.platform == "aws"
@@ -5578,9 +5578,9 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/logs/index.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/logs/
         title: AWS Documentation - AWS CLI Command Reference - logs
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/index.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
         title: AWS Documentation - AWS CLI Command Reference - ec2
       - url: https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs
         title: Terraform registry - Cloud Posse AWS Utils Provider
@@ -5795,7 +5795,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/dynamodb/index.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/dynamodb/
         title: AWS Documentation - AWS CLI Command Reference - DynamoDB
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
@@ -7558,9 +7558,9 @@ queries:
                     DBSubnetGroupDescription: "Private subnets for RDS cluster"
             ```
     refs:
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html
         title: AWS CLI Command Reference - create-db-cluster
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/modify-db-cluster.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-cluster.html
         title: AWS CLI Command Reference - modify-db-cluster
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance#publicly_accessible-1
         title: Terraform Registry - rds_cluster_instance
@@ -7774,9 +7774,9 @@ queries:
                     - !Ref PrivateSubnet2
             ```
     refs:
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
         title: AWS CLI Command Reference - create-db-instance
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/modify-db-instance.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-instance.html
         title: AWS CLI Command Reference - modify-db-instance
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#publicly_accessible-1
         title: Terraform Registry - aws_db_instance
@@ -8187,7 +8187,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/redshift/index.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/redshift/
         title: AWS Documentation - AWS CLI Command Reference - Redshift
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
@@ -8358,7 +8358,7 @@ queries:
                         DeleteOnTermination: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-deleting-volume.html
+      - url: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-deleting-volume.html
         title: AWS Documentation - Delete an Amazon EBS volume
   - uid: mondoo-aws-security-ec2-volume-inuse-check-aws
     filters: asset.platform == "aws-ebs-volume" && aws.ec2.volume.attachments != empty
@@ -8527,7 +8527,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security.html
         title: Amazon EC2 Security
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html
+      - url: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modifying-snapshot-permissions.html
         title: Share an Amazon EBS Snapshot
   - uid: mondoo-aws-security-ebs-snapshot-public-restorable-check-aws
     filters: asset.platform == "aws-ebs-snapshot"
@@ -10786,7 +10786,7 @@ queries:
                   EnableKeyRotation: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/encryption-at-rest.html
         title: Encryption of Data at Rest for Amazon Elasticsearch Service
       - url: https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html
         title: AWS Well-Architected Security Pillar
@@ -10950,7 +10950,7 @@ queries:
                     Enabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/ntn.html
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ntn.html
         title: AWS Documentation - Node-to-node encryption for Amazon Elasticsearch Service
       - url: https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html
         title: AWS Well-Architected Security Pillar
@@ -11898,7 +11898,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: Amazon VPC Security Best Practices
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
   - uid: mondoo-aws-security-secgroup-restricted-ssh-aws
     filters: asset.platform == "aws-security-group"
@@ -12090,7 +12090,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: Amazon VPC Security Best Practices
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
   - uid: mondoo-aws-security-secgroup-restricted-vnc-aws
     filters: asset.platform == "aws-security-group"
@@ -12311,7 +12311,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: Amazon VPC Security Best Practices
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
   - uid: mondoo-aws-security-secgroup-restricted-rdp-aws
     filters: asset.platform == "aws-security-group"
@@ -12534,7 +12534,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: Amazon VPC Security Best Practices
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
   - uid: mondoo-aws-security-secgroup-restrict-traffic-aws
     filters: asset.platform == "aws-security-group"
@@ -17287,7 +17287,7 @@ queries:
                       Privileged: false
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security-runtime.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
@@ -17472,7 +17472,7 @@ queries:
                       ReadonlyRootFilesystem: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security-runtime.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html
         title: AWS Documentation - ECS controls
@@ -20513,7 +20513,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-findings.html
         title: AWS Documentation - IAM Access Analyzer findings
-      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-work-with-findings.html
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-concepts.html
         title: AWS Documentation - Working with findings
   - uid: mondoo-aws-security-sns-topic-encrypted
     title: Ensure SNS topics are encrypted with KMS
@@ -21282,7 +21282,7 @@ queries:
                   AtRestEncryptionEnabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
         title: AWS Documentation - ElastiCache at-rest encryption
   - uid: mondoo-aws-security-elasticache-encryption-at-rest-cluster
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -21459,7 +21459,7 @@ queries:
                   TransitEncryptionEnabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/in-transit-encryption.html
         title: AWS Documentation - ElastiCache in-transit encryption
   - uid: mondoo-aws-security-elasticache-encryption-in-transit-cluster
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -21630,7 +21630,7 @@ queries:
                   AuthToken: !Ref RedisAuthToken
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html
         title: AWS Documentation - Authenticating with the Redis AUTH command
   - uid: mondoo-aws-security-elasticache-redis-auth-enabled-cluster
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -23240,7 +23240,7 @@ queries:
                       User: "1000"
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security-runtime.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html
         title: AWS Documentation - Runtime security for Amazon ECS
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
@@ -24686,7 +24686,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Managing grants
   - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
@@ -24838,7 +24838,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html
+      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Managing grants
   - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
@@ -33603,7 +33603,7 @@ queries:
                   KmsKeyId: !Ref KMSKey
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
   - uid: mondoo-aws-security-documentdb-cluster-encrypted-aws
     filters: asset.platform == "aws-documentdb-cluster"
@@ -33779,7 +33779,7 @@ queries:
                   KmsKeyId: !GetAtt KMSKey.Arn
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk
         title: AWS KMS Customer Managed Keys
@@ -33940,7 +33940,7 @@ queries:
                   AutoMinorVersionUpgrade: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-modify.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/db-instance-modify.html
         title: Modifying an Amazon DocumentDB Instance
   - uid: mondoo-aws-security-documentdb-instance-auto-minor-version-upgrade-aws
     filters: asset.platform == "aws-documentdb-instance"
@@ -34129,7 +34129,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.networking.html
         title: Amazon DocumentDB - Network security
-      - url: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/docdb/modify-db-instance.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/docdb/modify-db-instance.html
         title: AWS CLI Command Reference - docdb modify-db-instance
   - uid: mondoo-aws-security-documentdb-instance-public-access-check-aws
     filters: asset.platform == "aws-documentdb-instance"
@@ -34610,7 +34610,7 @@ queries:
                     AdvancedSecurityMode: ENFORCED
             ```
     refs:
-      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html
+      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html
         title: Adding advanced security to a user pool
   - uid: mondoo-aws-security-cognito-user-pool-advanced-security-enforced-aws
     filters: asset.platform == "aws-cognito-userpool"
@@ -40802,7 +40802,7 @@ queries:
 
             Snapshots created from this cluster will automatically inherit encryption.
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/encryption-at-rest.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/encryption-at-rest.html
         title: Amazon DocumentDB Encryption at Rest
       - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/backup_restore-dump_restore_docdb.html
         title: Amazon DocumentDB Migrating Data
@@ -49799,7 +49799,7 @@ queries:
                             sts:ExternalId: !Ref ExternalId
             ```
     refs:
-      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
         title: How to use an external ID when granting access to your AWS resources to a third party
       - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgid
         title: AWS global condition context keys - aws:PrincipalOrgID
@@ -50481,7 +50481,7 @@ queries:
                     EnforceHTTPS: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-data-protection.html
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/data-protection.html
         title: Amazon Elasticsearch Service - Data Protection
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html
         title: AWS Security Hub - Elasticsearch controls reference
@@ -50648,7 +50648,7 @@ queries:
                     TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-data-protection.html
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/data-protection.html
         title: Amazon Elasticsearch Service - Data Protection
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html
         title: AWS Security Hub - Elasticsearch controls reference
@@ -50818,7 +50818,7 @@ queries:
                       Enabled: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/audit-logs.html
+      - url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html
         title: Amazon Elasticsearch Service - Audit Logs
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html
         title: AWS Security Hub - Elasticsearch controls reference
@@ -52661,7 +52661,7 @@ queries:
                   SnapshotRetentionLimit: 7
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/backups.html
         title: AWS Documentation - Backup and restore for ElastiCache for Redis
   - uid: mondoo-aws-security-elasticache-backup-retention-aws
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -53850,7 +53850,7 @@ queries:
                     - audit
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/event-auditing.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/event-auditing.html
         title: AWS Documentation - Auditing Amazon DocumentDB events
   - uid: mondoo-aws-security-documentdb-cluster-log-export-aws
     filters: asset.platform == "aws-documentdb-cluster"
@@ -55316,7 +55316,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html
         title: AWS Documentation - Launch configurations
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+      - url: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html
         title: AWS Documentation - Amazon EBS encryption
   - uid: mondoo-aws-security-ec2-launch-config-encrypted-volumes-aws
     filters: asset.platform == "aws"
@@ -56974,7 +56974,7 @@ queries:
 
             Always specify explicit `VpcSecurityGroupIds` rather than relying on the default security group.
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/security.html
         title: AWS Documentation - Amazon DocumentDB security
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/default-security-group.html
         title: AWS Documentation - Default security groups
@@ -57151,7 +57151,7 @@ queries:
                   MasterPasswordSecretKmsKeyId: !Ref RedshiftKmsKey
             ```
     refs:
-      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-clusters-console.html
+      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
         title: AWS Documentation - Managing clusters using the console
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-passwords.html
         title: AWS Documentation - Managing cluster master passwords
@@ -57897,7 +57897,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
         title: AWS Documentation - Task definition parameters
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security.html
         title: AWS Documentation - Amazon ECS best practices - Security
   - uid: mondoo-aws-security-ecs-init-process-enabled-aws
     filters: asset.platform == "aws-ecs-taskdefinition"
@@ -58049,7 +58049,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html
         title: AWS Documentation - Fargate task networking
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-outbound.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html
         title: AWS Documentation - ECS networking best practices
   # No Terraform variants: this check evaluates the exposure computed for a live
   # `aws.ecs.service` (the task's resolved ENI combined with its attached security
@@ -58189,7 +58189,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html
         title: AWS Documentation - Fargate task networking
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-outbound.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-best-practices.html
         title: AWS Documentation - ECS networking best practices
   # No Terraform variants: this check evaluates the image string resolved on the live
   # `aws.ecs.container` runtime asset, which has no Terraform/CloudFormation representation.
@@ -58308,7 +58308,7 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html
         title: AWS Documentation - Amazon ECR image tag mutability
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/security-tasks-containers.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-tasks-containers.html
         title: AWS Documentation - ECS task and container security best practices
   # No Terraform variants: this check evaluates the image string resolved on the live
   # `aws.ecs.container` runtime asset, which has no Terraform/CloudFormation representation.
@@ -58446,7 +58446,7 @@ queries:
       # lexical, not semantic (e.g. "1.10.0" < "1.4.0"), so a `>= "1.4.0"` allow-list
       # would be incorrect — keep this explicit list and extend it whenever AWS retires
       # another version (including a future 1.4.0):
-      # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html
+      # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
       aws.ecs.containers.where(platformFamily == "Linux" && platformVersion != empty).all(
         platformVersion != "1.0.0" &&
         platformVersion != "1.1.0" &&
@@ -58551,9 +58551,9 @@ queries:
                   PlatformVersion: "LATEST"
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
         title: AWS Documentation - AWS Fargate platform versions
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html
+      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
         title: AWS Documentation - Fargate Linux platform versions
   - uid: mondoo-aws-security-lambda-in-vpc
     title: Ensure Lambda functions are deployed within a VPC
@@ -59083,9 +59083,9 @@ queries:
                   KmsKeyId: !Ref MyKmsKey
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
         title: AWS Documentation - ElastiCache at-rest encryption
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/security.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/security.html
         title: AWS Documentation - Security in Amazon ElastiCache
   - uid: mondoo-aws-security-elasticache-cmk-encryption-aws
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -61454,7 +61454,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-doc-syntax.html
+      - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-syntax-data-elements-parameters.html
         title: AWS Documentation - SSM Document sharing
   - uid: mondoo-aws-security-ssm-document-not-public-aws
     filters: asset.platform == "aws"
@@ -64505,7 +64505,7 @@ queries:
                         Resource: "*"
             ```
     refs:
-      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html
+      - url: https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-policies.html
         title: AWS Documentation - Resource-based policies for Secrets Manager
   # Passes when there is no resource policy; otherwise requires the policy not grant Allow to a wildcard principal.
   # MQL has no grouping parentheses, so this relies on && binding tighter than ||:
@@ -65442,7 +65442,7 @@ queries:
                   StandardsArn: !Sub "arn:aws:securityhub:${AWS::Region}::standards/aws-foundational-security-best-practices/v/1.0.0"
             ```
     refs:
-      - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html
+      - url: https://docs.aws.amazon.com/securityhub/latest/userguide/standards-view-manage.html
         title: Security standards in AWS Security Hub
   - uid: mondoo-aws-security-securityhub-standards-enabled-aws
     filters: asset.platform == "aws"
@@ -66238,7 +66238,7 @@ queries:
                   AutoMinorVersionUpgrade: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-maintain.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/db-instance-maintain.html
         title: AWS Documentation - Maintaining Amazon DocumentDB
   - uid: mondoo-aws-security-documentdb-cluster-auto-minor-version-upgrade-aws
     filters: asset.platform == "aws-documentdb-cluster"
@@ -67292,7 +67292,7 @@ queries:
                       SourceSecurityGroupId: !Ref AppSecurityGroup
             ```
     refs:
-      - url: https://redis.io/docs/management/security/
+      - url: https://redis.io/docs/latest/management/security/
         title: Redis Security Documentation
   - uid: mondoo-aws-security-secgroup-restricted-redis-aws
     filters: asset.platform == "aws-security-group"
@@ -68767,7 +68767,7 @@ queries:
                       CidrIp: "203.0.113.0/24"  # Replace with your trusted IP range
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
       - url: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html
         title: AWS Systems Manager Session Manager
@@ -68929,7 +68929,7 @@ queries:
                       SourceSecurityGroupId: !Ref AppSecurityGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html
+      - url: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
         title: Security Group Rules Reference
       - url: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html
         title: AWS VPC Security Best Practices
@@ -72700,7 +72700,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.aws.amazon.com/step-functions/latest/dg/concepts-iam.html
+      - url: https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html
         title: IAM and Step Functions
   - uid: mondoo-aws-security-sfn-role-no-wildcard-resource-aws
     filters: asset.platform == "aws"
@@ -74611,7 +74611,7 @@ queries:
             }
             ```
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSNotSupportingCredentials
         title: MDN Web Docs - CORS request did not succeed
       - url: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html
         title: Configuring CORS for an HTTP API
@@ -76012,9 +76012,9 @@ queries:
                   SnapshotRetentionLimit: 7
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/at-rest-encryption.html
         title: ElastiCache at-rest encryption
-      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups.html
+      - url: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/backups.html
         title: ElastiCache backup and restore
   - uid: mondoo-aws-security-elasticache-snapshot-kms-encryption-aws
     filters: asset.platform == "aws-elasticache-cluster" && aws.elasticache.cluster.engine == "redis"
@@ -76340,7 +76340,7 @@ queries:
                   EncryptionKeyArn: !GetAtt StudioKmsKey.Arn
             ```
     refs:
-      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-security.html
+      - url: https://docs.aws.amazon.com/emr/latest/ManagementGuide/how-emr-studio-works.html#emr-studio-access-control
         title: EMR Studio security and encryption
   - uid: mondoo-aws-security-emr-studio-cmk-encryption-aws
     filters: asset.platform == "aws"
@@ -78731,7 +78731,7 @@ queries:
         # No CloudFormation remediation: there is no CloudFormation resource for DocumentDB snapshot sharing; use
         # the console or CLI above.
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/backup_restore-share_cluster_snapshots.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/backup_restore-share_cluster_snapshots.html
         title: AWS Documentation - Sharing Amazon DocumentDB cluster snapshots
 
   # No Terraform variants: public snapshot sharing is imperative restore-attribute state with no Terraform analog.
@@ -81614,7 +81614,7 @@ queries:
         # No Terraform remediation: group membership is expressed across separate aws_iam_group_membership / aws_iam_user_group_membership resources, so asserting that an empty group carries no policies requires cross-resource correlation not representable structurally.
         # No CloudFormation remediation: the same cross-resource correlation between AWS::IAM::Group and its membership/policy resources is required and cannot be expressed structurally.
     refs:
-      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage.html
+      - url: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html
         title: AWS Documentation - IAM user groups
   - uid: mondoo-aws-security-iam-group-no-admin-policy-aws
     filters: asset.platform == "aws-iam-group"
@@ -84853,7 +84853,7 @@ queries:
           desc: |
             The CloudFormation `AWS::DocDB::DBInstance` resource does not expose a Performance Insights KMS key property, so there is no CloudFormation analog for this setting. Manage the Performance Insights KMS key on DocumentDB instances through the AWS Console or the AWS CLI.
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/performance-insights.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/performance-insights.html
         title: Monitoring with Amazon DocumentDB Performance Insights
   - uid: mondoo-aws-security-documentdb-instance-pi-cmk-encrypted-aws
     filters: asset.platform == "aws-documentdb-instance"
@@ -85895,7 +85895,7 @@ queries:
                       RequireSymbols: true
             ```
     refs:
-      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html
+      - url: https://docs.aws.amazon.com/cognito/latest/developerguide/managing-users-passwords.html
         title: Amazon Cognito user pool password policies
   # No Terraform variants: isPublic is a runtime rollup over the queue's resource policy that accounts for policy conditions; public exposure in Terraform source is already covered by mondoo-aws-security-sqs-no-wildcard-policy.
   - uid: mondoo-aws-security-sqs-queue-not-public
@@ -86134,7 +86134,7 @@ queries:
                   DBClusterParameterGroupName: !Ref DocDBClusterParameterGroup
             ```
     refs:
-      - url: https://docs.aws.amazon.com/documentdb/latest/developerguide/security.encryption.ssl.html
+      - url: https://docs.aws.amazon.com/documentdb/latest/devguide/security.encryption.ssl.html
         title: Encrypting Amazon DocumentDB data in transit
   - uid: mondoo-aws-security-sagemaker-notebook-in-vpc
     title: Ensure SageMaker notebook instances are deployed within a VPC

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -2142,7 +2142,7 @@ queries:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
         title: Lambda runtimes
       - url: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy
-        title: Lambda runtimes
+        title: Lambda runtime deprecation policy
   - uid: mondoo-aws-security-lambda-no-deprecated-runtime-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |
@@ -4257,7 +4257,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
-        title: AWS Documentation - ec2
+        title: AWS Documentation - AWS CLI Command Reference - ec2
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
   - uid: mondoo-aws-security-vpc-default-security-group-closed-aws
@@ -4835,7 +4835,7 @@ queries:
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
         title: AWS Documentation - Blocking public access to your Amazon S3 storage
-      - url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
+      - url: https://docs.aws.amazon.com/cli/latest/reference/s3api/put-public-access-block.html
         title: AWS CLI Command Reference - aws s3api put-public-access-block
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block
         title: Terraform Documentation - AWS Provider - aws_s3_bucket_public_access_block
@@ -5579,9 +5579,9 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/logs/
-        title: AWS Documentation - logs
+        title: AWS Documentation - AWS CLI Command Reference - logs
       - url: https://docs.aws.amazon.com/cli/latest/reference/ec2/
-        title: AWS Documentation - ec2
+        title: AWS Documentation - AWS CLI Command Reference - ec2
       - url: https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs
         title: Terraform registry - Cloud Posse AWS Utils Provider
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
@@ -5796,7 +5796,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/dynamodb/
-        title: AWS Documentation - dynamodb
+        title: AWS Documentation - AWS CLI Command Reference - DynamoDB
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
       - url: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html
@@ -8184,7 +8184,7 @@ queries:
       - url: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-controls-reference.html
         title: AWS Documentation - Security Hub controls reference
       - url: https://docs.aws.amazon.com/cli/latest/reference/redshift/
-        title: AWS Documentation - redshift
+        title: AWS Documentation - AWS CLI Command Reference - Redshift
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
         title: Terraform Documentation - AWS Provider
   - uid: mondoo-aws-security-redshift-cluster-public-access-check-aws
@@ -13691,8 +13691,6 @@ queries:
           desc: |
             Do not embed secrets such as AWS access keys, passwords, or API tokens in the `UserData` property of `AWS::EC2::Instance`. Instead, use IAM instance profiles and retrieve secrets at boot time from Secrets Manager or SSM Parameter Store.
     refs:
-      - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
-        title: AWS Documentation - Run commands when you launch an EC2 instance with user data input
       - url: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
         title: AWS Documentation - Run commands when you launch an EC2 instance with user data input
       - url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
@@ -24682,8 +24680,6 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
-        title: AWS Documentation - Grants in AWS KMS
   - uid: mondoo-aws-security-kms-grants-no-create-grant-aws
     filters: asset.platform == "aws-kms-key" && aws.kms.key.metadata.KeyManager == "CUSTOMER"
     mql: aws.kms.key.grants.none(operations.contains("CreateGrant"))
@@ -24832,8 +24828,6 @@ queries:
           desc: |
             To ensure KMS key grants do not use wildcard principals in CloudFormation, note that CloudFormation does not natively support managing KMS grants. Use the AWS CLI, SDK, or a CloudFormation custom resource to manage KMS grants and ensure specific principal ARNs are used instead of wildcards.
     refs:
-      - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
-        title: AWS Documentation - Grants in AWS KMS
       - url: https://docs.aws.amazon.com/kms/latest/developerguide/grants.html
         title: AWS Documentation - Grants in AWS KMS
   - uid: mondoo-aws-security-kms-no-wildcard-grant-principals-aws
@@ -40473,8 +40467,6 @@ queries:
                       SecretArn: !Ref DBSecret
             ```
     refs:
-      - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
-        title: AWS Documentation - Amazon RDS Proxy
       - url: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html
         title: AWS Documentation - Amazon RDS Proxy
   - uid: mondoo-aws-security-rds-proxy-tls-required-aws
@@ -58549,8 +58541,6 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
         title: AWS Documentation - Fargate platform versions for Amazon ECS
-      - url: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-fargate.html
-        title: AWS Documentation - Fargate platform versions for Amazon ECS
   - uid: mondoo-aws-security-lambda-in-vpc
     title: Ensure Lambda functions are deployed within a VPC
     impact: 70
@@ -58700,8 +58690,6 @@ queries:
     refs:
       - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
         title: AWS Documentation - Configuring a Lambda function to access resources in a VPC
-      - url: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
-        title: AWS Documentation - Giving Lambda functions access to resources in an Amazon VPC
   - uid: mondoo-aws-security-lambda-in-vpc-aws
     filters: asset.platform == "aws-lambda-function"
     mql: |

--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -33197,8 +33197,8 @@ queries:
 
             Note: OS version updates may not be supported via CloudFormation update. Use the AWS CLI for in-place upgrades.
     refs:
-      - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_microsoft_ad.html
-        title: AWS Managed Microsoft AD
+      - url: https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_maintain.html
+        title: AWS Documentation - Maintain your AWS Managed Microsoft AD
   - uid: mondoo-aws-security-directoryservice-os-version-aws
     filters: asset.platform == "aws-directoryservice-directory"
     mql: |
@@ -44099,8 +44099,8 @@ queries:
                     - !Ref PrivateSubnet
             ```
     refs:
-      - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/managing-amazon-mq-broker.html
-        title: Managing an Amazon MQ broker
+      - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/private-networking.html
+        title: Amazon MQ - Private networking
       - url: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html
         title: Amazon MQ - API Authentication and Authorization
   - uid: mondoo-aws-security-mq-no-public-access-aws
@@ -57139,8 +57139,6 @@ queries:
                   MasterPasswordSecretKmsKeyId: !Ref RedshiftKmsKey
             ```
     refs:
-      - url: https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html
-        title: AWS Documentation - Cluster operations
       - url: https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-secrets-manager-integration.html
         title: AWS Documentation - Managing Amazon Redshift admin passwords using AWS Secrets Manager
   - uid: mondoo-aws-security-redshift-secrets-manager-cmk-aws
@@ -67643,7 +67641,7 @@ queries:
             ```
     refs:
       - url: https://www.elastic.co/docs/deploy-manage/security
-        title: Security
+        title: Elasticsearch security
   - uid: mondoo-aws-security-secgroup-restricted-elasticsearch-aws
     filters: asset.platform == "aws-security-group"
     mql: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -12762,7 +12762,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+      - url: https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint
         title: Using private endpoints for Azure App Service
   - uid: mondoo-azure-security-function-app-private-endpoints-azure
     filters: |
@@ -13823,7 +13823,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/ip-services/associate-public-ip-address-vm
+      - url: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/associate-public-ip-address-vm
         title: Associate a public IP address to a virtual machine
   - uid: mondoo-azure-security-compute-vm-no-public-ip-azure
     filters: |
@@ -14555,7 +14555,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-overview
+      - url: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview
         title: Azure Virtual Network overview
   - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-azure
     filters: |
@@ -20903,7 +20903,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/databricks/security/network/front-end/public-access
+      - url: https://learn.microsoft.com/en-us/azure/databricks/security/network/front-end
         title: Configure public network access for Azure Databricks
   - uid: mondoo-azure-security-databricks-public-access-disabled-azure
     filters: |
@@ -21594,7 +21594,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os
+      - url: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image
         title: Auto-upgrade AKS cluster node OS images
   - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-azure
     filters: |
@@ -24015,7 +24015,7 @@ queries:
           desc: |
             To ensure AKS uses WireGuard for transit encryption in Terraform, wireGuard transit encryption for AKS is only configurable via Azure CLI or the Azure API. The `azurerm_kubernetes_cluster` Terraform resource does not currently support the WireGuard enablement flag. Use the Azure CLI to enable WireGuard on the cluster after provisioning with Terraform.
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/aks/wireguard
+      - url: https://learn.microsoft.com/en-us/azure/aks/container-network-security-wireguard-encryption-concepts
         title: WireGuard-based encryption in AKS
   - uid: mondoo-azure-security-aks-wireguard-transit-encryption-azure
     filters: |
@@ -24424,7 +24424,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+      - url: https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint
         title: Azure App Service Private Endpoints
   - uid: mondoo-azure-security-app-service-public-network-access-disabled-azure
     filters: |
@@ -26088,7 +26088,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-customer-managed-keys
+      - url: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-encryption
         title: Configure customer-managed keys for Azure Cache for Redis
   # Customer-managed key encryption is only available on the Enterprise/Managed Redis
   # tier, which Terraform models as azurerm_managed_redis with a customer_managed_key
@@ -31827,7 +31827,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-quarantine
+      - url: https://learn.microsoft.com/en-us/azure/architecture/patterns/quarantine
         title: Quarantine pattern for Azure Container Registry
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled-azure
     filters: |
@@ -32505,7 +32505,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/storage/common/storage-encryption-scope-overview
+      - url: https://learn.microsoft.com/en-us/azure/storage/blobs/encryption-scope-overview
         title: Encryption scopes for Blob storage
   - uid: mondoo-azure-security-storage-encryption-scope-cmk-azure
     filters: |
@@ -32813,7 +32813,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-sets
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
         title: Azure disk encryption sets
   - uid: mondoo-azure-security-compute-disk-encryption-set-cmk-azure
     filters: |
@@ -32970,7 +32970,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-sets
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
         title: Azure disk encryption sets
   - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation-azure
     filters: |
@@ -34855,7 +34855,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/backup/backup-azure-enhanced-security
+      - url: https://learn.microsoft.com/en-us/azure/backup/backup-azure-security-feature
         title: Security features for protecting Azure Backup
   - uid: mondoo-azure-security-recovery-vault-enhanced-security-azure
     filters: |
@@ -35605,7 +35605,7 @@ queries:
               --vault-name <VaultName> > policy.json
             ```
 
-            Edit `policy.json` to set `schedulePolicy`, `retentionPolicy`, and `timeZone` to match your RPO/RTO. The schema is documented at [Azure Backup policies for Azure VMs](https://learn.microsoft.com/en-us/azure/backup/backup-azure-vm-backup-policy-concept). Then:
+            Edit `policy.json` to set `schedulePolicy`, `retentionPolicy`, and `timeZone` to match your RPO/RTO. The schema is documented at [Azure Backup policies for Azure VMs](https://learn.microsoft.com/en-us/azure/backup/backup-azure-vms-introduction). Then:
 
             ```bash
             az backup policy create \
@@ -42839,7 +42839,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/azure-sql/database/sql-database-vulnerability-assessment
+      - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/sql-azure-vulnerability-assessment-overview
         title: SQL Vulnerability Assessment helps you identify database vulnerabilities
   - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-azure
     filters: |
@@ -44947,7 +44947,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-concept-authenticate-azure-active-directory
+      - url: https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-concept-authorize-azure-active-directory
         title: Authenticate with Microsoft Entra ID for Azure SignalR Service
   - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_signalr_service")
@@ -51074,7 +51074,7 @@ queries:
             ```
         # No Terraform remediation: the azurerm provider has no proxy agent attribute on any virtual machine resource, and shelling out through a null_resource would not produce a managed setting.
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/metadata-security-protocol
+      - url: https://learn.microsoft.com/en-us/azure/virtual-machines/metadata-security-protocol/overview
         title: Azure Metadata Security Protocol
   - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-azure
     filters: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-azure-security
     name: Mondoo Microsoft Azure Security
-    version: 10.1.1
+    version: 10.1.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -8618,7 +8618,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac
+      - url: https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization
         title: Use Azure RBAC for Kubernetes Authorization
   - uid: mondoo-azure-security-aks-rbac-enabled-azure
     filters: |
@@ -19860,7 +19860,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-data-encryption
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/security/security-data-encryption
         title: Data encryption with customer-managed key for Azure Database for PostgreSQL Flexible Server
   - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled
     title: Ensure MySQL flexible servers disable public network access
@@ -25591,7 +25591,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-data-encryption
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/security/security-data-encryption
         title: Data encryption for Azure Database for PostgreSQL Flexible Server
   - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_postgresql_flexible_server")
@@ -47359,7 +47359,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/data-explorer/customer-managed-keys-portal
+      - url: https://learn.microsoft.com/en-us/azure/data-explorer/customer-managed-keys
         title: Configure customer-managed keys for Azure Data Explorer
   - uid: mondoo-azure-security-kusto-cluster-cmk-encryption-azure
     filters: |
@@ -52041,7 +52041,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/synapse-analytics/security/synapse-workspace-managed-identity
+      - url: https://learn.microsoft.com/en-us/azure/data-factory/data-factory-service-identity
         title: Azure Synapse workspace managed identity
   - uid: mondoo-azure-security-synapse-managed-identity-azure
     filters: |

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -8619,7 +8619,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization
-        title: Use Azure RBAC for Kubernetes Authorization
+        title: Use Microsoft Entra ID Authorization for the Kubernetes API in Azure Kubernetes Service (AKS)
   - uid: mondoo-azure-security-aks-rbac-enabled-azure
     filters: |
       asset.platform == "azure-aks-cluster"
@@ -11397,7 +11397,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/kubernetes-monitoring-overview
-        title: Container Insights overview
+        title: Kubernetes monitoring in Azure Monitor
   - uid: mondoo-azure-security-aks-container-insights-enabled-azure
     filters: |
       asset.platform == "azure-aks-cluster"
@@ -12763,7 +12763,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint
-        title: Using private endpoints for Azure App Service
+        title: Use Private Endpoints for Apps
   - uid: mondoo-azure-security-function-app-private-endpoints-azure
     filters: |
       asset.platform == "azure-app-service-webapp" &&
@@ -14556,7 +14556,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview
-        title: Azure Virtual Network overview
+        title: What is Azure Virtual Network?
   - uid: mondoo-azure-security-network-vnet-vm-protection-enabled-azure
     filters: |
       asset.platform == "azure-virtual-network"
@@ -15750,7 +15750,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-connect-role-based-access-control
-        title: Configure role-based access control with Azure AD for Azure Cosmos DB
+        title: Connect using role-based access control and Microsoft Entra ID
   - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-azure
     filters: |
       asset.platform == "azure-cosmosdb"
@@ -16286,7 +16286,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql
-        title: High availability in Azure Cosmos DB
+        title: Reliability in Azure Cosmos DB
   - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-azure
     filters: |
       asset.platform == "azure-cosmosdb" &&
@@ -16797,7 +16797,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-customer-managed-keys
-        title: Configure customer-managed keys for your Azure Cosmos DB account
+        title: Configure Customer-Managed Keys
   - uid: mondoo-azure-security-cosmosdb-cmk-encryption-azure
     filters: |
       asset.platform == "azure-cosmosdb"
@@ -19861,7 +19861,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/postgresql/security/security-data-encryption
-        title: Data encryption with customer-managed key for Azure Database for PostgreSQL Flexible Server
+        title: Data Encryption at Rest in Azure Database for PostgreSQL Flexible Server
   - uid: mondoo-azure-security-mysql-flexible-server-public-access-disabled
     title: Ensure MySQL flexible servers disable public network access
     impact: 80
@@ -20904,7 +20904,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/databricks/security/network/front-end
-        title: Configure public network access for Azure Databricks
+        title: Users to Azure Databricks networking
   - uid: mondoo-azure-security-databricks-public-access-disabled-azure
     filters: |
       asset.platform == "azure"
@@ -21595,7 +21595,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image
-        title: Auto-upgrade AKS cluster node OS images
+        title: Autoupgrade Node OS Images in Azure Kubernetes Service (AKS)
   - uid: mondoo-azure-security-aks-node-os-auto-upgrade-enabled-azure
     filters: |
       asset.platform == "azure-aks-cluster"
@@ -24016,7 +24016,7 @@ queries:
             To ensure AKS uses WireGuard for transit encryption in Terraform, wireGuard transit encryption for AKS is only configurable via Azure CLI or the Azure API. The `azurerm_kubernetes_cluster` Terraform resource does not currently support the WireGuard enablement flag. Use the Azure CLI to enable WireGuard on the cluster after provisioning with Terraform.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/aks/container-network-security-wireguard-encryption-concepts
-        title: WireGuard-based encryption in AKS
+        title: WireGuard Encryption with Advanced Container Networking Services
   - uid: mondoo-azure-security-aks-wireguard-transit-encryption-azure
     filters: |
       asset.platform == "azure-aks-cluster"
@@ -24425,7 +24425,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint
-        title: Azure App Service Private Endpoints
+        title: Use Private Endpoints for Apps
   - uid: mondoo-azure-security-app-service-public-network-access-disabled-azure
     filters: |
       asset.platform == "azure-app-service-webapp"
@@ -25592,7 +25592,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/postgresql/security/security-data-encryption
-        title: Data encryption for Azure Database for PostgreSQL Flexible Server
+        title: Data Encryption at Rest in Azure Database for PostgreSQL Flexible Server
   - uid: mondoo-azure-security-postgresql-flexible-cmk-encryption-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_postgresql_flexible_server")
     mql: |
@@ -26089,7 +26089,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-encryption
-        title: Configure customer-managed keys for Azure Cache for Redis
+        title: Configure disk encryption in Azure Cache for Redis
   # Customer-managed key encryption is only available on the Enterprise/Managed Redis
   # tier, which Terraform models as azurerm_managed_redis with a customer_managed_key
   # block. The classic azurerm_redis_cache resource has no CMK argument.
@@ -29875,7 +29875,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/data-factory/data-factory-service-identity
-        title: Managed identity for Azure Data Factory
+        title: Managed identity
   - uid: mondoo-azure-security-datafactory-managed-identity-azure
     filters: |
       asset.platform == "azure-datafactory"
@@ -31655,7 +31655,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-endpoints
-        title: Connect privately to an Azure container registry using Azure Private Link
+        title: Set Up Private Endpoint with Private Link for ACR
   - uid: mondoo-azure-security-acr-private-endpoints-azure
     filters: |
       asset.platform == "azure-container-registry"
@@ -31828,7 +31828,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/architecture/patterns/quarantine
-        title: Quarantine pattern for Azure Container Registry
+        title: Quarantine pattern
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled-azure
     filters: |
       asset.platform == "azure-container-registry"
@@ -32814,7 +32814,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
-        title: Azure disk encryption sets
+        title: Overview of managed disk encryption options
   - uid: mondoo-azure-security-compute-disk-encryption-set-cmk-azure
     filters: |
       asset.platform == "azure"
@@ -32971,7 +32971,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview
-        title: Azure disk encryption sets
+        title: Overview of managed disk encryption options
   - uid: mondoo-azure-security-compute-disk-encryption-set-auto-rotation-azure
     filters: |
       asset.platform == "azure"
@@ -34856,7 +34856,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/backup/backup-azure-security-feature
-        title: Security features for protecting Azure Backup
+        title: Security features that protect hybrid backups
   - uid: mondoo-azure-security-recovery-vault-enhanced-security-azure
     filters: |
       asset.platform == "azure-recovery-services-vault"
@@ -42840,7 +42840,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/defender-for-cloud/sql-azure-vulnerability-assessment-overview
-        title: SQL Vulnerability Assessment helps you identify database vulnerabilities
+        title: Scan your Azure SQL databases for vulnerabilities
   - uid: mondoo-azure-security-sql-server-vulnerability-assessment-recurring-scans-azure
     filters: |
       asset.platform == "azure-sql-server"
@@ -44948,7 +44948,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-concept-authorize-azure-active-directory
-        title: Authenticate with Microsoft Entra ID for Azure SignalR Service
+        title: Authorize access with Microsoft Entra ID for Azure SignalR Service
   - uid: mondoo-azure-security-signalr-local-auth-disabled-terraform-hcl
     filters: asset.platform == "terraform-hcl" && terraform.resources.contains(nameLabel == "azurerm_signalr_service")
     mql: |
@@ -47360,7 +47360,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/data-explorer/customer-managed-keys
-        title: Configure customer-managed keys for Azure Data Explorer
+        title: Configure Customer-managed-keys
   - uid: mondoo-azure-security-kusto-cluster-cmk-encryption-azure
     filters: |
       asset.platform == "azure"
@@ -51075,7 +51075,7 @@ queries:
         # No Terraform remediation: the azurerm provider has no proxy agent attribute on any virtual machine resource, and shelling out through a null_resource would not produce a managed setting.
     refs:
       - url: https://learn.microsoft.com/en-us/azure/virtual-machines/metadata-security-protocol/overview
-        title: Azure Metadata Security Protocol
+        title: Metadata Security Protocol (MSP)
   - uid: mondoo-azure-security-compute-vm-proxy-agent-enabled-azure
     filters: |
       asset.platform == "azure-compute-vm-api"
@@ -52042,7 +52042,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/data-factory/data-factory-service-identity
-        title: Azure Synapse workspace managed identity
+        title: Managed identity
   - uid: mondoo-azure-security-synapse-managed-identity-azure
     filters: |
       asset.platform == "azure-synapse-workspace"

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -29875,7 +29875,7 @@ queries:
             ```
     refs:
       - url: https://learn.microsoft.com/en-us/azure/data-factory/data-factory-service-identity
-        title: Managed identity
+        title: Managed identity for Azure Data Factory
   - uid: mondoo-azure-security-datafactory-managed-identity-azure
     filters: |
       asset.platform == "azure-datafactory"
@@ -31827,8 +31827,8 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/architecture/patterns/quarantine
-        title: Quarantine pattern
+      - url: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-faq#how-do-i-enable-automatic-image-quarantine-for-a-registry-
+        title: Enable automatic image quarantine for a registry
   - uid: mondoo-azure-security-acr-quarantine-policy-enabled-azure
     filters: |
       asset.platform == "azure-container-registry"
@@ -52040,9 +52040,6 @@ queries:
               }
             }
             ```
-    refs:
-      - url: https://learn.microsoft.com/en-us/azure/data-factory/data-factory-service-identity
-        title: Managed identity
   - uid: mondoo-azure-security-synapse-managed-identity-azure
     filters: |
       asset.platform == "azure-synapse-workspace"

--- a/content/mondoo-azure-security.mql.yaml
+++ b/content/mondoo-azure-security.mql.yaml
@@ -11396,7 +11396,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview
+      - url: https://learn.microsoft.com/en-us/azure/azure-monitor/containers/kubernetes-monitoring-overview
         title: Container Insights overview
   - uid: mondoo-azure-security-aks-container-insights-enabled-azure
     filters: |
@@ -15749,7 +15749,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-connect-role-based-access-control
         title: Configure role-based access control with Azure AD for Azure Cosmos DB
   - uid: mondoo-azure-security-cosmosdb-local-auth-disabled-azure
     filters: |
@@ -16285,7 +16285,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/high-availability
+      - url: https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql
         title: High availability in Azure Cosmos DB
   - uid: mondoo-azure-security-cosmosdb-automatic-failover-enabled-azure
     filters: |
@@ -16796,7 +16796,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-cmk
+      - url: https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-customer-managed-keys
         title: Configure customer-managed keys for your Azure Cosmos DB account
   - uid: mondoo-azure-security-cosmosdb-cmk-encryption-azure
     filters: |
@@ -25750,7 +25750,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore
+      - url: https://learn.microsoft.com/en-us/azure/postgresql/backup-restore/concepts-backup-restore
         title: Backup and restore in Azure Database for PostgreSQL Flexible Server
   - uid: mondoo-azure-security-postgresql-flexible-geo-backup-azure
     filters: |
@@ -31654,7 +31654,7 @@ queries:
             }
             ```
     refs:
-      - url: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-link
+      - url: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-endpoints
         title: Connect privately to an Azure container registry using Azure Private Link
   - uid: mondoo-azure-security-acr-private-endpoints-azure
     filters: |

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -442,7 +442,7 @@ queries:
     refs:
       - url: https://my.f5.com/manage/s/article/K13156
         title: F5 - Configuring the cipher strength for SSL profiles
-      - url: https://tools.ietf.org/html/rfc7465
+      - url: https://datatracker.ietf.org/doc/html/rfc7465
         title: RFC 7465 - Prohibiting RC4 Cipher Suites
 
   - uid: mondoo-bigip-security-server-ssl-secure-ciphers
@@ -542,7 +542,7 @@ queries:
     refs:
       - url: https://my.f5.com/manage/s/article/K13156
         title: F5 - Configuring the cipher strength for SSL profiles
-      - url: https://tools.ietf.org/html/rfc7465
+      - url: https://datatracker.ietf.org/doc/html/rfc7465
         title: RFC 7465 - Prohibiting RC4 Cipher Suites
 
   - uid: mondoo-bigip-security-server-ssl-authenticate-backend

--- a/content/mondoo-bigip-security.mql.yaml
+++ b/content/mondoo-bigip-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-bigip-security
     name: Mondoo F5 BIG-IP Security
-    version: 1.0.4
+    version: 1.0.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -110,7 +110,7 @@ queries:
                ```
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Security
+        title: Cassandra Security
   - uid: mondoo-cassandra-security-authorization-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra enforces authorization
@@ -175,7 +175,7 @@ queries:
                ```
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Security
+        title: Cassandra Security
   - uid: mondoo-cassandra-security-client-encryption-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra encrypts client-to-node traffic
@@ -243,7 +243,7 @@ queries:
             3. Perform a rolling restart of the cluster so every node picks up the new setting.
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Security
+        title: Cassandra Security
   - uid: mondoo-cassandra-security-audit-logging-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra enables audit logging

--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cassandra-security
     name: Mondoo Apache Cassandra Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -109,7 +109,7 @@ queries:
                CREATE ROLE app WITH PASSWORD = 'strong-password' AND LOGIN = true;
                ```
     refs:
-      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/security/authentication.html
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
         title: Cassandra Authentication
   - uid: mondoo-cassandra-security-authorization-enabled
     filters: asset.platform == "cassandra"
@@ -174,7 +174,7 @@ queries:
                GRANT SELECT ON KEYSPACE app_data TO app;
                ```
     refs:
-      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/security/authorization.html
+      - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
         title: Cassandra Authorization
   - uid: mondoo-cassandra-security-client-encryption-enabled
     filters: asset.platform == "cassandra"

--- a/content/mondoo-cassandra-security.mql.yaml
+++ b/content/mondoo-cassandra-security.mql.yaml
@@ -110,7 +110,7 @@ queries:
                ```
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Cassandra Authentication
+        title: Security
   - uid: mondoo-cassandra-security-authorization-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra enforces authorization
@@ -175,7 +175,7 @@ queries:
                ```
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Cassandra Authorization
+        title: Security
   - uid: mondoo-cassandra-security-client-encryption-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra encrypts client-to-node traffic
@@ -243,7 +243,7 @@ queries:
             3. Perform a rolling restart of the cluster so every node picks up the new setting.
     refs:
       - url: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/security.html
-        title: Cassandra TLS/SSL Encryption
+        title: Security
   - uid: mondoo-cassandra-security-audit-logging-enabled
     filters: asset.platform == "cassandra"
     title: Ensure Cassandra enables audit logging

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-client
     name: Mondoo Chef Infra Client Security
-    version: 1.3.5
+    version: 1.3.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -411,7 +411,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.chef.io/config_rb_client/
+      - url: https://docs.chef.io/client/19/install/config_rb_client/
         title: Chef Infra Client Configuration Reference
   - uid: client-pem-permissions
     title: Ensure /etc/chef/client.pem is owned by root:root with mode 600 or 640
@@ -581,7 +581,7 @@ queries:
 
             To prevent the key from landing on new nodes in the first place, bootstrap with `knife bootstrap` using your own user credentials. Knife performs a validatorless bootstrap by default in Chef Infra Client 15 and later, so validation.pem is never written to the node.
     refs:
-      - url: https://docs.chef.io/install_bootstrap/
+      - url: https://docs.chef.io/client/19/install/bootstrap/
         title: Chef Bootstrap Guide
   - uid: non-eol-infra-client
     title: Ensure a non-EOL Chef Infra Client or Cinc Client release is used
@@ -949,5 +949,5 @@ queries:
             ssl_verify_mode :verify_peer
             ```
     refs:
-      - url: https://docs.chef.io/config_rb_client/
+      - url: https://docs.chef.io/client/19/install/config_rb_client/
         title: Chef Infra Client Configuration Reference

--- a/content/mondoo-chef-infra-client.mql.yaml
+++ b/content/mondoo-chef-infra-client.mql.yaml
@@ -582,7 +582,7 @@ queries:
             To prevent the key from landing on new nodes in the first place, bootstrap with `knife bootstrap` using your own user credentials. Knife performs a validatorless bootstrap by default in Chef Infra Client 15 and later, so validation.pem is never written to the node.
     refs:
       - url: https://docs.chef.io/client/19/install/bootstrap/
-        title: Chef Bootstrap Guide
+        title: Bootstrap a node with Chef Infra
   - uid: non-eol-infra-client
     title: Ensure a non-EOL Chef Infra Client or Cinc Client release is used
     impact: 70

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: chef-infra-server
     name: Mondoo Chef Infra Server Security
-    version: 1.3.4
+    version: 1.3.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -554,7 +554,7 @@ queries:
 
             2. Review the [Chef Infra Server upgrade documentation](https://docs.chef.io/server/upgrades/) for your upgrade path.
 
-            3. Download and install the latest supported version from the [Chef Downloads page](https://www.chef.io/downloads/tools/infra-server).
+            3. Download and install the latest supported version from the [Chef Downloads page](https://www.chef.io/downloads).
 
             **Upgrade Planning Considerations**:
 

--- a/content/mondoo-chef-infra-server.mql.yaml
+++ b/content/mondoo-chef-infra-server.mql.yaml
@@ -1437,5 +1437,5 @@ queries:
 
             Note: Chef Infra Server 15.7 and later automatically set the configuration backup path to `600` permissions on each `chef-server-ctl` execution.
     refs:
-      - url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28864
+      - url: https://www.cve.org/CVERecord?id=CVE-2023-28864
         title: CVE-2023-28864

--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-clickhousecloud-security
     name: Mondoo ClickHouse Cloud Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-clickhousecloud-security.mql.yaml
+++ b/content/mondoo-clickhousecloud-security.mql.yaml
@@ -127,9 +127,9 @@ queries:
             }
             ```
     refs:
-      - url: https://clickhouse.com/docs/en/cloud/security/setting-ip-filters
+      - url: https://clickhouse.com/docs/products/cloud/guides/security/connectivity/setting-ip-filters
         title: ClickHouse Cloud IP access lists
-      - url: https://clickhouse.com/docs/cloud/manage/api/api-overview
+      - url: https://clickhouse.com/docs/products/cloud/features/admin-features/api/api-overview
         title: ClickHouse Cloud API
   - uid: mondoo-clickhousecloud-security-services-not-open-to-all-ips-clickhousecloud
     filters: asset.platform == "clickhousecloud"
@@ -238,7 +238,7 @@ queries:
 
             To hold the encryption key yourself rather than letting ClickHouse manage it, also set `encryption_key` and `encryption_assumed_role_identifier`. Those arguments select customer-managed keys; they do not turn the feature on by themselves.
     refs:
-      - url: https://clickhouse.com/docs/en/cloud/security/cmek
+      - url: https://clickhouse.com/docs/products/cloud/guides/security/cmek
         title: ClickHouse Cloud data encryption
   - uid: mondoo-clickhousecloud-security-services-encryption-at-rest-clickhousecloud
     filters: asset.platform == "clickhousecloud"

--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -164,4 +164,4 @@ queries:
             ```
     refs:
       - url: https://clickhouse.com/docs/concepts/features/security/tls/configuring-tls
-        title: ClickHouse configuring SSL-TLS
+        title: Configuring TLS

--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-clickhousedb-security
     name: Mondoo ClickHouse Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-clickhousedb-security.mql.yaml
+++ b/content/mondoo-clickhousedb-security.mql.yaml
@@ -98,7 +98,7 @@ queries:
             </users>
             ```
     refs:
-      - url: https://clickhouse.com/docs/en/operations/access-rights
+      - url: https://clickhouse.com/docs/concepts/features/security/access-rights
         title: ClickHouse access control and account management
   - uid: mondoo-clickhousedb-security-secure-tcp-port-enabled
     filters: asset.platform == "clickhousedb"
@@ -163,5 +163,5 @@ queries:
             </clickhouse>
             ```
     refs:
-      - url: https://clickhouse.com/docs/en/guides/sre/configuring-ssl
+      - url: https://clickhouse.com/docs/concepts/features/security/tls/configuring-tls
         title: ClickHouse configuring SSL-TLS

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -2194,7 +2194,7 @@ queries:
             ```
     refs:
       - url: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
-        title: Cloudflare API Tokens
+        title: Create API token
   - uid: mondoo-cloudflare-security-api-tokens-have-ip-allowlist
     title: Ensure API tokens have an IP allowlist configured
     impact: 60
@@ -2315,7 +2315,7 @@ queries:
             ```
     refs:
       - url: https://developers.cloudflare.com/fundamentals/api/how-to/control-api-access/
-        title: Cloudflare - Control API access
+        title: Cloudflare - Control API Access
   # No Terraform variants: the check inspects each accepted member's twoFactorAuthenticationEnabled flag, which is per-user account state managed by the underlying Cloudflare user — not configuration declared by cloudflare_account_member HCL.
   - uid: mondoo-cloudflare-security-members-have-two-factor
     filters: asset.platform == "cloudflare-account"
@@ -2407,7 +2407,7 @@ queries:
       - url: https://developers.cloudflare.com/fundamentals/user-profiles/2fa/
         title: Cloudflare two-factor authentication
       - url: https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/list/
-        title: Cloudflare API - List account members
+        title: List Members
   # No Terraform variants: the check inspects each token's modifiedOn timestamp (when its secret was last rotated), which is runtime telemetry with no analog in cloudflare_api_token HCL — Terraform expresses desired token configuration, not the age of the current secret.
   - uid: mondoo-cloudflare-security-api-tokens-not-older-than-365-days
     filters: asset.platform == "cloudflare-account"
@@ -2488,7 +2488,7 @@ queries:
         # No Terraform remediation: rotating a token's secret is an imperative API operation (PUT .../tokens/{id}/value) with no representation in cloudflare_api_token HCL — the resource declares token configuration, not a rotation action.
     refs:
       - url: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
-        title: Cloudflare API token management
+        title: Create API token
   - uid: mondoo-cloudflare-security-ssl-not-off-cloudflare
     filters: |
       asset.platform == "cloudflare-zone"

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -1403,7 +1403,7 @@ queries:
             }
             ```
     refs:
-      - url: https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/
+      - url: https://developers.cloudflare.com/fundamentals/user-profiles/2fa/
         title: Cloudflare two-factor authentication
   - uid: mondoo-cloudflare-security-dnssec-active
     title: Ensure DNSSEC is active on every zone
@@ -2314,7 +2314,7 @@ queries:
             }
             ```
     refs:
-      - url: https://developers.cloudflare.com/fundamentals/api/how-to/secure-api-tokens-with-restrictive-permissions/
+      - url: https://developers.cloudflare.com/fundamentals/api/how-to/control-api-access/
         title: Cloudflare API token IP filtering
   # No Terraform variants: the check inspects each accepted member's twoFactorAuthenticationEnabled flag, which is per-user account state managed by the underlying Cloudflare user — not configuration declared by cloudflare_account_member HCL.
   - uid: mondoo-cloudflare-security-members-have-two-factor
@@ -2404,7 +2404,7 @@ queries:
             ```
         # No Terraform remediation: per-user two-factor enrollment is owned by each Cloudflare user account, not by account-membership configuration. The cloudflare_account_member resource grants role membership but does not declare or enforce the underlying user's 2FA state, so there is no HCL change that can remediate this finding.
     refs:
-      - url: https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/
+      - url: https://developers.cloudflare.com/fundamentals/user-profiles/2fa/
         title: Cloudflare two-factor authentication
       - url: https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/list/
         title: Cloudflare API - List account members
@@ -2487,7 +2487,7 @@ queries:
             ```
         # No Terraform remediation: rotating a token's secret is an imperative API operation (PUT .../tokens/{id}/value) with no representation in cloudflare_api_token HCL — the resource declares token configuration, not a rotation action.
     refs:
-      - url: https://developers.cloudflare.com/fundamentals/api/how-to/manage-api-tokens/
+      - url: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
         title: Cloudflare API token management
   - uid: mondoo-cloudflare-security-ssl-not-off-cloudflare
     filters: |

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-cloudflare-security
     name: Mondoo Cloudflare Security
-    version: 1.1.3
+    version: 1.1.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -2315,7 +2315,7 @@ queries:
             ```
     refs:
       - url: https://developers.cloudflare.com/fundamentals/api/how-to/control-api-access/
-        title: Cloudflare API token IP filtering
+        title: Cloudflare - Control API access
   # No Terraform variants: the check inspects each accepted member's twoFactorAuthenticationEnabled flag, which is per-user account state managed by the underlying Cloudflare user — not configuration declared by cloudflare_account_member HCL.
   - uid: mondoo-cloudflare-security-members-have-two-factor
     filters: asset.platform == "cloudflare-account"

--- a/content/mondoo-cloudflare-security.mql.yaml
+++ b/content/mondoo-cloudflare-security.mql.yaml
@@ -2406,7 +2406,7 @@ queries:
     refs:
       - url: https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/
         title: Cloudflare two-factor authentication
-      - url: https://developers.cloudflare.com/api/operations/account-members-list-members
+      - url: https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/list/
         title: Cloudflare API - List account members
   # No Terraform variants: the check inspects each token's modifiedOn timestamp (when its secret was last rotated), which is runtime telemetry with no analog in cloudflare_api_token HCL — Terraform expresses desired token configuration, not the age of the current secret.
   - uid: mondoo-cloudflare-security-api-tokens-not-older-than-365-days

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -2393,7 +2393,7 @@ queries:
             ```
     refs:
       - url: https://docs.databricks.com/aws/en/security/auth/access-control
-        title: Databricks secret access control lists
+        title: Access control lists
   - uid: mondoo-databricks-security-secret-scope-not-world-readable-workspace
     filters: asset.platform == "databricks-workspace"
     mql: |

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-databricks-security
     name: Mondoo Databricks Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -2392,7 +2392,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.databricks.com/aws/en/security/secrets/acl
+      - url: https://docs.databricks.com/aws/en/security/auth/access-control
         title: Databricks secret access control lists
   - uid: mondoo-databricks-security-secret-scope-not-world-readable-workspace
     filters: asset.platform == "databricks-workspace"

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -29,7 +29,7 @@ policies:
         - Mosaic AI model serving guardrails
         - Account identity and service principal hygiene
 
-        Learn more about scanning Databricks in the [cnspec documentation](https://mondoo.com/docs/cnspec/saas/databricks).
+        Learn more about scanning Databricks in the [cnspec documentation](https://mondoo.com/docs/cnspec/databases/databricks).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-databricks-security.mql.yaml
+++ b/content/mondoo-databricks-security.mql.yaml
@@ -2392,8 +2392,8 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.databricks.com/aws/en/security/auth/access-control
-        title: Access control lists
+      - url: https://docs.databricks.com/aws/en/security/secrets/
+        title: Databricks secret management
   - uid: mondoo-databricks-security-secret-scope-not-world-readable-workspace
     filters: asset.platform == "databricks-workspace"
     mql: |

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -4342,7 +4342,7 @@ queries:
             Confirm the change by listing the agents again and checking that the deployment visibility is no longer `VISIBILITY_PUBLIC`.
         # No Terraform remediation: GradientAI agents have no digitalocean Terraform resource.
     refs:
-      - url: https://docs.digitalocean.com/products/gradientai-platform/
+      - url: https://docs.digitalocean.com/products/inference/
         title: DigitalOcean GradientAI platform
   # No Terraform variants: GradientAI agents are managed through the GradientAI API and control
   # panel; the digitalocean Terraform provider has no resource representing an agent or its
@@ -4417,7 +4417,7 @@ queries:
         # No Terraform remediation: GradientAI agents have no digitalocean Terraform resource, so
         # guardrail attachment cannot be expressed in Terraform.
     refs:
-      - url: https://docs.digitalocean.com/products/gradientai-platform/
+      - url: https://docs.digitalocean.com/products/inference/
         title: DigitalOcean GradientAI platform
 
   # No Terraform variants: GradientAI knowledge bases are managed through the GradientAI
@@ -4491,7 +4491,7 @@ queries:
         # command to toggle the public flag on an existing knowledge base; use the control panel above.
         # No Terraform remediation: GradientAI knowledge bases have no digitalocean Terraform resource.
     refs:
-      - url: https://docs.digitalocean.com/products/gradientai-platform/
+      - url: https://docs.digitalocean.com/products/inference/
         title: DigitalOcean GradientAI platform
 
   # No Terraform variants: DigitalOcean Functions are deployed imperatively via

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -193,7 +193,7 @@ queries:
         # No Terraform remediation: email verification is an interactive account-level
         # flow with no provider resource — the same limitation as the CLI above.
     refs:
-      - url: https://docs.digitalocean.com/products/accounts/security/
+      - url: https://docs.digitalocean.com/platform/teams/how-to/view-security-history/
         title: DigitalOcean account security
 
   - uid: mondoo-digitalocean-security-droplet-in-vpc
@@ -1515,7 +1515,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/upgrade-major-version/
+      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/upgrade-version/
         title: Upgrade a managed database major version
 
   - uid: mondoo-digitalocean-security-db-engine-supported-version-digitalocean
@@ -1647,7 +1647,7 @@ queries:
             Replace the certificate file in every client trust store, restart services, and confirm new connections succeed.
         # No Terraform remediation: the CA certificate is provisioned and rotated by DigitalOcean, not declared in digitalocean_database_cluster HCL. Terraform-managed clusters still pull the active CA via the runtime API; remediation is to refresh the trust store on consumers, which is a deployment-time concern outside Terraform.
     refs:
-      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure-cluster/
+      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
         title: Secure a managed database cluster with TLS
 
   # No Terraform variants: connectionSslEnabled reflects the SSL flag on the live
@@ -1729,7 +1729,7 @@ queries:
             Update each application's connection string to require TLS, such as appending `?sslmode=require` for PostgreSQL, then restart the connecting services and confirm sessions negotiate TLS.
         # No Terraform remediation: TLS on managed database connections is enforced by the DigitalOcean platform and is not a declarable argument on digitalocean_database_cluster. Requiring TLS is a client-side connection-string concern that lives outside the cluster's Terraform definition.
     refs:
-      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure-cluster/
+      - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
         title: Secure a managed database cluster with TLS
 
   - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
@@ -2496,7 +2496,7 @@ queries:
               --sso-enabled
             ```
     refs:
-      - url: https://docs.digitalocean.com/products/kubernetes/how-to/manage-cluster-access/
+      - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
         title: Manage DOKS cluster access
 
   # No Terraform variants: SSO configuration was added to the DigitalOcean godo
@@ -2579,7 +2579,7 @@ queries:
               --sso-required
             ```
     refs:
-      - url: https://docs.digitalocean.com/products/kubernetes/how-to/manage-cluster-access/
+      - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
         title: Manage DOKS cluster access
 
   - uid: mondoo-digitalocean-security-doks-in-vpc
@@ -2795,7 +2795,7 @@ queries:
         # surfaced only by the live API; the digitalocean_kubernetes_cluster resource does not
         # express the control-plane firewall, so it cannot be remediated through Terraform.
     refs:
-      - url: https://docs.digitalocean.com/products/kubernetes/how-to/configure-control-plane-firewall/
+      - url: https://docs.digitalocean.com/products/kubernetes/how-to/add-control-plane-firewall/
         title: Configure the DOKS control plane firewall
 
   # No Terraform variants: this check inspects the certificate's notAfter validity
@@ -2892,7 +2892,7 @@ queries:
             After creating the replacement, update any load balancers, CDN endpoints, or App Platform apps to reference the new certificate.
         # No Terraform remediation: expiry is not a configurable field. A digitalocean_certificate resource can provision a replacement, but Terraform cannot express or assert the validity window of an issued certificate.
     refs:
-      - url: https://docs.digitalocean.com/products/networking/certificates/
+      - url: https://docs.digitalocean.com/platform/teams/how-to/manage-certificates/
         title: DigitalOcean TLS certificates
 
   - uid: mondoo-digitalocean-security-cdn-has-certificate
@@ -2992,7 +2992,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.digitalocean.com/products/networking/cdn/how-to/use-custom-subdomain/
+      - url: https://docs.digitalocean.com/products/spaces/how-to/enable-cdn/
         title: CDN custom subdomain and TLS
 
   - uid: mondoo-digitalocean-security-cdn-has-certificate-digitalocean
@@ -4754,7 +4754,7 @@ queries:
         # digitalocean Terraform resource; they are managed only through doctl and
         # the control panel.
     refs:
-      - url: https://docs.digitalocean.com/products/functions/how-to/manage-namespaces/
+      - url: https://docs.digitalocean.com/products/functions/how-to/create-namespaces/
         title: Manage Functions namespaces
 
   # No Terraform variants: image visibility is not an argument on
@@ -4833,7 +4833,7 @@ queries:
         # No Terraform remediation: image visibility is not a digitalocean_custom_image
         # argument; publishing and unpublishing are imperative actions outside Terraform.
     refs:
-      - url: https://docs.digitalocean.com/products/images/custom-images/
+      - url: https://docs.digitalocean.com/products/custom-images/
         title: DigitalOcean custom images
 
   # No Terraform variants: the load balancer firewall is a nested block whose

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-digitalocean-security
     name: Mondoo DigitalOcean Security
-    version: 2.5.3
+    version: 2.5.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -2497,7 +2497,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
-        title: Manage DOKS cluster access
+        title: Connect to a DigitalOcean Kubernetes cluster
 
   # No Terraform variants: SSO configuration was added to the DigitalOcean godo
   # SDK in v1.187.0 and the digitalocean Terraform provider does not yet expose
@@ -2580,7 +2580,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
-        title: Manage DOKS cluster access
+        title: Connect to a DigitalOcean Kubernetes cluster
 
   - uid: mondoo-digitalocean-security-doks-in-vpc
     title: Ensure DOKS clusters are deployed inside a VPC
@@ -2993,7 +2993,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/spaces/how-to/enable-cdn/
-        title: CDN custom subdomain and TLS
+        title: Enable the DigitalOcean Spaces CDN
 
   - uid: mondoo-digitalocean-security-cdn-has-certificate-digitalocean
     filters: asset.platform == "digitalocean"
@@ -4755,7 +4755,7 @@ queries:
         # the control panel.
     refs:
       - url: https://docs.digitalocean.com/products/functions/how-to/create-namespaces/
-        title: Manage Functions namespaces
+        title: Create namespaces to organize DigitalOcean Functions
 
   # No Terraform variants: image visibility is not an argument on
   # digitalocean_custom_image; publishing or unpublishing an image is a separate

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -193,9 +193,8 @@ queries:
         # No Terraform remediation: email verification is an interactive account-level
         # flow with no provider resource — the same limitation as the CLI above.
     refs:
-      - url: https://docs.digitalocean.com/platform/teams/how-to/view-security-history/
-        title: How to View Security History
-
+      - url: https://docs.digitalocean.com/platform/accounts/settings/
+        title: DigitalOcean account settings
   - uid: mondoo-digitalocean-security-droplet-in-vpc
     title: Ensure Droplets are deployed inside a VPC
     impact: 70

--- a/content/mondoo-digitalocean-security.mql.yaml
+++ b/content/mondoo-digitalocean-security.mql.yaml
@@ -194,7 +194,7 @@ queries:
         # flow with no provider resource — the same limitation as the CLI above.
     refs:
       - url: https://docs.digitalocean.com/platform/teams/how-to/view-security-history/
-        title: DigitalOcean account security
+        title: How to View Security History
 
   - uid: mondoo-digitalocean-security-droplet-in-vpc
     title: Ensure Droplets are deployed inside a VPC
@@ -1156,7 +1156,7 @@ queries:
         # No Terraform remediation: the same cross-resource correlation limitation as the variants above. Trusted Sources are a separate digitalocean_database_firewall resource referencing cluster_id, so an HCL snippet cannot assert coverage of an arbitrary cluster.
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
-        title: Secure a managed database cluster
+        title: How to Secure PostgreSQL Managed Database Clusters
 
   - uid: mondoo-digitalocean-security-db-in-private-network
     title: Ensure managed databases are attached to a private network
@@ -1375,7 +1375,7 @@ queries:
         # and db-firewall-configured Terraform remediations instead.
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
-        title: Secure a managed database cluster
+        title: How to Secure PostgreSQL Managed Database Clusters
 
   - uid: mondoo-digitalocean-security-db-engine-supported-version
     title: Ensure managed database engines are not running an EOL version
@@ -1516,7 +1516,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/upgrade-version/
-        title: Upgrade a managed database major version
+        title: How to Upgrade PostgreSQL to a New Version
 
   - uid: mondoo-digitalocean-security-db-engine-supported-version-digitalocean
     filters: asset.platform == "digitalocean-database"
@@ -1648,7 +1648,7 @@ queries:
         # No Terraform remediation: the CA certificate is provisioned and rotated by DigitalOcean, not declared in digitalocean_database_cluster HCL. Terraform-managed clusters still pull the active CA via the runtime API; remediation is to refresh the trust store on consumers, which is a deployment-time concern outside Terraform.
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
-        title: Secure a managed database cluster with TLS
+        title: How to Secure PostgreSQL Managed Database Clusters
 
   # No Terraform variants: connectionSslEnabled reflects the SSL flag on the live
   # connection object returned by the DigitalOcean API, which the platform sets on
@@ -1730,7 +1730,7 @@ queries:
         # No Terraform remediation: TLS on managed database connections is enforced by the DigitalOcean platform and is not a declarable argument on digitalocean_database_cluster. Requiring TLS is a client-side connection-string concern that lives outside the cluster's Terraform definition.
     refs:
       - url: https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/
-        title: Secure a managed database cluster with TLS
+        title: How to Secure PostgreSQL Managed Database Clusters
 
   - uid: mondoo-digitalocean-security-lb-http-redirected-to-https
     title: Ensure load balancers redirect HTTP traffic to HTTPS
@@ -2497,7 +2497,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
-        title: Connect to a DigitalOcean Kubernetes cluster
+        title: How to Connect to a DigitalOcean Kubernetes Cluster
 
   # No Terraform variants: SSO configuration was added to the DigitalOcean godo
   # SDK in v1.187.0 and the digitalocean Terraform provider does not yet expose
@@ -2580,7 +2580,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/
-        title: Connect to a DigitalOcean Kubernetes cluster
+        title: How to Connect to a DigitalOcean Kubernetes Cluster
 
   - uid: mondoo-digitalocean-security-doks-in-vpc
     title: Ensure DOKS clusters are deployed inside a VPC
@@ -2796,7 +2796,7 @@ queries:
         # express the control-plane firewall, so it cannot be remediated through Terraform.
     refs:
       - url: https://docs.digitalocean.com/products/kubernetes/how-to/add-control-plane-firewall/
-        title: Configure the DOKS control plane firewall
+        title: How to Add a Control Plane Firewall
 
   # No Terraform variants: this check inspects the certificate's notAfter validity
   # window — runtime telemetry set at issuance, not a configuration field. The
@@ -2893,7 +2893,7 @@ queries:
         # No Terraform remediation: expiry is not a configurable field. A digitalocean_certificate resource can provision a replacement, but Terraform cannot express or assert the validity window of an issued certificate.
     refs:
       - url: https://docs.digitalocean.com/platform/teams/how-to/manage-certificates/
-        title: DigitalOcean TLS certificates
+        title: How to Manage SSL Certificates on DigitalOcean Teams
 
   - uid: mondoo-digitalocean-security-cdn-has-certificate
     title: Ensure CDN endpoints with a custom domain have a TLS certificate attached
@@ -2993,7 +2993,7 @@ queries:
             ```
     refs:
       - url: https://docs.digitalocean.com/products/spaces/how-to/enable-cdn/
-        title: Enable the DigitalOcean Spaces CDN
+        title: How to Enable the DigitalOcean Spaces CDN
 
   - uid: mondoo-digitalocean-security-cdn-has-certificate-digitalocean
     filters: asset.platform == "digitalocean"
@@ -4343,7 +4343,7 @@ queries:
         # No Terraform remediation: GradientAI agents have no digitalocean Terraform resource.
     refs:
       - url: https://docs.digitalocean.com/products/inference/
-        title: DigitalOcean GradientAI platform
+        title: Inference
   # No Terraform variants: GradientAI agents are managed through the GradientAI API and control
   # panel; the digitalocean Terraform provider has no resource representing an agent or its
   # attached guardrails, so there is nothing to assert in HCL, plan, or state.
@@ -4418,7 +4418,7 @@ queries:
         # guardrail attachment cannot be expressed in Terraform.
     refs:
       - url: https://docs.digitalocean.com/products/inference/
-        title: DigitalOcean GradientAI platform
+        title: Inference
 
   # No Terraform variants: GradientAI knowledge bases are managed through the GradientAI
   # API and control panel; the digitalocean Terraform provider has no resource representing
@@ -4492,7 +4492,7 @@ queries:
         # No Terraform remediation: GradientAI knowledge bases have no digitalocean Terraform resource.
     refs:
       - url: https://docs.digitalocean.com/products/inference/
-        title: DigitalOcean GradientAI platform
+        title: Inference
 
   # No Terraform variants: DigitalOcean Functions are deployed imperatively via
   # `doctl serverless deploy` and a project.yml manifest; there is no digitalocean
@@ -4755,7 +4755,7 @@ queries:
         # the control panel.
     refs:
       - url: https://docs.digitalocean.com/products/functions/how-to/create-namespaces/
-        title: Create namespaces to organize DigitalOcean Functions
+        title: How to Create Namespaces to Organize DigitalOcean Functions
 
   # No Terraform variants: image visibility is not an argument on
   # digitalocean_custom_image; publishing or unpublishing an image is a separate

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -435,7 +435,7 @@ queries:
             }
             ```
     refs:
-      - url: https://support.google.com/a/answer/140034?hl=en
+      - url: https://knowledge.workspace.google.com/admin/domains/set-up-mx-records-for-google-workspace?hl=en
         title: Set up MX records for Google Workspace email
   - uid: mondoo-dns-security-dnssec-enabled
     title: Ensure DNSSEC is enabled

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-dns-security
     name: Mondoo DNS Security
-    version: 1.6.1
+    version: 1.6.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -167,7 +167,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.cisa.gov/dns-security
+      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
         title: CISA DNS Security
   - uid: mondoo-dns-security-no-ip-for-ns-mx-records
     title: Ensure NS and MX records are not pointing to IP addresses
@@ -262,7 +262,7 @@ queries:
 
             Route 53 creates the apex `NS` record as soon as the hosted zone exists, so a plain `aws_route53_record` of type `NS` at the apex fails to apply with a "but it already exists" error. `allow_overwrite = true` lets the same run manage the record. Reading the values from `name_servers` also keeps them the hostnames Route 53 assigned, which is what this check requires. Where you run your own nameservers, list their hostnames instead and publish an `A` or `AAAA` record for each.
     refs:
-      - url: https://www.cisa.gov/dns-security
+      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
         title: CISA DNS Security
   - uid: mondoo-dns-security-no-legacy-ms-365-mx-records
     title: Ensure legacy MX records are not used with Microsoft 365
@@ -535,7 +535,7 @@ queries:
 
             Terraform can sign the zone, but publishing the DS record at the registrar is a registrar operation. Where the registrar is not the DNS host, complete that step in the registrar's control panel or API.
     refs:
-      - url: https://www.icann.org/resources/pages/dnssec-what-is-it-why-is-it-important-2019-03-05-en
+      - url: https://www.icann.org/resources/pages/dnssec-what-is-it-why-important-2019-03-05-en
         title: ICANN DNSSEC Overview
   - uid: mondoo-dns-security-no-wildcard
     title: Ensure no wildcard DNS records are configured
@@ -646,7 +646,7 @@ queries:
 
             Remove any `name = "*.example.com"` resource once the explicit records are in place.
     refs:
-      - url: https://www.cisa.gov/dns-security
+      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
         title: CISA DNS Security
   - uid: mondoo-dns-security-ns-redundancy
     title: Ensure at least two NS records exist
@@ -831,5 +831,5 @@ queries:
 
             Where a short TTL is needed for a planned cutover, change `ttl` in a dedicated commit and revert it once the migration completes, so the low value does not silently become permanent.
     refs:
-      - url: https://www.cisa.gov/dns-security
+      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
         title: CISA DNS Security

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -168,7 +168,7 @@ queries:
             ```
     refs:
       - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: CISA DNS Security
+        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-no-ip-for-ns-mx-records
     title: Ensure NS and MX records are not pointing to IP addresses
     impact: 75
@@ -263,7 +263,7 @@ queries:
             Route 53 creates the apex `NS` record as soon as the hosted zone exists, so a plain `aws_route53_record` of type `NS` at the apex fails to apply with a "but it already exists" error. `allow_overwrite = true` lets the same run manage the record. Reading the values from `name_servers` also keeps them the hostnames Route 53 assigned, which is what this check requires. Where you run your own nameservers, list their hostnames instead and publish an `A` or `AAAA` record for each.
     refs:
       - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: CISA DNS Security
+        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-no-legacy-ms-365-mx-records
     title: Ensure legacy MX records are not used with Microsoft 365
     impact: 80
@@ -436,7 +436,7 @@ queries:
             ```
     refs:
       - url: https://knowledge.workspace.google.com/admin/domains/set-up-mx-records-for-google-workspace?hl=en
-        title: Set up MX records for Google Workspace email
+        title: Set up MX records for Google Workspace
   - uid: mondoo-dns-security-dnssec-enabled
     title: Ensure DNSSEC is enabled
     impact: 75
@@ -536,7 +536,7 @@ queries:
             Terraform can sign the zone, but publishing the DS record at the registrar is a registrar operation. Where the registrar is not the DNS host, complete that step in the registrar's control panel or API.
     refs:
       - url: https://www.icann.org/resources/pages/dnssec-what-is-it-why-important-2019-03-05-en
-        title: ICANN DNSSEC Overview
+        title: DNSSEC – What Is It and Why Is It Important?
   - uid: mondoo-dns-security-no-wildcard
     title: Ensure no wildcard DNS records are configured
     impact: 85
@@ -647,7 +647,7 @@ queries:
             Remove any `name = "*.example.com"` resource once the explicit records are in place.
     refs:
       - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: CISA DNS Security
+        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-ns-redundancy
     title: Ensure at least two NS records exist
     impact: 60
@@ -832,4 +832,4 @@ queries:
             Where a short TTL is needed for a planned cutover, change `ttl` in a dedicated commit and revert it once the migration completes, so the low value does not silently become permanent.
     refs:
       - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: CISA DNS Security
+        title: Protective Domain Name System (DNS) Resolver

--- a/content/mondoo-dns-security.mql.yaml
+++ b/content/mondoo-dns-security.mql.yaml
@@ -166,9 +166,6 @@ queries:
               ttl     = 1
             }
             ```
-    refs:
-      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-no-ip-for-ns-mx-records
     title: Ensure NS and MX records are not pointing to IP addresses
     impact: 75
@@ -261,9 +258,6 @@ queries:
             ```
 
             Route 53 creates the apex `NS` record as soon as the hosted zone exists, so a plain `aws_route53_record` of type `NS` at the apex fails to apply with a "but it already exists" error. `allow_overwrite = true` lets the same run manage the record. Reading the values from `name_servers` also keeps them the hostnames Route 53 assigned, which is what this check requires. Where you run your own nameservers, list their hostnames instead and publish an `A` or `AAAA` record for each.
-    refs:
-      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-no-legacy-ms-365-mx-records
     title: Ensure legacy MX records are not used with Microsoft 365
     impact: 80
@@ -645,9 +639,6 @@ queries:
             ```
 
             Remove any `name = "*.example.com"` resource once the explicit records are in place.
-    refs:
-      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: Protective Domain Name System (DNS) Resolver
   - uid: mondoo-dns-security-ns-redundancy
     title: Ensure at least two NS records exist
     impact: 60
@@ -830,6 +821,3 @@ queries:
             ```
 
             Where a short TTL is needed for a planned cutover, change `ttl` in a dedicated commit and revert it once the migration completes, so the low value does not silently become permanent.
-    refs:
-      - url: https://www.cisa.gov/resources-tools/services/protective-domain-name-system-dns-resolver
-        title: Protective Domain Name System (DNS) Resolver

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -171,8 +171,8 @@ queries:
             sudo systemctl is-active falcon-sensor
             ```
     refs:
-      - url: https://www.nist.gov/publications/guide-endpoint-detection-and-response
-        title: NIST Guide to EDR
+      - url: https://csrc.nist.gov/pubs/sp/800/83/r1/final
+        title: 'NIST SP 800-83 Rev. 1: Guide to Malware Incident Prevention and Handling'
   - uid: mondoo-edr-policy-ensure-edr-agent-is-installed-macos
     filters: asset.platform == 'macos'
     mql: |
@@ -380,8 +380,8 @@ queries:
             sudo systemctl is-active falcon-sensor
             ```
     refs:
-      - url: https://www.nist.gov/publications/guide-endpoint-detection-and-response
-        title: NIST Guide to EDR
+      - url: https://csrc.nist.gov/pubs/sp/800/83/r1/final
+        title: 'NIST SP 800-83 Rev. 1: Guide to Malware Incident Prevention and Handling'
   - uid: mondoo-edr-policy-ensure-crowdstrike-agent-is-running-macos
     filters: |
       asset.platform == 'macos' &&

--- a/content/mondoo-edr-policy.mql.yaml
+++ b/content/mondoo-edr-policy.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-edr-policy
     name: Mondoo Endpoint Detection and Response (EDR)
-    version: 1.6.3
+    version: 1.6.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-elasticsearch-security.mql.yaml
+++ b/content/mondoo-elasticsearch-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-elasticsearch-security
     name: Mondoo Elasticsearch Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-elasticsearch-security.mql.yaml
+++ b/content/mondoo-elasticsearch-security.mql.yaml
@@ -116,7 +116,7 @@ queries:
                bin/elasticsearch-reset-password -u elastic
                ```
     refs:
-      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
+      - url: https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings
         title: Elasticsearch security settings
   - uid: mondoo-elasticsearch-security-anonymous-access-disabled
     filters: asset.platform == "elasticsearch"
@@ -182,7 +182,7 @@ queries:
                ```
             2. Restart Elasticsearch on each node so the change takes effect.
     refs:
-      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/anonymous-access.html
+      - url: https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
         title: Enabling anonymous access
   - uid: mondoo-elasticsearch-security-tls-enabled
     filters: asset.platform == "elasticsearch"
@@ -261,7 +261,7 @@ queries:
                ```
             3. Restart Elasticsearch on each node so the change takes effect.
     refs:
-      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-tls.html
+      - url: https://www.elastic.co/docs/deploy-manage/security/set-up-basic-security-plus-https
         title: Set up basic security plus HTTPS
   - uid: mondoo-elasticsearch-security-audit-logging-enabled
     filters: asset.platform == "elasticsearch"
@@ -332,5 +332,5 @@ queries:
                ```
             3. Restart Elasticsearch on each node so the change takes effect.
     refs:
-      - url: https://www.elastic.co/guide/en/elasticsearch/reference/current/auditing-settings.html
+      - url: https://www.elastic.co/docs/deploy-manage/security/logging-configuration/enabling-audit-logs
         title: Auditing security settings

--- a/content/mondoo-elasticsearch-security.mql.yaml
+++ b/content/mondoo-elasticsearch-security.mql.yaml
@@ -262,7 +262,7 @@ queries:
             3. Restart Elasticsearch on each node so the change takes effect.
     refs:
       - url: https://www.elastic.co/docs/deploy-manage/security/set-up-basic-security-plus-https
-        title: Set up basic security plus HTTPS
+        title: Set up HTTPS
   - uid: mondoo-elasticsearch-security-audit-logging-enabled
     filters: asset.platform == "elasticsearch"
     title: Ensure Elasticsearch enables audit logging
@@ -333,4 +333,4 @@ queries:
             3. Restart Elasticsearch on each node so the change takes effect.
     refs:
       - url: https://www.elastic.co/docs/deploy-manage/security/logging-configuration/enabling-audit-logs
-        title: Auditing security settings
+        title: Enable audit logging

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-email-security
     name: Mondoo Email Security
-    version: 1.4.1
+    version: 1.4.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-email-security.mql.yaml
+++ b/content/mondoo-email-security.mql.yaml
@@ -193,7 +193,7 @@ queries:
         title: Reverse DNS Lookup
       - url: https://en.wikipedia.org/wiki/Forward-confirmed_reverse_DNS
         title: Forward-confirmed reverse DNS
-      - url: https://support.google.com/a/answer/81126?hl=en#ip
+      - url: https://support.google.com/mail/answer/81126?hl=en#ip
         title: Google Email sender guidelines - IP Addresses
   - uid: mondoo-email-security-txt-record
     title: Domain Apex should have a TXT record
@@ -350,7 +350,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.easyredir.com/blog/what-is-an-apex-domain/
+      - url: https://www.urllo.com/resources/learn/what-is-an-apex-domain
         title: A Record
   - uid: mondoo-email-security-spf
     title: Ensure SPF record is set
@@ -719,7 +719,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
   - uid: mondoo-email-security-spf-no-permit-all
     title: Ensure SPF does not use permissive +all
@@ -806,7 +806,7 @@ queries:
     refs:
       - url: https://datatracker.ietf.org/doc/html/rfc7208#section-5.1
         title: 'RFC 7208: Sender Policy Framework - "all" Mechanism'
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
   - uid: mondoo-email-security-spf-dns-record
     title: Do not use deprecated SPF DNS Record Type
@@ -959,7 +959,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
       - url: https://en.wikipedia.org/wiki/DMARC
         title: DMARC
@@ -1038,7 +1038,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
       - url: https://en.wikipedia.org/wiki/DMARC
         title: DMARC
@@ -1114,7 +1114,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
       - url: https://en.wikipedia.org/wiki/DMARC
         title: DMARC
@@ -1188,7 +1188,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
       - url: https://en.wikipedia.org/wiki/DMARC
         title: DMARC
@@ -1262,7 +1262,7 @@ queries:
             }
             ```
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
   - uid: mondoo-email-security-dkim
     title: Ensure DKIM is configured
@@ -1353,7 +1353,7 @@ queries:
 
             The `p=` value comes from the mail provider and is a long base64 string, truncated here. Terraform publishes the public half only; enabling signing remains a console or API action against the mail provider.
     refs:
-      - url: https://www.m3aawg.org/sites/default/files/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
+      - url: https://www.m3aawg.org/sites/default/files/legacy/m3aawg-email-authentication-recommended-best-practices-09-2020.pdf
         title: M3AAWG Email Authentication Recommended Best Practices (2020)
       - url: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
         title: DomainKeys Identified Mail

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -176,7 +176,7 @@ queries:
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If your current version is several releases behind the GA target, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time rather than jumping directly. Back up the configuration and verify the device is healthy after each hop before starting the next one:
+            Download a GA firmware image from [Fortinet Support](https://support.fortinet.com), stage it on a TFTP server, and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If your current version is several releases behind the GA target, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool/fortigate) and upgrade one hop at a time rather than jumping directly. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```text
             execute restore image tftp <filename> <tftp_server_ip>
@@ -184,7 +184,7 @@ queries:
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware
         title: FortiOS firmware management
-      - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/
+      - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
 
   - uid: mondoo-fortios-security-firmware-mature-release
@@ -270,7 +270,7 @@ queries:
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If the target Mature release is several versions ahead, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade one hop at a time. Back up the configuration and verify the device is healthy after each hop before starting the next one:
+            Download a Mature release from [Fortinet Support](https://support.fortinet.com) and install it. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** If the target Mature release is several versions ahead, follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool/fortigate) and upgrade one hop at a time. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```text
             execute restore image tftp <filename> <tftp_server_ip>
@@ -278,7 +278,7 @@ queries:
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware
         title: FortiOS firmware management
-      - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/
+      - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
 
   - uid: mondoo-fortios-security-firmware-supported-major-version
@@ -345,7 +345,7 @@ queries:
             1. Navigate to **System > Firmware & Registration**
             2. Review the available firmware versions for a supported major version (7.x or later)
             3. Plan the upgrade path carefully — Fortinet recommends upgrading through intermediate versions rather than skipping major releases
-            4. Consult the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) to determine the recommended upgrade sequence
+            4. Consult the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool/fortigate) to determine the recommended upgrade sequence
             5. Back up the configuration before each upgrade step
             6. Perform the upgrade during a maintenance window
 
@@ -366,7 +366,7 @@ queries:
             execute backup full-config tftp <filename> <tftp_server_ip>
             ```
 
-            Follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool) and upgrade through each required intermediate version. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** Run the command once per hop in the supported sequence rather than jumping straight to the target version, because skipping intermediate releases can corrupt the configuration migration. Back up the configuration and verify the device is healthy after each hop before starting the next one:
+            Follow the [FortiOS upgrade path tool](https://docs.fortinet.com/upgrade-tool/fortigate) and upgrade through each required intermediate version. **`execute restore image` reboots the device immediately with no confirmation prompt and interrupts all traffic until FortiOS comes back up, so run it only during a maintenance window.** Run the command once per hop in the supported sequence rather than jumping straight to the target version, because skipping intermediate releases can corrupt the configuration migration. Back up the configuration and verify the device is healthy after each hop before starting the next one:
 
             ```text
             execute restore image tftp <filename> <tftp_server_ip>
@@ -376,7 +376,7 @@ queries:
         title: FortiOS firmware management
       - url: https://support.fortinet.com/Information/ProductLifeCycle.aspx
         title: Fortinet product life cycle
-      - url: https://docs.fortinet.com/upgrade-tool
+      - url: https://docs.fortinet.com/upgrade-tool/fortigate
         title: FortiOS upgrade path tool
 
   - uid: mondoo-fortios-security-admin-timeout

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-fortios-security
     name: Mondoo Fortinet FortiOS Security
-    version: 1.0.4
+    version: 1.0.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -182,8 +182,8 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
-        title: FortiOS firmware management
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
+        title: FortiOS firmware upgrades
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
 
@@ -276,8 +276,8 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
-        title: FortiOS firmware management
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
+        title: FortiOS firmware upgrades
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
 
@@ -372,8 +372,8 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
-        title: FortiOS firmware management
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
+        title: FortiOS firmware upgrades
       - url: https://support.fortinet.com/support/#/lifecycle
         title: Fortinet product life cycle
       - url: https://docs.fortinet.com/upgrade-tool/fortigate
@@ -530,7 +530,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/153747/administrative-access-using-certificates
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/616955/configuring-ports
         title: Changing the FortiOS admin ports
 
   - uid: mondoo-fortios-security-admin-ssh-non-default-port
@@ -604,7 +604,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/153747/administrative-access-using-certificates
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/616955/configuring-ports
         title: Changing the FortiOS admin ports
 
   - uid: mondoo-fortios-security-admin-scp-disabled
@@ -1008,7 +1008,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
-        title: FortiOS NTP configuration
+        title: FortiOS system time and NTP
 
   - uid: mondoo-fortios-security-ntp-servers-configured
     title: Ensure NTP servers are configured
@@ -1094,7 +1094,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
-        title: FortiOS NTP configuration
+        title: FortiOS system time and NTP
 
   - uid: mondoo-fortios-security-log-implicit-deny
     title: Ensure implicit deny traffic is logged

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -182,7 +182,7 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
         title: FortiOS firmware management
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
@@ -253,7 +253,7 @@ queries:
             4. Select a firmware version with "Mature" maturity status
             5. Click **Upgrade** and follow the prompts; the device reboots to complete the upgrade
 
-            Consult the [Fortinet firmware maturity documentation](https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware) to identify which releases have reached Mature status for your platform.
+            Consult the [Fortinet firmware maturity documentation](https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels) to identify which releases have reached Mature status for your platform.
         - id: cli
           desc: |
             **Using the CLI**
@@ -276,7 +276,7 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
         title: FortiOS firmware management
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
         title: FortiOS release notes
@@ -321,7 +321,7 @@ queries:
 
         1. Log in to the FortiGate web interface.
         2. Navigate to **System > Firmware & Registration**.
-        3. Note the major version of the current firmware and check it against the [Fortinet product life cycle](https://support.fortinet.com/Information/ProductLifeCycle.aspx).
+        3. Note the major version of the current firmware and check it against the [Fortinet product life cycle](https://support.fortinet.com/support/#/lifecycle).
 
         A passing result shows a supported major version (7.x or later). A failing result shows a version that has reached end of engineering support or end of life.
 
@@ -372,9 +372,9 @@ queries:
             execute restore image tftp <filename> <tftp_server_ip>
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/738610/firmware
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/173707/firmware-maturity-levels
         title: FortiOS firmware management
-      - url: https://support.fortinet.com/Information/ProductLifeCycle.aspx
+      - url: https://support.fortinet.com/support/#/lifecycle
         title: Fortinet product life cycle
       - url: https://docs.fortinet.com/upgrade-tool/fortigate
         title: FortiOS upgrade path tool
@@ -452,7 +452,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/995498/gui-idle-timeout
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/215451/setting-the-idle-timeout-time
         title: FortiOS admin session timeout
 
   - uid: mondoo-fortios-security-admin-https-non-default-port
@@ -530,7 +530,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/262062/changing-the-admin-ports
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/153747/administrative-access-using-certificates
         title: Changing the FortiOS admin ports
 
   - uid: mondoo-fortios-security-admin-ssh-non-default-port
@@ -604,7 +604,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/262062/changing-the-admin-ports
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/153747/administrative-access-using-certificates
         title: Changing the FortiOS admin ports
 
   - uid: mondoo-fortios-security-admin-scp-disabled
@@ -763,7 +763,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/940498/ha
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/587596/ha
         title: FortiOS high availability
 
   - uid: mondoo-fortios-security-ha-session-pickup
@@ -835,7 +835,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/940498/ha
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/587596/ha
         title: FortiOS high availability
 
   - uid: mondoo-fortios-security-dns-over-tls
@@ -924,7 +924,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/391295/dns
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/780581/dns
         title: FortiOS DNS configuration
 
   - uid: mondoo-fortios-security-ntp-sync-enabled
@@ -1007,7 +1007,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/867830/ntp
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
         title: FortiOS NTP configuration
 
   - uid: mondoo-fortios-security-ntp-servers-configured
@@ -1093,7 +1093,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/867830/ntp
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
         title: FortiOS NTP configuration
 
   - uid: mondoo-fortios-security-log-implicit-deny
@@ -1159,7 +1159,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-local-in-denied-unicast
@@ -1236,7 +1236,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-extended-format
@@ -1302,7 +1302,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-no-user-anonymization
@@ -1368,7 +1368,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-syslog-enabled
@@ -1449,7 +1449,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-external-destination
@@ -1545,7 +1545,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-fortianalyzer-encryption
@@ -1622,7 +1622,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-log-fortianalyzer-reliable
@@ -1699,7 +1699,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/239623/logging
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
         title: FortiOS logging configuration
 
   - uid: mondoo-fortios-security-no-disabled-policies
@@ -1796,7 +1796,7 @@ queries:
 
             Re-enabling a policy puts it back into the match order at its existing sequence number, so confirm the traffic it permits is still intended before running this.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/954936/firewall-policies
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/656084/firewall-policy
         title: FortiOS firewall policies
 
   - uid: mondoo-fortios-security-no-allow-all-rule
@@ -1968,7 +1968,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/954936/firewall-policies
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/656084/firewall-policy
         title: FortiOS firewall policies
 
   - uid: mondoo-fortios-security-policy-utm-enabled
@@ -2059,7 +2059,7 @@ queries:
 
             The `certificate-inspection` profile reads only the certificate metadata and works without further setup. The `deep-inspection` profile decrypts and re-encrypts TLS sessions and catches threats hidden inside encrypted payloads, but it requires deploying the FortiGate CA certificate to every client's trust store first, otherwise users get certificate warnings.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/178074/security-profiles
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/680955/security-profiles
         title: FortiOS security profiles
 
   - uid: mondoo-fortios-security-policy-ssl-inspection
@@ -2139,7 +2139,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/88976/ssl-ssh-inspection
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/929997/ssl-ssh-inspection
         title: FortiOS SSL/SSH inspection
 
   - uid: mondoo-fortios-security-wan-no-management-access
@@ -2228,7 +2228,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/552515/interfaces
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/154471/interfaces
         title: FortiOS interface configuration
       - url: https://www.fortiguard.com/psirt
         title: FortiGuard PSIRT advisories
@@ -2328,7 +2328,7 @@ queries:
 
             Do not use `unset` to remove telnet. The `unset` keyword takes no protocol argument: `unset allowaccess` resets the whole field, removing every management protocol from the interface, including the session you may be using to administer the device.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/552515/interfaces
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/154471/interfaces
         title: FortiOS interface configuration
 
   - uid: mondoo-fortios-security-bgp-log-neighbor-changes
@@ -2402,7 +2402,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/247086/bgp
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/750736/bgp
         title: FortiOS BGP configuration
 
   - uid: mondoo-fortios-security-bgp-graceful-restart
@@ -2483,7 +2483,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/247086/bgp
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/750736/bgp
         title: FortiOS BGP configuration
 
   - uid: mondoo-fortios-security-ospf-log-neighbor-changes
@@ -2557,7 +2557,7 @@ queries:
             end
             ```
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/933988/ospf
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/561713/ospf
         title: FortiOS OSPF configuration
 
   - uid: mondoo-fortios-security-fortiguard-antispam-active
@@ -2641,7 +2641,7 @@ queries:
 
             `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/42459/fortiguard
         title: FortiOS FortiGuard configuration
       - url: https://support.fortinet.com
         title: Fortinet support portal
@@ -2727,7 +2727,7 @@ queries:
 
             `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/42459/fortiguard
         title: FortiOS FortiGuard configuration
       - url: https://support.fortinet.com
         title: Fortinet support portal
@@ -2813,7 +2813,7 @@ queries:
 
             `execute update-now` only pulls fresh packages when the device already has a registered, unexpired contract. It does not renew or register a license, so an expired subscription must be renewed and re-registered with Fortinet first, after which the device picks up the new entitlement and the updates succeed.
     refs:
-      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/584498/fortiguard
+      - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/42459/fortiguard
         title: FortiOS FortiGuard configuration
       - url: https://support.fortinet.com
         title: Fortinet support portal

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -375,10 +375,9 @@ queries:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
         title: FortiOS firmware upgrades
       - url: https://support.fortinet.com/support/#/lifecycle
-        title: Ticketing
+        title: Fortinet product life cycle
       - url: https://docs.fortinet.com/upgrade-tool/fortigate
-        title: Fortinet Document Library
-
+        title: FortiGate firmware upgrade path tool
   - uid: mondoo-fortios-security-admin-timeout
     title: Ensure admin session timeout is 5 minutes or less
     impact: 70

--- a/content/mondoo-fortios-security.mql.yaml
+++ b/content/mondoo-fortios-security.mql.yaml
@@ -185,7 +185,7 @@ queries:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
         title: FortiOS firmware upgrades
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
-        title: FortiOS release notes
+        title: Introduction and supported models
 
   - uid: mondoo-fortios-security-firmware-mature-release
     title: Ensure firmware has reached mature release status
@@ -279,7 +279,7 @@ queries:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
         title: FortiOS firmware upgrades
       - url: https://docs.fortinet.com/document/fortigate/latest/fortios-release-notes/760203/introduction-and-supported-models
-        title: FortiOS release notes
+        title: Introduction and supported models
 
   - uid: mondoo-fortios-security-firmware-supported-major-version
     title: Ensure firmware is a supported major version
@@ -375,9 +375,9 @@ queries:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/596131/upgrading-individual-devices
         title: FortiOS firmware upgrades
       - url: https://support.fortinet.com/support/#/lifecycle
-        title: Fortinet product life cycle
+        title: Ticketing
       - url: https://docs.fortinet.com/upgrade-tool/fortigate
-        title: FortiOS upgrade path tool
+        title: Fortinet Document Library
 
   - uid: mondoo-fortios-security-admin-timeout
     title: Ensure admin session timeout is 5 minutes or less
@@ -453,7 +453,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/215451/setting-the-idle-timeout-time
-        title: FortiOS admin session timeout
+        title: Setting the idle timeout time
 
   - uid: mondoo-fortios-security-admin-https-non-default-port
     title: Ensure HTTPS admin port is non-default
@@ -1008,7 +1008,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
-        title: FortiOS system time and NTP
+        title: Setting the system time
 
   - uid: mondoo-fortios-security-ntp-servers-configured
     title: Ensure NTP servers are configured
@@ -1094,7 +1094,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/512210/setting-the-system-time
-        title: FortiOS system time and NTP
+        title: Setting the system time
 
   - uid: mondoo-fortios-security-log-implicit-deny
     title: Ensure implicit deny traffic is logged
@@ -1160,7 +1160,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-local-in-denied-unicast
     title: Ensure denied local-in unicast traffic is logged
@@ -1237,7 +1237,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-extended-format
     title: Ensure extended log format is enabled
@@ -1303,7 +1303,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-no-user-anonymization
     title: Ensure user anonymization is disabled in logs
@@ -1369,7 +1369,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-syslog-enabled
     title: Ensure syslog forwarding is enabled
@@ -1450,7 +1450,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-external-destination
     title: Ensure an external log destination is configured
@@ -1546,7 +1546,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-fortianalyzer-encryption
     title: Ensure FortiAnalyzer uses strong encryption
@@ -1623,7 +1623,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-log-fortianalyzer-reliable
     title: Ensure FortiAnalyzer reliable logging is enabled
@@ -1700,7 +1700,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/202167/logging-and-reporting-concepts
-        title: FortiOS logging configuration
+        title: Logging and reporting concepts
 
   - uid: mondoo-fortios-security-no-disabled-policies
     title: Ensure no firewall policies are disabled
@@ -1797,7 +1797,7 @@ queries:
             Re-enabling a policy puts it back into the match order at its existing sequence number, so confirm the traffic it permits is still intended before running this.
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/656084/firewall-policy
-        title: FortiOS firewall policies
+        title: Firewall policy
 
   - uid: mondoo-fortios-security-no-allow-all-rule
     title: Ensure no allow-all firewall rules exist
@@ -1969,7 +1969,7 @@ queries:
             ```
     refs:
       - url: https://docs.fortinet.com/document/fortigate/latest/administration-guide/656084/firewall-policy
-        title: FortiOS firewall policies
+        title: Firewall policy
 
   - uid: mondoo-fortios-security-policy-utm-enabled
     title: Ensure UTM profiles are enabled on accept rules

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -2654,7 +2654,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that `/etc/ssh/sshd_config` is owned by `root:wheel` and is not readable by group or other users.
 
@@ -2761,7 +2761,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH private host key files under `/etc/ssh/` are owned by root with mode 0600 or more restrictive.
 
@@ -2875,7 +2875,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH public host key files have no write or execute permissions for group or other.
 
@@ -2982,7 +2982,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server is configured to use only strong, modern ciphers and that no weak ciphers such as 3DES, Blowfish, CAST128, or CBC-mode AES are permitted.
 
@@ -3120,7 +3120,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong Message Authentication Code (MAC) algorithms and that weak algorithms such as MD5, SHA1-96, RIPEMD160, and UMAC-64 variants are not permitted.
 
@@ -3258,7 +3258,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong key exchange algorithms and that weak algorithms such as diffie-hellman-group1-sha1 and diffie-hellman-group14-sha1 are not permitted.
 
@@ -3403,7 +3403,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server does not allow the root account to log in with a password.
 
@@ -3549,7 +3549,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH does not allow authentication with empty passwords.
 
@@ -3687,7 +3687,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that host-based authentication is disabled in SSH.
 
@@ -3825,7 +3825,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that users cannot set environment variables through SSH.
 
@@ -3963,7 +3963,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH ignores `.rhosts` and `.shosts` files for authentication.
 
@@ -4101,7 +4101,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH `MaxAuthTries` is set to 4 or less to limit the number of authentication attempts per connection.
 
@@ -4240,7 +4240,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server closes connections that have not authenticated within one minute.
 
@@ -4386,7 +4386,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH `LogLevel` is set to `INFO` or `VERBOSE`, providing an adequate audit trail.
 
@@ -4527,7 +4527,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that the SSH server terminates sessions whose client has stopped responding.
 
@@ -4690,7 +4690,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH forwarding (X11, TCP, agent, and StreamLocal) is disabled.
 
@@ -4828,7 +4828,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: OpenSSH sshd_config(5)
+          title: sshd_config(5)
       desc: |
         This check verifies that SSH is configured to use PAM (Pluggable Authentication Modules).
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -2654,7 +2654,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that `/etc/ssh/sshd_config` is owned by `root:wheel` and is not readable by group or other users.
 
@@ -2761,7 +2761,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH private host key files under `/etc/ssh/` are owned by root with mode 0600 or more restrictive.
 
@@ -2875,7 +2875,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH public host key files have no write or execute permissions for group or other.
 
@@ -2982,7 +2982,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server is configured to use only strong, modern ciphers and that no weak ciphers such as 3DES, Blowfish, CAST128, or CBC-mode AES are permitted.
 
@@ -3120,7 +3120,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong Message Authentication Code (MAC) algorithms and that weak algorithms such as MD5, SHA1-96, RIPEMD160, and UMAC-64 variants are not permitted.
 
@@ -3258,7 +3258,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong key exchange algorithms and that weak algorithms such as diffie-hellman-group1-sha1 and diffie-hellman-group14-sha1 are not permitted.
 
@@ -3403,7 +3403,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server does not allow the root account to log in with a password.
 
@@ -3549,7 +3549,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH does not allow authentication with empty passwords.
 
@@ -3687,7 +3687,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that host-based authentication is disabled in SSH.
 
@@ -3825,7 +3825,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that users cannot set environment variables through SSH.
 
@@ -3963,7 +3963,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH ignores `.rhosts` and `.shosts` files for authentication.
 
@@ -4101,7 +4101,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH `MaxAuthTries` is set to 4 or less to limit the number of authentication attempts per connection.
 
@@ -4240,7 +4240,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server closes connections that have not authenticated within one minute.
 
@@ -4386,7 +4386,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH `LogLevel` is set to `INFO` or `VERBOSE`, providing an adequate audit trail.
 
@@ -4527,7 +4527,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server terminates sessions whose client has stopped responding.
 
@@ -4690,7 +4690,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH forwarding (X11, TCP, agent, and StreamLocal) is disabled.
 
@@ -4828,7 +4828,7 @@ queries:
     docs:
       refs:
         - url: https://man.openbsd.org/sshd_config
-          title: sshd_config(5)
+          title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH is configured to use PAM (Pluggable Authentication Modules).
 

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -2653,7 +2653,7 @@ queries:
       }
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that `/etc/ssh/sshd_config` is owned by `root:wheel` and is not readable by group or other users.
@@ -2760,7 +2760,7 @@ queries:
       }
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH private host key files under `/etc/ssh/` are owned by root with mode 0600 or more restrictive.
@@ -2874,7 +2874,7 @@ queries:
       }
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH public host key files have no write or execute permissions for group or other.
@@ -2981,7 +2981,7 @@ queries:
       sshd.config.ciphers.containsOnly(["chacha20-poly1305@openssh.com","aes256-gcm@openssh.com","aes128-gcm@openssh.com","aes256-ctr","aes192-ctr","aes128-ctr"])
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server is configured to use only strong, modern ciphers and that no weak ciphers such as 3DES, Blowfish, CAST128, or CBC-mode AES are permitted.
@@ -3119,7 +3119,7 @@ queries:
       sshd.config.macs.containsOnly(["umac-128-etm@openssh.com","hmac-sha2-256-etm@openssh.com","hmac-sha2-512-etm@openssh.com","umac-128@openssh.com","hmac-sha2-256","hmac-sha2-512"])
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong Message Authentication Code (MAC) algorithms and that weak algorithms such as MD5, SHA1-96, RIPEMD160, and UMAC-64 variants are not permitted.
@@ -3257,7 +3257,7 @@ queries:
       sshd.config.kexs.containsOnly(["sntrup761x25519-sha512@openssh.com","curve25519-sha256@libssh.org","curve25519-sha256","diffie-hellman-group18-sha512","diffie-hellman-group16-sha512"])
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server uses only strong key exchange algorithms and that weak algorithms such as diffie-hellman-group1-sha1 and diffie-hellman-group14-sha1 are not permitted.
@@ -3402,7 +3402,7 @@ queries:
       sshd.config.params["PermitRootLogin"].in(["no", "prohibit-password", "without-password"])
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server does not allow the root account to log in with a password.
@@ -3548,7 +3548,7 @@ queries:
       sshd.config.params["PermitEmptyPasswords"] == "no"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH does not allow authentication with empty passwords.
@@ -3686,7 +3686,7 @@ queries:
       sshd.config.params["HostbasedAuthentication"] == "no"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that host-based authentication is disabled in SSH.
@@ -3824,7 +3824,7 @@ queries:
       sshd.config.params["PermitUserEnvironment"] == "no"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that users cannot set environment variables through SSH.
@@ -3962,7 +3962,7 @@ queries:
       sshd.config.params["IgnoreRhosts"] == "yes"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH ignores `.rhosts` and `.shosts` files for authentication.
@@ -4100,7 +4100,7 @@ queries:
       sshd.config.params["MaxAuthTries"] <= 4
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH `MaxAuthTries` is set to 4 or less to limit the number of authentication attempts per connection.
@@ -4239,7 +4239,7 @@ queries:
       sshd.config.params["LoginGraceTime"] <= 60
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server closes connections that have not authenticated within one minute.
@@ -4385,7 +4385,7 @@ queries:
       sshd.config.params["LogLevel"] == /^(INFO|VERBOSE)$/
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH `LogLevel` is set to `INFO` or `VERBOSE`, providing an adequate audit trail.
@@ -4526,7 +4526,7 @@ queries:
       sshd.config.params["ClientAliveCountMax"] <= 3
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that the SSH server terminates sessions whose client has stopped responding.
@@ -4689,7 +4689,7 @@ queries:
       sshd.config.params["DisableForwarding"] == "yes"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH forwarding (X11, TCP, agent, and StreamLocal) is disabled.
@@ -4827,7 +4827,7 @@ queries:
       sshd.config.params["UsePAM"] == "yes"
     docs:
       refs:
-        - url: https://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
+        - url: https://man.openbsd.org/sshd_config
           title: OpenSSH sshd_config(5)
       desc: |
         This check verifies that SSH is configured to use PAM (Pluggable Authentication Modules).

--- a/content/mondoo-freebsd-security.mql.yaml
+++ b/content/mondoo-freebsd-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-freebsd-security
     name: Mondoo FreeBSD Security
-    version: 1.2.3
+    version: 1.2.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -22242,7 +22242,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://docs.cloud.google.com/vertex-ai/docs/predictions/private-service-connect
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/private-service-connect
         title: Using Private Service Connect with Vertex AI
   - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
     filters: asset.platform == 'gcp-vertexai-endpoint'
@@ -27874,7 +27874,7 @@ queries:
               --network=projects/<project>/global/networks/<vpc>
             ```
     refs:
-      - url: https://docs.cloud.google.com/vertex-ai/docs/vector-search/setup
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/setup
         title: Vertex AI - Setup index endpoint
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
     filters: asset.platform == 'gcp-project'
@@ -40703,7 +40703,7 @@ queries:
         # resources with no long-lived Terraform resource; use the CLI or SDK to submit
         # jobs without enableWebAccess at submission time.
     refs:
-      - url: https://docs.cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/training/monitor-debug-interactive-shell
         title: Vertex AI - Enable web access for custom training
   - uid: mondoo-gcp-security-cloud-tasks-queue-not-publicly-accessible
     title: Ensure Cloud Tasks queues are not publicly accessible

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -656,7 +656,7 @@ queries:
               gcloud compute instances start INSTANCE_NAME
               ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -853,7 +853,7 @@ queries:
               gcloud compute instances start INSTANCE_NAME
               ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -1050,7 +1050,7 @@ queries:
             gcloud compute instances add-metadata INSTANCE_NAME --metadata enable-oslogin=TRUE
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -1226,7 +1226,7 @@ queries:
             gcloud storage buckets remove-iam-policy-binding gs://BUCKET_NAME --member=allAuthenticatedUsers --role=roles/storage.objectViewer
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/best-practices#security
+      - url: https://docs.cloud.google.com/storage/docs/best-practices#security
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-bucket-not-anonymously-publicly-accessible-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -1372,7 +1372,7 @@ queries:
             gsutil uniformbucketlevelaccess set on gs://BUCKET_NAME
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/best-practices#security
+      - url: https://docs.cloud.google.com/storage/docs/best-practices#security
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-buckets-have-uniform-bucket-level-access-enabled-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -1503,7 +1503,7 @@ queries:
             gcloud storage buckets update gs://BUCKET_NAME --public-access-prevention
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/best-practices#security
+      - url: https://docs.cloud.google.com/storage/docs/best-practices#security
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-bucket-public-access-prevention-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -1676,7 +1676,7 @@ queries:
             gcloud storage buckets update gs://BUCKET_NAME --default-encryption-key=projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/best-practices#security
+      - url: https://docs.cloud.google.com/storage/docs/best-practices#security
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-bucket-cmek-encryption-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -1824,7 +1824,7 @@ queries:
             gcloud storage buckets update gs://BUCKET_NAME --lock-retention-period
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/best-practices#security
+      - url: https://docs.cloud.google.com/storage/docs/best-practices#security
         title: Cloud Storage Security Best Practices
   - uid: mondoo-gcp-security-cloud-storage-bucket-retention-policy-locked-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -2624,7 +2624,7 @@ queries:
             bq update --use_legacy_sql=false --view "SELECT column1, column2 FROM \`project.dataset.table\`" PROJECT_ID:DATASET_ID.VIEW_ID
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql
+      - url: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql
         title: Migrating from Legacy SQL to GoogleSQL
   - uid: mondoo-gcp-security-bigquery-views-no-legacy-sql-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -2932,7 +2932,7 @@ queries:
                 ```
                 Check the `ipAddresses` section in the output to confirm the absence of an entry with `type: PRIMARY`.
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-mysql-instances-not-publicly-exposed-gcp
     filters: asset.platform == 'gcp-sql-mysql'
@@ -3095,7 +3095,7 @@ queries:
 
             Always configure new Cloud SQL MySQL instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-mysql-connections-require-ssl-tls-gcp
     filters: asset.platform == 'gcp-sql-mysql'
@@ -3245,7 +3245,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/flags
+      - url: https://docs.cloud.google.com/sql/docs/mysql/flags
         title: Configure database flags
   - uid: mondoo-gcp-security-cloud-sql-mysql-skip-show-database-enabled-gcp
     filters: asset.platform == 'gcp-sql-mysql'
@@ -3399,7 +3399,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-mysql-local-infile-disabled-gcp
     filters: asset.platform == 'gcp-sql-mysql'
@@ -3561,7 +3561,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/postgres/flags
+      - url: https://docs.cloud.google.com/sql/docs/postgres/flags
         title: Configure database flags for Cloud SQL for PostgreSQL
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-error-verbosity-default-verbose-gcp
     filters: |
@@ -3722,7 +3722,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/postgres/flags
+      - url: https://docs.cloud.google.com/sql/docs/postgres/flags
         title: Configure database flags for Cloud SQL for PostgreSQL
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-connections-enabled-gcp
     filters: |
@@ -3883,7 +3883,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/postgres/flags
+      - url: https://docs.cloud.google.com/sql/docs/postgres/flags
         title: Configure database flags for Cloud SQL for PostgreSQL
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-disconnections-enabled-gcp
     filters: |
@@ -4076,7 +4076,7 @@ queries:
             ```
             Replace `INSTANCE_NAME`, `ZONE`, and `ACCESS_CONFIG_NAME` with the appropriate values.
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -4265,7 +4265,7 @@ queries:
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -4430,7 +4430,7 @@ queries:
             ```
             Replace `INSTANCE_NAME` and `ZONE` with the appropriate values. This command will either add the key if it doesn't exist or update its value to `true` if it does.
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -4607,7 +4607,7 @@ queries:
 
             Replace placeholders like `INSTANCE_NAME`, `ZONE`, and `N2D_MACHINE_TYPE` with appropriate values.
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -4798,7 +4798,7 @@ queries:
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -4985,7 +4985,7 @@ queries:
             gcloud compute instances start INSTANCE_NAME --zone=ZONE
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -5179,7 +5179,7 @@ queries:
 
             Replace `INSTANCE_NAME` and `ZONE` with the appropriate values for your instance.
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://cloud.google.com/compute/docs/security
         title: Google Compute Engine Security
@@ -5346,7 +5346,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-postgres-instances-not-publicly-exposed-gcp
     filters: |
@@ -5511,7 +5511,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-sql-server-instance-not-publicly-exposed-gcp
     filters: |
@@ -5682,7 +5682,7 @@ queries:
 
             Always configure new Cloud SQL PostgreSQL instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-postgres-connections-require-ssl-tls-gcp
     filters: |
@@ -5855,7 +5855,7 @@ queries:
 
             Always configure new Cloud SQL for SQL Server instances with `ssl_mode = "ENCRYPTED_ONLY"` during creation via Terraform. Regularly audit instances to ensure compliance.
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/best-practices
+      - url: https://docs.cloud.google.com/sql/docs/mysql/best-practices
         title: Cloud SQL Best Practices
   - uid: mondoo-gcp-security-cloud-sql-sql-server-connections-require-ssl-tls-gcp
     filters: |
@@ -6800,7 +6800,7 @@ queries:
 
             Always configure DNSSEC for public DNS zones in your Terraform configurations. Use Terraform validation rules or policy-as-code tools to ensure DNSSEC is enabled for all public zones. Regularly audit your Terraform configurations to ensure compliance.
     refs:
-      - url: https://cloud.google.com/dns/docs/dnssec
+      - url: https://docs.cloud.google.com/dns/docs/dnssec
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-dnssec-enabled-gcp
     filters: |
@@ -6959,7 +6959,7 @@ queries:
 
             Always use strong cryptographic algorithms in your Terraform DNSSEC configurations. Avoid RSASHA1 and prefer RSASHA256, RSASHA512, or ECDSA algorithms. Use Terraform validation rules to prevent weak algorithms from being deployed.
     refs:
-      - url: https://cloud.google.com/dns/docs/dnssec
+      - url: https://docs.cloud.google.com/dns/docs/dnssec
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-ksk-not-used-gcp
     filters: |
@@ -7124,7 +7124,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/dns/docs/dnssec
+      - url: https://docs.cloud.google.com/dns/docs/dnssec
         title: Cloud DNS DNSSEC
   - uid: mondoo-gcp-security-cloud-dns-rsasha1-zsk-not-used-gcp
     filters: |
@@ -7453,7 +7453,7 @@ queries:
 
             Always set `non_existence = "nsec3"` in your Terraform DNSSEC configurations for public zones. Use Terraform validation rules or policy-as-code tools to ensure NSEC3 is consistently applied.
     refs:
-      - url: https://cloud.google.com/dns/docs/dnssec
+      - url: https://docs.cloud.google.com/dns/docs/dnssec
         title: Cloud DNS DNSSEC
       - url: https://datatracker.ietf.org/doc/html/rfc5155
         title: RFC 5155 - DNS Security (DNSSEC) Hashed Authenticated Denial of Existence
@@ -7644,7 +7644,7 @@ queries:
               --source-ranges=10.0.0.0/8
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: VPC Firewall Rules
   - uid: mondoo-gcp-security-firewall-no-ingress-ssh-from-internet-gcp
     filters: |
@@ -7812,7 +7812,7 @@ queries:
               --source-ranges=10.0.0.0/8
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: VPC Firewall Rules
   - uid: mondoo-gcp-security-firewall-no-ingress-rdp-from-internet-gcp
     filters: |
@@ -7980,7 +7980,7 @@ queries:
               --source-ranges=TRUSTED_CIDR_RANGE
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: VPC Firewall Rules
   - uid: mondoo-gcp-security-firewall-no-unrestricted-ingress-all-protocols-gcp
     filters: |
@@ -8144,7 +8144,7 @@ queries:
               --source-ranges=10.0.0.0/8
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: VPC Firewall Rules
   - uid: mondoo-gcp-security-firewall-no-ingress-database-ports-from-internet-gcp
     filters: |
@@ -8302,7 +8302,7 @@ queries:
               --rules=tcp:80,tcp:443
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: VPC Firewall Rules
   - uid: mondoo-gcp-security-firewall-no-overly-permissive-ingress-gcp
     filters: |
@@ -8450,7 +8450,7 @@ queries:
             gcloud container clusters update CLUSTER_NAME --zone ZONE --no-enable-legacy-authorization
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/security-overview
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-legacy-abac-disabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -8586,7 +8586,7 @@ queries:
             gcloud container clusters update CLUSTER_NAME --zone ZONE --enable-master-authorized-networks --master-authorized-networks CIDR1,CIDR2
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/security-overview
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-master-authorized-networks-enabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -8716,7 +8716,7 @@ queries:
             gcloud container clusters update CLUSTER_NAME --zone ZONE --logging=SYSTEM,WORKLOAD
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/security-overview
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-stackdriver-logging-enabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -8854,7 +8854,7 @@ queries:
             gcloud container clusters update CLUSTER_NAME --zone ZONE --enable-network-policy
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/security-overview
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-network-policy-enabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -8986,7 +8986,7 @@ queries:
             gcloud container clusters create CLUSTER_NAME --zone ZONE
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/security-overview
         title: GKE Security Overview
   - uid: mondoo-gcp-security-gke-cluster-alpha-disabled-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -9121,7 +9121,7 @@ queries:
               --zone ZONE
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
         title: GKE Workload Identity documentation
   - uid: mondoo-gcp-security-gke-workload-identity-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -9258,7 +9258,7 @@ queries:
               --zone ZONE
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation
         title: GKE Private cluster documentation
   - uid: mondoo-gcp-security-gke-private-cluster-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -9396,7 +9396,7 @@ queries:
               --zone ZONE
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes
         title: GKE Shielded Nodes documentation
   - uid: mondoo-gcp-security-gke-shielded-nodes-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -9703,7 +9703,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/binary-authorization/docs/overview
+      - url: https://docs.cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
       - url: https://cloud.google.com/binary-authorization/docs/enabling-binauthz-gke
         title: Enabling Binary Authorization for GKE
@@ -9849,7 +9849,7 @@ queries:
               --zone ZONE
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels
         title: GKE Release channels documentation
   - uid: mondoo-gcp-security-gke-release-channel-configured-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -9984,7 +9984,7 @@ queries:
             gcloud compute networks subnets create SUBNET_NAME --network=NEW_NETWORK_NAME --region=REGION --range=CIDR_RANGE
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/vpc
+      - url: https://docs.cloud.google.com/vpc/docs/vpc
         title: Google Cloud VPC Documentation
   - uid: mondoo-gcp-security-compute-network-not-legacy-gcp
     filters: asset.platform == "gcp-compute-network"
@@ -10122,7 +10122,7 @@ queries:
             gcloud compute networks subnets update SUBNET_NAME --region=REGION --enable-flow-logs --logging-aggregation-interval=interval-5-sec --logging-flow-sampling=0.5 --logging-metadata=include-all
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/vpc
+      - url: https://docs.cloud.google.com/vpc/docs/vpc
         title: Google Cloud VPC Documentation
   - uid: mondoo-gcp-security-compute-subnetwork-flow-logs-enabled-gcp
     filters: asset.platform == "gcp-compute-subnetwork"
@@ -10252,7 +10252,7 @@ queries:
             gcloud compute networks subnets update SUBNET_NAME --region=REGION --enable-private-ip-google-access
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/vpc
+      - url: https://docs.cloud.google.com/vpc/docs/vpc
         title: Google Cloud VPC Documentation
   - uid: mondoo-gcp-security-compute-subnetwork-private-google-access-enabled-gcp
     filters: asset.platform == "gcp-compute-subnetwork"
@@ -10384,7 +10384,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/redis/auth-overview
+      - url: https://docs.cloud.google.com/memorystore/docs/redis/about-redis-auth
         title: Cloud Memorystore Redis AUTH documentation
   - uid: mondoo-gcp-security-cloud-redis-auth-enabled-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
@@ -10553,7 +10553,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/redis/about-cmek
+      - url: https://docs.cloud.google.com/memorystore/docs/redis/about-cmek
         title: Cloud Memorystore Redis CMEK documentation
   - uid: mondoo-gcp-security-cloud-redis-cmek-configured-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
@@ -10728,9 +10728,9 @@ queries:
             gcloud iam service-accounts keys delete KEY_ID --iam-account=SA_EMAIL
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
+      - url: https://docs.cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
         title: Best practices for managing service account keys
-      - url: https://cloud.google.com/iam/docs/service-account-overview
+      - url: https://docs.cloud.google.com/iam/docs/service-account-overview
         title: Service account overview
   - uid: mondoo-gcp-security-iam-no-user-managed-service-account-keys-gcp
     filters: asset.platform == 'gcp-iam-service-account'
@@ -10891,9 +10891,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/service-account-types#default
+      - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
         title: Default service accounts
-      - url: https://cloud.google.com/iam/docs/best-practices-service-accounts
+      - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
         title: Best practices for service accounts
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-gcp
     filters: |
@@ -11102,7 +11102,7 @@ queries:
             gcloud iam service-accounts keys delete OLD_KEY_ID --iam-account=SA_EMAIL
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
+      - url: https://docs.cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys
         title: Best practices for managing service account keys
   - uid: mondoo-gcp-security-iam-service-account-keys-rotated-90-days-gcp
     filters: asset.platform == 'gcp-iam-service-account'
@@ -11247,7 +11247,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+      - url: https://docs.cloud.google.com/iam/docs/keys-create-delete
         title: Creating and managing service account keys
   - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-gcp
     filters: asset.platform == 'gcp-iam-service-account'
@@ -11348,7 +11348,7 @@ queries:
             ```
         # No Terraform remediation: service-account inactivity is runtime telemetry from Policy Intelligence, not a Terraform-managed attribute; the fix is to disable or delete the unused account.
     refs:
-      - url: https://cloud.google.com/iam/docs/service-account-monitoring
+      - url: https://docs.cloud.google.com/iam/docs/service-account-monitoring
         title: Monitor usage of service accounts and keys
   - uid: mondoo-gcp-security-logging-bucket-retention-30-days
     title: Ensure Cloud Logging log buckets have at least 30-day retention
@@ -11449,7 +11449,7 @@ queries:
             gcloud logging buckets update BUCKET_ID --location=LOCATION --retention-days=30
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/buckets
+      - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
       - url: https://cloud.google.com/logging/docs/storage
         title: Cloud Logging storage
@@ -11586,7 +11586,7 @@ queries:
 
             Note: This action is irreversible. Ensure retention settings are correct before locking.
     refs:
-      - url: https://cloud.google.com/logging/docs/buckets
+      - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
       - url: https://cloud.google.com/logging/docs/storage#locked-bucket
         title: Locked log buckets
@@ -11729,7 +11729,7 @@ queries:
               --cmek-kms-key-name=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/routing/managed-encryption-storage
+      - url: https://docs.cloud.google.com/logging/docs/routing/managed-encryption-storage
         title: Customer-managed encryption keys for Cloud Logging
   - uid: mondoo-gcp-security-logging-bucket-cmek-encryption-gcp
     filters: asset.platform == 'gcp-logging-bucket'
@@ -11869,7 +11869,7 @@ queries:
     refs:
       - url: https://cloud.google.com/logging/docs/export
         title: Routing and storage overview
-      - url: https://cloud.google.com/logging/docs/export/configure_export_v2
+      - url: https://docs.cloud.google.com/logging/docs/export/configure_export_v2
         title: Configure log sinks
   - uid: mondoo-gcp-security-logging-sinks-configured-gcp
     filters: asset.platform == 'gcp-project'
@@ -11987,7 +11987,7 @@ queries:
               --topic-encryption-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/encryption
+      - url: https://docs.cloud.google.com/pubsub/docs/encryption
         title: Pub/Sub encryption
   - uid: mondoo-gcp-security-pubsub-topic-cmek-encryption-gcp
     filters: asset.platform == 'gcp-pubsub-topic'
@@ -12118,7 +12118,7 @@ queries:
               --expiration-period=31d
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/subscription-properties
+      - url: https://docs.cloud.google.com/pubsub/docs/subscription-properties
         title: Subscription properties
   - uid: mondoo-gcp-security-pubsub-subscription-expiration-configured-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
@@ -12254,7 +12254,7 @@ queries:
               --role="ROLE_NAME"
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/access-control
+      - url: https://docs.cloud.google.com/pubsub/docs/access-control
         title: Pub/Sub access control
   - uid: mondoo-gcp-security-pubsub-topic-not-publicly-accessible-gcp
     filters: asset.platform == 'gcp-pubsub-topic'
@@ -12403,7 +12403,7 @@ queries:
               --role="ROLE_NAME"
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/access-control
+      - url: https://docs.cloud.google.com/pubsub/docs/access-control
         title: Pub/Sub access control
   - uid: mondoo-gcp-security-pubsub-subscription-not-publicly-accessible-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
@@ -12552,7 +12552,7 @@ queries:
               --ingress-settings=internal-only
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/networking/network-settings
+      - url: https://docs.cloud.google.com/run/docs/configuring/networking-best-practices
         title: Cloud Functions networking settings
   - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -12704,7 +12704,7 @@ queries:
               --service-account=CUSTOM_SA_EMAIL
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/securing/function-identity
+      - url: https://docs.cloud.google.com/functions/docs/securing/function-identity
         title: Cloud Functions identity
   - uid: mondoo-gcp-security-cloud-functions-no-default-service-account-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -12877,7 +12877,7 @@ queries:
               --egress-settings=all
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/networking/connecting-vpc
+      - url: https://docs.cloud.google.com/run/docs/configuring/connecting-vpc
         title: Connecting to a VPC network
   - uid: mondoo-gcp-security-cloud-functions-vpc-connector-configured-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -13022,7 +13022,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/securing/cmek
+      - url: https://docs.cloud.google.com/functions/docs/securing/cmek
         title: Customer-managed encryption keys for Cloud Functions
   - uid: mondoo-gcp-security-cloud-functions-cmek-encryption-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -13159,7 +13159,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/securing/ingress
+      - url: https://docs.cloud.google.com/run/docs/securing/ingress
         title: Restricting ingress for Cloud Run
   - uid: mondoo-gcp-security-cloud-run-ingress-restricted-gcp
     filters: asset.platform == 'gcp-cloudrun-service'
@@ -13299,7 +13299,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/securing/using-cmek
+      - url: https://docs.cloud.google.com/run/docs/securing/using-cmek
         title: Using customer-managed encryption keys with Cloud Run
   - uid: mondoo-gcp-security-cloud-run-cmek-encryption-gcp
     filters: asset.platform == 'gcp-cloudrun-service'
@@ -13447,7 +13447,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/securing/service-identity
+      - url: https://docs.cloud.google.com/run/docs/securing/service-identity
         title: Cloud Run service identity
   - uid: mondoo-gcp-security-cloud-run-no-default-service-account-gcp
     filters: asset.platform == 'gcp-cloudrun-service'
@@ -13605,7 +13605,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/configuring/vpc-connectors
+      - url: https://docs.cloud.google.com/run/docs/configuring/vpc-connectors
         title: Connecting to a VPC network from Cloud Run
   - uid: mondoo-gcp-security-cloud-run-vpc-access-configured-gcp
     filters: asset.platform == 'gcp-cloudrun-service'
@@ -13754,7 +13754,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/securing/service-identity
+      - url: https://docs.cloud.google.com/run/docs/securing/service-identity
         title: Cloud Run service identity
   - uid: mondoo-gcp-security-cloud-run-job-no-default-service-account-gcp
     filters: asset.platform == 'gcp-cloudrun-job'
@@ -13920,7 +13920,7 @@ queries:
               --region=REGION
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/securing/using-cmek
+      - url: https://docs.cloud.google.com/run/docs/securing/using-cmek
         title: Using customer-managed encryption keys with Cloud Run
   - uid: mondoo-gcp-security-cloud-run-job-cmek-encryption-gcp
     filters: asset.platform == 'gcp-cloudrun-job'
@@ -14064,7 +14064,7 @@ queries:
               --gce-pd-kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/customer-managed-encryption
+      - url: https://docs.cloud.google.com/managed-spark/docs/concepts/configuring-clusters/customer-managed-encryption
         title: Customer-managed encryption keys for Dataproc
   - uid: mondoo-gcp-security-dataproc-cluster-encryption-configured-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -14209,7 +14209,7 @@ queries:
               --subnet=SUBNET_NAME
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/network
+      - url: https://docs.cloud.google.com/managed-spark/docs/concepts/configuring-clusters/network
         title: Dataproc cluster network configuration
   - uid: mondoo-gcp-security-dataproc-cluster-internal-ip-only-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -14630,7 +14630,7 @@ queries:
               --service-account=CUSTOM_SA_EMAIL
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts
+      - url: https://docs.cloud.google.com/managed-spark/docs/concepts/configuring-clusters/service-accounts
         title: Dataproc service accounts
   - uid: mondoo-gcp-security-dataproc-cluster-no-default-service-account-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -14780,9 +14780,9 @@ queries:
 
             Configure attestors and sign your images before you enforce `REQUIRE_ATTESTATION`. Without attestors in place, the policy blocks every deployment to your GKE clusters, including system pods, and causes a full outage. To stage the change safely, set the enforcement mode to a dry-run or audit-only mode first and confirm that legitimate images pass.
     refs:
-      - url: https://cloud.google.com/binary-authorization/docs/overview
+      - url: https://docs.cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
-      - url: https://cloud.google.com/binary-authorization/docs/configuring-policy-cli
+      - url: https://docs.cloud.google.com/binary-authorization/docs/configuring-policy-cli
         title: Configuring a Binary Authorization policy
   - uid: mondoo-gcp-security-binary-authorization-default-rule-not-allow-all-gcp
     filters: asset.platform == 'gcp-project'
@@ -14920,7 +14920,7 @@ queries:
             gcloud container binauthz policy import policy.yaml
             ```
     refs:
-      - url: https://cloud.google.com/binary-authorization/docs/overview
+      - url: https://docs.cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
   - uid: mondoo-gcp-security-binary-authorization-global-policy-enabled-gcp
     filters: asset.platform == 'gcp-project'
@@ -15052,9 +15052,9 @@ queries:
               --api-target=service=maps-backend.googleapis.com
             ```
     refs:
-      - url: https://cloud.google.com/docs/authentication/api-keys
+      - url: https://docs.cloud.google.com/docs/authentication/api-keys
         title: API keys overview
-      - url: https://cloud.google.com/docs/authentication/api-keys#api_key_restrictions
+      - url: https://docs.cloud.google.com/docs/authentication/api-keys#api_key_restrictions
         title: API key restrictions
   - uid: mondoo-gcp-security-api-keys-api-restrictions-configured-gcp
     filters: asset.platform == 'gcp-apikey'
@@ -15204,7 +15204,7 @@ queries:
               --allowed-referrers=https://example.com/*
             ```
     refs:
-      - url: https://cloud.google.com/docs/authentication/api-keys#api_key_restrictions
+      - url: https://docs.cloud.google.com/docs/authentication/api-keys#api_key_restrictions
         title: API key restrictions
   - uid: mondoo-gcp-security-api-keys-application-restrictions-configured-gcp
     filters: asset.platform == 'gcp-apikey'
@@ -15359,7 +15359,7 @@ queries:
             gcloud services api-keys delete KEY_ID --project=PROJECT_ID
             ```
     refs:
-      - url: https://cloud.google.com/docs/authentication/api-keys
+      - url: https://docs.cloud.google.com/docs/authentication/api-keys
         title: API keys overview
   - uid: mondoo-gcp-security-api-keys-not-stale-gcp
     filters: asset.platform == 'gcp-apikey'
@@ -15480,9 +15480,9 @@ queries:
               --subnet-mode=custom
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/vpc#default-network
+      - url: https://docs.cloud.google.com/vpc/docs/vpc#default-network
         title: Default network
-      - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+      - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-compute-network-default-deleted-gcp
     filters: asset.platform == 'gcp-compute-network'
@@ -15614,7 +15614,7 @@ queries:
               --networks=NETWORK_NAME
             ```
     refs:
-      - url: https://cloud.google.com/dns/docs/monitoring
+      - url: https://docs.cloud.google.com/dns/docs/monitoring
         title: Cloud DNS logging and monitoring
   - uid: mondoo-gcp-security-compute-network-dns-logging-enabled-gcp
     filters: asset.platform == 'gcp-project'
@@ -15756,7 +15756,7 @@ queries:
 
             Avoid using CIDR ranges of /15 or larger (broader than /16) for individual subnets. Use separate subnets for different workloads and environments to maintain proper network segmentation.
     refs:
-      - url: https://cloud.google.com/vpc/docs/subnets
+      - url: https://docs.cloud.google.com/vpc/docs/subnets
         title: Subnets overview
   - uid: mondoo-gcp-security-compute-subnetwork-not-overly-broad-cidr-gcp
     filters: |
@@ -15922,7 +15922,7 @@ queries:
               --transit-encryption-mode=server-authentication
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/redis/in-transit-encryption
+      - url: https://docs.cloud.google.com/memorystore/docs/redis/about-in-transit-encryption
         title: Cloud Memorystore for Redis in-transit encryption documentation
   - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
@@ -16064,7 +16064,7 @@ queries:
               --size=1
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/redis/redis-tiers
+      - url: https://docs.cloud.google.com/memorystore/docs/redis/redis-tiers
         title: Memorystore for Redis tiers
   - uid: mondoo-gcp-security-cloud-redis-standard-ha-tier-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
@@ -16197,7 +16197,7 @@ queries:
               --auth-mode=iam-auth
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/cluster/about-iam-auth
+      - url: https://docs.cloud.google.com/memorystore/docs/cluster/about-iam-auth
         title: Cloud Memorystore for Redis Cluster IAM authentication documentation
   - uid: mondoo-gcp-security-cloud-redis-cluster-iam-auth-enabled-memorystore-rediscluster
     filters: asset.platform == "gcp-memorystore-rediscluster"
@@ -16482,9 +16482,9 @@ queries:
 
             Note: CMEK must be configured at secret creation time. To migrate an existing secret, create a new CMEK-encrypted secret and add the secret data as a new version.
     refs:
-      - url: https://cloud.google.com/secret-manager/docs/cmek
+      - url: https://docs.cloud.google.com/secret-manager/docs/cmek
         title: Customer-managed encryption keys for Secret Manager
-      - url: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+      - url: https://docs.cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
         title: Creating and accessing secrets
   - uid: mondoo-gcp-security-secretmanager-cmek-encryption-gcp
     filters: asset.platform == 'gcp-secretmanager-secret'
@@ -16655,9 +16655,9 @@ queries:
 
             Note: Set `--next-rotation-time` to a future RFC 3339 timestamp; gcloud rejects a time that has already elapsed. A Pub/Sub topic must be configured on the secret to receive rotation notifications. The rotation period is specified in seconds (for example, 7776000s for 90 days).
     refs:
-      - url: https://cloud.google.com/secret-manager/docs/secret-rotation
+      - url: https://docs.cloud.google.com/secret-manager/docs/secret-rotation
         title: Secret rotation in Secret Manager
-      - url: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+      - url: https://docs.cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
         title: Creating and accessing secrets
   - uid: mondoo-gcp-security-secretmanager-rotation-configured-gcp
     filters: asset.platform == 'gcp-secretmanager-secret'
@@ -16814,9 +16814,9 @@ queries:
               --role='roles/secretmanager.secretAccessor'
             ```
     refs:
-      - url: https://cloud.google.com/secret-manager/docs/access-control
+      - url: https://docs.cloud.google.com/secret-manager/docs/access-control
         title: Secret Manager access control with IAM
-      - url: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+      - url: https://docs.cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
         title: Creating and accessing secrets
   - uid: mondoo-gcp-security-secretmanager-not-publicly-accessible-gcp
     filters: asset.platform == 'gcp-secretmanager-secret'
@@ -16973,9 +16973,9 @@ queries:
 
             If it returns `True`, the instance has IP forwarding enabled. To remediate, create a replacement instance without the `--can-ip-forward` flag.
     refs:
-      - url: https://cloud.google.com/vpc/docs/using-routes#canipforward
+      - url: https://docs.cloud.google.com/vpc/docs/using-routes#canipforward
         title: Google Cloud VPC - IP Forwarding
-      - url: https://cloud.google.com/compute/docs/instances/create-start-instance
+      - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
   - uid: mondoo-gcp-security-compute-instances-ip-forwarding-disabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
@@ -17119,9 +17119,9 @@ queries:
             gcloud compute instances add-metadata INSTANCE_NAME --zone=ZONE --metadata=serial-port-enable=false
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
+      - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
         title: Google Cloud - Troubleshooting using the serial console
-      - url: https://cloud.google.com/compute/docs/instances/interacting-with-serial-console
+      - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
         title: Google Cloud - Interacting with the serial console
   - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
@@ -17271,7 +17271,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+      - url: https://docs.cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-disk-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -17422,7 +17422,7 @@ queries:
 
             The frontend is unreachable between deleting and re-creating the rule, so perform this change during a maintenance window.
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/forwarding-rule-concepts
         title: Google Cloud - Forwarding rule concepts
   - uid: mondoo-gcp-security-forwarding-rule-not-all-ports-gcp
     filters: asset.platform == 'gcp-project'
@@ -17579,7 +17579,7 @@ queries:
 
             *Note: This overwrites all existing authorized networks. Include all required networks in a comma-separated list.*
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/authorize-networks
+      - url: https://docs.cloud.google.com/sql/docs/mysql/authorize-networks
         title: Cloud SQL - Authorize with authorized networks
   - uid: mondoo-gcp-security-cloud-sql-no-overly-permissive-authorized-networks-gcp-mysql
     filters: asset.platform == 'gcp-sql-mysql'
@@ -17761,7 +17761,7 @@ queries:
               --password-policy-disallow-username-substring
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/built-in-authentication
+      - url: https://docs.cloud.google.com/sql/docs/mysql/built-in-authentication
         title: Cloud SQL - Built-in database authentication
   - uid: mondoo-gcp-security-cloud-sql-password-policy-enabled-gcp-mysql
     filters: asset.platform == 'gcp-sql-mysql'
@@ -17917,7 +17917,7 @@ queries:
               --disk-encryption-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/configure-cmek
+      - url: https://docs.cloud.google.com/sql/docs/mysql/configure-cmek
         title: Cloud SQL - Using customer-managed encryption keys
   - uid: mondoo-gcp-security-cloud-sql-cmek-encryption-gcp-mysql
     filters: asset.platform == 'gcp-sql-mysql'
@@ -18056,7 +18056,7 @@ queries:
               --database-encryption-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets
         title: GKE - Application-layer secrets encryption
   - uid: mondoo-gcp-security-gke-database-encryption-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -18212,7 +18212,7 @@ queries:
 
             Drain the old pool's nodes before deleting it so workloads reschedule onto the new pool.
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes
         title: GKE - Shielded GKE Nodes
   - uid: mondoo-gcp-security-gke-node-pool-secure-boot-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -18381,7 +18381,7 @@ queries:
               --set-secrets=API_KEY=projects/PROJECT/secrets/SECRET_NAME:latest
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/configuring/secrets
+      - url: https://docs.cloud.google.com/run/docs/configuring/services/secrets
         title: Cloud Functions - Using secrets
   - uid: mondoo-gcp-security-cloud-functions-no-plaintext-secrets-in-env-vars-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -18562,7 +18562,7 @@ queries:
               --docker-repository=projects/PROJECT/locations/LOCATION/repositories/REPOSITORY
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/building#docker-repo
+      - url: https://docs.cloud.google.com/functions/docs/building#image_registry
         title: Cloud Functions - Specifying a Docker repository
   - uid: mondoo-gcp-security-cloud-functions-docker-repository-configured-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -18705,9 +18705,9 @@ queries:
               --no-preview
             ```
     refs:
-      - url: https://cloud.google.com/armor/docs/security-policy-overview
+      - url: https://docs.cloud.google.com/armor/docs/security-policy-overview
         title: Cloud Armor security policies overview
-      - url: https://cloud.google.com/armor/docs/configure-security-policies
+      - url: https://docs.cloud.google.com/armor/docs/configure-security-policies
         title: Configure Cloud Armor security policies
   - uid: mondoo-gcp-security-cloud-armor-rules-not-preview-only-gcp
     filters: asset.platform == 'gcp-project'
@@ -18871,9 +18871,9 @@ queries:
               --action=deny-403
             ```
     refs:
-      - url: https://cloud.google.com/armor/docs/security-policy-overview
+      - url: https://docs.cloud.google.com/armor/docs/security-policy-overview
         title: Cloud Armor security policies overview
-      - url: https://cloud.google.com/armor/docs/configure-security-policies
+      - url: https://docs.cloud.google.com/armor/docs/configure-security-policies
         title: Configure Cloud Armor security policies
   - uid: mondoo-gcp-security-cloud-armor-default-rule-not-allow-gcp
     filters: asset.platform == 'gcp-project'
@@ -19003,9 +19003,9 @@ queries:
               --min-tls-version=1.2
             ```
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: SSL policies concepts
-      - url: https://cloud.google.com/load-balancing/docs/use-ssl-policies
+      - url: https://docs.cloud.google.com/load-balancing/docs/use-ssl-policies
         title: Using SSL policies
   - uid: mondoo-gcp-security-ssl-policy-min-tls-1-2-gcp
     filters: asset.platform == 'gcp-project'
@@ -19159,7 +19159,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/traffic-director/docs/reference/network-security/rest/v1beta1/projects.locations.serverTlsPolicies
+      - url: https://docs.cloud.google.com/service-mesh/docs/reference/network-security/rest/v1beta1/projects.locations.serverTlsPolicies
         title: ServerTlsPolicy resource reference
   - uid: mondoo-gcp-security-server-tls-policy-disallow-plaintext-gcp
     filters: asset.platform == 'gcp-project'
@@ -19284,7 +19284,7 @@ queries:
               --profile=MODERN
             ```
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: SSL policies concepts
   - uid: mondoo-gcp-security-ssl-policy-modern-or-restricted-profile-gcp
     filters: asset.platform == 'gcp-project'
@@ -19556,9 +19556,9 @@ queries:
               --no-enable-endpoint-independent-mapping
             ```
     refs:
-      - url: https://cloud.google.com/nat/docs/overview
+      - url: https://docs.cloud.google.com/nat/docs/overview
         title: Cloud NAT overview
-      - url: https://cloud.google.com/nat/docs/ports-and-addresses
+      - url: https://docs.cloud.google.com/nat/docs/ports-and-addresses
         title: Cloud NAT ports and addresses
   - uid: mondoo-gcp-security-cloud-nat-no-endpoint-independent-mapping-gcp
     filters: asset.platform == 'gcp-project'
@@ -19717,9 +19717,9 @@ queries:
             gcloud projects set-iam-policy PROJECT_ID policy.json
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/audit
+      - url: https://docs.cloud.google.com/logging/docs/audit
         title: Cloud Audit Logs overview
-      - url: https://cloud.google.com/logging/docs/audit/configure-data-access
+      - url: https://docs.cloud.google.com/logging/docs/audit/configure-data-access
         title: Configure Data Access audit logs
   - uid: mondoo-gcp-security-audit-logging-enabled-all-services-gcp
     filters: asset.platform == 'gcp-project'
@@ -19876,9 +19876,9 @@ queries:
               --project=PROJECT_ID
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+      - url: https://docs.cloud.google.com/compute/docs/ip-addresses/configure-static-external-ip-address
         title: External IP addresses
-      - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+      - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-gcp
     filters: asset.platform == 'gcp-project'
@@ -20009,9 +20009,9 @@ queries:
               compute.disableSerialPortAccess --project=PROJECT_ID
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/instances/interacting-with-serial-console
+      - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
         title: Interacting with the serial console
-      - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+      - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
     filters: asset.platform == 'gcp-project'
@@ -20152,9 +20152,9 @@ queries:
               storage.uniformBucketLevelAccess --project=PROJECT_ID
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/uniform-bucket-level-access
+      - url: https://docs.cloud.google.com/storage/docs/uniform-bucket-level-access
         title: Uniform bucket-level access
-      - url: https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints
+      - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-uniform-bucket-level-access-gcp
     filters: asset.platform == 'gcp-project'
@@ -20298,9 +20298,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/resource-manager/docs/project-liens
+      - url: https://docs.cloud.google.com/resource-manager/docs/project-liens
         title: Preventing accidental project deletion
-      - url: https://cloud.google.com/resource-manager/reference/rest/v1/liens
+      - url: https://docs.cloud.google.com/resource-manager/reference/rest/v1/liens
         title: Resource Manager API - Liens
 
   - uid: mondoo-gcp-security-project-deletion-lien-gcp
@@ -20414,7 +20414,7 @@ queries:
               --kms-key-name=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/firestore/docs/cmek
+      - url: https://docs.cloud.google.com/firestore/native/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Firestore
   - uid: mondoo-gcp-security-firestore-cmek-encryption-gcp
     filters: asset.platform == 'gcp-firestore-database'
@@ -20555,7 +20555,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/spanner/docs/cmek
+      - url: https://docs.cloud.google.com/spanner/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Cloud Spanner
   - uid: mondoo-gcp-security-spanner-cmek-encryption-gcp
     filters: asset.platform == 'gcp-spanner-instance'
@@ -20699,7 +20699,7 @@ queries:
               --cluster-config=id=CLUSTER_ID,zone=ZONE,nodes=3,kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/bigtable/docs/cmek
+      - url: https://docs.cloud.google.com/bigtable/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Bigtable
   - uid: mondoo-gcp-security-bigtable-cmek-encryption-gcp
     filters: asset.platform == 'gcp-bigtable-instance'
@@ -20840,7 +20840,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/alloydb/docs/cmek
+      - url: https://docs.cloud.google.com/alloydb/docs/cmek
         title: Customer-managed encryption keys (CMEK) for AlloyDB
   - uid: mondoo-gcp-security-alloydb-cmek-encryption-gcp
     filters: asset.platform == 'gcp-alloydb-cluster'
@@ -20989,7 +20989,7 @@ queries:
     refs:
       - url: https://cloud.google.com/alloydb/docs/connect-overview
         title: AlloyDB connectivity overview
-      - url: https://cloud.google.com/alloydb/docs/connect-public-ip
+      - url: https://docs.cloud.google.com/alloydb/docs/connect-public-ip
         title: Connect using public IP
   - uid: mondoo-gcp-security-alloydb-no-public-ip-gcp
     filters: asset.platform == 'gcp-alloydb-cluster'
@@ -21134,7 +21134,7 @@ queries:
     refs:
       - url: https://cloud.google.com/alloydb/docs/private-service-connect-enable
         title: Enable Private Service Connect on AlloyDB
-      - url: https://cloud.google.com/vpc/docs/private-service-connect
+      - url: https://docs.cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect overview
   - uid: mondoo-gcp-security-alloydb-psc-enabled-gcp
     filters: asset.platform == 'gcp-alloydb-cluster'
@@ -21275,9 +21275,9 @@ queries:
 
             The gcloud value `standard` selects the same basic tier that the API and Terraform call `BASIC` (`security_posture_config.mode = "BASIC"`). The value names differ between gcloud and the API or Terraform, but they configure the equivalent tier.
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/about-security-posture-dashboard
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/about-security-posture-dashboard
         title: GKE Security Posture overview
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/protect-workload-configuration
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/protect-workload-configuration
         title: Protect workload configuration
   - uid: mondoo-gcp-security-gke-security-posture-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -21425,7 +21425,7 @@ queries:
 
             Note: IKE version cannot be updated on existing tunnels. You must delete and recreate the tunnel.
     refs:
-      - url: https://cloud.google.com/network-connectivity/docs/vpn/concepts/overview
+      - url: https://docs.cloud.google.com/network-connectivity/docs/vpn/concepts/overview
         title: Cloud VPN overview
       - url: https://cloud.google.com/network-connectivity/docs/vpn/how-to/creating-vpn-dynamic-routes
         title: Creating VPN tunnels
@@ -21627,9 +21627,9 @@ queries:
               --node-pool-soak-duration=3600s
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies
         title: Node pool upgrade strategies
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/upgrading-a-cluster
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/upgrading-a-cluster
         title: Upgrading a cluster
   - uid: mondoo-gcp-security-gke-node-pool-upgrade-strategy-configured-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -21789,9 +21789,9 @@ queries:
 
             Note: Ensure all applications are using Cloud SQL connectors before enabling enforcement, as direct IP connections will be rejected.
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/connect-auth-proxy
+      - url: https://docs.cloud.google.com/sql/docs/mysql/connect-auth-proxy
         title: Connect using the Cloud SQL Auth Proxy
-      - url: https://cloud.google.com/sql/docs/mysql/connect-connectors
+      - url: https://docs.cloud.google.com/sql/docs/mysql/connect-connectors
         title: Connect using Cloud SQL Language Connectors
   - uid: mondoo-gcp-security-cloud-sql-connector-enforcement-gcp-mysql
     filters: asset.platform == 'gcp-sql-mysql'
@@ -21938,7 +21938,7 @@ queries:
               --access-restriction=WITHIN_PROJECT
             ```
     refs:
-      - url: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-vault
+      - url: https://docs.cloud.google.com/backup-disaster-recovery/docs/concepts/backup-vault
         title: Backup vaults overview
   - uid: mondoo-gcp-security-backupdr-vault-access-restricted-gcp
     filters: asset.platform == 'gcp-project'
@@ -22094,7 +22094,7 @@ queries:
               --encryption-kms-key-name=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-endpoint-cmek-encryption-gcp
     filters: asset.platform == 'gcp-vertexai-endpoint'
@@ -22388,7 +22388,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-model-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -22522,7 +22522,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-dataset-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -22654,7 +22654,7 @@ queries:
 
             Replace PIPELINE_SPEC_JSON with the compiled pipeline definition produced by the Kubeflow Pipelines SDK.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-pipeline-job-cmek-encryption-gcp
     filters: asset.platform == 'gcp-vertexai-pipelinejob'
@@ -22757,7 +22757,7 @@ queries:
 
             Replace PIPELINE_SPEC_JSON with the compiled pipeline definition produced by the Kubeflow Pipelines SDK.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/vpc-peering
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/vpc-peering
         title: VPC Network Peering for Vertex AI
   - uid: mondoo-gcp-security-vertexai-pipeline-job-vpc-network-gcp
     filters: asset.platform == 'gcp-vertexai-pipelinejob'
@@ -22873,7 +22873,7 @@ queries:
 
             Replace PIPELINE_SPEC_JSON with the compiled pipeline definition produced by the Kubeflow Pipelines SDK.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/pipelines/configure-project#service-account
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/pipelines/configure-project#service-account
         title: Configure a service account for Vertex AI Pipelines
   - uid: mondoo-gcp-security-vertexai-pipeline-job-no-default-service-account-gcp
     filters: asset.platform == 'gcp-vertexai-pipelinejob'
@@ -23013,7 +23013,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertexai-feature-online-store-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -23160,7 +23160,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: Google Cloud Documentation - VPC firewall rules
   - uid: mondoo-gcp-security-firewall-no-unrestricted-egress-gcp
     filters: |
@@ -23329,7 +23329,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: Google Cloud Documentation - VPC firewall rules
   - uid: mondoo-gcp-security-firewall-no-egress-all-ports-gcp
     filters: |
@@ -23483,7 +23483,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata
         title: Google Cloud Documentation - Protecting cluster metadata
   - uid: mondoo-gcp-security-gke-legacy-metadata-disabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -23638,7 +23638,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication
         title: Google Cloud Documentation - Authenticating to the Kubernetes API server
   - uid: mondoo-gcp-security-gke-legacy-client-auth-disabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -23779,7 +23779,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades
         title: Google Cloud Documentation - Node auto-upgrades
   - uid: mondoo-gcp-security-gke-node-auto-upgrade-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -23917,7 +23917,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair
         title: Google Cloud Documentation - Node auto-repair
   - uid: mondoo-gcp-security-gke-node-auto-repair-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -24067,7 +24067,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
         title: Google Cloud Documentation - Use least privilege service accounts for nodes
   - uid: mondoo-gcp-security-gke-dedicated-service-account-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -24214,7 +24214,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/alias-ips
         title: Google Cloud Documentation - VPC-native clusters
   - uid: mondoo-gcp-security-gke-ip-aliasing-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -24345,7 +24345,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/container-optimized-os/docs
+      - url: https://docs.cloud.google.com/container-optimized-os/docs
         title: Google Cloud Documentation - Container-Optimized OS
   - uid: mondoo-gcp-security-gke-cos-node-image-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -24500,7 +24500,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/backup-recovery/backing-up
+      - url: https://docs.cloud.google.com/sql/docs/mysql/backup-recovery/manage-standard-backups
         title: Google Cloud Documentation - Backing up and restoring Cloud SQL
   - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
     filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
@@ -24648,7 +24648,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/sqlserver/flags
+      - url: https://docs.cloud.google.com/sql/docs/sqlserver/flags
         title: Google Cloud Documentation - Configuring database flags for SQL Server
   - uid: mondoo-gcp-security-cloud-sql-sqlserver-cross-db-ownership-chaining-disabled-gcp
     filters: |
@@ -24809,7 +24809,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/sqlserver/flags
+      - url: https://docs.cloud.google.com/sql/docs/sqlserver/flags
         title: Google Cloud Documentation - Configuring database flags for SQL Server
   - uid: mondoo-gcp-security-cloud-sql-sqlserver-contained-db-auth-disabled-gcp
     filters: |
@@ -24970,7 +24970,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/postgres/flags
+      - url: https://docs.cloud.google.com/sql/docs/postgres/flags
         title: Google Cloud Documentation - Configuring database flags for PostgreSQL
   - uid: mondoo-gcp-security-cloud-sql-postgres-log-lock-waits-enabled-gcp
     filters: asset.platform == 'gcp-sql-postgresql'
@@ -25129,7 +25129,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls
         title: Google Cloud Documentation - VPC firewall rules
   - uid: mondoo-gcp-security-firewall-no-large-port-range-gcp
     filters: |
@@ -25295,7 +25295,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/firewall/docs/firewall-policies
+      - url: https://docs.cloud.google.com/firewall/docs/firewall-policies
         title: Hierarchical firewall policies
   - uid: mondoo-gcp-security-hierarchical-firewall-policy-no-unrestricted-ingress-gcp
     filters: asset.platform == 'gcp-org'
@@ -25428,7 +25428,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules
+      - url: https://docs.cloud.google.com/firewall/docs/firewalls#default_firewall_rules
         title: Google Cloud Documentation - Default firewall rules
   - uid: mondoo-gcp-security-firewall-default-rules-restricted-gcp
     filters: |
@@ -25573,7 +25573,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/disks/customer-supplied-encryption
+      - url: https://docs.cloud.google.com/compute/docs/disks/customer-supplied-encryption
         title: Google Cloud Documentation - Customer-supplied encryption keys
   - uid: mondoo-gcp-security-compute-disk-csek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -25727,7 +25727,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata
         title: Google Cloud Documentation - Protecting cluster metadata
   - uid: mondoo-gcp-security-gke-metadata-concealment-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -25895,7 +25895,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation
         title: Google Cloud Documentation - Private clusters
   - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -26024,7 +26024,7 @@ queries:
 
             Replace `ORGANIZATION_ID` with your GCP organization ID.
     refs:
-      - url: https://cloud.google.com/vpc-service-controls/docs/overview
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/overview
         title: VPC Service Controls overview
       - url: https://cloud.google.com/vpc-service-controls/docs/create-access-levels
         title: Create access levels
@@ -26147,9 +26147,9 @@ queries:
 
             Replace `POLICY_ID` with the access policy ID and `PROJECT_NUMBER` with the project number to protect.
     refs:
-      - url: https://cloud.google.com/vpc-service-controls/docs/service-perimeters
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/service-perimeters
         title: Service perimeters overview
-      - url: https://cloud.google.com/vpc-service-controls/docs/create-service-perimeters
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/create-service-perimeters
         title: Create a service perimeter
   - uid: mondoo-gcp-security-vpc-sc-service-perimeters-gcp
     filters: asset.platform == 'gcp-org'
@@ -26268,7 +26268,7 @@ queries:
 
             Remove any `spec` block to ensure the perimeter is not in dry-run mode.
     refs:
-      - url: https://cloud.google.com/vpc-service-controls/docs/dry-run-mode
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/dry-run-mode
         title: VPC Service Controls dry-run mode
       - url: https://cloud.google.com/vpc-service-controls/docs/manage-perimeters
         title: Manage service perimeters
@@ -26508,7 +26508,7 @@ queries:
             gcloud storage buckets update gs://<bucket> --soft-delete-duration=14d
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/soft-delete
+      - url: https://docs.cloud.google.com/storage/docs/soft-delete
         title: Cloud Storage - Soft delete
   - uid: mondoo-gcp-security-cloud-storage-bucket-soft-delete-enabled-gcp
     filters: asset.platform == 'gcp-storage-bucket'
@@ -26627,7 +26627,7 @@ queries:
             gcloud storage buckets create gs://<bucket> --enable-per-object-retention
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/object-lock
+      - url: https://docs.cloud.google.com/storage/docs/object-lock
         title: Cloud Storage - Object retention (Bucket Lock)
   - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict
     title: Ensure KMS key access justifications exclude customer-initiated support
@@ -26905,7 +26905,7 @@ queries:
             gcloud compute routes delete <route-name>
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/routes
+      - url: https://docs.cloud.google.com/vpc/docs/routes
         title: GCP VPC Routes
   - uid: mondoo-gcp-security-compute-route-no-internet-gateway-to-sensitive-subnets-gcp
     filters: asset.platform == 'gcp-project'
@@ -27042,7 +27042,7 @@ queries:
               --connection-preference=ACCEPT_MANUAL
             ```
     refs:
-      - url: https://cloud.google.com/vpc/docs/private-service-connect
+      - url: https://docs.cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect
   - uid: mondoo-gcp-security-compute-service-attachment-consumer-reviewed-gcp
     filters: asset.platform == 'gcp-project'
@@ -27216,7 +27216,7 @@ queries:
             gcloud sql users delete <legacy-user> --instance=<instance>
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/iam-authentication
+      - url: https://docs.cloud.google.com/sql/docs/mysql/iam-authentication
         title: Cloud SQL - IAM database authentication
   - uid: mondoo-gcp-security-cloud-sql-users-use-iam-auth-gcp
     filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
@@ -27356,7 +27356,7 @@ queries:
             gcloud compute target-ssl-proxies update <proxy> --ssl-policy=<policy>
             ```
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: GCP - SSL policies
   - uid: mondoo-gcp-security-target-ssl-proxy-has-explicit-policy-gcp
     filters: asset.platform == 'gcp-project'
@@ -27502,7 +27502,7 @@ queries:
 
             Note: Enabling enforcement recreates all node pools in the cluster, which can disrupt running workloads. Clusters using GKE Dataplane V2 enforce network policy natively and do not require these steps.
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy
         title: GKE - Configuring network policy
   - uid: mondoo-gcp-security-gke-network-policy-provider-specified-gcp
     filters: asset.platform == "gcp-gke-cluster"
@@ -27654,7 +27654,7 @@ queries:
               --notification-config=pubsub=ENABLED,pubsub-topic=projects/<project>/topics/<topic>
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-notifications
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cluster-notifications
         title: GKE - Cluster notifications
   # No Terraform variants: the runtime check confirms presence of any active
   # google_gke_backup_backup_plan but does not correlate plans to specific clusters.
@@ -27769,7 +27769,7 @@ queries:
               --backup-retain-days=30
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke
         title: Backup for GKE overview
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public
     title: Ensure Vertex AI index endpoints are not publicly accessible
@@ -28013,7 +28013,7 @@ queries:
               --config=config.yaml
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/custom-service-account
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/custom-service-account
         title: Vertex AI - Use a custom service account
   - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr
     title: Ensure IAP tunnel destination groups do not use overly broad CIDR ranges
@@ -28120,7 +28120,7 @@ queries:
               --ip-range-list=10.20.5.0/24,10.20.6.0/24
             ```
     refs:
-      - url: https://cloud.google.com/iap/docs/tcp-by-host
+      - url: https://docs.cloud.google.com/iap/docs/tcp-by-host
         title: IAP - TCP forwarding with destination groups
   - uid: mondoo-gcp-security-iap-tunnel-dest-group-no-broad-cidr-gcp
     filters: asset.platform == 'gcp-project'
@@ -28276,7 +28276,7 @@ queries:
               "https://dlp.googleapis.com/v2/projects/<project>/jobTriggers/<trigger-id>"
             ```
     refs:
-      - url: https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers
+      - url: https://docs.cloud.google.com/sensitive-data-protection/docs/creating-job-triggers
         title: DLP - Creating job triggers
   - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types
     title: Ensure DLP inspect templates include common credential info types
@@ -28410,7 +28410,7 @@ queries:
               "https://dlp.googleapis.com/v2/projects/<project>/inspectTemplates/<template-id>"
             ```
     refs:
-      - url: https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference
+      - url: https://docs.cloud.google.com/sensitive-data-protection/docs/infotypes-reference
         title: DLP - InfoTypes reference
   - uid: mondoo-gcp-security-dlp-inspect-template-covers-credential-info-types-gcp
     filters: asset.platform == 'gcp-project'
@@ -29614,7 +29614,7 @@ queries:
               --filter='state="ACTIVE" AND severity="CRITICAL"'
             ```
     refs:
-      - url: https://cloud.google.com/security-command-center/docs/how-to-notifications
+      - url: https://docs.cloud.google.com/security-command-center/docs/how-to-notifications
         title: Setting up finding notifications
   - uid: mondoo-gcp-security-scc-notification-configs-gcp
     filters: asset.platform == 'gcp-org'
@@ -29846,7 +29846,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/alloydb/docs/reference/database-flags
+      - url: https://docs.cloud.google.com/alloydb/docs/reference/database-flags
         title: AlloyDB database flags
       - url: https://www.postgresql.org/docs/current/runtime-config-logging.html
         title: PostgreSQL - runtime logging configuration
@@ -30014,9 +30014,9 @@ queries:
             gcloud sql backups delete BACKUP_ID --instance=INSTANCE_NAME
             ```
     refs:
-      - url: https://cloud.google.com/sql/docs/mysql/cmek
+      - url: https://docs.cloud.google.com/sql/docs/mysql/cmek
         title: Cloud SQL - Using customer-managed encryption keys
-      - url: https://cloud.google.com/sql/docs/mysql/backup-recovery/backups
+      - url: https://docs.cloud.google.com/sql/docs/mysql/backup-recovery/backups
         title: Cloud SQL - About backups
   - uid: mondoo-gcp-security-bigquery-aws-azure-connections-use-identity-federation
     title: Ensure BigQuery AWS and Azure connections use identity federation
@@ -30143,9 +30143,9 @@ queries:
               CONNECTION_ID
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/omni-aws-create-connection
+      - url: https://docs.cloud.google.com/bigquery/docs/omni-aws-create-connection
         title: BigQuery Omni - Create AWS connection with identity federation
-      - url: https://cloud.google.com/bigquery/docs/omni-azure-create-connection
+      - url: https://docs.cloud.google.com/bigquery/docs/omni-azure-create-connection
         title: BigQuery Omni - Create Azure connection with identity federation
   - uid: mondoo-gcp-security-bigquery-aws-azure-connections-use-identity-federation-gcp
     filters: asset.platform == 'gcp-bigquery-dataset'
@@ -30325,9 +30325,9 @@ queries:
             rm -f /tmp/bq-cred.json
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries
+      - url: https://docs.cloud.google.com/bigquery/docs/cloud-sql-federated-queries
         title: BigQuery - Cloud SQL federated queries
-      - url: https://cloud.google.com/sql/docs/mysql/create-manage-users
+      - url: https://docs.cloud.google.com/sql/docs/mysql/create-manage-users
         title: Cloud SQL - Managing users
   # No Terraform variants: BigQuery's google_bigquery_connection cloud_resource
   # block has no input field for service_account_id — the delegated SA is
@@ -30462,7 +30462,7 @@ queries:
     refs:
       - url: https://cloud.google.com/bigquery/docs/connect-to-resource
         title: BigQuery - Cloud Resource connections
-      - url: https://cloud.google.com/iam/docs/service-account-overview#default
+      - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
         title: Default service accounts - security considerations
   - uid: mondoo-gcp-security-spanner-backup-schedule-cmek-encryption
     title: Ensure Spanner backup schedules use customer-managed encryption
@@ -30589,7 +30589,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/spanner/docs/cmek
+      - url: https://docs.cloud.google.com/spanner/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Cloud Spanner
       - url: https://cloud.google.com/spanner/docs/backup-schedules
         title: Cloud Spanner - Backup schedules
@@ -30765,9 +30765,9 @@ queries:
               --role=roles/viewer
             ```
     refs:
-      - url: https://cloud.google.com/spanner/docs/iam
+      - url: https://docs.cloud.google.com/spanner/docs/iam
         title: Cloud Spanner - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-spanner-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-spanner-instance'
@@ -30987,9 +30987,9 @@ queries:
               --role=ROLE_NAME
             ```
     refs:
-      - url: https://cloud.google.com/spanner/docs/iam
+      - url: https://docs.cloud.google.com/spanner/docs/iam
         title: Cloud Spanner - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-spanner-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-spanner-instance'
@@ -31169,7 +31169,7 @@ queries:
               --authorization-mode=IAM_AUTH
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/about-iam-auth
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/about-iam-auth
         title: Memorystore IAM authentication overview
   - uid: mondoo-gcp-security-memorystore-iam-auth-enabled-gcp
     filters: asset.platform == 'gcp-memorystore-instance'
@@ -31294,7 +31294,7 @@ queries:
               --transit-encryption-mode=SERVER_AUTHENTICATION
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/about-in-transit-encryption
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/about-in-transit-encryption
         title: Memorystore in-transit encryption overview
   - uid: mondoo-gcp-security-memorystore-transit-encryption-enabled-gcp
     filters: asset.platform == 'gcp-memorystore-instance'
@@ -31421,7 +31421,7 @@ queries:
               --kms-key=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/about-cmek
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/about-cmek
         title: Memorystore CMEK overview
   - uid: mondoo-gcp-security-memorystore-cmek-encryption-gcp
     filters: asset.platform == 'gcp-memorystore-instance'
@@ -31788,7 +31788,7 @@ queries:
               --engine-configs=maxmemory-policy=allkeys-lru
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/supported-instance-configurations
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/supported-instance-configurations
         title: Supported Memorystore instance configurations
   - uid: mondoo-gcp-security-memorystore-engine-config-protected-mode-gcp
     filters: asset.platform == 'gcp-memorystore-instance'
@@ -31906,7 +31906,7 @@ queries:
               --engine-version=VALKEY_8_0
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/release-notes
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/release-notes
         title: Memorystore release notes
       - url: https://valkey.io/security/
         title: Valkey security advisories
@@ -32044,7 +32044,7 @@ queries:
             EOF
             ```
     refs:
-      - url: https://cloud.google.com/datastream/docs/use-cmek
+      - url: https://docs.cloud.google.com/datastream/docs/use-cmek
         title: Use CMEK with Datastream
   - uid: mondoo-gcp-security-datastream-stream-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -32193,7 +32193,7 @@ queries:
               --private-connection=PRIVATE_CONNECTION_ID
             ```
     refs:
-      - url: https://cloud.google.com/datastream/docs/network-connectivity-options
+      - url: https://docs.cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-static-service-ip-connectivity-gcp
     filters: asset.platform == 'gcp-project'
@@ -32328,7 +32328,7 @@ queries:
               --private-connection=PRIVATE_CONNECTION_ID
             ```
     refs:
-      - url: https://cloud.google.com/datastream/docs/network-connectivity-options
+      - url: https://docs.cloud.google.com/datastream/docs/network-connectivity-options
         title: Datastream network connectivity options
   - uid: mondoo-gcp-security-datastream-no-forward-ssh-connectivity-gcp
     filters: asset.platform == 'gcp-project'
@@ -32485,7 +32485,7 @@ queries:
               --oracle-secret-manager-stored-password=projects/PROJECT/secrets/SECRET_NAME/versions/VERSION
             ```
     refs:
-      - url: https://cloud.google.com/datastream/docs/configure-your-source-database
+      - url: https://docs.cloud.google.com/datastream/docs/configure-your-source-oracle-database
         title: Configure your Datastream source database (Secret Manager)
   - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
     filters: asset.platform == 'gcp-project'
@@ -32673,7 +32673,7 @@ queries:
         # private connection itself is manageable, but its routes are only
         # reachable through the API and gcloud.
     refs:
-      - url: https://cloud.google.com/datastream/docs/private-connectivity
+      - url: https://docs.cloud.google.com/datastream/docs/vpc-peering
         title: Datastream private connectivity
   - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-gcp
     filters: asset.platform == 'gcp-project'
@@ -32792,9 +32792,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/storage/docs/uniform-bucket-level-access
+      - url: https://docs.cloud.google.com/storage/docs/uniform-bucket-level-access
         title: Cloud Storage - Uniform bucket-level access
-      - url: https://cloud.google.com/storage/docs/public-access-prevention
+      - url: https://docs.cloud.google.com/storage/docs/public-access-prevention
         title: Cloud Storage - Public access prevention
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc
     title: Ensure Datastream private connections do not peer the default VPC
@@ -32904,7 +32904,7 @@ queries:
               --subnet=10.10.0.0/29
             ```
     refs:
-      - url: https://cloud.google.com/datastream/docs/private-connectivity
+      - url: https://docs.cloud.google.com/datastream/docs/vpc-peering
         title: Datastream private connectivity
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-gcp
     filters: asset.platform == 'gcp-project'
@@ -33054,7 +33054,7 @@ queries:
               --node-memory=1GB
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/memcached/networking
+      - url: https://docs.cloud.google.com/memorystore/docs/memcached/networking
         title: Memorystore for Memcached - Networking
   - uid: mondoo-gcp-security-memcache-instance-not-default-vpc-gcp
     filters: asset.platform == 'gcp-memcache-instance'
@@ -33177,7 +33177,7 @@ queries:
             ```
         # No Terraform remediation: the discovery endpoint IP is output-only (computed by GCP from the authorized network's IP allocation) and cannot be set directly in any Terraform resource argument.
     refs:
-      - url: https://cloud.google.com/memorystore/docs/memcached/auto-discovery-overview
+      - url: https://docs.cloud.google.com/memorystore/docs/memcached/about-auto-discovery
         title: Memorystore for Memcached - Auto Discovery
     filters: asset.platform == 'gcp-memcache-instance'
     mql: |
@@ -33286,7 +33286,7 @@ queries:
               --memcached-version=1.6.15
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/memcached/release-notes
+      - url: https://docs.cloud.google.com/memorystore/docs/memcached/release-notes
         title: Memorystore for Memcached release notes
       - url: https://github.com/memcached/memcached/wiki/ReleaseNotes
         title: Memcached upstream release notes (CVE history)
@@ -33429,9 +33429,9 @@ queries:
               --role=ROLE_NAME
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/access/iam
+      - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-compute-snapshot-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-project'
@@ -33584,9 +33584,9 @@ queries:
               --role=roles/compute.storageAdmin
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/access/iam
+      - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-project'
@@ -33757,9 +33757,9 @@ queries:
               --role=ROLE_NAME
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/access/iam
+      - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-compute-image-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-compute-image'
@@ -33911,9 +33911,9 @@ queries:
               --role=roles/compute.imageUser
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/access/iam
+      - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-compute-image'
@@ -34073,7 +34073,7 @@ queries:
               --kms-key=projects/KMS_PROJECT/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/artifact-registry/docs/cmek
+      - url: https://docs.cloud.google.com/artifact-registry/docs/cmek
         title: Artifact Registry - Enable customer-managed encryption keys
   - uid: mondoo-gcp-security-artifact-registry-repository-cmek-encryption-gcp
     filters: asset.platform == 'gcp-artifactregistry-repository'
@@ -34219,7 +34219,7 @@ queries:
 
             Repeat the command for any other roles bound to public principals (`roles/artifactregistry.writer`, `roles/artifactregistry.admin`, etc.).
     refs:
-      - url: https://cloud.google.com/artifact-registry/docs/access-control
+      - url: https://docs.cloud.google.com/artifact-registry/docs/access-control
         title: Artifact Registry - Access control with IAM
   - uid: mondoo-gcp-security-artifact-registry-repository-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-artifactregistry-repository'
@@ -34378,7 +34378,7 @@ queries:
               --allow-vulnerability-scanning
             ```
     refs:
-      - url: https://cloud.google.com/artifact-analysis/docs/container-scanning-overview
+      - url: https://docs.cloud.google.com/artifact-analysis/docs/container-scanning-overview
         title: Container scanning overview
   - uid: mondoo-gcp-security-artifact-registry-repository-vulnerability-scanning-enabled-gcp
     filters: |
@@ -34548,7 +34548,7 @@ queries:
             gcloud builds triggers import --source=trigger.yaml
             ```
     refs:
-      - url: https://cloud.google.com/build/docs/securing-builds/use-secrets
+      - url: https://docs.cloud.google.com/build/docs/securing-builds/use-secrets
         title: Cloud Build - Use secrets from Secret Manager
   - uid: mondoo-gcp-security-cloud-build-trigger-no-plaintext-secrets-in-substitutions-gcp
     filters: asset.platform == 'gcp-project'
@@ -34706,7 +34706,7 @@ queries:
               --no-public-egress
             ```
     refs:
-      - url: https://cloud.google.com/build/docs/private-pools/private-pools-overview
+      - url: https://docs.cloud.google.com/build/docs/private-pools/private-pools-overview
         title: Cloud Build - Private pools overview
   - uid: mondoo-gcp-security-cloud-build-worker-pool-private-gcp
     filters: asset.platform == 'gcp-project'
@@ -34837,7 +34837,7 @@ queries:
               --service-account=projects/PROJECT/serviceAccounts/cloudbuild-runner@PROJECT.iam.gserviceaccount.com
             ```
     refs:
-      - url: https://cloud.google.com/build/docs/cloud-build-service-account
+      - url: https://docs.cloud.google.com/build/docs/cloud-build-service-account
         title: Cloud Build service account
   - uid: mondoo-gcp-security-cloud-build-trigger-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
@@ -34995,7 +34995,7 @@ queries:
 
             For Beam Python pipelines pass `--no_use_public_ips` and `--subnetwork`.
     refs:
-      - url: https://cloud.google.com/dataflow/docs/guides/routes-firewall#turn_off_external_ip_address
+      - url: https://docs.cloud.google.com/dataflow/docs/guides/routes-firewall#turn_off_external_ip_address
         title: Dataflow - Turn off external IP addresses
   - uid: mondoo-gcp-security-dataflow-job-no-public-ips-gcp
     filters: asset.platform == 'gcp-project'
@@ -35162,7 +35162,7 @@ queries:
 
             For Beam Python pipelines pass `--service_account_email`.
     refs:
-      - url: https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#worker_service_account
+      - url: https://docs.cloud.google.com/dataflow/docs/concepts/security-and-permissions#worker-service-account
         title: Dataflow - Worker service account
   - uid: mondoo-gcp-security-dataflow-job-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
@@ -35346,7 +35346,7 @@ queries:
               --kms-key=projects/KMS_PROJECT/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/filestore/docs/cmek
+      - url: https://docs.cloud.google.com/filestore/docs/cmek
         title: Filestore - Customer-managed encryption keys
   - uid: mondoo-gcp-security-filestore-instance-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -35494,7 +35494,7 @@ queries:
             done
             ```
     refs:
-      - url: https://cloud.google.com/datastore/docs/access/iam
+      - url: https://docs.cloud.google.com/datastore/docs/access/iam
         title: Firestore in Datastore mode - Identity and Access Management
   - uid: mondoo-gcp-security-firestore-project-iam-no-public-datastore-roles-gcp
     filters: asset.platform == 'gcp-project'
@@ -35625,7 +35625,7 @@ queries:
             ```
         # No Terraform remediation: Vertex AI custom training jobs are imperative API operations with no Terraform resource analog; the fix lives in the job submission tooling, not in static infrastructure configuration.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/custom-service-account
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/custom-service-account
         title: Vertex AI - Use a custom service account
   - uid: mondoo-gcp-security-essential-contacts-security-category-configured
     title: Ensure Essential Contacts cover the SECURITY notification category
@@ -35743,7 +35743,7 @@ queries:
               --organization=ORG_ID
             ```
     refs:
-      - url: https://cloud.google.com/resource-manager/docs/managing-notification-contacts
+      - url: https://docs.cloud.google.com/resource-manager/docs/managing-notification-contacts
         title: Manage Essential Contacts
   - uid: mondoo-gcp-security-essential-contacts-security-category-configured-gcp
     filters: asset.platform == 'gcp-project'
@@ -35897,9 +35897,9 @@ queries:
 
             `internal-and-cloud-load-balancing` is also acceptable when an internal load balancer is required.
     refs:
-      - url: https://cloud.google.com/appengine/docs/standard/application-security
+      - url: https://docs.cloud.google.com/appengine/docs/standard/application-security
         title: App Engine application security
-      - url: https://cloud.google.com/iap/docs/enabling-app-engine
+      - url: https://docs.cloud.google.com/iap/docs/enabling-app-engine
         title: Enabling IAP for App Engine
   - uid: mondoo-gcp-security-appengine-iap-or-vpc-only-ingress-gcp
     filters: asset.platform == 'gcp-project'
@@ -36055,9 +36055,9 @@ queries:
 
             Ensure the supplied `openapi.yaml` declares `securityDefinitions` and applies a `security` requirement to every operation.
     refs:
-      - url: https://cloud.google.com/api-gateway/docs/authentication-method
+      - url: https://docs.cloud.google.com/api-gateway/docs/authentication-method
         title: API Gateway authentication methods
-      - url: https://cloud.google.com/api-gateway/docs/openapi-overview
+      - url: https://docs.cloud.google.com/api-gateway/docs/openapi-overview
         title: API Gateway OpenAPI overview
   - uid: mondoo-gcp-security-apigateway-config-requires-authentication-terraform-hcl
     filters: |
@@ -36205,9 +36205,9 @@ queries:
               --signed-url-cache-max-age=7200s
             ```
     refs:
-      - url: https://cloud.google.com/cdn/docs/using-signed-urls
+      - url: https://docs.cloud.google.com/cdn/docs/using-signed-urls
         title: Using signed URLs with Cloud CDN
-      - url: https://cloud.google.com/cdn/docs/using-signed-cookies
+      - url: https://docs.cloud.google.com/cdn/docs/using-signed-cookies
         title: Using signed cookies with Cloud CDN
   - uid: mondoo-gcp-security-cloud-cdn-backend-signed-urls-required-gcp
     filters: asset.platform == 'gcp-project'
@@ -36510,9 +36510,9 @@ queries:
               --disable-public-ip
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/create
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/instances/create
         title: Create a Vertex AI Workbench instance
-      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-network
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/introduction
         title: Manage Vertex AI Workbench network options
   - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-hcl
     filters: |
@@ -36664,7 +36664,7 @@ queries:
               --kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/composer/docs/composer-2/configure-cmek-encryption
+      - url: https://docs.cloud.google.com/composer/docs/composer-2/configure-cmek-encryption
         title: Configure CMEK encryption for Cloud Composer
   - uid: mondoo-gcp-security-composer-environment-cmek-encryption-terraform-hcl
     filters: |
@@ -36819,7 +36819,7 @@ queries:
               --web-server-allow-ip=ip_range=10.0.0.0/8,description="corp network"
             ```
     refs:
-      - url: https://cloud.google.com/composer/docs/composer-3/configure-private-ip
+      - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
         title: Configure Private IP environments
       - url: https://cloud.google.com/composer/docs/composer-3/configure-network-access-control
         title: Configure web server network access control
@@ -36989,7 +36989,7 @@ queries:
               --dataflow-kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys
+      - url: https://docs.cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys
         title: Use customer-managed encryption keys with Dataflow
   - uid: mondoo-gcp-security-dataflow-job-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -37269,7 +37269,7 @@ queries:
               --cmek-kms-key-name=projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/routing/managed-encryption-storage
+      - url: https://docs.cloud.google.com/logging/docs/routing/managed-encryption-storage
         title: Customer-managed encryption keys for Cloud Logging
   - uid: mondoo-gcp-security-logging-sink-destination-cmek-encryption-gcp
     filters: asset.platform == 'gcp-logging-bucket'
@@ -37418,7 +37418,7 @@ queries:
               --kms-key-name=projects/KMS_PROJECT/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/routing/managed-encryption
+      - url: https://docs.cloud.google.com/logging/docs/routing/managed-encryption
         title: Configure CMEK for log routing
       - url: https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.locations/getCmekSettings
         title: Logging CMEK settings API
@@ -37602,7 +37602,7 @@ queries:
               --kms-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-vertex-ai-job-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -37803,9 +37803,9 @@ queries:
               --min-tls-version=1.2
             ```
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/ssl-policies-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/ssl-policies-concepts
         title: GCP - SSL policies concepts
-      - url: https://cloud.google.com/load-balancing/docs/use-ssl-policies
+      - url: https://docs.cloud.google.com/load-balancing/docs/use-ssl-policies
         title: GCP - Using SSL policies
   - uid: mondoo-gcp-security-https-lb-ssl-policy-min-tls-1-2-gcp
     filters: asset.platform == 'gcp-project'
@@ -37989,7 +37989,7 @@ queries:
             gcloud app versions delete OLD_VERSION --service=SERVICE_NAME
             ```
     refs:
-      - url: https://cloud.google.com/appengine/docs/standard/reference/app-yaml
+      - url: https://docs.cloud.google.com/appengine/docs/standard/reference/app-yaml
         title: App Engine - app.yaml reference
       - url: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_standard_app_version
         title: Terraform - google_app_engine_standard_app_version
@@ -38145,7 +38145,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/functions/docs/securing/managing-access-iam
+      - url: https://docs.cloud.google.com/functions/docs/securing/managing-access-iam
         title: Authorizing access to Cloud Functions
   - uid: mondoo-gcp-security-cloud-functions-no-public-invocation-gcp
     filters: asset.platform == 'gcp-cloud-function'
@@ -38310,7 +38310,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+      - url: https://docs.cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-snapshot-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -38447,7 +38447,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+      - url: https://docs.cloud.google.com/compute/docs/disks/customer-managed-encryption
         title: Protecting resources with Cloud KMS keys
   - uid: mondoo-gcp-security-compute-image-cmek-encryption-gcp
     filters: asset.platform == 'gcp-compute-image'
@@ -38578,7 +38578,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/service-account-impersonation
+      - url: https://docs.cloud.google.com/iam/docs/service-account-impersonation
         title: Service account impersonation
   - uid: mondoo-gcp-security-iam-service-account-not-impersonatable-gcp
     filters: asset.platform == 'gcp-iam-service-account'
@@ -38724,7 +38724,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kms/docs/iam
+      - url: https://docs.cloud.google.com/kms/docs/iam
         title: Cloud KMS permissions and roles
   - uid: mondoo-gcp-security-cloud-kms-keyring-not-publicly-accessible-gcp
     filters: asset.platform == 'gcp-kms-keyring'
@@ -38871,7 +38871,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/appengine/docs/standard/creating-firewalls
+      - url: https://docs.cloud.google.com/appengine/docs/standard/creating-firewalls
         title: Creating App Engine firewalls
   - uid: mondoo-gcp-security-appengine-firewall-no-public-ingress-gcp
     filters: asset.platform == 'gcp-project'
@@ -39094,7 +39094,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/eventarc/docs/use-cmek
+      - url: https://docs.cloud.google.com/eventarc/docs/use-cmek
         title: Use customer-managed encryption keys with Eventarc
   - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -39212,7 +39212,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys for Vertex AI
   - uid: mondoo-gcp-security-pubsub-topic-schema-validation-enabled
     title: Ensure Pub/Sub topics enforce a message schema
@@ -39325,7 +39325,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/schemas
+      - url: https://docs.cloud.google.com/pubsub/docs/schemas
         title: Pub/Sub schemas overview
   - uid: mondoo-gcp-security-pubsub-topic-schema-validation-enabled-gcp
     filters: asset.platform == 'gcp-pubsub-topic'
@@ -39454,7 +39454,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/resource-location-restriction
+      - url: https://docs.cloud.google.com/pubsub/docs/resource-location-restriction
         title: Pub/Sub resource location restriction
   - uid: mondoo-gcp-security-pubsub-topic-message-storage-policy-configured-gcp
     filters: asset.platform == 'gcp-pubsub-topic'
@@ -39585,7 +39585,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/push
+      - url: https://docs.cloud.google.com/pubsub/docs/push
         title: Pub/Sub push subscriptions
   - uid: mondoo-gcp-security-pubsub-subscription-push-endpoint-https-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
@@ -39728,7 +39728,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/handling-failures
+      - url: https://docs.cloud.google.com/pubsub/docs/dead-letter-topics
         title: Pub/Sub - Handling message failures
   - uid: mondoo-gcp-security-pubsub-subscription-dead-letter-configured-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
@@ -40125,7 +40125,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/deploying#images
+      - url: https://docs.cloud.google.com/run/docs/deploying#images
         title: Cloud Run - Deploying container images
   - uid: mondoo-gcp-security-cloud-run-job-image-not-latest-tag-gcp
     filters: asset.platform == 'gcp-cloudrun-job'
@@ -40289,7 +40289,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/configuring/vpc-direct-vpc
+      - url: https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc
         title: Cloud Run - Configuring VPC egress
   - uid: mondoo-gcp-security-cloud-run-job-vpc-egress-configured-gcp
     filters: asset.platform == 'gcp-cloudrun-job'
@@ -40420,7 +40420,7 @@ queries:
         # cannot traverse with key-name regex matching; the runtime check covers this
         # control surface instead.
     refs:
-      - url: https://cloud.google.com/run/docs/configuring/secrets
+      - url: https://docs.cloud.google.com/run/docs/configuring/services/secrets
         title: Cloud Run - Using secrets from Secret Manager
   - uid: mondoo-gcp-security-cloud-run-job-no-plaintext-secrets-in-env-gcp
     filters: asset.platform == 'gcp-cloudrun-job'
@@ -40529,7 +40529,7 @@ queries:
         # resources with no long-lived Terraform resource; use the CLI or SDK to submit
         # jobs with an encryptionSpec at submission time.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Vertex AI CMEK overview
 # No Terraform variants: Vertex AI custom jobs are short-lived imperative API resources with no Terraform analog.
   - uid: mondoo-gcp-security-vertexai-custom-job-private-network
@@ -40617,7 +40617,7 @@ queries:
         # resources with no long-lived Terraform resource; use the CLI or SDK to submit
         # jobs with a network field at submission time.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/vpc-peering
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/vpc-peering
         title: Vertex AI - VPC Network Peering
 # No Terraform variants: Vertex AI custom jobs are short-lived imperative API resources with no Terraform analog.
   - uid: mondoo-gcp-security-vertexai-custom-job-web-access-disabled
@@ -40828,9 +40828,9 @@ queries:
               --role=roles/cloudtasks.enqueuer
             ```
     refs:
-      - url: https://cloud.google.com/tasks/docs/reference-access-control
+      - url: https://docs.cloud.google.com/tasks/docs/access-control
         title: Cloud Tasks - Access control with IAM
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-cloud-tasks-queue-not-publicly-accessible-gcp
     filters: asset.platform == 'gcp-project'
@@ -40985,9 +40985,9 @@ queries:
               --role=roles/cloudtasks.enqueuer
             ```
     refs:
-      - url: https://cloud.google.com/tasks/docs/reference-access-control
+      - url: https://docs.cloud.google.com/tasks/docs/access-control
         title: Cloud Tasks - Access control with IAM
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-cloud-tasks-queue-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-project'
@@ -41155,9 +41155,9 @@ queries:
               --role=roles/bigtable.reader
             ```
     refs:
-      - url: https://cloud.google.com/bigtable/docs/access-control
+      - url: https://docs.cloud.google.com/bigtable/docs/access-control
         title: Cloud Bigtable - Access control with IAM
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-bigtable-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-bigtable-instance'
@@ -41307,9 +41307,9 @@ queries:
               --role=roles/bigtable.user
             ```
     refs:
-      - url: https://cloud.google.com/bigtable/docs/access-control
+      - url: https://docs.cloud.google.com/bigtable/docs/access-control
         title: Cloud Bigtable - Access control with IAM
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-bigtable-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-bigtable-instance'
@@ -41477,9 +41477,9 @@ queries:
               policy.json
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/iam/iam
+      - url: https://docs.cloud.google.com/managed-spark/docs/concepts/iam/iam
         title: Dataproc - Dataproc permissions and IAM roles
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-dataproc-cluster-iam-no-public-principals-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -41635,9 +41635,9 @@ queries:
               policy.json
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/iam/iam
+      - url: https://docs.cloud.google.com/managed-spark/docs/concepts/iam/iam
         title: Dataproc - Dataproc permissions and IAM roles
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM - Basic (primitive) roles
   - uid: mondoo-gcp-security-dataproc-cluster-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -41813,9 +41813,9 @@ queries:
               --role=roles/run.invoker
             ```
     refs:
-      - url: https://cloud.google.com/run/docs/authenticating/public
+      - url: https://docs.cloud.google.com/run/docs/authenticating/public
         title: Cloud Run - Allowing public (unauthenticated) access
-      - url: https://cloud.google.com/iam/docs/overview#allusers
+      - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-cloud-run-no-public-invocation-gcp
     filters: asset.platform == 'gcp-cloudrun-service'
@@ -41982,9 +41982,9 @@ queries:
               --source=workflow.yaml
             ```
     refs:
-      - url: https://cloud.google.com/workflows/docs/authentication
+      - url: https://docs.cloud.google.com/workflows/docs/authentication
         title: Workflows - Manage workflow access and identity
-      - url: https://cloud.google.com/iam/docs/service-account-overview#default
+      - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
         title: IAM - Default service accounts
   - uid: mondoo-gcp-security-workflows-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
@@ -42118,7 +42118,7 @@ queries:
     refs:
       - url: https://cloud.google.com/workflows/docs/cmek
         title: Workflows - Use customer-managed encryption keys
-      - url: https://cloud.google.com/kms/docs/cmek
+      - url: https://docs.cloud.google.com/kms/docs/cmek
         title: Cloud KMS - Customer-managed encryption keys
   - uid: mondoo-gcp-security-workflows-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -42251,7 +42251,7 @@ queries:
     refs:
       - url: https://cloud.google.com/workflows/docs/log-workflow-calls
         title: Workflows - Send logs to Cloud Logging
-      - url: https://cloud.google.com/workflows/docs/reference/rest/v1/projects.locations.workflows#calllevel
+      - url: https://docs.cloud.google.com/workflows/docs/reference/rest/v1/projects.locations.workflows#callloglevel
         title: Workflows - Call log level reference
   - uid: mondoo-gcp-security-workflows-call-logging-enabled-gcp
     filters: asset.platform == 'gcp-project'
@@ -42371,9 +42371,9 @@ queries:
         # No Terraform remediation: the token identity lives in the job's nested http_target
         # oidc_token/oauth_token block; the runtime asserts the effective authentication configuration.
     refs:
-      - url: https://cloud.google.com/scheduler/docs/http-target-auth
+      - url: https://docs.cloud.google.com/scheduler/docs/http-target-auth
         title: Cloud Scheduler - Use authentication with HTTP targets
-      - url: https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules
+      - url: https://docs.cloud.google.com/scheduler/docs/configuring/cron-job-schedules
         title: Cloud Scheduler - Configure job schedules
   # No Terraform variants: the enforced identity is resolved from the job's nested
   # http_target oidc_token/oauth_token block, which the runtime evaluates as the effective
@@ -42460,9 +42460,9 @@ queries:
         # No Terraform remediation: the token identity lives in the job's nested http_target
         # oidc_token/oauth_token block; the runtime asserts the effective service account.
     refs:
-      - url: https://cloud.google.com/scheduler/docs/http-target-auth
+      - url: https://docs.cloud.google.com/scheduler/docs/http-target-auth
         title: Cloud Scheduler - Use authentication with HTTP targets
-      - url: https://cloud.google.com/iam/docs/best-practices-service-accounts
+      - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
         title: IAM - Best practices for using service accounts
   # No Terraform variants: the google_cloud_ids_endpoint Terraform resource does not expose a
   # traffic-logging argument; whether traffic logs are enabled is only observable at runtime.
@@ -42548,7 +42548,7 @@ queries:
         # No Terraform remediation: the google_cloud_ids_endpoint resource does not expose a
         # traffic-logging argument, so the setting cannot be asserted or fixed through Terraform.
     refs:
-      - url: https://cloud.google.com/intrusion-detection-system/docs/configuring-ids
+      - url: https://docs.cloud.google.com/intrusion-detection-system/docs/configuring-ids
         title: Cloud IDS - Configure an IDS endpoint
       - url: https://cloud.google.com/intrusion-detection-system/docs/viewing-threat-details
         title: Cloud IDS - View threats and traffic logs
@@ -42637,9 +42637,9 @@ queries:
         # No Terraform remediation: the google_batch_job resource does not expose the task group
         # permissive-SSH setting, so it cannot be asserted or fixed through Terraform.
     refs:
-      - url: https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#taskgroup
+      - url: https://docs.cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#taskgroup
         title: Batch - TaskGroup reference (permissiveSsh)
-      - url: https://cloud.google.com/batch/docs/create-run-job
+      - url: https://docs.cloud.google.com/batch/docs/create-run-job
         title: Batch - Create and run a job
   - uid: mondoo-gcp-security-iam-project-no-public-members
     title: Ensure the project IAM policy grants no roles to public members
@@ -42748,9 +42748,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/overview
+      - url: https://docs.cloud.google.com/iam/docs/overview
         title: IAM overview
-      - url: https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains
+      - url: https://docs.cloud.google.com/organization-policy/restrict-domains
         title: Restricting identities by domain
   - uid: mondoo-gcp-security-iam-project-no-public-members-gcp
     filters: asset.platform == 'gcp-project'
@@ -42903,9 +42903,9 @@ queries:
 
             Scoping the grant this way limits the caller to the single service account named in `service_account_id`, rather than every service account in the project.
     refs:
-      - url: https://cloud.google.com/iam/docs/service-account-impersonation
+      - url: https://docs.cloud.google.com/iam/docs/service-account-impersonation
         title: Service account impersonation
-      - url: https://cloud.google.com/iam/docs/workload-identity-federation
+      - url: https://docs.cloud.google.com/iam/docs/workload-identity-federation
         title: Workload Identity Federation
   - uid: mondoo-gcp-security-iam-project-no-service-account-impersonation-gcp
     filters: asset.platform == 'gcp-project'
@@ -43066,9 +43066,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/creating-custom-roles
+      - url: https://docs.cloud.google.com/iam/docs/creating-custom-roles
         title: Creating and managing custom roles
-      - url: https://cloud.google.com/iam/docs/service-account-permissions
+      - url: https://docs.cloud.google.com/iam/docs/service-account-permissions
         title: Service account permissions
   - uid: mondoo-gcp-security-iam-custom-roles-no-service-account-impersonation-gcp
     filters: asset.platform == 'gcp-project'
@@ -43244,9 +43244,9 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/iam/docs/understanding-roles#basic
+      - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
         title: IAM basic roles
-      - url: https://cloud.google.com/iam/docs/best-practices-for-using-and-managing-service-accounts
+      - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
         title: Best practices for using and managing service accounts
 
   - uid: mondoo-gcp-security-iam-project-no-primitive-roles-gcp
@@ -43677,7 +43677,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys (CMEK) for Vertex AI
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption-gcp
     filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
@@ -43813,7 +43813,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/security/shielded-cloud/shielded-vm
+      - url: https://docs.cloud.google.com/compute/shielded-vm/docs/shielded-vm
         title: Shielded VM
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
     filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
@@ -43954,7 +43954,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/colab/docs/runtimes
+      - url: https://docs.cloud.google.com/colab/docs/runtimes
         title: Colab Enterprise runtimes
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-private-network-gcp
     filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
@@ -44094,7 +44094,7 @@ queries:
             The service account is fixed at creation, so an existing instance has to be
             replaced rather than edited in place.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-identity
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/introduction
         title: Manage identity and access for Vertex AI Workbench instances
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
@@ -44236,7 +44236,7 @@ queries:
             ```
         # No Terraform remediation: RAG corpora are created through the Vertex AI RAG Engine API and have no dedicated Terraform resource that expresses the encryption key.
     refs:
-      - url: https://cloud.google.com/vertex-ai/generative-ai/docs/rag-engine/rag-overview
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/rag-engine/rag-overview
         title: Vertex AI RAG Engine overview
   - uid: mondoo-gcp-security-vertexai-job-cmek-encryption
     title: Ensure Vertex AI batch prediction and tuning jobs use CMEK
@@ -44323,5 +44323,5 @@ queries:
             ```
         # No Terraform remediation: Vertex AI batch prediction and tuning jobs are imperative API calls with no dedicated Terraform resource that expresses the encryption key.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/general/cmek
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/cmek
         title: Customer-managed encryption keys (CMEK) for Vertex AI

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gcp-security
     name: Mondoo Google Cloud (GCP) Security
-    version: 9.11.0
+    version: 9.11.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -1988,7 +1988,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery Security Best Practices
+        title: BigQuery data governance
   - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: |
@@ -2157,7 +2157,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery Security Best Practices
+        title: BigQuery data governance
   - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.kmsKey != null
@@ -2325,7 +2325,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery Security Best Practices
+        title: BigQuery data governance
   - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.tables.all(kmsKey != null)
@@ -2477,7 +2477,7 @@ queries:
             2. Recreate existing models within the CMEK-protected dataset to ensure they use customer-managed encryption.
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery Security Best Practices
+        title: BigQuery data governance
   - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.models.all(kmsKey != null)
@@ -2779,7 +2779,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery Security Best Practices
+        title: BigQuery data governance
   - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.access.none(entityType == "DOMAIN")
@@ -9553,7 +9553,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access
-        title: Restrict default RBAC bindings in GKE
+        title: Restrict anonymous access in GKE
   - uid: mondoo-gcp-security-gke-rbac-no-insecure-system-bindings-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
@@ -11451,8 +11451,8 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
-      - url: https://docs.cloud.google.com/logging/docs/routing/overview
-        title: Cloud Logging storage
+      - url: https://docs.cloud.google.com/logging/docs/buckets
+        title: Configure log buckets
   - uid: mondoo-gcp-security-logging-bucket-retention-30-days-gcp
     filters: asset.platform == 'gcp-logging-bucket'
     mql: |
@@ -11588,7 +11588,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
-      - url: https://docs.cloud.google.com/logging/docs/routing/overview
+      - url: https://docs.cloud.google.com/logging/docs/buckets#locking-logs-buckets
         title: Locked log buckets
   - uid: mondoo-gcp-security-logging-bucket-locked-gcp
     filters: |
@@ -14457,7 +14457,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/compute/shielded-vm/docs/shielded-vm
-        title: Shielded VMs in Dataproc
+        title: Shielded VM overview
   - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
     mql: |
@@ -17121,8 +17121,6 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
         title: Google Cloud - Troubleshooting using the serial console
-      - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
-        title: Google Cloud - Interacting with the serial console
   - uid: mondoo-gcp-security-compute-instances-serial-port-disabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
     mql: |
@@ -20010,7 +20008,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
-        title: Interacting with the serial console
+        title: Troubleshooting using the serial console
       - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-serial-port-disabled-gcp
@@ -27874,8 +27872,8 @@ queries:
               --network=projects/<project>/global/networks/<vpc>
             ```
     refs:
-      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/setup
-        title: Vertex AI - Setup index endpoint
+      - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/deploy-index-public
+        title: Vertex AI - Deploy and manage public index endpoints
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -29726,7 +29724,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/security-command-center/docs/how-to-export-data
-        title: Exporting findings to BigQuery
+        title: Exporting Security Command Center data
   - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
     filters: asset.platform == 'gcp-org'
     mql: |
@@ -31679,7 +31677,7 @@ queries:
             Recreate the instance without the public endpoint variant if any auto-connection has `connectionType: PUBLIC_ENDPOINT`.
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/valkey/networking
-        title: Memorystore and Private Service Connect
+        title: Memorystore for Valkey networking
     filters: asset.platform == 'gcp-memorystore-instance'
     mql: |
       gcp.project.memorystoreService.instance.pscAttachmentDetails.all(connectionType != "PUBLIC_ENDPOINT")
@@ -36821,8 +36819,8 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
         title: Configure Private IP environments
-      - url: https://docs.cloud.google.com/composer/docs/composer-3/access-control
-        title: Configure web server network access control
+      - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
+        title: Change environment networking type
   - uid: mondoo-gcp-security-composer-environment-private-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -42551,7 +42549,7 @@ queries:
       - url: https://docs.cloud.google.com/intrusion-detection-system/docs/configuring-ids
         title: Cloud IDS - Configure an IDS endpoint
       - url: https://docs.cloud.google.com/intrusion-detection-system/docs/logging
-        title: Cloud IDS - View threats and traffic logs
+        title: Cloud IDS logging information
   # No Terraform variants: the google_batch_job Terraform resource does not expose the task
   # group permissive-SSH setting; it is only observable on the submitted job at runtime.
   - uid: mondoo-gcp-security-batch-job-permissive-ssh-disabled
@@ -43451,7 +43449,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/domains/docs/overview
-        title: Lock and unlock a domain
+        title: Cloud Domains overview
   - uid: mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -43564,7 +43562,7 @@ queries:
         # dns_settings, not the published state this check asserts.
     refs:
       - url: https://docs.cloud.google.com/dns/docs/dnssec-advanced
-        title: DNSSEC configuration in Cloud Domains
+        title: Use advanced DNSSEC
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption
     title: Ensure Vertex AI notebook runtime templates are encrypted with CMEK
     impact: 70

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -659,7 +659,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -856,7 +856,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -1053,7 +1053,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
     mql: gcp.compute.instance.metadata['enable-oslogin'] == true
@@ -1988,7 +1988,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery data governance
+        title: Introduction to data governance in BigQuery
   - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: |
@@ -2157,7 +2157,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery data governance
+        title: Introduction to data governance in BigQuery
   - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.kmsKey != null
@@ -2325,7 +2325,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery data governance
+        title: Introduction to data governance in BigQuery
   - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.tables.all(kmsKey != null)
@@ -2477,7 +2477,7 @@ queries:
             2. Recreate existing models within the CMEK-protected dataset to ensure they use customer-managed encryption.
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery data governance
+        title: Introduction to data governance in BigQuery
   - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.models.all(kmsKey != null)
@@ -2779,7 +2779,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/data-governance
-        title: BigQuery data governance
+        title: Introduction to data governance in BigQuery
   - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
     mql: gcp.bigquery.dataset.access.none(entityType == "DOMAIN")
@@ -4079,7 +4079,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -4268,7 +4268,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -4433,7 +4433,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -4610,7 +4610,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -4801,7 +4801,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -4988,7 +4988,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -5182,7 +5182,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
       - url: https://docs.cloud.google.com/compute/docs/access
-        title: Google Compute Engine Security
+        title: Access control overview
   - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
     filters: |
       asset.platform == 'gcp-compute-instance'
@@ -6023,7 +6023,7 @@ queries:
             Always review IAM policies for KMS crypto keys during code reviews. Use Terraform validation rules or policy-as-code tools to prevent public access grants. Regularly audit your Terraform configurations to ensure compliance.
     refs:
       - url: https://docs.cloud.google.com/kms/docs
-        title: Cloud KMS Documentation
+        title: Cloud Key Management Service documentation
   - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: |
@@ -6187,7 +6187,7 @@ queries:
             Always configure key rotation periods in your Terraform KMS configurations. Use Terraform validation rules or policy-as-code tools to ensure rotation periods are set to 90 days or less. Regularly audit your Terraform configurations to ensure compliance with key rotation requirements.
     refs:
       - url: https://docs.cloud.google.com/kms/docs
-        title: Cloud KMS Documentation
+        title: Cloud Key Management Service documentation
   - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: |
@@ -6348,7 +6348,7 @@ queries:
             For existing keys, the destroy scheduled duration cannot be changed. Create a new key with the correct duration and migrate encrypted data. Key destruction is irreversible and destroys all data still encrypted with that key, so retain the old key until you have confirmed that all data has been re-encrypted with the new key.
     refs:
       - url: https://docs.cloud.google.com/kms/docs
-        title: Cloud KMS Documentation
+        title: Cloud Key Management Service documentation
   - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: |
@@ -6502,7 +6502,7 @@ queries:
             Keyring and key location are immutable and key destruction is irreversible. Retain the old global keys until you have confirmed that all data has been re-encrypted with the new regional keys, then schedule the old keys for destruction.
     refs:
       - url: https://docs.cloud.google.com/kms/docs
-        title: Cloud KMS Documentation
+        title: Cloud Key Management Service documentation
   - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: gcp.project.kms.keyring.location != "global"
@@ -6652,7 +6652,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/kms/docs
-        title: Cloud KMS Documentation
+        title: Cloud Key Management Service documentation
   - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-gcp
     filters: asset.platform == "gcp-kms-keyring"
     mql: |
@@ -7293,7 +7293,7 @@ queries:
       - url: https://docs.cloud.google.com/dns/docs/dnssec-advanced
         title: Configure DNSSEC advanced settings
       - url: https://www.iana.org/assignments/dns-sec-alg-numbers/
-        title: IANA DNS Security Algorithm Numbers
+        title: Domain Name System Security (DNSSEC) Algorithm Numbers
   - uid: mondoo-gcp-security-cloud-dns-no-weak-dnssec-algorithms-gcp
     filters: |
       asset.platform == "gcp-dns-zone"
@@ -9259,7 +9259,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation
-        title: GKE Private cluster documentation
+        title: Customize your network isolation in GKE
   - uid: mondoo-gcp-security-gke-private-cluster-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
@@ -9553,7 +9553,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access
-        title: Restrict anonymous access in GKE
+        title: Best practices for hardening your cluster's security
   - uid: mondoo-gcp-security-gke-rbac-no-insecure-system-bindings-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
@@ -9706,7 +9706,7 @@ queries:
       - url: https://docs.cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
       - url: https://docs.cloud.google.com/binary-authorization/docs/enable-cluster
-        title: Enabling Binary Authorization for GKE
+        title: Enable enforcement on an existing cluster
 
   - uid: mondoo-gcp-security-gke-binary-authorization-enabled-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -10385,7 +10385,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/redis/about-redis-auth
-        title: Cloud Memorystore Redis AUTH documentation
+        title: About Redis AUTH
   - uid: mondoo-gcp-security-cloud-redis-auth-enabled-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
     mql: |
@@ -10892,9 +10892,9 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
-        title: Default service accounts
+        title: Types of service accounts
       - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
-        title: Best practices for service accounts
+        title: Best practices for using service accounts securely
   - uid: mondoo-gcp-security-iam-default-service-accounts-disabled-gcp
     filters: |
       asset.platform == 'gcp-iam-service-account'
@@ -11248,7 +11248,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/iam/docs/keys-create-delete
-        title: Creating and managing service account keys
+        title: Create and delete service account keys
   - uid: mondoo-gcp-security-iam-no-disabled-service-account-keys-gcp
     filters: asset.platform == 'gcp-iam-service-account'
     mql: |
@@ -11868,7 +11868,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/logging/docs/routing/overview
-        title: Routing and storage overview
+        title: Route log entries
       - url: https://docs.cloud.google.com/logging/docs/export/configure_export_v2
         title: Configure log sinks
   - uid: mondoo-gcp-security-logging-sinks-configured-gcp
@@ -12553,7 +12553,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/run/docs/configuring/networking-best-practices
-        title: Cloud Functions networking settings
+        title: Best practices for Cloud Run networking
   - uid: mondoo-gcp-security-cloud-functions-ingress-restricted-gcp
     filters: asset.platform == 'gcp-cloud-function'
     mql: |
@@ -15923,7 +15923,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/redis/about-in-transit-encryption
-        title: Cloud Memorystore for Redis in-transit encryption documentation
+        title: About in-transit encryption
   - uid: mondoo-gcp-security-cloud-redis-transit-encryption-enabled-memorystore-redis
     filters: asset.platform == "gcp-memorystore-redis"
     mql: |
@@ -16331,7 +16331,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/cluster/deletion-protection
-        title: Cloud Memorystore for Redis Cluster deletion protection documentation
+        title: Prevent deletion of a cluster
   - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-memorystore-rediscluster
     filters: asset.platform == "gcp-memorystore-rediscluster"
     mql: |
@@ -19875,7 +19875,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/compute/docs/ip-addresses/configure-static-external-ip-address
-        title: External IP addresses
+        title: Configure static external IP addresses
       - url: https://docs.cloud.google.com/organization-policy/reference/org-policy-constraints
         title: Organization policy constraints
   - uid: mondoo-gcp-security-org-policy-vm-external-ip-restricted-gcp
@@ -20986,7 +20986,7 @@ queries:
             Note: Disabling public IP also clears the instance's list of authorized external networks.
     refs:
       - url: https://docs.cloud.google.com/alloydb/docs/connection-overview
-        title: AlloyDB connectivity overview
+        title: Connection overview
       - url: https://docs.cloud.google.com/alloydb/docs/connect-public-ip
         title: Connect using public IP
   - uid: mondoo-gcp-security-alloydb-no-public-ip-gcp
@@ -21131,7 +21131,7 @@ queries:
             After the cluster is ready, configure consumer PSC endpoints from the VPCs that need access.
     refs:
       - url: https://docs.cloud.google.com/alloydb/docs/configure-private-service-connect
-        title: Enable Private Service Connect on AlloyDB
+        title: Connect to an instance using Private Service Connect
       - url: https://docs.cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect overview
   - uid: mondoo-gcp-security-alloydb-psc-enabled-gcp
@@ -21426,7 +21426,7 @@ queries:
       - url: https://docs.cloud.google.com/network-connectivity/docs/vpn/concepts/overview
         title: Cloud VPN overview
       - url: https://docs.cloud.google.com/network-connectivity/docs/vpn/how-to/creating-ha-vpn
-        title: Creating VPN tunnels
+        title: Create an HA VPN gateway to a peer VPN gateway
   - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -24499,7 +24499,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/sql/docs/mysql/backup-recovery/manage-standard-backups
-        title: Google Cloud Documentation - Backing up and restoring Cloud SQL
+        title: Google Cloud Documentation - Manage standard backups
   - uid: mondoo-gcp-security-cloud-sql-automated-backups-enabled-gcp
     filters: asset.platform == 'gcp-sql-mysql' || asset.platform == 'gcp-sql-postgresql' || asset.platform == 'gcp-sql-sqlserver'
     mql: |
@@ -25894,7 +25894,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation
-        title: Google Cloud Documentation - Private clusters
+        title: Google Cloud Documentation - Customize your network isolation in GKE
   - uid: mondoo-gcp-security-gke-control-plane-private-endpoint-gcp
     filters: asset.platform == 'gcp-gke-cluster'
     mql: |
@@ -26025,7 +26025,7 @@ queries:
       - url: https://docs.cloud.google.com/vpc-service-controls/docs/overview
         title: VPC Service Controls overview
       - url: https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level
-        title: Create access levels
+        title: Creating a basic access level
   - uid: mondoo-gcp-security-vpc-sc-access-policies-defined-gcp
     filters: asset.platform == 'gcp-org'
     mql: |
@@ -26400,9 +26400,9 @@ queries:
             Replace `POLICY_ID` with the access policy ID and adjust the IP ranges to match your trusted networks.
     refs:
       - url: https://docs.cloud.google.com/vpc-service-controls/docs/use-access-levels
-        title: Access levels overview
+        title: Allow access to protected resources from outside a perimeter
       - url: https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level
-        title: Create an access level
+        title: Creating a basic access level
   - uid: mondoo-gcp-security-vpc-sc-access-levels-defined-gcp
     filters: asset.platform == 'gcp-org'
     mql: |
@@ -26742,7 +26742,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/assured-workloads/key-access-justifications/docs/overview
-        title: Cloud KMS - Key Access Justifications
+        title: Overview of Key Access Justifications
   - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-gcp
     filters: asset.platform == 'gcp-kms-keyring'
     mql: |
@@ -29724,7 +29724,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/security-command-center/docs/how-to-export-data
-        title: Exporting Security Command Center data
+        title: Overview of exporting Security Command Center data
   - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
     filters: asset.platform == 'gcp-org'
     mql: |
@@ -30459,9 +30459,9 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/bigquery/docs/create-cloud-resource-connection
-        title: BigQuery - Cloud Resource connections
+        title: Create and set up a Cloud resource connection
       - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
-        title: Default service accounts - security considerations
+        title: Types of service accounts
   - uid: mondoo-gcp-security-spanner-backup-schedule-cmek-encryption
     title: Ensure Spanner backup schedules use customer-managed encryption
     impact: 70
@@ -30590,7 +30590,7 @@ queries:
       - url: https://docs.cloud.google.com/spanner/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Cloud Spanner
       - url: https://docs.cloud.google.com/spanner/docs/backup/create-manage-backup-schedules
-        title: Cloud Spanner - Backup schedules
+        title: Create and manage backup schedules
   - uid: mondoo-gcp-security-spanner-backup-schedule-cmek-encryption-gcp
     filters: asset.platform == 'gcp-spanner-instance'
     mql: |
@@ -30766,7 +30766,7 @@ queries:
       - url: https://docs.cloud.google.com/spanner/docs/iam
         title: Cloud Spanner - IAM roles and permissions
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-spanner-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-spanner-instance'
     mql: |
@@ -31537,7 +31537,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/valkey/backups
-        title: Memorystore backup and restore
+        title: About backups
     variants:
       - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-gcp
         tags:
@@ -31677,7 +31677,7 @@ queries:
             Recreate the instance without the public endpoint variant if any auto-connection has `connectionType: PUBLIC_ENDPOINT`.
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/valkey/networking
-        title: Memorystore for Valkey networking
+        title: Networking
     filters: asset.platform == 'gcp-memorystore-instance'
     mql: |
       gcp.project.memorystoreService.instance.pscAttachmentDetails.all(connectionType != "PUBLIC_ENDPOINT")
@@ -32484,7 +32484,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/datastream/docs/configure-your-source-oracle-database
-        title: Configure your Datastream source database (Secret Manager)
+        title: Configure a source Oracle database
   - uid: mondoo-gcp-security-datastream-source-uses-secret-manager-password-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -32672,7 +32672,7 @@ queries:
         # reachable through the API and gcloud.
     refs:
       - url: https://docs.cloud.google.com/datastream/docs/vpc-peering
-        title: Datastream private connectivity
+        title: Configure VPC peering
   - uid: mondoo-gcp-security-datastream-routes-no-public-cidr-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -32903,7 +32903,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/datastream/docs/vpc-peering
-        title: Datastream private connectivity
+        title: Configure VPC peering
   - uid: mondoo-gcp-security-datastream-private-connection-not-default-vpc-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -33176,7 +33176,7 @@ queries:
         # No Terraform remediation: the discovery endpoint IP is output-only (computed by GCP from the authorized network's IP allocation) and cannot be set directly in any Terraform resource argument.
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/memcached/about-auto-discovery
-        title: Memorystore for Memcached - Auto Discovery
+        title: About the Auto Discovery service
     filters: asset.platform == 'gcp-memcache-instance'
     mql: |
       gcp.project.memcacheService.instance.discoveryEndpoint.find(/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/) != []
@@ -33585,7 +33585,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-compute-snapshot-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -33912,7 +33912,7 @@ queries:
       - url: https://docs.cloud.google.com/compute/docs/access/iam
         title: Compute Engine - IAM roles and permissions
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-compute-image-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-compute-image'
     mql: |
@@ -36365,7 +36365,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/workstations/docs/create-cluster
-        title: Configure a private Cloud Workstations cluster
+        title: Create a workstation cluster
   - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_workstations_workstation_cluster')
@@ -36511,7 +36511,7 @@ queries:
       - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/instances/create
         title: Create a Vertex AI Workbench instance
       - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/introduction
-        title: Manage Vertex AI Workbench network options
+        title: Introduction to Agent Platform Workbench
   - uid: mondoo-gcp-security-vertex-ai-workbench-no-public-ip-terraform-hcl
     filters: |
       asset.platform == 'terraform-hcl' && terraform.resources.contains(nameLabel == 'google_workbench_instance' || nameLabel == 'google_notebooks_instance')
@@ -36818,9 +36818,9 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
-        title: Configure Private IP environments
+        title: Change environment networking type (Private or Public IP)
       - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
-        title: Change environment networking type
+        title: Change environment networking type (Private or Public IP)
   - uid: mondoo-gcp-security-composer-environment-private-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -39727,7 +39727,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/pubsub/docs/dead-letter-topics
-        title: Pub/Sub - Handling message failures
+        title: Dead-letter topics
   - uid: mondoo-gcp-security-pubsub-subscription-dead-letter-configured-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
     mql: |
@@ -39859,7 +39859,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/pubsub/docs/detach-subscriptions
-        title: Pub/Sub - Detaching subscriptions
+        title: Detach subscriptions
   - uid: mondoo-gcp-security-pubsub-subscription-not-detached-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
     mql: |
@@ -39988,7 +39988,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/firestore/native/docs/pitr
-        title: Firestore point-in-time recovery
+        title: Point-in-time recovery (PITR) overview
   - uid: mondoo-gcp-security-firestore-point-in-time-recovery-enabled-gcp
     filters: asset.platform == 'gcp-firestore-database'
     mql: |
@@ -40827,7 +40827,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/tasks/docs/access-control
-        title: Cloud Tasks - Access control with IAM
+        title: Access control with IAM
       - url: https://docs.cloud.google.com/iam/docs/overview#principals
         title: IAM - Public principals (allUsers, allAuthenticatedUsers)
   - uid: mondoo-gcp-security-cloud-tasks-queue-not-publicly-accessible-gcp
@@ -40984,9 +40984,9 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/tasks/docs/access-control
-        title: Cloud Tasks - Access control with IAM
+        title: Access control with IAM
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-cloud-tasks-queue-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -41308,7 +41308,7 @@ queries:
       - url: https://docs.cloud.google.com/bigtable/docs/access-control
         title: Cloud Bigtable - Access control with IAM
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-bigtable-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-bigtable-instance'
     mql: |
@@ -41636,7 +41636,7 @@ queries:
       - url: https://docs.cloud.google.com/managed-spark/docs/concepts/iam/iam
         title: Dataproc - Dataproc permissions and IAM roles
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM - Basic (primitive) roles
+        title: Roles overview
   - uid: mondoo-gcp-security-dataproc-cluster-iam-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
     mql: |
@@ -41983,7 +41983,7 @@ queries:
       - url: https://docs.cloud.google.com/workflows/docs/authentication
         title: Workflows - Manage workflow access and identity
       - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
-        title: IAM - Default service accounts
+        title: Types of service accounts
   - uid: mondoo-gcp-security-workflows-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -42115,7 +42115,7 @@ queries:
         # track; the CMEK key is set only through Terraform (crypto_key_name), the console, or the REST API.
     refs:
       - url: https://docs.cloud.google.com/workflows/docs/use-cmek
-        title: Workflows - Use customer-managed encryption keys
+        title: Use customer-managed encryption keys
       - url: https://docs.cloud.google.com/kms/docs/cmek
         title: Cloud KMS - Customer-managed encryption keys
   - uid: mondoo-gcp-security-workflows-cmek-encryption-gcp
@@ -42248,7 +42248,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/workflows/docs/log-workflow
-        title: Workflows - Send logs to Cloud Logging
+        title: Send execution logs to Cloud Logging
       - url: https://docs.cloud.google.com/workflows/docs/reference/rest/v1/projects.locations.workflows#callloglevel
         title: Workflows - Call log level reference
   - uid: mondoo-gcp-security-workflows-call-logging-enabled-gcp
@@ -42461,7 +42461,7 @@ queries:
       - url: https://docs.cloud.google.com/scheduler/docs/http-target-auth
         title: Cloud Scheduler - Use authentication with HTTP targets
       - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
-        title: IAM - Best practices for using service accounts
+        title: Best practices for using service accounts securely
   # No Terraform variants: the google_cloud_ids_endpoint Terraform resource does not expose a
   # traffic-logging argument; whether traffic logs are enabled is only observable at runtime.
   - uid: mondoo-gcp-security-cloud-ids-endpoint-traffic-logs-enabled
@@ -42749,7 +42749,7 @@ queries:
       - url: https://docs.cloud.google.com/iam/docs/overview
         title: IAM overview
       - url: https://docs.cloud.google.com/organization-policy/restrict-domains
-        title: Restricting identities by domain
+        title: Restrict identities with domain-restricted sharing
   - uid: mondoo-gcp-security-iam-project-no-public-members-gcp
     filters: asset.platform == 'gcp-project'
     mql: |
@@ -43243,9 +43243,9 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/iam/docs/roles-overview#basic
-        title: IAM basic roles
+        title: Roles overview
       - url: https://docs.cloud.google.com/iam/docs/best-practices-service-accounts
-        title: Best practices for using and managing service accounts
+        title: Best practices for using service accounts securely
 
   - uid: mondoo-gcp-security-iam-project-no-primitive-roles-gcp
     filters: asset.platform == 'gcp-project'
@@ -43812,7 +43812,7 @@ queries:
             ```
     refs:
       - url: https://docs.cloud.google.com/compute/shielded-vm/docs/shielded-vm
-        title: Shielded VM
+        title: Shielded VM overview
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-shielded-vm-gcp
     filters: asset.platform == 'gcp-vertexai-notebookruntimetemplate'
     mql: |
@@ -44093,7 +44093,7 @@ queries:
             replaced rather than edited in place.
     refs:
       - url: https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/introduction
-        title: Manage identity and access for Vertex AI Workbench instances
+        title: Introduction to Agent Platform Workbench
   - uid: mondoo-gcp-security-workbench-instance-no-default-service-account-gcp
     filters: asset.platform == 'gcp-project'
     mql: |

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -11451,8 +11451,6 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
-      - url: https://docs.cloud.google.com/logging/docs/buckets
-        title: Configure log buckets
   - uid: mondoo-gcp-security-logging-bucket-retention-30-days-gcp
     filters: asset.platform == 'gcp-logging-bucket'
     mql: |
@@ -36817,8 +36815,6 @@ queries:
               --web-server-allow-ip=ip_range=10.0.0.0/8,description="corp network"
             ```
     refs:
-      - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
-        title: Change environment networking type (Private or Public IP)
       - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
         title: Change environment networking type (Private or Public IP)
   - uid: mondoo-gcp-security-composer-environment-private-gcp

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -31675,7 +31675,7 @@ queries:
             Recreate the instance without the public endpoint variant if any auto-connection has `connectionType: PUBLIC_ENDPOINT`.
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/valkey/networking
-        title: Networking
+        title: Memorystore for Valkey networking
     filters: asset.platform == 'gcp-memorystore-instance'
     mql: |
       gcp.project.memorystoreService.instance.pscAttachmentDetails.all(connectionType != "PUBLIC_ENDPOINT")

--- a/content/mondoo-gcp-security.mql.yaml
+++ b/content/mondoo-gcp-security.mql.yaml
@@ -658,7 +658,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-instances-are-not-configured-use-default-service-account-gcp
     filters: |
@@ -855,7 +855,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-instances-not-configured-with-default-service-account-full-access-cloud-api-gcp
     filters: |
@@ -1052,7 +1052,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-oslogin-enabled-gcp
     filters: asset.platform == 'gcp-compute-instance'
@@ -1987,7 +1987,7 @@ queries:
             bq update --source=dataset.json PROJECT_ID:DATASET_ID
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/best-practices-security
+      - url: https://docs.cloud.google.com/bigquery/docs/data-governance
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-dataset-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -2156,7 +2156,7 @@ queries:
             bq update --default_kms_key=projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY PROJECT_ID:DATASET_ID
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/best-practices-security
+      - url: https://docs.cloud.google.com/bigquery/docs/data-governance
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-dataset-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -2324,7 +2324,7 @@ queries:
             bq rm --table PROJECT_ID:DATASET_ID.SOURCE_TABLE
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/best-practices-security
+      - url: https://docs.cloud.google.com/bigquery/docs/data-governance
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-tables-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -2476,7 +2476,7 @@ queries:
 
             2. Recreate existing models within the CMEK-protected dataset to ensure they use customer-managed encryption.
     refs:
-      - url: https://cloud.google.com/bigquery/docs/best-practices-security
+      - url: https://docs.cloud.google.com/bigquery/docs/data-governance
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-models-cmek-encryption-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -2778,7 +2778,7 @@ queries:
             bq update --source=dataset.json PROJECT_ID:DATASET_ID
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/best-practices-security
+      - url: https://docs.cloud.google.com/bigquery/docs/data-governance
         title: BigQuery Security Best Practices
   - uid: mondoo-gcp-security-bigquery-dataset-no-domain-wide-access-gcp
     filters: asset.platform == "gcp-bigquery-dataset"
@@ -4078,7 +4078,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-no-public-ip-gcp
     filters: |
@@ -4267,7 +4267,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-no-default-service-account-gcp
     filters: |
@@ -4432,7 +4432,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-block-project-wide-ssh-keys-gcp
     filters: |
@@ -4609,7 +4609,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-confidential-vm-service-enabled-gcp
     filters: |
@@ -4800,7 +4800,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-secure-boot-enabled-gcp
     filters: |
@@ -4987,7 +4987,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-vtpm-enabled-gcp
     filters: |
@@ -5181,7 +5181,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/compute/docs/instances/create-start-instance
         title: Google Compute Engine Instance Documentation
-      - url: https://cloud.google.com/compute/docs/security
+      - url: https://docs.cloud.google.com/compute/docs/access
         title: Google Compute Engine Security
   - uid: mondoo-gcp-security-compute-instances-integrity-monitoring-enabled-gcp
     filters: |
@@ -6022,7 +6022,7 @@ queries:
 
             Always review IAM policies for KMS crypto keys during code reviews. Use Terraform validation rules or policy-as-code tools to prevent public access grants. Regularly audit your Terraform configurations to ensure compliance.
     refs:
-      - url: https://cloud.google.com/kms/docs/reference
+      - url: https://docs.cloud.google.com/kms/docs
         title: Cloud KMS Documentation
   - uid: mondoo-gcp-security-cloud-kms-cryptokeys-not-publicly-accessible-gcp
     filters: asset.platform == "gcp-kms-keyring"
@@ -6186,7 +6186,7 @@ queries:
 
             Always configure key rotation periods in your Terraform KMS configurations. Use Terraform validation rules or policy-as-code tools to ensure rotation periods are set to 90 days or less. Regularly audit your Terraform configurations to ensure compliance with key rotation requirements.
     refs:
-      - url: https://cloud.google.com/kms/docs/reference
+      - url: https://docs.cloud.google.com/kms/docs
         title: Cloud KMS Documentation
   - uid: mondoo-gcp-security-cloud-kms-keys-rotated-90-days-gcp
     filters: asset.platform == "gcp-kms-keyring"
@@ -6347,7 +6347,7 @@ queries:
 
             For existing keys, the destroy scheduled duration cannot be changed. Create a new key with the correct duration and migrate encrypted data. Key destruction is irreversible and destroys all data still encrypted with that key, so retain the old key until you have confirmed that all data has been re-encrypted with the new key.
     refs:
-      - url: https://cloud.google.com/kms/docs/reference
+      - url: https://docs.cloud.google.com/kms/docs
         title: Cloud KMS Documentation
   - uid: mondoo-gcp-security-cloud-kms-keys-destroy-scheduled-duration-gcp
     filters: asset.platform == "gcp-kms-keyring"
@@ -6501,7 +6501,7 @@ queries:
 
             Keyring and key location are immutable and key destruction is irreversible. Retain the old global keys until you have confirmed that all data has been re-encrypted with the new regional keys, then schedule the old keys for destruction.
     refs:
-      - url: https://cloud.google.com/kms/docs/reference
+      - url: https://docs.cloud.google.com/kms/docs
         title: Cloud KMS Documentation
   - uid: mondoo-gcp-security-cloud-kms-keyring-not-global-location-gcp
     filters: asset.platform == "gcp-kms-keyring"
@@ -6651,7 +6651,7 @@ queries:
               --next-rotation-time=NEXT_ROTATION_TIME
             ```
     refs:
-      - url: https://cloud.google.com/kms/docs/reference
+      - url: https://docs.cloud.google.com/kms/docs
         title: Cloud KMS Documentation
   - uid: mondoo-gcp-security-cloud-kms-encrypt-decrypt-keys-rotation-configured-gcp
     filters: asset.platform == "gcp-kms-keyring"
@@ -7290,9 +7290,9 @@ queries:
 
             After the new keys are active, update the DS record at the domain's registrar.
     refs:
-      - url: https://cloud.google.com/dns/docs/dnssec-config-advanced
+      - url: https://docs.cloud.google.com/dns/docs/dnssec-advanced
         title: Configure DNSSEC advanced settings
-      - url: https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+      - url: https://www.iana.org/assignments/dns-sec-alg-numbers/
         title: IANA DNS Security Algorithm Numbers
   - uid: mondoo-gcp-security-cloud-dns-no-weak-dnssec-algorithms-gcp
     filters: |
@@ -9552,7 +9552,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/kubernetes-engine/docs/how-to/restrict-default-bindings
+      - url: https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access
         title: Restrict default RBAC bindings in GKE
   - uid: mondoo-gcp-security-gke-rbac-no-insecure-system-bindings-gcp
     filters: asset.platform == 'gcp-gke-cluster'
@@ -9705,7 +9705,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/binary-authorization/docs/overview
         title: Binary Authorization overview
-      - url: https://cloud.google.com/binary-authorization/docs/enabling-binauthz-gke
+      - url: https://docs.cloud.google.com/binary-authorization/docs/enable-cluster
         title: Enabling Binary Authorization for GKE
 
   - uid: mondoo-gcp-security-gke-binary-authorization-enabled-gcp
@@ -11451,7 +11451,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
-      - url: https://cloud.google.com/logging/docs/storage
+      - url: https://docs.cloud.google.com/logging/docs/routing/overview
         title: Cloud Logging storage
   - uid: mondoo-gcp-security-logging-bucket-retention-30-days-gcp
     filters: asset.platform == 'gcp-logging-bucket'
@@ -11588,7 +11588,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/buckets
         title: Cloud Logging buckets overview
-      - url: https://cloud.google.com/logging/docs/storage#locked-bucket
+      - url: https://docs.cloud.google.com/logging/docs/routing/overview
         title: Locked log buckets
   - uid: mondoo-gcp-security-logging-bucket-locked-gcp
     filters: |
@@ -11867,7 +11867,7 @@ queries:
               --log-filter='logName:"cloudaudit.googleapis.com"'
             ```
     refs:
-      - url: https://cloud.google.com/logging/docs/export
+      - url: https://docs.cloud.google.com/logging/docs/routing/overview
         title: Routing and storage overview
       - url: https://docs.cloud.google.com/logging/docs/export/configure_export_v2
         title: Configure log sinks
@@ -14456,7 +14456,7 @@ queries:
               --shielded-integrity-monitoring
             ```
     refs:
-      - url: https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/shielded-vms
+      - url: https://docs.cloud.google.com/compute/shielded-vm/docs/shielded-vm
         title: Shielded VMs in Dataproc
   - uid: mondoo-gcp-security-dataproc-cluster-shielded-vms-gcp
     filters: asset.platform == 'gcp-dataproc-cluster'
@@ -16330,7 +16330,7 @@ queries:
               --deletion-protection
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/cluster/about-delete-protection
+      - url: https://docs.cloud.google.com/memorystore/docs/cluster/deletion-protection
         title: Cloud Memorystore for Redis Cluster deletion protection documentation
   - uid: mondoo-gcp-security-cloud-redis-cluster-deletion-protection-enabled-memorystore-rediscluster
     filters: asset.platform == "gcp-memorystore-rediscluster"
@@ -19435,7 +19435,7 @@ queries:
               --global
             ```
     refs:
-      - url: https://cloud.google.com/load-balancing/docs/ssl-certificates-concepts
+      - url: https://docs.cloud.google.com/load-balancing/docs/ssl-certificates
         title: SSL certificates overview
   - uid: mondoo-gcp-security-ssl-certificate-not-expired-gcp
     filters: asset.platform == 'gcp-project'
@@ -20987,7 +20987,7 @@ queries:
 
             Note: Disabling public IP also clears the instance's list of authorized external networks.
     refs:
-      - url: https://cloud.google.com/alloydb/docs/connect-overview
+      - url: https://docs.cloud.google.com/alloydb/docs/connection-overview
         title: AlloyDB connectivity overview
       - url: https://docs.cloud.google.com/alloydb/docs/connect-public-ip
         title: Connect using public IP
@@ -21132,7 +21132,7 @@ queries:
 
             After the cluster is ready, configure consumer PSC endpoints from the VPCs that need access.
     refs:
-      - url: https://cloud.google.com/alloydb/docs/private-service-connect-enable
+      - url: https://docs.cloud.google.com/alloydb/docs/configure-private-service-connect
         title: Enable Private Service Connect on AlloyDB
       - url: https://docs.cloud.google.com/vpc/docs/private-service-connect
         title: Private Service Connect overview
@@ -21427,7 +21427,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/network-connectivity/docs/vpn/concepts/overview
         title: Cloud VPN overview
-      - url: https://cloud.google.com/network-connectivity/docs/vpn/how-to/creating-vpn-dynamic-routes
+      - url: https://docs.cloud.google.com/network-connectivity/docs/vpn/how-to/creating-ha-vpn
         title: Creating VPN tunnels
   - uid: mondoo-gcp-security-vpn-tunnels-use-ikev2-gcp
     filters: asset.platform == 'gcp-project'
@@ -22242,7 +22242,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/predictions/using-private-service-connect
+      - url: https://docs.cloud.google.com/vertex-ai/docs/predictions/private-service-connect
         title: Using Private Service Connect with Vertex AI
   - uid: mondoo-gcp-security-vertexai-endpoint-private-service-connect-gcp
     filters: asset.platform == 'gcp-vertexai-endpoint'
@@ -26026,7 +26026,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/vpc-service-controls/docs/overview
         title: VPC Service Controls overview
-      - url: https://cloud.google.com/vpc-service-controls/docs/create-access-levels
+      - url: https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level
         title: Create access levels
   - uid: mondoo-gcp-security-vpc-sc-access-policies-defined-gcp
     filters: asset.platform == 'gcp-org'
@@ -26270,7 +26270,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/vpc-service-controls/docs/dry-run-mode
         title: VPC Service Controls dry-run mode
-      - url: https://cloud.google.com/vpc-service-controls/docs/manage-perimeters
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/manage-service-perimeters
         title: Manage service perimeters
   - uid: mondoo-gcp-security-vpc-sc-perimeter-enforced-gcp
     filters: asset.platform == 'gcp-org'
@@ -26401,9 +26401,9 @@ queries:
 
             Replace `POLICY_ID` with the access policy ID and adjust the IP ranges to match your trusted networks.
     refs:
-      - url: https://cloud.google.com/vpc-service-controls/docs/access-levels
+      - url: https://docs.cloud.google.com/vpc-service-controls/docs/use-access-levels
         title: Access levels overview
-      - url: https://cloud.google.com/vpc-service-controls/docs/create-access-levels
+      - url: https://docs.cloud.google.com/access-context-manager/docs/create-basic-access-level
         title: Create an access level
   - uid: mondoo-gcp-security-vpc-sc-access-levels-defined-gcp
     filters: asset.platform == 'gcp-org'
@@ -26743,7 +26743,7 @@ queries:
               --allowed-access-reasons=CUSTOMER_INITIATED_ACCESS,GOOGLE_INITIATED_SYSTEM_OPERATION
             ```
     refs:
-      - url: https://cloud.google.com/kms/docs/key-access-justifications
+      - url: https://docs.cloud.google.com/assured-workloads/key-access-justifications/docs/overview
         title: Cloud KMS - Key Access Justifications
   - uid: mondoo-gcp-security-cloud-kms-key-access-justifications-strict-gcp
     filters: asset.platform == 'gcp-kms-keyring'
@@ -27874,7 +27874,7 @@ queries:
               --network=projects/<project>/global/networks/<vpc>
             ```
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/vector-search/setup/setup-index-endpoint
+      - url: https://docs.cloud.google.com/vertex-ai/docs/vector-search/setup
         title: Vertex AI - Setup index endpoint
   - uid: mondoo-gcp-security-vertexai-index-endpoint-not-public-gcp
     filters: asset.platform == 'gcp-project'
@@ -29725,7 +29725,7 @@ queries:
               --filter='state="ACTIVE"'
             ```
     refs:
-      - url: https://cloud.google.com/security-command-center/docs/how-to-export-data-bigquery
+      - url: https://docs.cloud.google.com/security-command-center/docs/how-to-export-data
         title: Exporting findings to BigQuery
   - uid: mondoo-gcp-security-scc-bigquery-exports-gcp
     filters: asset.platform == 'gcp-org'
@@ -30460,7 +30460,7 @@ queries:
               --role=roles/storage.objectViewer
             ```
     refs:
-      - url: https://cloud.google.com/bigquery/docs/connect-to-resource
+      - url: https://docs.cloud.google.com/bigquery/docs/create-cloud-resource-connection
         title: BigQuery - Cloud Resource connections
       - url: https://docs.cloud.google.com/iam/docs/service-account-types#default
         title: Default service accounts - security considerations
@@ -30591,7 +30591,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/spanner/docs/cmek
         title: Customer-managed encryption keys (CMEK) for Cloud Spanner
-      - url: https://cloud.google.com/spanner/docs/backup-schedules
+      - url: https://docs.cloud.google.com/spanner/docs/backup/create-manage-backup-schedules
         title: Cloud Spanner - Backup schedules
   - uid: mondoo-gcp-security-spanner-backup-schedule-cmek-encryption-gcp
     filters: asset.platform == 'gcp-spanner-instance'
@@ -31538,7 +31538,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/backup-and-restore
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/backups
         title: Memorystore backup and restore
     variants:
       - uid: mondoo-gcp-security-memorystore-backup-cmek-encryption-gcp
@@ -31678,7 +31678,7 @@ queries:
 
             Recreate the instance without the public endpoint variant if any auto-connection has `connectionType: PUBLIC_ENDPOINT`.
     refs:
-      - url: https://cloud.google.com/memorystore/docs/valkey/about-private-service-connect
+      - url: https://docs.cloud.google.com/memorystore/docs/valkey/networking
         title: Memorystore and Private Service Connect
     filters: asset.platform == 'gcp-memorystore-instance'
     mql: |
@@ -31908,9 +31908,9 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/memorystore/docs/valkey/release-notes
         title: Memorystore release notes
-      - url: https://valkey.io/security/
+      - url: https://valkey.io/topics/security/
         title: Valkey security advisories
-      - url: https://redis.io/security/
+      - url: https://redis.io/docs/latest/operate/oss_and_stack/management/security/
         title: Redis security advisories
     filters: asset.platform == 'gcp-memorystore-instance'
     mql: |
@@ -36366,7 +36366,7 @@ queries:
               --enable-private-endpoint
             ```
     refs:
-      - url: https://cloud.google.com/workstations/docs/configure-private-cluster
+      - url: https://docs.cloud.google.com/workstations/docs/create-cluster
         title: Configure a private Cloud Workstations cluster
   - uid: mondoo-gcp-security-workstations-cluster-private-cluster-terraform-hcl
     filters: |
@@ -36821,7 +36821,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type
         title: Configure Private IP environments
-      - url: https://cloud.google.com/composer/docs/composer-3/configure-network-access-control
+      - url: https://docs.cloud.google.com/composer/docs/composer-3/access-control
         title: Configure web server network access control
   - uid: mondoo-gcp-security-composer-environment-private-gcp
     filters: asset.platform == 'gcp-project'
@@ -37130,7 +37130,7 @@ queries:
               --encryption-key=projects/PROJECT/locations/REGION/keyRings/RING/cryptoKeys/KEY
             ```
     refs:
-      - url: https://cloud.google.com/healthcare-api/docs/how-tos/cmek
+      - url: https://docs.cloud.google.com/healthcare-api/docs/cmek
         title: Configure Cloud Healthcare API with CMEK
   - uid: mondoo-gcp-security-healthcare-dataset-cmek-encryption-terraform-hcl
     filters: |
@@ -37420,7 +37420,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/logging/docs/routing/managed-encryption
         title: Configure CMEK for log routing
-      - url: https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.locations/getCmekSettings
+      - url: https://docs.cloud.google.com/logging/docs/reference/v2/rest/v2/projects/getCmekSettings
         title: Logging CMEK settings API
   - uid: mondoo-gcp-security-logging-log-router-cmek-encryption-gcp
     filters: asset.platform == 'gcp-project'
@@ -38989,7 +38989,7 @@ queries:
               }'
             ```
     refs:
-      - url: https://cloud.google.com/certificate-authority-service/docs/cmek
+      - url: https://docs.cloud.google.com/kms/docs/cmek
         title: Customer-managed encryption keys for Certificate Authority Service
   - uid: mondoo-gcp-security-eventarc-channel-cmek-encryption
     title: Ensure Eventarc channels are encrypted with CMEK
@@ -39860,7 +39860,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/pubsub/docs/subscription-detach
+      - url: https://docs.cloud.google.com/pubsub/docs/detach-subscriptions
         title: Pub/Sub - Detaching subscriptions
   - uid: mondoo-gcp-security-pubsub-subscription-not-detached-gcp
     filters: asset.platform == 'gcp-pubsub-subscription'
@@ -39989,7 +39989,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/firestore/docs/point-in-time-recovery
+      - url: https://docs.cloud.google.com/firestore/native/docs/pitr
         title: Firestore point-in-time recovery
   - uid: mondoo-gcp-security-firestore-point-in-time-recovery-enabled-gcp
     filters: asset.platform == 'gcp-firestore-database'
@@ -40703,7 +40703,7 @@ queries:
         # resources with no long-lived Terraform resource; use the CLI or SDK to submit
         # jobs without enableWebAccess at submission time.
     refs:
-      - url: https://cloud.google.com/vertex-ai/docs/training/monitor-training#enable_web_access
+      - url: https://docs.cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell
         title: Vertex AI - Enable web access for custom training
   - uid: mondoo-gcp-security-cloud-tasks-queue-not-publicly-accessible
     title: Ensure Cloud Tasks queues are not publicly accessible
@@ -42116,7 +42116,7 @@ queries:
         # No CLI remediation: gcloud workflows deploy exposes no KMS key flag on any release
         # track; the CMEK key is set only through Terraform (crypto_key_name), the console, or the REST API.
     refs:
-      - url: https://cloud.google.com/workflows/docs/cmek
+      - url: https://docs.cloud.google.com/workflows/docs/use-cmek
         title: Workflows - Use customer-managed encryption keys
       - url: https://docs.cloud.google.com/kms/docs/cmek
         title: Cloud KMS - Customer-managed encryption keys
@@ -42249,7 +42249,7 @@ queries:
               --source=workflow.yaml
             ```
     refs:
-      - url: https://cloud.google.com/workflows/docs/log-workflow-calls
+      - url: https://docs.cloud.google.com/workflows/docs/log-workflow
         title: Workflows - Send logs to Cloud Logging
       - url: https://docs.cloud.google.com/workflows/docs/reference/rest/v1/projects.locations.workflows#callloglevel
         title: Workflows - Call log level reference
@@ -42550,7 +42550,7 @@ queries:
     refs:
       - url: https://docs.cloud.google.com/intrusion-detection-system/docs/configuring-ids
         title: Cloud IDS - Configure an IDS endpoint
-      - url: https://cloud.google.com/intrusion-detection-system/docs/viewing-threat-details
+      - url: https://docs.cloud.google.com/intrusion-detection-system/docs/logging
         title: Cloud IDS - View threats and traffic logs
   # No Terraform variants: the google_batch_job Terraform resource does not expose the task
   # group permissive-SSH setting; it is only observable on the submitted job at runtime.
@@ -43450,7 +43450,7 @@ queries:
             }
             ```
     refs:
-      - url: https://cloud.google.com/domains/docs/lock-unlock-domain
+      - url: https://docs.cloud.google.com/domains/docs/overview
         title: Lock and unlock a domain
   - uid: mondoo-gcp-security-cloud-domains-registration-transfer-lock-enabled-gcp
     filters: asset.platform == 'gcp-project'
@@ -43563,7 +43563,7 @@ queries:
         # the google_clouddomains_registration resource only expresses DNSSEC as ds_records configuration under
         # dns_settings, not the published state this check asserts.
     refs:
-      - url: https://cloud.google.com/domains/docs/dnssec-advanced
+      - url: https://docs.cloud.google.com/dns/docs/dnssec-advanced
         title: DNSSEC configuration in Cloud Domains
   - uid: mondoo-gcp-security-vertexai-notebook-runtime-template-cmek-encryption
     title: Ensure Vertex AI notebook runtime templates are encrypted with CMEK

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-repository-best-practices
     name: Mondoo GitHub Repository Best Practices
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices

--- a/content/mondoo-github-best-practices.mql.yaml
+++ b/content/mondoo-github-best-practices.mql.yaml
@@ -355,7 +355,7 @@ queries:
 
             GitHub provides a collection of `.gitignore` templates for various programming languages and frameworks. When creating a new repository, you can select a template from the "Add .gitignore" dropdown menu.
 
-            For more details, see [Ignoring files](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files).
+            For more details, see [Ignoring files](https://docs.github.com/en/get-started/git-basics/ignoring-files).
         - id: terraform
           desc: |
             **Using Terraform**
@@ -395,7 +395,7 @@ queries:
 
             The `tr -d '\n'` step keeps the encoded value on a single line. GNU coreutils `base64`, the default on most Linux distributions, wraps its output at 76 columns unless you pass `-w 0`.
     refs:
-      - url: https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+      - url: https://docs.github.com/en/get-started/git-basics/ignoring-files
         title: Ignoring files
   - uid: mondoo-github-repository-best-practices-include-authors
     title: Ensure the README.md includes authors

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -522,7 +522,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy
-        title: GitHub Docs - Adding a security policy to your repository
+        title: Adding a security policy to your repository
   # No Terraform variants: this check asks "does the repository's default branch have a
   # protection rule?" Verifying that requires cross-resource correlation — matching
   # github_repository.default_branch against the patterns on github_branch_protection
@@ -1728,7 +1728,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy
-        title: GitHub Docs - Adding a security policy to your repository
+        title: Adding a security policy to your repository
   # No Terraform variants: this check inspects the contents of every file tracked by the
   # repository to detect binary artifacts. File contents are a git tree property, not a
   # Terraform-declared configuration — Terraform manages resource state, not the bytes
@@ -1928,7 +1928,7 @@ queries:
       - url: https://docs.github.com/en/code-security
         title: GitHub Code Security
       - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-auto-triage-rules
-        title: About Dependabot auto-triage rules
+        title: Dependabot auto-triage rules
   - uid: mondoo-github-organization-security-fork-private-repos
     title: Ensure organization members cannot fork private repositories
     impact: 80
@@ -2272,7 +2272,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/code-security/concepts/secret-security/push-protection
-        title: Push protection for repositories and organizations
+        title: Push protection
   - uid: mondoo-github-organization-security-secret-scanning-push-protection-new-repos-github
     filters: asset.platform == "github-org"
     mql: github.organization.secretScanningPushProtectionEnabledForNewRepos == true
@@ -2766,7 +2766,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-secret-scanning-alerts
-        title: Managing alerts from secret scanning
+        title: Manage secret scanning alerts
   - uid: mondoo-github-repository-security-webhooks-use-ssl
     title: Ensure repository webhooks use SSL verification
     impact: 70
@@ -3031,7 +3031,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/actions/reference/security/secure-use
-        title: Security hardening for GitHub Actions
+        title: Secure use reference
       - url: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
         title: Managing GitHub Actions settings for a repository
   - uid: mondoo-github-repository-security-actions-require-sha-pinning-github
@@ -3154,9 +3154,9 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-code-scanning-alerts/resolve-alerts
-        title: Managing code scanning alerts for your repository
+        title: Resolving code scanning alerts
       - url: https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning
-        title: About code scanning
+        title: Code scanning
   # No Terraform variants: open-alert state is runtime telemetry from the GitHub Dependabot
   # alerts API, produced after dependency graph analysis identifies vulnerable packages in
   # the repository's manifests. Alerts and their severities are not Terraform configuration.
@@ -3250,7 +3250,7 @@ queries:
       - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-dependabot-alerts/view-dependabot-alerts
         title: Viewing and updating Dependabot alerts
       - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-alerts
-        title: About Dependabot alerts
+        title: Dependabot alerts
   - uid: mondoo-github-repository-security-require-pull-request-reviews
     title: Ensure repository default branch requires pull request reviews
     impact: 90
@@ -3676,7 +3676,7 @@ queries:
             ```
     refs:
       - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
-        title: Using environments for deployment
+        title: Managing environments for deployment
       - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
         title: Managing environments for deployment
   - uid: mondoo-github-repository-security-environment-prevent-self-review-github
@@ -3930,7 +3930,7 @@ queries:
       - url: https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-security-and-analysis-settings-for-your-organization
         title: Managing security and analysis settings for your organization
       - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph
-        title: About the dependency graph
+        title: Dependency graph
   - uid: mondoo-github-organization-security-dependency-graph-new-repos-github
     filters: asset.platform == "github-org"
     mql: |

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3677,8 +3677,6 @@ queries:
     refs:
       - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
         title: Managing environments for deployment
-      - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
-        title: Managing environments for deployment
   - uid: mondoo-github-repository-security-environment-prevent-self-review-github
     filters: asset.platform == "github-repo"
     mql: |

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -365,7 +365,7 @@ queries:
             3. Under "Base permissions," select "Read," or select "No permission" and grant repository access explicitly through teams.
             4. Save the changes.
 
-            For more details, see [Setting base permissions for an organization](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/setting-base-permissions-for-an-organization) in the GitHub documentation.
+            For more details, see [Setting base permissions for an organization](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -476,7 +476,7 @@ queries:
             4. Click **Start setup**.
             5. Add information about supported versions and how to report vulnerabilities, then commit the new `SECURITY.md` file.
 
-            For more details, see [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) in the GitHub documentation.
+            For more details, see [Adding a security policy to your repository](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -521,7 +521,7 @@ queries:
             )"
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
+      - url: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy
         title: GitHub Docs - Adding a security policy to your repository
   # No Terraform variants: this check asks "does the repository's default branch have a
   # protection rule?" Verifying that requires cross-resource correlation — matching
@@ -1697,7 +1697,7 @@ queries:
             4. Click **Start setup**.
             5. Add information about supported versions and how to report vulnerabilities, then commit the new `SECURITY.md` file.
 
-            For more details, see [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) in the GitHub documentation.
+            For more details, see [Adding a security policy to your repository](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1727,7 +1727,7 @@ queries:
             )"
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
+      - url: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy
         title: GitHub Docs - Adding a security policy to your repository
   # No Terraform variants: this check inspects the contents of every file tracked by the
   # repository to detect binary artifacts. File contents are a git tree property, not a
@@ -1885,7 +1885,7 @@ queries:
             2. Define the configuration for Dependabot, including the package ecosystems and update schedule.
             3. Save the changes.
 
-            For more details, see [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) in the GitHub documentation.
+            For more details, see [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -1927,7 +1927,7 @@ queries:
     refs:
       - url: https://docs.github.com/en/code-security
         title: GitHub Code Security
-      - url: https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules
+      - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-auto-triage-rules
         title: About Dependabot auto-triage rules
   - uid: mondoo-github-organization-security-fork-private-repos
     title: Ensure organization members cannot fork private repositories
@@ -2127,7 +2127,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -2247,7 +2247,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -2271,7 +2271,7 @@ queries:
               -F secret_scanning_push_protection_enabled_for_new_repositories=true
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations
+      - url: https://docs.github.com/en/code-security/concepts/secret-security/push-protection
         title: Push protection for repositories and organizations
   - uid: mondoo-github-organization-security-secret-scanning-push-protection-new-repos-github
     filters: asset.platform == "github-org"
@@ -2369,7 +2369,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -2491,7 +2491,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -2515,7 +2515,7 @@ queries:
               -F dependabot_security_updates_enabled_for_new_repositories=true
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+      - url: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates
         title: Configuring Dependabot security updates
   - uid: mondoo-github-organization-security-dependabot-security-updates-new-repos-github
     filters: asset.platform == "github-org"
@@ -2747,7 +2747,7 @@ queries:
                - **Close the alert**: After remediation, close the alert with the appropriate resolution (revoked, false positive, used in tests, etc.).
             4. Verify that the revoked credential is no longer valid by testing access.
 
-            For more details, see [Managing alerts from secret scanning](https://docs.github.com/en/code-security/secret-scanning/managing-alerts-from-secret-scanning) in the GitHub documentation.
+            For more details, see [Managing alerts from secret scanning](https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-secret-scanning-alerts) in the GitHub documentation.
         - id: cli
           desc: |
             **Using GitHub CLI**
@@ -2765,7 +2765,7 @@ queries:
               -f state=resolved -f resolution=revoked
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/secret-scanning/managing-alerts-from-secret-scanning
+      - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-secret-scanning-alerts
         title: Managing alerts from secret scanning
   - uid: mondoo-github-repository-security-webhooks-use-ssl
     title: Ensure repository webhooks use SSL verification
@@ -2994,7 +2994,7 @@ queries:
             - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
             ```
 
-            For more details, see [Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) in the GitHub documentation.
+            For more details, see [Using third-party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) in the GitHub documentation.
         - id: cli
           desc: |
             **Using GitHub CLI**
@@ -3030,7 +3030,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+      - url: https://docs.github.com/en/actions/reference/security/secure-use
         title: Security hardening for GitHub Actions
       - url: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
         title: Managing GitHub Actions settings for a repository
@@ -3135,7 +3135,7 @@ queries:
                - **Dismiss false positives**: If the alert is a false positive, dismiss it with a reason.
             4. For repositories without code scanning, go to **Settings**. In the sidebar under "Security," click **Advanced Security**, then set up CodeQL analysis under "Code Security."
 
-            For more details, see [Managing code scanning alerts](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/managing-code-scanning-alerts-for-your-repository) in the GitHub documentation.
+            For more details, see [Managing code scanning alerts](https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-code-scanning-alerts/resolve-alerts) in the GitHub documentation.
         - id: cli
           desc: |
             **Using GitHub CLI**
@@ -3153,9 +3153,9 @@ queries:
               -f state=dismissed -f dismissed_reason="won't fix"
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/managing-code-scanning-alerts-for-your-repository
+      - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-code-scanning-alerts/resolve-alerts
         title: Managing code scanning alerts for your repository
-      - url: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning
+      - url: https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning
         title: About code scanning
   # No Terraform variants: open-alert state is runtime telemetry from the GitHub Dependabot
   # alerts API, produced after dependency graph analysis identifies vulnerable packages in
@@ -3229,7 +3229,7 @@ queries:
                - If the alert is a false positive, dismiss it with documented justification.
             5. Ensure Dependabot alerts are enabled. Go to **Settings**, and in the sidebar under "Security," click **Advanced Security**.
 
-            For more details, see [Viewing and updating Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts) in the GitHub documentation.
+            For more details, see [Viewing and updating Dependabot alerts](https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-dependabot-alerts/view-dependabot-alerts) in the GitHub documentation.
         - id: cli
           desc: |
             **Using GitHub CLI**
@@ -3247,9 +3247,9 @@ queries:
               -f state=dismissed -f dismissed_reason="tolerable_risk"
             ```
     refs:
-      - url: https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts
+      - url: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-dependabot-alerts/view-dependabot-alerts
         title: Viewing and updating Dependabot alerts
-      - url: https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts
+      - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-alerts
         title: About Dependabot alerts
   - uid: mondoo-github-repository-security-require-pull-request-reviews
     title: Ensure repository default branch requires pull request reviews
@@ -3640,7 +3640,7 @@ queries:
             5. Check **Prevent self-review** to prevent the person who triggered the deployment from approving it.
             6. Click **Save protection rules**.
 
-            For more details, see [Using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) in the GitHub documentation.
+            For more details, see [Using environments for deployment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3675,9 +3675,9 @@ queries:
             EOF
             ```
     refs:
-      - url: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
+      - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
         title: Using environments for deployment
-      - url: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
+      - url: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
         title: Managing environments for deployment
   - uid: mondoo-github-repository-security-environment-prevent-self-review-github
     filters: asset.platform == "github-repo"
@@ -3778,7 +3778,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3903,7 +3903,7 @@ queries:
             4. Save the configuration.
             5. Apply the configuration to your repositories and mark it as the default for newly created repositories.
 
-            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/securing-your-organization/enabling-security-features-in-your-organization/applying-a-custom-security-configuration) in the GitHub documentation.
+            For more details, see [Applying a custom security configuration](https://docs.github.com/en/code-security/how-tos/secure-at-scale/configure-organization-security/establish-complete-coverage/apply-custom-configuration) in the GitHub documentation.
         - id: terraform
           desc: |
             **Using Terraform**
@@ -3929,7 +3929,7 @@ queries:
     refs:
       - url: https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-security-and-analysis-settings-for-your-organization
         title: Managing security and analysis settings for your organization
-      - url: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph
+      - url: https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph
         title: About the dependency graph
   - uid: mondoo-github-organization-security-dependency-graph-new-repos-github
     filters: asset.platform == "github-org"

--- a/content/mondoo-github-security.mql.yaml
+++ b/content/mondoo-github-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-github-organization-security
     name: Mondoo GitHub Organization Security
-    version: 1.8.6
+    version: 1.8.7
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -56,7 +56,7 @@ policies:
     scoring_system: highest impact
   - uid: mondoo-github-repository-security
     name: Mondoo GitHub Repository Security
-    version: 1.8.5
+    version: 1.8.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -157,7 +157,7 @@ queries:
 
             GitLab rejects the change while any project or subgroup in the group has a higher visibility level. Change those to private or internal first.
 
-            For more details, see [Change group visibility](https://docs.gitlab.com/user/public_access.html#change-group-visibility).
+            For more details, see [Change group visibility](https://docs.gitlab.com/user/public_access/#change-group-visibility).
         - id: cli
           desc: |
             To make the visibility of a GitLab group private using the `glab` CLI:
@@ -168,7 +168,7 @@ queries:
 
             The request fails while any project or subgroup in the group has a higher visibility level. Change those to private or internal first.
 
-            For more details, see the [Groups API](https://docs.gitlab.com/api/groups.html#update-group).
+            For more details, see the [Groups API](https://docs.gitlab.com/api/groups/#update-group-attributes).
         - id: terraform
           desc: |
             To make the visibility of a GitLab group private using Terraform:
@@ -185,7 +185,7 @@ queries:
     refs:
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
-      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
+      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls/
         title: GitLab Visibility and Access Controls
   - uid: mondoo-gitlab-security-private-group-gitlab
     filters: asset.platform == "gitlab-group"
@@ -294,7 +294,7 @@ queries:
               -f two_factor_grace_period=48
             ```
 
-            For more details, see the [Groups API](https://docs.gitlab.com/api/groups.html#update-group).
+            For more details, see the [Groups API](https://docs.gitlab.com/api/groups/#update-group-attributes).
         - id: terraform
           desc: |
             To require two-factor authentication for all users in a GitLab group using Terraform:
@@ -309,7 +309,7 @@ queries:
 
             For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group).
     refs:
-      - url: https://docs.gitlab.com/user/profile/account/two_factor_authentication.html
+      - url: https://docs.gitlab.com/user/profile/account/two_factor_authentication/
         title: GitLab Two-Factor Authentication
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
@@ -425,7 +425,7 @@ queries:
 
             On self-managed instances, administrators can also set **Default project visibility** to **Private** under **Admin area** > **Settings** > **General** > **Visibility and access controls**.
 
-            For more details, see [Change project visibility](https://docs.gitlab.com/user/public_access.html#change-project-visibility).
+            For more details, see [Change project visibility](https://docs.gitlab.com/user/public_access/#change-project-visibility).
         - id: cli
           desc: |
             To set a public project to private using the `glab` CLI:
@@ -436,7 +436,7 @@ queries:
             glab api --method PUT projects/PROJECT_ID -f visibility=private
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To set every project in the group to private using Terraform:
@@ -466,7 +466,7 @@ queries:
 
             For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project).
     refs:
-      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
+      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls/
         title: GitLab Visibility and Access Controls
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
@@ -565,7 +565,7 @@ queries:
             4. Under **Project visibility**, select **Private**.
             5. Click **Save changes**.
 
-            For more details, see [Change project visibility](https://docs.gitlab.com/user/public_access.html#change-project-visibility).
+            For more details, see [Change project visibility](https://docs.gitlab.com/user/public_access/#change-project-visibility).
         - id: cli
           desc: |
             To make an individual GitLab project private using the `glab` CLI:
@@ -574,7 +574,7 @@ queries:
             glab api --method PUT projects/PROJECT_ID -f visibility=private
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To make an individual GitLab project private using Terraform:
@@ -592,7 +592,7 @@ queries:
     refs:
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
-      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
+      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls/
         title: GitLab Visibility and Access Controls
   - uid: mondoo-gitlab-security-private-project-gitlab
     filters: asset.platform == "gitlab-project"
@@ -684,7 +684,7 @@ queries:
             4. Set **Approvals required** to at least 1.
             5. Click **Save changes**.
 
-            For more details, see [Merge request approval rules](https://docs.gitlab.com/user/project/merge_requests/approvals/rules.html).
+            For more details, see [Merge request approval rules](https://docs.gitlab.com/user/project/merge_requests/approvals/rules/).
         - id: cli
           desc: |
             Merge request approval rules require a GitLab Premium or Ultimate subscription. The commands below have no effect on the Free tier, where this control is unavailable.
@@ -698,7 +698,7 @@ queries:
               -f name=Default -f approvals_required=1
             ```
 
-            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html#create-project-level-rule).
+            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals/#create-an-approval-rule-for-a-project).
         - id: terraform
           desc: |
             To require merge request approvals using Terraform:
@@ -799,7 +799,7 @@ queries:
             4. Check **Prevent approval by merge request creator (author)**.
             5. Click **Save changes**.
 
-            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
+            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings/).
         - id: cli
           desc: |
             Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
@@ -811,7 +811,7 @@ queries:
               -f merge_requests_author_approval=false
             ```
 
-            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html#change-configuration).
+            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals/#update-approval-configuration-for-a-project).
         - id: terraform
           desc: |
             To prevent merge request authors from approving their own requests using Terraform:
@@ -927,7 +927,7 @@ queries:
             4. Check **Remove all approvals**.
             5. Click **Save changes**.
 
-            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html#remove-all-approvals-when-commits-are-added-to-the-source-branch).
+            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings/#remove-all-approvals-when-commits-are-added-to-the-source-branch).
         - id: cli
           desc: |
             Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
@@ -939,7 +939,7 @@ queries:
               -f reset_approvals_on_push=true
             ```
 
-            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html#change-configuration).
+            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals/#update-approval-configuration-for-a-project).
         - id: terraform
           desc: |
             To reset merge request approvals when new commits are pushed using Terraform:
@@ -1054,7 +1054,7 @@ queries:
             4. Check **Prevent approvals by users who add commits**.
             5. Click **Save changes**.
 
-            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings.html).
+            For more details, see [Merge request approval settings](https://docs.gitlab.com/user/project/merge_requests/approvals/settings/).
         - id: cli
           desc: |
             Merge request approval settings require a GitLab Premium or Ultimate subscription. The command below has no effect on the Free tier, where this control is unavailable.
@@ -1066,7 +1066,7 @@ queries:
               -f merge_requests_disable_committers_approval=true
             ```
 
-            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals.html#change-configuration).
+            For more details, see the [Merge request approvals API](https://docs.gitlab.com/api/merge_request_approvals/#update-approval-configuration-for-a-project).
         - id: terraform
           desc: |
             To prevent committers from approving merge requests they contributed to using Terraform:
@@ -1199,7 +1199,7 @@ queries:
               -f name=BRANCH_NAME -f allow_force_push=false
             ```
 
-            For more details, see the [Protected branches API](https://docs.gitlab.com/api/protected_branches.html#update-a-protected-branch).
+            For more details, see the [Protected branches API](https://docs.gitlab.com/api/protected_branches/#update-a-protected-branch).
         - id: terraform
           desc: |
             To disable force push on the default branch using Terraform:
@@ -1218,7 +1218,7 @@ queries:
     refs:
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
-      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
+      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls/
         title: GitLab Visibility and Access Controls
   - uid: mondoo-gitlab-security-no-force-push-default-branch-gitlab
     filters: asset.platform == "gitlab-project"
@@ -1324,7 +1324,7 @@ queries:
               -f only_allow_merge_if_pipeline_succeeds=true
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To require a successful pipeline before merging using Terraform:
@@ -1450,7 +1450,7 @@ queries:
               -f prevent_forking_outside_group=true
             ```
 
-            For more details, see the [Groups API](https://docs.gitlab.com/api/groups.html#update-group).
+            For more details, see the [Groups API](https://docs.gitlab.com/api/groups/#update-group-attributes).
         - id: terraform
           desc: |
             To prevent forking projects outside the group using Terraform:
@@ -1467,7 +1467,7 @@ queries:
     refs:
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
-      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls.html
+      - url: https://docs.gitlab.com/administration/settings/visibility_and_access_controls/
         title: GitLab Visibility and Access Controls
   - uid: mondoo-gitlab-security-group-prevent-forking-outside-gitlab
     filters: asset.platform == "gitlab-group" && gitlab.namespace.plan != "free"
@@ -1565,7 +1565,7 @@ queries:
             5. Create replacement tokens with appropriate expiration dates of 90 days or less.
             6. Update any integrations using the old tokens.
 
-            For more details, see [Project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens.html).
+            For more details, see [Project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/).
         - id: cli
           desc: |
             To create a project access token with an expiration date using the `glab` CLI:
@@ -1578,7 +1578,7 @@ queries:
 
             Revoke existing tokens without expiration and replace them with expiring tokens.
 
-            For more details, see the [Project access tokens API](https://docs.gitlab.com/api/project_access_tokens.html).
+            For more details, see the [Project access tokens API](https://docs.gitlab.com/api/project_access_tokens/).
         - id: terraform
           desc: |
             To create project access tokens with an expiration date using Terraform:
@@ -1596,7 +1596,7 @@ queries:
 
             For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_access_token).
     refs:
-      - url: https://docs.gitlab.com/user/project/settings/project_access_tokens.html
+      - url: https://docs.gitlab.com/user/project/settings/project_access_tokens/
         title: GitLab Project Access Tokens
       - url: https://docs.gitlab.com/user/project/settings/
         title: GitLab Project Settings
@@ -1696,7 +1696,7 @@ queries:
             5. Create replacement tokens with appropriate expiration dates of 90 days or less.
             6. Update any integrations using the old tokens.
 
-            For more details, see [Group access tokens](https://docs.gitlab.com/user/group/settings/group_access_tokens.html).
+            For more details, see [Group access tokens](https://docs.gitlab.com/user/group/settings/group_access_tokens/).
         - id: cli
           desc: |
             To create a group access token with an expiration date using the `glab` CLI:
@@ -1709,7 +1709,7 @@ queries:
 
             Revoke existing tokens without expiration and replace them with expiring tokens.
 
-            For more details, see the [Group access tokens API](https://docs.gitlab.com/api/group_access_tokens.html).
+            For more details, see the [Group access tokens API](https://docs.gitlab.com/api/group_access_tokens/).
         - id: terraform
           desc: |
             To create group access tokens with an expiration date using Terraform:
@@ -1727,7 +1727,7 @@ queries:
 
             For more details, see the Terraform [GitLab Provider](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_access_token).
     refs:
-      - url: https://docs.gitlab.com/user/group/settings/group_access_tokens.html
+      - url: https://docs.gitlab.com/user/group/settings/group_access_tokens/
         title: GitLab Group Access Tokens
       - url: https://docs.gitlab.com/user/group/
         title: GitLab Group Settings
@@ -1840,7 +1840,7 @@ queries:
               -f can_push=false
             ```
 
-            For more details, see the [Deploy keys API](https://docs.gitlab.com/api/deploy_keys.html#update-deploy-key).
+            For more details, see the [Deploy keys API](https://docs.gitlab.com/api/deploy_keys/#update-a-deploy-key).
         - id: terraform
           desc: |
             To create deploy keys without push access using Terraform:
@@ -2071,7 +2071,7 @@ queries:
               -f prevent_secrets=true
             ```
 
-            For more details, see the [Push rules API](https://docs.gitlab.com/api/projects.html#edit-project-push-rule).
+            For more details, see the [Push rules API](https://docs.gitlab.com/api/project_push_rules/#update-push-rules-of-a-project).
         - id: terraform
           desc: |
             To reject files containing secrets using Terraform:
@@ -2201,7 +2201,7 @@ queries:
               -f reject_unsigned_commits=true
             ```
 
-            For more details, see the [Push rules API](https://docs.gitlab.com/api/projects.html#edit-project-push-rule).
+            For more details, see the [Push rules API](https://docs.gitlab.com/api/project_push_rules/#update-push-rules-of-a-project).
         - id: terraform
           desc: |
             To reject unsigned commits using Terraform:
@@ -2331,7 +2331,7 @@ queries:
               -f commit_committer_check=true
             ```
 
-            For more details, see the [Push rules API](https://docs.gitlab.com/api/projects.html#edit-project-push-rule).
+            For more details, see the [Push rules API](https://docs.gitlab.com/api/project_push_rules/#update-push-rules-of-a-project).
         - id: terraform
           desc: |
             To verify the committer is a GitLab user using Terraform:
@@ -2459,7 +2459,7 @@ queries:
               -f member_check=true
             ```
 
-            For more details, see the [Push rules API](https://docs.gitlab.com/api/projects.html#edit-project-push-rule).
+            For more details, see the [Push rules API](https://docs.gitlab.com/api/project_push_rules/#update-push-rules-of-a-project).
         - id: terraform
           desc: |
             To require commit authors to be GitLab users using Terraform:
@@ -2577,7 +2577,7 @@ queries:
 
             GitLab renamed this attribute from `pre_receive_secret_detection_enabled` in 17.11. Use the old name on instances older than that.
 
-            For more details, see the [Project security settings API](https://docs.gitlab.com/api/project_security_settings.html).
+            For more details, see the [Project security settings API](https://docs.gitlab.com/api/project_security_settings/).
         - id: terraform
           desc: |
             Secret push protection requires a GitLab Ultimate subscription.
@@ -2689,7 +2689,7 @@ queries:
               -f masked=true
             ```
 
-            For more details, see the [Project-level variables API](https://docs.gitlab.com/api/project_level_variables.html#update-a-variable).
+            For more details, see the [Project-level variables API](https://docs.gitlab.com/api/project_level_variables/#update-a-variable).
         - id: terraform
           desc: |
             To mask a CI/CD variable using Terraform:
@@ -2819,7 +2819,7 @@ queries:
               -f protected=true
             ```
 
-            For more details, see the [Project-level variables API](https://docs.gitlab.com/api/project_level_variables.html#update-a-variable).
+            For more details, see the [Project-level variables API](https://docs.gitlab.com/api/project_level_variables/#update-a-variable).
         - id: terraform
           desc: |
             To protect a CI/CD variable using Terraform:
@@ -2945,7 +2945,7 @@ queries:
               -f enabled=true
             ```
 
-            For more details, see the [Job token scope API](https://docs.gitlab.com/api/project_job_token_scopes.html).
+            For more details, see the [Job token scope API](https://docs.gitlab.com/api/project_job_token_scopes/).
         - id: terraform
           desc: |
             To restrict inbound CI/CD job token access using Terraform:
@@ -3069,7 +3069,7 @@ queries:
               -f enable_ssl_verification=true
             ```
 
-            For more details, see the [Project webhooks API](https://docs.gitlab.com/api/project_webhooks.html#edit-a-project-webhook).
+            For more details, see the [Project webhooks API](https://docs.gitlab.com/api/project_webhooks/#update-a-project-webhook).
         - id: terraform
           desc: |
             To enforce SSL verification on a webhook using Terraform:
@@ -3191,7 +3191,7 @@ queries:
               -f allow_merge_on_skipped_pipeline=false
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To block merges when the pipeline is skipped using Terraform:
@@ -3317,7 +3317,7 @@ queries:
               -f only_allow_merge_if_all_discussions_are_resolved=true
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To require all discussions to be resolved before merge using Terraform:
@@ -3443,7 +3443,7 @@ queries:
               -f public_jobs=false
             ```
 
-            For more details, see the [Projects API](https://docs.gitlab.com/api/projects.html#edit-project).
+            For more details, see the [Projects API](https://docs.gitlab.com/api/projects/#update-a-project).
         - id: terraform
           desc: |
             To stop exposing CI/CD job logs to non-members using Terraform:

--- a/content/mondoo-gitlab-security.mql.yaml
+++ b/content/mondoo-gitlab-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-gitlab-security
     name: Mondoo GitLab Security
-    version: 1.9.1
+    version: 1.9.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -128,9 +128,9 @@ queries:
             For more details, see [Deploy 2-Step Verification](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification).
     refs:
       - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
-        title: Google Workspace - Deploy 2-Step Verification
+        title: Protect your business with 2-Step Verification
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-limit-super-admins
     title: Ensure no more than four users have super admin permissions
     impact: 60
@@ -201,7 +201,7 @@ queries:
             For more details, see [Pre-built administrator roles](https://knowledge.workspace.google.com/admin/users/prebuilt-administrator-roles).
     refs:
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-minimum-super-admins
     title: Ensure more than one user has super admin permissions
     impact: 60
@@ -272,7 +272,7 @@ queries:
             For more details, see [Assign specific admin roles](https://knowledge.workspace.google.com/admin/users/add-an-account-for-a-new-user).
     refs:
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-less-secure-app-access-should-not-be-allowed
     title: Users should not be allowed less secure app access
     impact: 70
@@ -341,9 +341,9 @@ queries:
             For more details, see [Transition from less secure apps to OAuth](https://support.google.com/a/answer/14114704).
     refs:
       - url: https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data
-        title: Google Workspace - Control Third-Party App Access
+        title: Control which apps access Google Workspace data
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-super-admins-should-use-hardware-based-2fa
     title: Super users should use hardware-based security keys
     impact: 70
@@ -417,9 +417,9 @@ queries:
             For more details, see [Use a security key for 2-Step Verification](https://support.google.com/accounts/answer/6103523).
     refs:
       - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
-        title: Google Workspace - Deploy 2-Step Verification
+        title: Protect your business with 2-Step Verification
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-connected-apps-no-full-access
     title: Ensure no connected apps have full Gmail or Drive access
     impact: 80
@@ -499,9 +499,9 @@ queries:
             For more details, see [Control which third-party and internal apps access Google Workspace data](https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data).
     refs:
       - url: https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data
-        title: Google Workspace - Control Third-Party App Access
+        title: Control which apps access Google Workspace data
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-domains-verified
     title: Ensure all domains are verified
     impact: 70
@@ -571,9 +571,9 @@ queries:
             For more details, see [Verify your domain](https://knowledge.workspace.google.com/admin/domains/verify-your-domain-for-google-workspace).
     refs:
       - url: https://knowledge.workspace.google.com/admin/domains/verify-your-domain-for-google-workspace
-        title: Google Workspace - Verify Your Domain
+        title: Verify your domain for Google Workspace
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-calendar-no-public-sharing
     title: Ensure calendar sharing is not set to public
     impact: 60
@@ -658,9 +658,9 @@ queries:
             For more details, see [Set Calendar sharing options](https://knowledge.workspace.google.com/admin/calendar/set-google-calendar-sharing-options).
     refs:
       - url: https://knowledge.workspace.google.com/admin/calendar/set-google-calendar-sharing-options
-        title: Google Workspace - Set Calendar Sharing Options
+        title: Set Google Calendar sharing options
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-no-ip-whitelisted-users
     title: Ensure no users have IP whitelisting enabled
     impact: 60
@@ -738,9 +738,9 @@ queries:
             For more details, see [Context-Aware Access overview](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-context-aware-access).
     refs:
       - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-context-aware-access
-        title: Google Workspace - Context-Aware Access
+        title: Protect your business with Context-Aware Access
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-admins-not-guest-users
     title: Ensure admin accounts are not guest users
     impact: 80
@@ -809,9 +809,9 @@ queries:
             For more details, see [Security best practices for administrator accounts](https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts).
     refs:
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
       - url: https://knowledge.workspace.google.com/admin/users/add-an-account-for-a-new-user
-        title: Google Workspace - Assign Admin Roles
+        title: Add an account for a new user
   - uid: mondoo-googleworkspace-security-admins-enrolled-in-2sv
     title: Ensure all admin accounts have completed 2-step verification enrollment
     impact: 80
@@ -882,9 +882,9 @@ queries:
             For more details, see [Deploy 2-Step Verification](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification).
     refs:
       - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
-        title: Google Workspace - Deploy 2-Step Verification
+        title: Protect your business with 2-Step Verification
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts
   - uid: mondoo-googleworkspace-security-admins-no-pending-password-reset
     title: Ensure no admin accounts have a pending forced password change
     impact: 70
@@ -958,6 +958,6 @@ queries:
             For more details, see [Reset a user's password](https://knowledge.workspace.google.com/admin/users/reset-a-users-password).
     refs:
       - url: https://knowledge.workspace.google.com/admin/users/reset-a-users-password
-        title: Google Workspace - Reset a User's Password
+        title: Reset a user's password
       - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
-        title: Google Workspace Security Best Practices
+        title: Security best practices for administrator accounts

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-google-workspace-security
     name: Mondoo Google Workspace Security
-    version: 1.2.4
+    version: 1.2.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-google-workspace-security.mql.yaml
+++ b/content/mondoo-google-workspace-security.mql.yaml
@@ -125,11 +125,11 @@ queries:
 
             Users who have not enrolled when enforcement begins are locked out of their accounts, so confirm enrollment status before the enforcement date.
 
-            For more details, see [Deploy 2-Step Verification](https://support.google.com/a/answer/175197).
+            For more details, see [Deploy 2-Step Verification](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification).
     refs:
-      - url: https://support.google.com/a/answer/175197
+      - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
         title: Google Workspace - Deploy 2-Step Verification
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-limit-super-admins
     title: Ensure no more than four users have super admin permissions
@@ -196,11 +196,11 @@ queries:
             2. Go to **Directory** > **Users** and filter by the **Super Admin** role to list all current super admins.
             3. Decide which two to four users genuinely require full administrative control.
             4. For each super admin beyond that set, open the user, click **Admin roles and privileges**, and remove the **Super Admin** role assignment.
-            5. Assign a delegated role such as **User Management Admin** or **Help Desk Admin** that covers the tasks the user actually performs, or [create a custom role](https://support.google.com/a/answer/2406043) with only the required privileges.
+            5. Assign a delegated role such as **User Management Admin** or **Help Desk Admin** that covers the tasks the user actually performs, or [create a custom role](https://knowledge.workspace.google.com/admin/users/create-edit-and-delete-custom-admin-roles) with only the required privileges.
 
-            For more details, see [Pre-built administrator roles](https://support.google.com/a/answer/2405986).
+            For more details, see [Pre-built administrator roles](https://knowledge.workspace.google.com/admin/users/prebuilt-administrator-roles).
     refs:
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-minimum-super-admins
     title: Ensure more than one user has super admin permissions
@@ -269,9 +269,9 @@ queries:
             4. Next to the **Super Admin** role, turn on the assignment slider and click **Save**.
             5. Require the new super admin to enroll in 2-step verification with a hardware security key before relying on the account.
 
-            For more details, see [Assign specific admin roles](https://support.google.com/a/answer/33310).
+            For more details, see [Assign specific admin roles](https://knowledge.workspace.google.com/admin/users/add-an-account-for-a-new-user).
     refs:
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-less-secure-app-access-should-not-be-allowed
     title: Users should not be allowed less secure app access
@@ -340,9 +340,9 @@ queries:
 
             For more details, see [Transition from less secure apps to OAuth](https://support.google.com/a/answer/14114704).
     refs:
-      - url: https://support.google.com/a/answer/7281227
+      - url: https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data
         title: Google Workspace - Control Third-Party App Access
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-super-admins-should-use-hardware-based-2fa
     title: Super users should use hardware-based security keys
@@ -416,9 +416,9 @@ queries:
 
             For more details, see [Use a security key for 2-Step Verification](https://support.google.com/accounts/answer/6103523).
     refs:
-      - url: https://support.google.com/a/answer/175197
+      - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
         title: Google Workspace - Deploy 2-Step Verification
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-connected-apps-no-full-access
     title: Ensure no connected apps have full Gmail or Drive access
@@ -496,11 +496,11 @@ queries:
 
             7. Where the integration is still needed, work with the vendor to reauthorize it using narrower scopes such as `gmail.send` or `drive.file`.
 
-            For more details, see [Control which third-party and internal apps access Google Workspace data](https://support.google.com/a/answer/7281227).
+            For more details, see [Control which third-party and internal apps access Google Workspace data](https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data).
     refs:
-      - url: https://support.google.com/a/answer/7281227
+      - url: https://knowledge.workspace.google.com/admin/apps/control-which-apps-access-google-workspace-data
         title: Google Workspace - Control Third-Party App Access
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-domains-verified
     title: Ensure all domains are verified
@@ -568,11 +568,11 @@ queries:
             5. Return to the Admin console and click **Verify** to confirm the DNS record.
             6. Remove any domains that are no longer needed by your organization.
 
-            For more details, see [Verify your domain](https://support.google.com/a/answer/60216).
+            For more details, see [Verify your domain](https://knowledge.workspace.google.com/admin/domains/verify-your-domain-for-google-workspace).
     refs:
-      - url: https://support.google.com/a/answer/60216
+      - url: https://knowledge.workspace.google.com/admin/domains/verify-your-domain-for-google-workspace
         title: Google Workspace - Verify Your Domain
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-calendar-no-public-sharing
     title: Ensure calendar sharing is not set to public
@@ -655,11 +655,11 @@ queries:
               "https://www.googleapis.com/calendar/v3/calendars/jane@example.com/acl/default"
             ```
 
-            For more details, see [Set Calendar sharing options](https://support.google.com/a/answer/60765).
+            For more details, see [Set Calendar sharing options](https://knowledge.workspace.google.com/admin/calendar/set-google-calendar-sharing-options).
     refs:
-      - url: https://support.google.com/a/answer/60765
+      - url: https://knowledge.workspace.google.com/admin/calendar/set-google-calendar-sharing-options
         title: Google Workspace - Set Calendar Sharing Options
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-no-ip-whitelisted-users
     title: Ensure no users have IP whitelisting enabled
@@ -733,13 +733,13 @@ queries:
                  "https://admin.googleapis.com/admin/directory/v1/users/jane@example.com"
                ```
 
-            3. If the users relied on the exemption for network-based access, configure [context-aware access policies](https://support.google.com/a/answer/9275380) as the supported replacement for IP-based controls.
+            3. If the users relied on the exemption for network-based access, configure [context-aware access policies](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-context-aware-access) as the supported replacement for IP-based controls.
 
-            For more details, see [Context-Aware Access overview](https://support.google.com/a/answer/9275380).
+            For more details, see [Context-Aware Access overview](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-context-aware-access).
     refs:
-      - url: https://support.google.com/a/answer/9275380
+      - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-context-aware-access
         title: Google Workspace - Context-Aware Access
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-admins-not-guest-users
     title: Ensure admin accounts are not guest users
@@ -806,11 +806,11 @@ queries:
             4. Remove admin role assignments from guest accounts under **Admin roles and privileges**.
             5. If administrative access is needed, create a full organizational account for the individual instead.
 
-            For more details, see [Security best practices for administrator accounts](https://support.google.com/a/answer/9011373).
+            For more details, see [Security best practices for administrator accounts](https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts).
     refs:
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
-      - url: https://support.google.com/a/answer/33310
+      - url: https://knowledge.workspace.google.com/admin/users/add-an-account-for-a-new-user
         title: Google Workspace - Assign Admin Roles
   - uid: mondoo-googleworkspace-security-admins-enrolled-in-2sv
     title: Ensure all admin accounts have completed 2-step verification enrollment
@@ -879,11 +879,11 @@ queries:
                - Reduce or eliminate the enrollment grace period under **Security** > **Authentication** > **2-step verification**.
                - Consider temporarily removing admin privileges until enrollment is complete.
 
-            For more details, see [Deploy 2-Step Verification](https://support.google.com/a/answer/175197).
+            For more details, see [Deploy 2-Step Verification](https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification).
     refs:
-      - url: https://support.google.com/a/answer/175197
+      - url: https://knowledge.workspace.google.com/admin/security/protect-your-business-with-2-step-verification
         title: Google Workspace - Deploy 2-Step Verification
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices
   - uid: mondoo-googleworkspace-security-admins-no-pending-password-reset
     title: Ensure no admin accounts have a pending forced password change
@@ -955,9 +955,9 @@ queries:
             3. If the admin account is inactive or no longer needed, remove its admin privileges or suspend it in the [Google Admin console](https://admin.google.com/) under **Directory** > **Users**.
             4. Review why the password reset was triggered and investigate signs of compromise, such as suspicious sign-in events under **Reporting** > **Audit and investigation**.
 
-            For more details, see [Reset a user's password](https://support.google.com/a/answer/33319).
+            For more details, see [Reset a user's password](https://knowledge.workspace.google.com/admin/users/reset-a-users-password).
     refs:
-      - url: https://support.google.com/a/answer/33319
+      - url: https://knowledge.workspace.google.com/admin/users/reset-a-users-password
         title: Google Workspace - Reset a User's Password
-      - url: https://support.google.com/a/answer/9011373
+      - url: https://knowledge.workspace.google.com/admin/users/security-best-practices-for-administrator-accounts
         title: Google Workspace Security Best Practices

--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -535,7 +535,7 @@ queries:
 
             On Grafana Cloud you have no access to `grafana.ini` or the server process, so the default `admin` account does not apply in the same way. Manage administrators through the Grafana Cloud UI or the HTTP API instead.
     refs:
-      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
+      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/
         title: Grafana Authentication Configuration
   - uid: mondoo-grafana-datasources-use-proxy-mode
     title: Ensure datasources use proxy access mode
@@ -1009,7 +1009,7 @@ queries:
 
             After updating the configuration, restart the Grafana service so the change takes effect, then confirm each active user completes enrollment.
     refs:
-      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
+      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/
         title: Grafana Configure Authentication
   - uid: mondoo-grafana-saml-enabled
     filters: asset.platform == "grafana-org"
@@ -1074,5 +1074,5 @@ queries:
 
             After updating the configuration, restart the Grafana service so the change takes effect.
     refs:
-      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/
+      - url: https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/
         title: Grafana SAML Authentication

--- a/content/mondoo-grafana-security.mql.yaml
+++ b/content/mondoo-grafana-security.mql.yaml
@@ -4,7 +4,7 @@ policies:
   - summary: Secure Grafana organizations across service accounts, user roles, datasources, and alerting
     uid: mondoo-grafana-security
     name: Mondoo Grafana Security
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -129,7 +129,7 @@ queries:
             }
             ```
     refs:
-      - url: https://developer.hashicorp.com/hcp/docs/vault
+      - url: https://developer.hashicorp.com/hcp/docs/vault/what-is-hcp-vault
         title: HCP Vault
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hcp-security
     name: Mondoo HashiCorp Cloud Platform Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -130,7 +130,7 @@ queries:
             ```
     refs:
       - url: https://developer.hashicorp.com/hcp/docs/vault/what-is-hcp-vault
-        title: HCP Vault
+        title: HCP Vault Dedicated overview
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference
   - uid: mondoo-hcp-security-vault-no-public-endpoint-hcp-organization
@@ -253,7 +253,7 @@ queries:
             The block also accepts Datadog, Elasticsearch, Grafana, New Relic, Splunk, and generic HTTP destinations through their own argument sets; configure whichever destination the organization already collects logs in.
     refs:
       - url: https://developer.hashicorp.com/hcp/docs/vault/logs-metrics
-        title: HCP Vault audit logs
+        title: HCP Vault Dedicated logs and metrics overview
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference
   - uid: mondoo-hcp-security-vault-audit-log-export-hcp-organization

--- a/content/mondoo-hcp-security.mql.yaml
+++ b/content/mondoo-hcp-security.mql.yaml
@@ -252,7 +252,7 @@ queries:
 
             The block also accepts Datadog, Elasticsearch, Grafana, New Relic, Splunk, and generic HTTP destinations through their own argument sets; configure whichever destination the organization already collects logs in.
     refs:
-      - url: https://developer.hashicorp.com/hcp/docs/vault/audit-logs
+      - url: https://developer.hashicorp.com/hcp/docs/vault/logs-metrics
         title: HCP Vault audit logs
       - url: https://developer.hashicorp.com/hcp/api-docs/vault
         title: HCP Vault API reference

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -2005,7 +2005,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/certificates/overview/
+      - url: https://docs.hetzner.com/networking/certificates/overview/
         title: Hetzner Cloud Certificates overview
 
   # No Terraform variants: the `blocked` flag is set by Hetzner's abuse team based on observed traffic; it is not a configurable field on `hcloud_floating_ip` and Terraform carries no signal about it.
@@ -2145,7 +2145,7 @@ queries:
         # No CLI remediation: the `blocked` flag is set and cleared only by Hetzner's abuse team; neither the hcloud CLI nor the API can modify it.
         # No Terraform remediation: the `blocked` flag is set by Hetzner's abuse team based on observed traffic; it is not a configurable field on `hcloud_primary_ip`. The fix is investigation and remediation of the underlying workload, then a support request.
     refs:
-      - url: https://docs.hetzner.com/cloud/primary-ips/overview/
+      - url: https://docs.hetzner.com/cloud/servers/primary-ips/overview/
         title: Hetzner Cloud Primary IPs overview
 
   # No Terraform variants: the key algorithm and size are parsed from the SSH
@@ -2231,7 +2231,7 @@ queries:
         # key material generated with ssh-keygen, not an hcloud_ssh_key argument; the
         # fix is to generate and register a new key pair.
     refs:
-      - url: https://docs.hetzner.com/cloud/servers/getting-started/connecting-via-ssh/
+      - url: https://docs.hetzner.com/cloud/servers/getting-started/connecting-to-the-server/
         title: Hetzner Cloud SSH keys
 
   # No Terraform variants: selfSigned and signatureAlgorithm are derived by parsing
@@ -2337,7 +2337,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/certificates/overview/
+      - url: https://docs.hetzner.com/networking/certificates/overview/
         title: Hetzner Cloud Certificates overview
 
   # No Terraform variants: Hetzner Storage Boxes are not managed by the hcloud

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-hetzner-security
     name: Mondoo Hetzner Cloud Security
-    version: 2.3.2
+    version: 2.3.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -2232,7 +2232,7 @@ queries:
         # fix is to generate and register a new key pair.
     refs:
       - url: https://docs.hetzner.com/cloud/servers/getting-started/connecting-to-the-server/
-        title: Hetzner Cloud SSH keys
+        title: Connecting to your Server
 
   # No Terraform variants: selfSigned and signatureAlgorithm are derived by parsing
   # the certificate PEM at runtime. Terraform sources carry the certificate as an

--- a/content/mondoo-hetzner-security.mql.yaml
+++ b/content/mondoo-hetzner-security.mql.yaml
@@ -120,7 +120,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Servers** and open each server.
         3. Click the **Networking** tab.
         4. Review the **Private Networks** section.
@@ -179,7 +179,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/networks/overview/
+      - url: https://docs.hetzner.com/networking/networks/overview/
         title: Hetzner Cloud Networks overview
 
   - uid: mondoo-hetzner-security-server-in-private-network-hetzner
@@ -260,7 +260,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Servers** and open each server.
         3. Click the **Firewalls** tab.
         4. Review the list of applied firewalls.
@@ -379,7 +379,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Servers** and open each server.
         3. On the **Overview** tab, check the **Image** field.
         4. A deprecated image is noted with a deprecation warning or end-of-life indicator in the image name or description.
@@ -492,7 +492,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Servers** and open each server, then review the **Networking** tab for an assigned public IPv4 or IPv6 address.
         3. Open the **Firewalls** tab and review the inbound rules of every applied firewall; a server with no firewall admits all inbound traffic.
 
@@ -624,7 +624,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab, focusing on inbound rules.
         4. Check whether any inbound TCP rule for port 22 lists `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`) as the source.
@@ -780,7 +780,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab, focusing on inbound rules.
         4. Check whether any inbound TCP rule for port 3389 lists `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`) as the source.
@@ -941,7 +941,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab, focusing on inbound rules.
         4. Check whether any inbound TCP rule specifies a port of `3306`, `5432`, `27017`, `6379`, `9092`, `9200`, or `1433` with a source of `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`).
@@ -1105,7 +1105,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab, focusing on inbound rules.
         4. Check whether any inbound rule has the port set to `Any`, `1-65535`, or `0-65535` with a source of `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`).
@@ -1279,7 +1279,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab, focusing on outbound rules.
         4. Check whether any outbound rule has the port set to `Any`, `1-65535`, or `0-65535` with a destination of `Any IPv4` (`0.0.0.0/0`) or `Any IPv6` (`::/0`).
@@ -1440,7 +1440,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Firewalls** and open each firewall.
         3. Review the **Rules** tab.
 
@@ -1564,7 +1564,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Load Balancers** and open each load balancer.
         3. Click the **Services** tab.
         4. Verify that no plain HTTP service is configured and that the HTTPS service has **Redirect HTTP to HTTPS** enabled.
@@ -1620,7 +1620,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+      - url: https://docs.hetzner.com/networking/load-balancers/overview/
         title: Hetzner Cloud Load Balancers overview
 
   - uid: mondoo-hetzner-security-lb-http-redirected-to-https-hetzner
@@ -1707,7 +1707,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Load Balancers** and open each load balancer.
         3. Click the **Services** tab.
         4. Find any service configured for HTTPS (port 443) and verify that at least one certificate is listed under **Certificates**.
@@ -1765,7 +1765,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+      - url: https://docs.hetzner.com/networking/load-balancers/overview/
         title: Hetzner Cloud Load Balancers overview
 
   - uid: mondoo-hetzner-security-lb-https-service-has-certificate-hetzner
@@ -1840,7 +1840,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Load Balancers** and open each load balancer.
         3. Click the **Networking** tab and review the **Private Networks** section.
 
@@ -1905,7 +1905,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.hetzner.com/cloud/load-balancers/overview/
+      - url: https://docs.hetzner.com/networking/load-balancers/overview/
         title: Hetzner Cloud Load Balancers overview
 
   # No Terraform variants: certificate expiration (`notValidAfter`) is runtime metadata derived from the certificate material, not a configurable field on `hcloud_managed_certificate` / `hcloud_uploaded_certificate`. The Terraform config carries no signal about the current expiry date.
@@ -1948,7 +1948,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Certificates**.
         3. Review the **Expires** column for each certificate.
 
@@ -2048,7 +2048,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Floating IPs**.
         3. Review each floating IP for a blocked or suspended status indicator.
 
@@ -2118,7 +2118,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Primary IPs**.
         3. Review each primary IP for a blocked or suspended status indicator.
 
@@ -2193,7 +2193,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Security** > **SSH Keys**.
         3. Review the algorithm of each stored key.
 
@@ -2279,7 +2279,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Certificates**.
         3. Review the type and issuer of each certificate.
 
@@ -2383,7 +2383,7 @@ queries:
       audit: |
         ### Audit via Console
 
-        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.cloud) and select the project.
+        1. Log in to the [Hetzner Cloud Console](https://console.hetzner.com/) and select the project.
         2. Navigate to **Storage Boxes** and open each Storage Box.
         3. Review the access settings for external reachability.
 

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -202,7 +202,7 @@ queries:
                 iisreset
                 ```
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
         title: MDN Web Docs X-Content-Type-Options
       - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options
         title: OWASP HTTP Security Response Headers Cheat Sheet
@@ -340,7 +340,7 @@ queries:
             5. Once the policy no longer reports violations for legitimate traffic, remove the report-only header and add a header named `Content-Security-Policy` with the finished policy value.
             6. Click OK. The change takes effect immediately.
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
         title: MDN Web Docs Content Security Policy (CSP)
   - uid: mondoo-http-security-strict-transport-security
     title: Set Strict-Transport-Security (HSTS) HTTP header
@@ -462,7 +462,7 @@ queries:
 
             5. The setting applies to the next request. On IIS releases older than 10.0 version 1709 the `<hsts>` element does not exist, so emit the header from the application or from a URL Rewrite outbound rule conditioned on `HTTPS` being `on`.
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
   - uid: mondoo-http-security-obfuscate-server
     title: Remove or obfuscate the Server header
@@ -1143,7 +1143,7 @@ queries:
                 iisreset
                 ```
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options
         title: MDN Web Docs X-Frame-Options
       - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-frame-options
         title: OWASP HTTP Security Response Headers Cheat Sheet
@@ -1245,7 +1245,7 @@ queries:
                 iisreset
                 ```
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
         title: MDN Web Docs Referrer-Policy
       - url: https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#referrer-policy
         title: OWASP HTTP Security Response Headers Cheat Sheet
@@ -1351,7 +1351,7 @@ queries:
 
             4. The setting applies to the next request. If the site still carries a `Strict-Transport-Security` entry under `HTTP Response Headers`, remove it, because that copy is also sent over plain HTTP and can override the intended `max-age`.
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
       - url: https://hstspreload.org/
         title: HSTS Preload List Submission
@@ -1460,7 +1460,7 @@ queries:
             4. Do not enable `preload` unless you intend to submit the domain to browser preload lists, which is a long-term commitment that is slow to reverse.
             5. The setting applies to the next request.
     refs:
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security
   - uid: mondoo-http-security-hsts-preload
     title: Ensure HSTS preload is enabled
@@ -1582,5 +1582,5 @@ queries:
     refs:
       - url: https://hstspreload.org/
         title: HSTS Preload List Submission
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
         title: MDN Web Docs Strict-Transport-Security

--- a/content/mondoo-http-security.mql.yaml
+++ b/content/mondoo-http-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-http-security
     name: Mondoo HTTP Security
-    version: 1.4.0
+    version: 1.4.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -534,8 +534,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/connection-limit-edit-system.html
-        title: connection-limit
-
+        title: Junos connection-limit statement (System)
   - uid: mondoo-junos-security-ssh-rate-limit
     title: Ensure SSH rate limit is configured
     impact: 70
@@ -598,8 +597,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/rate-limit-edit-system.html
-        title: rate-limit
-
+        title: Junos rate-limit statement (System)
   # ==========================================
   # User Account Security
   # ==========================================

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-junos-security
     name: Mondoo Juniper Junos Security
-    version: 1.1.4
+    version: 1.1.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -176,7 +176,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
-        title: Junos SSH Root Login Configuration
+        title: ssh (System Services)
 
   - uid: mondoo-junos-security-ssh-no-weak-ciphers
     title: Ensure weak SSH ciphers are not configured
@@ -251,7 +251,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
-        title: Junos SSH Ciphers Configuration
+        title: ssh (System Services)
 
   - uid: mondoo-junos-security-ssh-no-weak-macs
     title: Ensure weak SSH MACs are not configured
@@ -325,7 +325,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
-        title: Junos SSH MACs Configuration
+        title: ssh (System Services)
 
   - uid: mondoo-junos-security-ssh-no-weak-key-exchanges
     title: Ensure weak SSH key exchange algorithms are not configured
@@ -400,7 +400,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
-        title: Junos SSH Key Exchange Configuration
+        title: ssh (System Services)
 
   - uid: mondoo-junos-security-ssh-tcp-forwarding-disabled
     title: Ensure SSH TCP forwarding is disabled
@@ -470,7 +470,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
-        title: Junos SSH TCP Forwarding Configuration
+        title: ssh (System Services)
 
   - uid: mondoo-junos-security-ssh-connection-limit
     title: Ensure SSH connection limit is configured
@@ -534,7 +534,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/connection-limit-edit-system.html
-        title: Junos SSH Connection Limit Configuration
+        title: connection-limit
 
   - uid: mondoo-junos-security-ssh-rate-limit
     title: Ensure SSH rate limit is configured
@@ -598,7 +598,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/rate-limit-edit-system.html
-        title: Junos SSH Rate Limit Configuration
+        title: rate-limit
 
   # ==========================================
   # User Account Security
@@ -689,7 +689,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-authentication-order.html
-        title: Junos User Authentication Configuration
+        title: Authentication Order for RADIUS TACACS+, and Local Password
 
   - uid: mondoo-junos-security-no-super-user-class-overuse
     title: Ensure minimal number of users have super-user privileges
@@ -771,7 +771,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-login-class-overview.html
-        title: Junos Login Classes Configuration
+        title: Login Classes Overview
 
   # ==========================================
   # Insecure Service Elimination
@@ -1070,7 +1070,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
-        title: Junos SNMP Configuration
+        title: Configure SNMPv3
 
   - uid: mondoo-junos-security-snmp-no-read-write
     title: Ensure SNMP communities do not have read-write access
@@ -1140,7 +1140,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
-        title: Junos SNMP Configuration
+        title: Configure SNMPv3
 
   - uid: mondoo-junos-security-snmp-client-lists
     title: Ensure SNMP communities restrict client access
@@ -1211,7 +1211,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
-        title: Junos SNMP Configuration
+        title: Configure SNMPv3
 
   # ==========================================
   # Logging and Auditing
@@ -1280,7 +1280,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/system-logging.html
-        title: Junos Syslog Configuration
+        title: Overview of System Logging
 
   - uid: mondoo-junos-security-syslog-secure-transport
     title: Ensure syslog uses secure transport
@@ -1361,7 +1361,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/system-logging.html
-        title: Junos Syslog Configuration
+        title: Overview of System Logging
 
   # ==========================================
   # Security Zone Hardening
@@ -1429,7 +1429,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/security-edit-log-security-policies.html
-        title: Junos Security Policy Logging
+        title: log (Security Policies)
 
   - uid: mondoo-junos-security-zones-have-screens
     title: Ensure untrust security zones have screen profiles applied
@@ -1497,7 +1497,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-untrust-zone-minimal-services
     title: Ensure untrust zone does not expose insecure host-inbound services
@@ -1646,7 +1646,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-screen-icmp-ping-death
     title: Ensure screen profiles have ICMP ping-of-death protection enabled
@@ -1710,7 +1710,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-screen-ip-source-route
     title: Ensure screen profiles have IP source route option protection enabled
@@ -1774,7 +1774,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-screen-tcp-land
     title: Ensure screen profiles have TCP land attack protection enabled
@@ -1838,7 +1838,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-screen-ip-tear-drop
     title: Ensure screen profiles have IP teardrop protection enabled
@@ -1902,7 +1902,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   - uid: mondoo-junos-security-screen-tcp-winnuke
     title: Ensure screen profiles have TCP WinNuke protection enabled
@@ -1966,7 +1966,7 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
-        title: Junos Screen IDS Configuration
+        title: Screens Options for Attack Detection and Prevention
 
   # ==========================================
   # License Compliance
@@ -2051,4 +2051,4 @@ queries:
             ```
     refs:
       - url: https://www.juniper.net/documentation/us/en/software/license/juniper-licensing-user-guide/index.html
-        title: Junos License Management
+        title: Juniper Licensing User Guide

--- a/content/mondoo-junos-security.mql.yaml
+++ b/content/mondoo-junos-security.mql.yaml
@@ -175,7 +175,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/root-login-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
         title: Junos SSH Root Login Configuration
 
   - uid: mondoo-junos-security-ssh-no-weak-ciphers
@@ -250,7 +250,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/ciphers-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
         title: Junos SSH Ciphers Configuration
 
   - uid: mondoo-junos-security-ssh-no-weak-macs
@@ -324,7 +324,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/macs-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
         title: Junos SSH MACs Configuration
 
   - uid: mondoo-junos-security-ssh-no-weak-key-exchanges
@@ -399,7 +399,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/key-exchange-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
         title: Junos SSH Key Exchange Configuration
 
   - uid: mondoo-junos-security-ssh-tcp-forwarding-disabled
@@ -469,7 +469,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/no-tcp-forwarding-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/ssh-edit-system.html
         title: Junos SSH TCP Forwarding Configuration
 
   - uid: mondoo-junos-security-ssh-connection-limit
@@ -533,7 +533,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/connection-limit-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/connection-limit-edit-system.html
         title: Junos SSH Connection Limit Configuration
 
   - uid: mondoo-junos-security-ssh-rate-limit
@@ -597,7 +597,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/ref/statement/rate-limit-edit-system-services-ssh.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/rate-limit-edit-system.html
         title: Junos SSH Rate Limit Configuration
 
   # ==========================================
@@ -688,7 +688,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-authentication.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-authentication-order.html
         title: Junos User Authentication Configuration
 
   - uid: mondoo-junos-security-no-super-user-class-overuse
@@ -770,7 +770,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/user-access-login-classes.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/user-access/topics/topic-map/junos-os-login-class-overview.html
         title: Junos Login Classes Configuration
 
   # ==========================================
@@ -1069,7 +1069,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
         title: Junos SNMP Configuration
 
   - uid: mondoo-junos-security-snmp-no-read-write
@@ -1139,7 +1139,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
         title: Junos SNMP Configuration
 
   - uid: mondoo-junos-security-snmp-client-lists
@@ -1210,7 +1210,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-snmpv3.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configure-snmpv3.html
         title: Junos SNMP Configuration
 
   # ==========================================
@@ -1279,7 +1279,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/system-logging.html
         title: Junos Syslog Configuration
 
   - uid: mondoo-junos-security-syslog-secure-transport
@@ -1360,7 +1360,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/syslog-messages-configuring.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/system-logging.html
         title: Junos Syslog Configuration
 
   # ==========================================
@@ -1428,7 +1428,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-policy-logging.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/cli-reference/topics/ref/statement/security-edit-log-security-policies.html
         title: Junos Security Policy Logging
 
   - uid: mondoo-junos-security-zones-have-screens
@@ -1496,7 +1496,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-untrust-zone-minimal-services
@@ -1645,7 +1645,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-screen-icmp-ping-death
@@ -1709,7 +1709,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-screen-ip-source-route
@@ -1773,7 +1773,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-screen-tcp-land
@@ -1837,7 +1837,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-screen-ip-tear-drop
@@ -1901,7 +1901,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   - uid: mondoo-junos-security-screen-tcp-winnuke
@@ -1965,7 +1965,7 @@ queries:
             commit
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/security-policies/topics/topic-map/security-screen-ids.html
+      - url: https://www.juniper.net/documentation/us/en/software/junos/denial-of-service/topics/topic-map/security-introduction-to-adp.html
         title: Junos Screen IDS Configuration
 
   # ==========================================
@@ -2050,5 +2050,5 @@ queries:
             show system license
             ```
     refs:
-      - url: https://www.juniper.net/documentation/us/en/software/junos/system-mgmt/topics/topic-map/license-management.html
+      - url: https://www.juniper.net/documentation/us/en/software/license/juniper-licensing-user-guide/index.html
         title: Junos License Management

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -2450,7 +2450,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-daemonset-ports-hostport
     title: DaemonSets should not bind to a host port
     impact: 40
@@ -2505,7 +2505,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-replicaset-ports-hostport
     title: ReplicaSets should not bind to a host port
     impact: 40
@@ -2560,7 +2560,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-job-ports-hostport
     title: Jobs should not bind to a host port
     impact: 40
@@ -2615,7 +2615,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-deployment-ports-hostport
     title: Deployments should not bind to a host port
     impact: 40
@@ -2670,7 +2670,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-statefulset-ports-hostport
     title: StatefulSets should not bind to a host port
     impact: 40
@@ -2725,7 +2725,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-cronjob-ports-hostport
     title: CronJobs should not bind to a host port
     impact: 40
@@ -2782,7 +2782,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
   - uid: mondoo-kubernetes-best-practices-ingress-cert-expiration
     title: Ingress certificates less than 15 days from expiration
     impact: 40

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-best-practices
     name: Mondoo Kubernetes Best Practices
-    version: 1.2.2
+    version: 1.2.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: best-practices

--- a/content/mondoo-kubernetes-best-practices.mql.yaml
+++ b/content/mondoo-kubernetes-best-practices.mql.yaml
@@ -2449,7 +2449,7 @@ queries:
                 protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-daemonset-ports-hostport
     title: DaemonSets should not bind to a host port
@@ -2504,7 +2504,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-replicaset-ports-hostport
     title: ReplicaSets should not bind to a host port
@@ -2559,7 +2559,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-job-ports-hostport
     title: Jobs should not bind to a host port
@@ -2614,7 +2614,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-deployment-ports-hostport
     title: Deployments should not bind to a host port
@@ -2669,7 +2669,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-statefulset-ports-hostport
     title: StatefulSets should not bind to a host port
@@ -2724,7 +2724,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-cronjob-ports-hostport
     title: CronJobs should not bind to a host port
@@ -2781,7 +2781,7 @@ queries:
                         protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
   - uid: mondoo-kubernetes-best-practices-ingress-cert-expiration
     title: Ingress certificates less than 15 days from expiration
@@ -2929,7 +2929,7 @@ queries:
 
         For workloads that intentionally run as singletons (e.g., leader-elected controllers), consider excluding them from this check or documenting the exception.
     refs:
-      - url: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+      - url: https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/
         title: Kubernetes Horizontal Pod Autoscaling
       - url: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
         title: Kubernetes Pod Disruptions

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-security
     name: Mondoo Kubernetes Cluster and Workload Security
-    version: 2.1.1
+    version: 2.1.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -10699,7 +10699,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-daemonset-ports-hostport
@@ -10766,7 +10766,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-replicaset-ports-hostport
@@ -10833,7 +10833,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-job-ports-hostport
@@ -10900,7 +10900,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-deployment-ports-hostport
@@ -10967,7 +10967,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-statefulset-ports-hostport
@@ -11034,7 +11034,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-cronjob-ports-hostport
@@ -11103,7 +11103,7 @@ queries:
         ```
     refs:
       - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
-        title: 'Kubernetes Configuration Best Practices: hostPort'
+        title: Kubernetes Configuration Good Practices
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
   - uid: mondoo-kubernetes-security-pod-hostpath-readonly

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -10255,7 +10255,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-daemonset-capability-sys-admin
     title: DaemonSets should not run with SYS_ADMIN capability
@@ -10318,7 +10318,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-replicaset-capability-sys-admin
     title: ReplicaSets should not run with SYS_ADMIN capability
@@ -10381,7 +10381,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-job-capability-sys-admin
     title: Jobs should not run with SYS_ADMIN capability
@@ -10444,7 +10444,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-deployment-capability-sys-admin
     title: Deployments should not run with SYS_ADMIN capability
@@ -10506,7 +10506,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-statefulset-capability-sys-admin
     title: StatefulSets should not run with SYS_ADMIN capability
@@ -10569,7 +10569,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-cronjob-capability-sys-admin
     title: CronJobs should not run with SYS_ADMIN capability
@@ -10634,7 +10634,7 @@ queries:
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Capabilities'
-      - url: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+      - url: https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities
         title: Docker default capabilities
   - uid: mondoo-kubernetes-security-pod-ports-hostport
     title: Pods should not bind to a host port
@@ -10698,7 +10698,7 @@ queries:
                 protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -10765,7 +10765,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -10832,7 +10832,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -10899,7 +10899,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -10966,7 +10966,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -11033,7 +11033,7 @@ queries:
                     protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'
@@ -11102,7 +11102,7 @@ queries:
                         protocol: TCP
         ```
     refs:
-      - url: https://kubernetes.io/docs/concepts/configuration/overview/#services
+      - url: https://kubernetes.io/blog/2025/11/25/configuration-good-practices/#use-dns-for-service-discovery
         title: 'Kubernetes Configuration Best Practices: hostPort'
       - url: https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
         title: 'Kubernetes Security Standards: Host Ports'

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -10993,7 +10993,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-rsyslog-is-installed-and-enabled
     title: Ensure rsyslog is installed
     impact: 50
@@ -12163,7 +12163,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-permissions-on-ssh-public-host-key-files-are-configured
     title: Ensure secure permissions on SSH public host key files are set
     impact: 80
@@ -12283,7 +12283,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-protocol-is-set-to-2
     title: Ensure SSH Protocol is set to 2
     impact: 80
@@ -12457,7 +12457,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-loglevel-is-appropriate
     title: Ensure SSH LogLevel is appropriate
     impact: 60
@@ -12698,7 +12698,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-x11-forwarding-is-disabled
     title: Ensure SSH X11 forwarding is disabled
     impact: 50
@@ -12933,7 +12933,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-maxauthtries-is-set-to-4-or-less
     title: Ensure SSH MaxAuthTries is set to 4 or less
     impact: 70
@@ -13168,7 +13168,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-ignorerhosts-is-enabled
     title: Ensure SSH IgnoreRhosts is enabled
     impact: 60
@@ -13403,7 +13403,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-hostbasedauthentication-is-disabled
     title: Ensure SSH HostbasedAuthentication is disabled
     impact: 70
@@ -13638,7 +13638,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-root-login-is-disabled
     title: Ensure SSH root login is disabled or set to prohibit-password
     impact: 100
@@ -13879,7 +13879,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-permitemptypasswords-is-disabled
     title: Ensure SSH PermitEmptyPasswords is disabled
     impact: 70
@@ -14114,7 +14114,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-permituserenvironment-is-disabled
     title: Ensure SSH PermitUserEnvironment is disabled
     impact: 70
@@ -14351,7 +14351,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-only-strong-ciphers-are-used
     title: Ensure only strong ciphers are used
     impact: 100
@@ -14612,7 +14612,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-only-strong-mac-algorithms-are-used
     title: Ensure only strong MAC algorithms are used
     impact: 80
@@ -14858,7 +14858,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-only-strong-kex-algorithms-are-used
     title: Ensure only strong key exchange algorithms are used
     impact: 100
@@ -15186,7 +15186,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-idle-timeout-interval-is-configured
     title: Ensure SSH Idle Timeout Interval is configured
     impact: 60
@@ -15475,7 +15475,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less
     title: Ensure SSH LoginGraceTime is set to one minute or less
     impact: 80
@@ -15709,7 +15709,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-access-is-limited
     title: Ensure SSH access is limited
     impact: 60
@@ -15891,7 +15891,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-ssh-warning-banner-is-configured
     title: Ensure SSH warning banner is configured
     impact: 30
@@ -16125,7 +16125,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: OpenSSH sshd_config Manual
+        title: sshd_config(5)
   - uid: mondoo-linux-security-permissions-on-etcpasswd-are-configured
     title: Ensure secure permissions on /etc/passwd are set
     impact: 100

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -10993,7 +10993,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-rsyslog-is-installed-and-enabled
     title: Ensure rsyslog is installed
     impact: 50
@@ -12163,7 +12163,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-permissions-on-ssh-public-host-key-files-are-configured
     title: Ensure secure permissions on SSH public host key files are set
     impact: 80
@@ -12283,7 +12283,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-protocol-is-set-to-2
     title: Ensure SSH Protocol is set to 2
     impact: 80
@@ -12457,7 +12457,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-loglevel-is-appropriate
     title: Ensure SSH LogLevel is appropriate
     impact: 60
@@ -12698,7 +12698,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-x11-forwarding-is-disabled
     title: Ensure SSH X11 forwarding is disabled
     impact: 50
@@ -12933,7 +12933,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-maxauthtries-is-set-to-4-or-less
     title: Ensure SSH MaxAuthTries is set to 4 or less
     impact: 70
@@ -13168,7 +13168,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-ignorerhosts-is-enabled
     title: Ensure SSH IgnoreRhosts is enabled
     impact: 60
@@ -13403,7 +13403,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-hostbasedauthentication-is-disabled
     title: Ensure SSH HostbasedAuthentication is disabled
     impact: 70
@@ -13638,7 +13638,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-root-login-is-disabled
     title: Ensure SSH root login is disabled or set to prohibit-password
     impact: 100
@@ -13879,7 +13879,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-permitemptypasswords-is-disabled
     title: Ensure SSH PermitEmptyPasswords is disabled
     impact: 70
@@ -14114,7 +14114,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-permituserenvironment-is-disabled
     title: Ensure SSH PermitUserEnvironment is disabled
     impact: 70
@@ -14351,7 +14351,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-only-strong-ciphers-are-used
     title: Ensure only strong ciphers are used
     impact: 100
@@ -14612,7 +14612,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-only-strong-mac-algorithms-are-used
     title: Ensure only strong MAC algorithms are used
     impact: 80
@@ -14858,7 +14858,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-only-strong-kex-algorithms-are-used
     title: Ensure only strong key exchange algorithms are used
     impact: 100
@@ -15186,7 +15186,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-idle-timeout-interval-is-configured
     title: Ensure SSH Idle Timeout Interval is configured
     impact: 60
@@ -15475,7 +15475,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-logingracetime-is-set-to-one-minute-or-less
     title: Ensure SSH LoginGraceTime is set to one minute or less
     impact: 80
@@ -15709,7 +15709,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-access-is-limited
     title: Ensure SSH access is limited
     impact: 60
@@ -15891,7 +15891,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-ssh-warning-banner-is-configured
     title: Ensure SSH warning banner is configured
     impact: 30
@@ -16125,7 +16125,7 @@ queries:
             ```
     refs:
       - url: https://man.openbsd.org/sshd_config
-        title: sshd_config(5)
+        title: OpenSSH sshd_config(5)
   - uid: mondoo-linux-security-permissions-on-etcpasswd-are-configured
     title: Ensure secure permissions on /etc/passwd are set
     impact: 100

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-linux-security
     name: Mondoo Linux Security
-    version: 2.8.2
+    version: 2.8.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -11132,7 +11132,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/master/
+      - url: https://www.rsyslog.com/doc/index.html
         title: rsyslog Documentation
   - uid: mondoo-linux-security-rsyslog-default-file-permissions-configured
     title: Ensure rsyslog default file permissions are configured
@@ -11299,7 +11299,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/master/
+      - url: https://www.rsyslog.com/doc/index.html
         title: rsyslog Documentation
   - uid: mondoo-linux-security-journald-is-configured-to-send-logs-to-rsyslog
     title: Ensure journald is configured to send logs to rsyslog
@@ -12023,7 +12023,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/master/
+      - url: https://www.rsyslog.com/doc/index.html
         title: rsyslog Documentation
   - uid: mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured
     title: Ensure secure permissions on SSH private host key files are set

--- a/content/mondoo-linux-security.mql.yaml
+++ b/content/mondoo-linux-security.mql.yaml
@@ -11132,7 +11132,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/index.html
+      - url: https://docs.rsyslog.com/
         title: rsyslog Documentation
   - uid: mondoo-linux-security-rsyslog-default-file-permissions-configured
     title: Ensure rsyslog default file permissions are configured
@@ -11299,7 +11299,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/index.html
+      - url: https://docs.rsyslog.com/
         title: rsyslog Documentation
   - uid: mondoo-linux-security-journald-is-configured-to-send-logs-to-rsyslog
     title: Ensure journald is configured to send logs to rsyslog
@@ -12023,7 +12023,7 @@ queries:
             end
             ```
     refs:
-      - url: https://www.rsyslog.com/doc/index.html
+      - url: https://docs.rsyslog.com/
         title: rsyslog Documentation
   - uid: mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured
     title: Ensure secure permissions on SSH private host key files are set

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-m365-security
     name: Mondoo Microsoft 365 Security
-    version: 2.4.3
+    version: 2.4.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -654,7 +654,7 @@ queries:
     refs:
       - url: https://learn.microsoft.com/en-us/entra/identity/conditional-access/overview
         title: Microsoft Entra Conditional Access
-      - url: https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication
+      - url: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-legacy-authentication
         title: Block Legacy Authentication with Conditional Access
   - uid: mondoo-m365-security-enable-conditional-access-policies-to-block-legacy-authentication-microsoft365
     filters: |

--- a/content/mondoo-m365-security.mql.yaml
+++ b/content/mondoo-m365-security.mql.yaml
@@ -2294,7 +2294,7 @@ queries:
             ```
         # No Terraform remediation: Exchange Online Safe Attachments policies have no Terraform provider.
     refs:
-      - url: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-about
+      - url: https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-about
         title: Safe Attachments in Microsoft Defender for Office 365
       - url: https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-policies-configure
         title: Set up Safe Attachments policies

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -2884,7 +2884,7 @@ queries:
 
             Enforcing password expiration may lead to some locked computers requiring administrative assistance. Ensure users are informed of the policy to minimize disruptions.
     refs:
-      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-mchlp2996/mac
+      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-on-mac-mh11784/mac
         title: Apple - Lock Screen Settings
   - uid: mondoo-macos-security-password-history
     title: Password History
@@ -3003,7 +3003,7 @@ queries:
 
             Enforcing password history may lead to some locked computers requiring administrative assistance. Ensure users are informed of the policy to minimize disruptions.
     refs:
-      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-mchlp2996/mac
+      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-on-mac-mh11784/mac
         title: Apple - Lock Screen Settings
   - uid: mondoo-macos-security-reduce-the-sudo-timeout-period
     title: Reduce the sudo timeout period
@@ -3299,7 +3299,7 @@ queries:
 
             Enforcing a minimum password length may inconvenience users accustomed to shorter passwords. However, the security benefits outweigh the potential inconvenience, especially in environments handling sensitive data.
     refs:
-      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-mchlp2996/mac
+      - url: https://support.apple.com/guide/mac-help/change-lock-screen-settings-on-mac-mh11784/mac
         title: Apple - Lock Screen Settings
   - uid: mondoo-macos-security-software-updates-automatic-check-enabled
     title: Ensure automatic checking of software updates enabled

--- a/content/mondoo-macos-security.mql.yaml
+++ b/content/mondoo-macos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-macos-security
     name: Mondoo macOS Security
-    version: 1.4.4
+    version: 1.4.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-mcp-security
     name: Mondoo Model Context Protocol (MCP) Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-mcp-security.mql.yaml
+++ b/content/mondoo-mcp-security.mql.yaml
@@ -141,7 +141,7 @@ queries:
             }
             ```
     refs:
-      - url: https://owasp.org/www-project-top-10-privacy-risks/
+      - url: https://owasp.github.io/www-project-top-10-privacy-risks/
         title: OWASP Privacy Risks
   - uid: mondoo-mcp-prompt-injection-detection
     title: Detect prompt injection attacks in MCP content
@@ -549,7 +549,7 @@ queries:
 
             For shared MCP servers, route changes through code review so a second author confirms metadata reads professionally before it ships.
     refs:
-      - url: https://blog.google/technology/ai/ai-principles/
+      - url: https://blog.google/innovation-and-ai/products/ai-principles/
         title: Content Moderation Best Practices
       - url: https://www.microsoft.com/en-us/ai/responsible-ai
         title: Responsible AI Guidelines
@@ -775,7 +775,7 @@ queries:
             }
             ```
     refs:
-      - url: https://owasp.org/www-project-top-10-privacy-risks/
+      - url: https://owasp.github.io/www-project-top-10-privacy-risks/
         title: OWASP Privacy Risks
-      - url: https://blog.google/technology/ai/ai-principles/
+      - url: https://blog.google/innovation-and-ai/products/ai-principles/
         title: Content Security Guidelines

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -138,7 +138,7 @@ queries:
             /ip service disable telnet
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Services
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services
         title: MikroTik RouterOS Services
 
   - uid: mondoo-mikrotik-security-ftp-service-disabled
@@ -198,7 +198,7 @@ queries:
             /ip service disable ftp
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Services
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services
         title: MikroTik RouterOS Services
 
   - uid: mondoo-mikrotik-security-www-service-disabled
@@ -260,7 +260,7 @@ queries:
             /ip service disable www
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Services
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services
         title: MikroTik RouterOS Services
 
   - uid: mondoo-mikrotik-security-api-service-disabled
@@ -322,7 +322,7 @@ queries:
             /ip service disable api
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/API
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/47579160/API
         title: MikroTik RouterOS API
 
   # ==========================================
@@ -391,7 +391,7 @@ queries:
 
             A service left with an empty `address` still accepts connections from any host, so repeat the command for each remaining enabled service.
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Services
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services
         title: MikroTik RouterOS Services
 
   - uid: mondoo-mikrotik-security-tls-services-modern-version
@@ -452,7 +452,7 @@ queries:
             /ip service set api-ssl tls-version=only-1.2
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Services
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/103841820/Services
         title: MikroTik RouterOS Services
 
   # ==========================================
@@ -523,7 +523,7 @@ queries:
             /user disable admin
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/User
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/8978504/User
         title: MikroTik RouterOS User Management
 
   - uid: mondoo-mikrotik-security-users-source-restricted
@@ -583,7 +583,7 @@ queries:
             /user set netadmin address=192.168.88.0/24
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/User
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/8978504/User
         title: MikroTik RouterOS User Management
 
   # ==========================================
@@ -658,7 +658,7 @@ queries:
 
             Where practical, also migrate to SNMP v3 with authentication and encryption and restrict SNMP access to trusted management hosts.
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/SNMP
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/8978519/SNMP
         title: MikroTik RouterOS SNMP
 
   # ==========================================
@@ -721,7 +721,7 @@ queries:
             /system ntp client set enabled=yes servers=time.cloudflare.com,pool.ntp.org
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/NTP
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/40992869/NTP
         title: MikroTik RouterOS NTP
 
   # ==========================================
@@ -786,7 +786,7 @@ queries:
             /ip dns set verify-doh-cert=yes
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/DNS
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/37748767/DNS
         title: MikroTik RouterOS DNS
 
   # ==========================================
@@ -855,7 +855,7 @@ queries:
             /ip firewall filter add chain=input action=drop
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Filter
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/48660574/Filter
         title: MikroTik RouterOS Firewall Filter
 
   - uid: mondoo-mikrotik-security-firewall-drop-invalid
@@ -916,7 +916,7 @@ queries:
             /ip firewall filter add chain=forward connection-state=invalid action=drop
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Connection+tracking
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/130220087/Connection+tracking
         title: MikroTik RouterOS Connection Tracking
 
   # ==========================================
@@ -981,7 +981,7 @@ queries:
             /interface/wifi/set [find name=wifi1] security.authentication-types=wpa2-psk,wpa3-psk security.passphrase=<strong-passphrase>
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/WiFi
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/224559120/WiFi
         title: MikroTik RouterOS WiFi
 
   - uid: mondoo-mikrotik-security-wifi-wpa3-enabled
@@ -1043,7 +1043,7 @@ queries:
             /interface/wifi/set [find name=wifi1] security.authentication-types=wpa2-psk,wpa3-psk
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/WiFi
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/224559120/WiFi
         title: MikroTik RouterOS WiFi
 
   # ==========================================
@@ -1106,5 +1106,5 @@ queries:
             /interface bridge set [find name=bridge1] protocol-mode=rstp
             ```
     refs:
-      - url: https://help.mikrotik.com/docs/display/ROS/Bridging+and+Switching
+      - url: https://help.mikrotik.com/docs/spaces/ROS/pages/328068/Bridging+and+Switching
         title: MikroTik RouterOS Bridging and Switching

--- a/content/mondoo-mikrotik-security.mql.yaml
+++ b/content/mondoo-mikrotik-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-mikrotik-security
     name: Mondoo MikroTik RouterOS Security
-    version: 1.0.2
+    version: 1.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -103,7 +103,7 @@ queries:
             2. Enable the requirement that members use multi-factor authentication.
             3. Save the change and confirm existing members enroll a second factor.
     refs:
-      - url: https://neon.tech/docs/manage/organizations
+      - url: https://neon.com/docs/manage/organizations
         title: Neon Organizations
   - uid: mondoo-neon-security-project-block-public-connections
     title: Ensure Neon projects block public connections
@@ -203,7 +203,7 @@ queries:
             }
             ```
     refs:
-      - url: https://neon.tech/docs/introduction/ip-allow
+      - url: https://neon.com/docs/introduction/ip-allow
         title: Neon IP Allow
       - url: https://neon.com/docs/cli/projects
         title: Neon CLI projects command
@@ -328,9 +328,9 @@ queries:
             }
             ```
     refs:
-      - url: https://neon.tech/docs/manage/projects
+      - url: https://neon.com/docs/manage/projects
         title: Neon Projects
-      - url: https://neon.com/docs/reference/api-reference
+      - url: https://neon.com/docs/reference/api
         title: Neon API reference
   - uid: mondoo-neon-security-project-no-stored-passwords-neon-organization
     filters: asset.platform == "neon-organization"

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-neon-security
     name: Mondoo Neon Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-neon-security.mql.yaml
+++ b/content/mondoo-neon-security.mql.yaml
@@ -331,7 +331,7 @@ queries:
       - url: https://neon.com/docs/manage/projects
         title: Neon Projects
       - url: https://neon.com/docs/reference/api
-        title: Neon API reference
+        title: Neon API
   - uid: mondoo-neon-security-project-no-stored-passwords-neon-organization
     filters: asset.platform == "neon-organization"
     mql: |

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -93,7 +93,7 @@ queries:
             2. Enable **Enforce multi-factor authentication**.
             3. Save the change and confirm existing members enroll a second factor.
     refs:
-      - url: https://docs.netlify.com/accounts-and-billing/team-management/team-level-security/
+      - url: https://docs.netlify.com/manage/accounts-and-billing/team-management/roles-and-permissions/
         title: Netlify team-level security
   # No Terraform variant or remediation: netlify/netlify 0.4.4 has no site resource, only settings resources
   # that attach to a site created elsewhere, and netlify_site_domain_settings carries just the four custom

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -177,7 +177,7 @@ queries:
               "https://api.netlify.com/api/v1/sites/$SITE_ID"
             ```
     refs:
-      - url: https://docs.netlify.com/domains-https/https-ssl/
+      - url: https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/
         title: Netlify HTTPS/SSL
       - url: https://open-api.netlify.com/#tag/site/operation/updateSite
         title: Netlify API updateSite

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -94,7 +94,7 @@ queries:
             3. Save the change and confirm existing members enroll a second factor.
     refs:
       - url: https://docs.netlify.com/manage/accounts-and-billing/team-management/roles-and-permissions/
-        title: Netlify roles and permissions
+        title: Roles and permissions
   # No Terraform variant or remediation: netlify/netlify 0.4.4 has no site resource, only settings resources
   # that attach to a site created elsewhere, and netlify_site_domain_settings carries just the four custom
   # domain arguments and domain_aliases. No resource in the provider exposes forced TLS, so it cannot be

--- a/content/mondoo-netlify-security.mql.yaml
+++ b/content/mondoo-netlify-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-netlify-security
     name: Mondoo Netlify Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -94,7 +94,7 @@ queries:
             3. Save the change and confirm existing members enroll a second factor.
     refs:
       - url: https://docs.netlify.com/manage/accounts-and-billing/team-management/roles-and-permissions/
-        title: Netlify team-level security
+        title: Netlify roles and permissions
   # No Terraform variant or remediation: netlify/netlify 0.4.4 has no site resource, only settings resources
   # that attach to a site created elsewhere, and netlify_site_domain_settings carries just the four custom
   # domain arguments and domain_aliases. No resource in the provider exposes forced TLS, so it cannot be

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-nutanix-security
     name: Mondoo Nutanix Security
-    version: 1.0.4
+    version: 1.0.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-nutanix-security.mql.yaml
+++ b/content/mondoo-nutanix-security.mql.yaml
@@ -31,7 +31,7 @@ policies:
         - [Nutanix Security Guide](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:Nutanix-Security-Guide)
         - [Nutanix Hardening Guide](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:wc-security-hardening-wc-c.html)
         - [Nutanix v4 API Reference](https://developers.nutanix.com/)
-        - [BSI IT-Grundschutz SYS.1.5 Virtualisation](https://www.bsi.bund.de/)
+        - [BSI IT-Grundschutz SYS.1.5 Virtualisation](https://www.bsi.bund.de/DE/Home/home_node.html)
 
         Learn more about scanning Nutanix in the [cnspec documentation](https://mondoo.com/docs/cnspec).
 

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -7811,7 +7811,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database/doc/security-features-adb-d.html
+      - url: https://docs.oracle.com/en/cloud/paas/autonomous-database/dedicated/adbaa/security-features-in-autonomous-ai-database-on-dedicated.html
         title: OCI - Autonomous Database Encryption
       - url: https://docs.oracle.com/en/cloud/paas/base-database/backup-recover/index.html
         title: OCI - Managing Database Backups

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -1169,7 +1169,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/encryption.htm
-        title: CIS OCI Foundations Benchmark 4.1.2
+        title: Object Storage Data Encryption
   - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-oci
     filters: asset.platform == "oci-objectstorage-bucket"
     mql: |
@@ -4085,7 +4085,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingcertificates.htm
-        title: OCI - Load Balancer Managed SSL Certificates
+        title: OCI - Load Balancer- Managed SSL Certificates
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-oci
     filters: asset.platform == "oci-loadbalancer"
     mql: |
@@ -4248,7 +4248,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm
-        title: OCI - Predefined SSL Cipher Suites
+        title: OCI - Predefined Load Balancer Cipher Suites
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-oci
     filters: asset.platform == "oci-loadbalancer"
     mql: |
@@ -4720,7 +4720,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrysigningimages_topic.htm
-        title: OCI - Signing Container Images
+        title: OCI - Signing Images for Security
   - uid: mondoo-oci-security-oke-image-policy-enabled-oci
     filters: asset.platform == "oci-oke-cluster"
     mql: |
@@ -5270,7 +5270,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
-        title: OCI - Autonomous Database Network Access
+        title: OCI - About Network Access Options
   - uid: mondoo-oci-security-adb-mtls-or-restricted-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -5421,7 +5421,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
-        title: OCI - Autonomous Database Network Access
+        title: OCI - About Network Access Options
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - About Network Access Options
   - uid: mondoo-oci-security-adb-no-public-management-urls-oci
@@ -5559,7 +5559,7 @@ queries:
         # No Terraform remediation: this check requires cross-resource lookup from `oci_database_db_system` to its referenced `oci_core_subnet` to read `prohibit_public_ip_on_vnic`; cross-resource graph traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Database/home.htm
-        title: OCI - Database Service Overview
+        title: OCI - Database
   # No Terraform variants: requires walking from `oci_database_db_system` to its subnet to that subnet's `oci_core_route_table` and inspecting route rules for an internet-gateway target. Three-hop cross-resource traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
   - uid: mondoo-oci-security-dbsystem-subnet-no-internet-gateway
     title: Ensure DB system subnets have no route to an internet gateway
@@ -6233,7 +6233,7 @@ queries:
             Write the region key, namespace, and tag as literal values for your tenancy. Interpolated variables cannot be evaluated during static analysis and fail the check.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/container-instances/overview-of-container-instances.htm
-        title: OCI Container Instances Overview
+        title: Overview of Container Instances
       - url: https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm
         title: OCI Registry (OCIR)
   - uid: mondoo-oci-security-container-instances-approved-registry-oci
@@ -6881,7 +6881,7 @@ queries:
             Any `oci_identity_policy` containing Endorse or Admit statements fails this check and must carry a documented exception.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/accessingresourcesacrosstenancies.htm
-        title: OCI - Accessing Resources Across Tenancies
+        title: OCI - Accessing Object Storage Resources Across Tenancies
   - uid: mondoo-oci-security-iam-no-cross-tenant-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |
@@ -7812,9 +7812,9 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en/cloud/paas/autonomous-database/dedicated/adbaa/security-features-in-autonomous-ai-database-on-dedicated.html
-        title: OCI - Autonomous Database Encryption
+        title: OCI - Security Features in Autonomous AI Database on Dedicated Exadata Infrastructure
       - url: https://docs.oracle.com/en/cloud/paas/base-database/backup-recover/index.html
-        title: OCI - Managing Database Backups
+        title: OCI - Back Up and Recovery in Base Database Service
   - uid: mondoo-oci-security-database-backups-customer-managed-encryption-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -8008,7 +8008,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingauthzauthn.htm
-        title: OCI - API Gateway Authentication Policies
+        title: OCI - Adding Authentication and Authorization to API Deployments
   - uid: mondoo-oci-security-apigateway-deployment-no-anonymous-access-oci
     filters: asset.platform == "oci-apigateway-deployment"
     mql: |
@@ -8192,7 +8192,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingauthzauthn.htm
-        title: OCI - API Gateway Authentication Policies
+        title: OCI - Adding Authentication and Authorization to API Deployments
   - uid: mondoo-oci-security-apigateway-deployment-authentication-configured-oci
     filters: asset.platform == "oci-apigateway-deployment"
     mql: |
@@ -8388,7 +8388,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingmtlssupport.htm
-        title: OCI - API Gateway Mutual TLS
+        title: OCI - Adding mTLS support to API Deployments
   - uid: mondoo-oci-security-apigateway-deployment-mtls-verified-oci
     filters: |
       asset.platform == "oci-apigateway-deployment" &&
@@ -8573,7 +8573,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingcorssupport.htm
-        title: OCI - API Gateway CORS Policies
+        title: OCI - Adding CORS support to API Deployments
   - uid: mondoo-oci-security-apigateway-deployment-no-wildcard-cors-oci
     filters: asset.platform == "oci-apigateway-deployment"
     mql: |
@@ -10508,7 +10508,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingkeys_topic-To_rotate_a_master_encryption_key.htm
-        title: OCI Vault key rotation documentation
+        title: Rotating a Key
   - uid: mondoo-oci-security-kms-keys-auto-rotation-enabled-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -11031,7 +11031,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en/cloud/paas/base-database/about/index.html
-        title: OCI Database service documentation
+        title: About Oracle Base Database Service
   - uid: mondoo-oci-security-dbsystem-customer-managed-encryption-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -11166,7 +11166,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/sec-manage-master-encryption-keys-oci-vault.html
-        title: OCI Autonomous Database customer-managed keys documentation
+        title: Manage Master Encryption Keys in OCI Vault
   - uid: mondoo-oci-security-adb-customer-managed-encryption-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -11304,7 +11304,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/vcn-flow-logs.htm
-        title: OCI VCN flow logs documentation
+        title: Flow Logs
   - uid: mondoo-oci-security-ipsec-tunnel-ikev2
     title: Ensure IPSec VPN tunnels negotiate IKEv2
     impact: 75
@@ -11726,7 +11726,7 @@ queries:
         # No Terraform remediation: internetReachable is a runtime verdict derived from the private-endpoint, access-control, and allowlist state; the configuration that drives it is remediated in Terraform by mondoo-oci-security-adb-mtls-or-restricted.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
-        title: OCI - Autonomous Database Network Access
+        title: OCI - About Network Access Options
   # No Terraform variants: standbyWhitelistedIps is the effective access control list reported for the Data Guard standby at runtime, and reflects the resolution of are_primary_whitelisted_ips_used. A static Terraform argument cannot express the resolved standby allowlist, so this evaluates the runtime value only.
   - uid: mondoo-oci-security-adb-standby-acl-not-open
     title: Ensure Autonomous Database standby ACLs exclude any-address entries
@@ -12329,7 +12329,7 @@ queries:
         # No Terraform remediation: the notebook session's private endpoint is set at creation and is not verified against a Terraform resource argument here; manage it through the console or CLI.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/data-science/using/pe-network.htm
-        title: OCI - Data Science Private Endpoints
+        title: OCI - Private Endpoints
 
   # ---------------------------------------------------------------------------
   # Network Firewall
@@ -12441,7 +12441,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/decryption-profile-create.htm
-        title: OCI Network Firewall decryption profiles
+        title: Create a Decryption Profile
   - uid: mondoo-oci-security-network-firewall-decryption-profile-strict-oci
     filters: asset.platform == 'oci'
     mql: |

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-oci-security
     name: Mondoo Oracle Cloud Infrastructure (OCI) Security
-    version: 4.6.1
+    version: 4.6.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -4085,7 +4085,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingcertificates.htm
-        title: OCI - Managing SSL Configurations
+        title: OCI - Load Balancer Managed SSL Certificates
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-oci
     filters: asset.platform == "oci-loadbalancer"
     mql: |
@@ -5423,7 +5423,7 @@ queries:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - Autonomous Database Network Access
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
-        title: OCI - Configure Private Endpoint Access
+        title: OCI - About Network Access Options
   - uid: mondoo-oci-security-adb-no-public-management-urls-oci
     filters: asset.platform == 'oci'
     mql: |
@@ -5901,7 +5901,7 @@ queries:
         # No Terraform remediation: `timeOfCurrentVersionExpiry` is runtime telemetry on the active secret version; the `oci_vault_secret` Terraform resource has no field that exposes whether the current version is past its expiry, and there is no HCL change that resolves an expired version.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingsecrets.htm
-        title: OCI - Rotating Secrets
+        title: OCI - Managing Secrets
   - uid: mondoo-oci-security-functions-config-no-credentials
     title: Ensure OCI Functions applications do not store credentials in config
     impact: 90
@@ -12614,7 +12614,7 @@ queries:
             ```
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/policies.htm
-        title: OCI Network Firewall security rules
+        title: OCI - Creating and Managing Firewall Policies
   - uid: mondoo-oci-security-network-firewall-no-allow-any-source-oci
     filters: asset.platform == 'oci'
     mql: |

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -5422,8 +5422,6 @@ queries:
     refs:
       - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - About Network Access Options
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
-        title: OCI - About Network Access Options
   - uid: mondoo-oci-security-adb-no-public-management-urls-oci
     filters: asset.platform == 'oci'
     mql: |

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -11030,7 +11030,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Database/Concepts/overview.htm
+      - url: https://docs.oracle.com/en/cloud/paas/base-database/about/index.html
         title: OCI Database service documentation
   - uid: mondoo-oci-security-dbsystem-customer-managed-encryption-oci
     filters: asset.platform == 'oci'

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -5557,7 +5557,7 @@ queries:
         # No Terraform remediation: this check requires cross-resource lookup from `oci_database_db_system` to its referenced `oci_core_subnet` to read `prohibit_public_ip_on_vnic`; cross-resource graph traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Database/home.htm
-        title: OCI - Database
+        title: OCI - Database service documentation
   # No Terraform variants: requires walking from `oci_database_db_system` to its subnet to that subnet's `oci_core_route_table` and inspecting route rules for an internet-gateway target. Three-hop cross-resource traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
   - uid: mondoo-oci-security-dbsystem-subnet-no-internet-gateway
     title: Ensure DB system subnets have no route to an internet gateway
@@ -6878,8 +6878,8 @@ queries:
 
             Any `oci_identity_policy` containing Endorse or Admit statements fails this check and must carry a documented exception.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/accessingresourcesacrosstenancies.htm
-        title: OCI - Accessing Object Storage Resources Across Tenancies
+      - url: https://docs.oracle.com/en-us/iaas/Content/Identity/policieshow/iam-cross-domain.htm
+        title: OCI - Cross-Tenancy Access Policies
   - uid: mondoo-oci-security-iam-no-cross-tenant-policies-oci
     filters: asset.platform == "oci-identity-policy"
     mql: |

--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -1168,7 +1168,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingbuckets_topic-Server_Side_Encryption_SSE.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/encryption.htm
         title: CIS OCI Foundations Benchmark 4.1.2
   - uid: mondoo-oci-security-object-storage-buckets-customer-managed-encryption-oci
     filters: asset.platform == "oci-objectstorage-bucket"
@@ -4084,7 +4084,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingsslconfigs.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingcertificates.htm
         title: OCI - Managing SSL Configurations
   - uid: mondoo-oci-security-loadbalancer-tls-minimum-1-2-oci
     filters: asset.platform == "oci-loadbalancer"
@@ -4247,7 +4247,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Balance/References/predefinedsslciphersuites.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm
         title: OCI - Predefined SSL Cipher Suites
   - uid: mondoo-oci-security-loadbalancer-no-weak-cipher-suites-oci
     filters: asset.platform == "oci-loadbalancer"
@@ -4608,7 +4608,7 @@ queries:
             ```
         # No Terraform remediation: `availableKubernetesUpgrades` is runtime telemetry derived from Oracle's supported-version list at scan time; no `oci_containerengine_cluster` Terraform argument exposes the count of pending upgrades, so there is no static HCL change that resolves this finding.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengupgradingk8smasternode.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm
         title: OCI - Upgrading Kubernetes on a Cluster
   - uid: mondoo-oci-security-oke-image-policy-enabled
     title: Ensure OKE clusters enable container image signature verification
@@ -4719,7 +4719,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengsigningimages_topic-Signing_Container_Images_Using_OCI_Registry.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrysigningimages_topic.htm
         title: OCI - Signing Container Images
   - uid: mondoo-oci-security-oke-image-policy-enabled-oci
     filters: asset.platform == "oci-oke-cluster"
@@ -5128,7 +5128,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengencryptingkubernetessecretsatrest.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengencryptingdata.htm
         title: OCI - Encrypting Kubernetes Secrets at Rest in Etcd
   - uid: mondoo-oci-security-oke-secrets-customer-managed-encryption-oci
     filters: asset.platform == "oci-oke-cluster"
@@ -5269,7 +5269,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-types.html
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - Autonomous Database Network Access
   - uid: mondoo-oci-security-adb-mtls-or-restricted-oci
     filters: asset.platform == 'oci'
@@ -5420,9 +5420,9 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-types.html
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - Autonomous Database Network Access
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/private-endpoint-overview.html
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - Configure Private Endpoint Access
   - uid: mondoo-oci-security-adb-no-public-management-urls-oci
     filters: asset.platform == 'oci'
@@ -5558,7 +5558,7 @@ queries:
             ```
         # No Terraform remediation: this check requires cross-resource lookup from `oci_database_db_system` to its referenced `oci_core_subnet` to read `prohibit_public_ip_on_vnic`; cross-resource graph traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Database/Concepts/databaseoverview.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Database/home.htm
         title: OCI - Database Service Overview
   # No Terraform variants: requires walking from `oci_database_db_system` to its subnet to that subnet's `oci_core_route_table` and inspecting route rules for an internet-gateway target. Three-hop cross-resource traversal is fragile in HCL/plan/state and unsupported by the patterns used elsewhere in this file.
   - uid: mondoo-oci-security-dbsystem-subnet-no-internet-gateway
@@ -5900,7 +5900,7 @@ queries:
             ```
         # No Terraform remediation: `timeOfCurrentVersionExpiry` is runtime telemetry on the active secret version; the `oci_vault_secret` Terraform resource has no field that exposes whether the current version is past its expiry, and there is no HCL change that resolves an expired version.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/rotatingsecrets.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingsecrets.htm
         title: OCI - Rotating Secrets
   - uid: mondoo-oci-security-functions-config-no-credentials
     title: Ensure OCI Functions applications do not store credentials in config
@@ -6020,7 +6020,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsusingconfigparams.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionspassingconfigparams-about.htm
         title: OCI - Passing Custom Configuration Parameters to Functions
       - url: https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsaccessingociresources.htm
         title: OCI - Accessing OCI Resources from Running Functions
@@ -6232,7 +6232,7 @@ queries:
 
             Write the region key, namespace, and tag as literal values for your tenancy. Interpolated variables cannot be evaluated during static analysis and fail the check.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/container-instances/overview.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/container-instances/overview-of-container-instances.htm
         title: OCI Container Instances Overview
       - url: https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryoverview.htm
         title: OCI Registry (OCIR)
@@ -6880,7 +6880,7 @@ queries:
 
             Any `oci_identity_policy` containing Endorse or Admit statements fails this check and must carry a documented exception.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/policiesaccessingtenancies.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/accessingresourcesacrosstenancies.htm
         title: OCI - Accessing Resources Across Tenancies
   - uid: mondoo-oci-security-iam-no-cross-tenant-policies-oci
     filters: asset.platform == "oci-identity-policy"
@@ -7811,9 +7811,9 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Database/Concepts/adbsecurity.htm
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database/doc/security-features-adb-d.html
         title: OCI - Autonomous Database Encryption
-      - url: https://docs.oracle.com/en-us/iaas/Content/Database/Tasks/managingbackups.htm
+      - url: https://docs.oracle.com/en/cloud/paas/base-database/backup-recover/index.html
         title: OCI - Managing Database Backups
   - uid: mondoo-oci-security-database-backups-customer-managed-encryption-oci
     filters: asset.platform == 'oci'
@@ -8007,7 +8007,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingauthenticationpolicies.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingauthzauthn.htm
         title: OCI - API Gateway Authentication Policies
   - uid: mondoo-oci-security-apigateway-deployment-no-anonymous-access-oci
     filters: asset.platform == "oci-apigateway-deployment"
@@ -8191,7 +8191,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingauthenticationpolicies.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingauthzauthn.htm
         title: OCI - API Gateway Authentication Policies
   - uid: mondoo-oci-security-apigateway-deployment-authentication-configured-oci
     filters: asset.platform == "oci-apigateway-deployment"
@@ -8387,7 +8387,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingmTLS.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingmtlssupport.htm
         title: OCI - API Gateway Mutual TLS
   - uid: mondoo-oci-security-apigateway-deployment-mtls-verified-oci
     filters: |
@@ -8572,7 +8572,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayusingcorspolicies.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/APIGateway/Tasks/apigatewayaddingcorssupport.htm
         title: OCI - API Gateway CORS Policies
   - uid: mondoo-oci-security-apigateway-deployment-no-wildcard-cors-oci
     filters: asset.platform == "oci-apigateway-deployment"
@@ -9874,7 +9874,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/cloud-guard/using/security-zones.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/security-zone/using/security-zones.htm
         title: OCI Cloud Guard Security Zones
   - uid: mondoo-oci-security-cloudguard-security-zone-inherit-after-delete
     title: Ensure Cloud Guard security zones inherit protection after deletion
@@ -9980,7 +9980,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/cloud-guard/using/security-zones.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/security-zone/using/security-zones.htm
         title: OCI Cloud Guard Security Zones
   - uid: mondoo-oci-security-cloudguard-security-zone-inherit-after-delete-oci
     filters: asset.platform == 'oci'
@@ -10507,7 +10507,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/rotatingkeys.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingkeys_topic-To_rotate_a_master_encryption_key.htm
         title: OCI Vault key rotation documentation
   - uid: mondoo-oci-security-kms-keys-auto-rotation-enabled-oci
     filters: asset.platform == 'oci'
@@ -11165,7 +11165,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/customer-managed-keys.html
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/sec-manage-master-encryption-keys-oci-vault.html
         title: OCI Autonomous Database customer-managed keys documentation
   - uid: mondoo-oci-security-adb-customer-managed-encryption-oci
     filters: asset.platform == 'oci'
@@ -11303,7 +11303,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/vcnflowlogs.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/vcn-flow-logs.htm
         title: OCI VCN flow logs documentation
   - uid: mondoo-oci-security-ipsec-tunnel-ikev2
     title: Ensure IPSec VPN tunnels negotiate IKEv2
@@ -11725,7 +11725,7 @@ queries:
             ```
         # No Terraform remediation: internetReachable is a runtime verdict derived from the private-endpoint, access-control, and allowlist state; the configuration that drives it is remediated in Terraform by mondoo-oci-security-adb-mtls-or-restricted.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-types.html
+      - url: https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/network-access-options.html
         title: OCI - Autonomous Database Network Access
   # No Terraform variants: standbyWhitelistedIps is the effective access control list reported for the Data Guard standby at runtime, and reflects the resolution of are_primary_whitelisted_ips_used. A static Terraform argument cannot express the resolved standby allowlist, so this evaluates the runtime value only.
   - uid: mondoo-oci-security-adb-standby-acl-not-open
@@ -12328,7 +12328,7 @@ queries:
             ```
         # No Terraform remediation: the notebook session's private endpoint is set at creation and is not verified against a Terraform resource argument here; manage it through the console or CLI.
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/data-science/using/pe-concepts.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/data-science/using/pe-network.htm
         title: OCI - Data Science Private Endpoints
 
   # ---------------------------------------------------------------------------
@@ -12440,7 +12440,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/decryption-profiles.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/decryption-profile-create.htm
         title: OCI Network Firewall decryption profiles
   - uid: mondoo-oci-security-network-firewall-decryption-profile-strict-oci
     filters: asset.platform == 'oci'
@@ -12613,7 +12613,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/security-rules.htm
+      - url: https://docs.oracle.com/en-us/iaas/Content/network-firewall/policies.htm
         title: OCI Network Firewall security rules
   - uid: mondoo-oci-security-network-firewall-no-allow-any-source-oci
     filters: asset.platform == 'oci'

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -278,7 +278,7 @@ queries:
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
     filters: asset.platform == "okta-org"
@@ -949,7 +949,7 @@ queries:
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Okta Sign-On Policies
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-okta-auth-openid-saml-api
     filters: asset.platform == "okta-org"
@@ -1072,7 +1072,7 @@ queries:
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
     filters: asset.platform == "okta-org"
@@ -1178,7 +1178,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
@@ -1284,7 +1284,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-factor-enrollment-notifications-api
     filters: asset.platform == "okta-org"
@@ -1390,7 +1390,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
@@ -1496,7 +1496,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/content/topics/security/security-home.htm
+      - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
         title: Okta Security Administration
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
@@ -3694,7 +3694,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/API_Trusted-Origins.htm
+      - url: https://help.okta.com/oie/en-us/content/topics/security/api-trusted-origins.htm
         title: Trusted Origins
   - uid: mondoo-okta-security-trusted-origins-https-api
     filters: asset.platform == "okta-org"
@@ -3811,7 +3811,7 @@ queries:
             }
             ```
     refs:
-      - url: https://help.okta.com/en-us/Content/Topics/Security/policies/configure-signon-policy.htm
+      - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Configure Sign-On Policies
   - uid: mondoo-okta-security-signon-requires-mfa-api
     filters: asset.platform == "okta-org"

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -279,7 +279,7 @@ queries:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
     filters: asset.platform == "okta-org"
     mql: |
@@ -803,7 +803,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
-        title: Okta Sign-On Policies
+        title: Configure an Okta sign-on policy
       - url: https://help.okta.com/en-us/content/topics/security/policies/policies-home.htm
         title: Okta Security Policies
   - uid: mondoo-okta-security-okta-enforce-session-lifetime-api
@@ -948,9 +948,9 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
-        title: Okta Sign-On Policies
+        title: Configure an Okta sign-on policy
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-okta-auth-openid-saml-api
     filters: asset.platform == "okta-org"
     mql: |
@@ -1073,7 +1073,7 @@ queries:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.reportSuspiciousActivityEnabled == true
@@ -1179,7 +1179,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForNewDeviceEnabled == true
@@ -1285,7 +1285,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-factor-enrollment-notifications-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForFactorEnrollmentEnabled == true
@@ -1391,7 +1391,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForFactorResetEnabled == true
@@ -1497,7 +1497,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta General Security settings
+        title: General Security
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForPasswordChangedEnabled == true
@@ -3695,7 +3695,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/oie/en-us/content/topics/security/api-trusted-origins.htm
-        title: Trusted Origins
+        title: Configure Trusted Origins
   - uid: mondoo-okta-security-trusted-origins-https-api
     filters: asset.platform == "okta-org"
     mql: okta.trustedOrigins.where(status == "ACTIVE").all(origin == /^https:\/\//)
@@ -3812,7 +3812,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
-        title: Configure Sign-On Policies
+        title: Configure an Okta sign-on policy
   - uid: mondoo-okta-security-signon-requires-mfa-api
     filters: asset.platform == "okta-org"
     mql: |

--- a/content/mondoo-okta-security.mql.yaml
+++ b/content/mondoo-okta-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-okta-security
     name: Mondoo Okta Organization Security
-    version: 2.3.6
+    version: 2.3.7
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -279,7 +279,7 @@ queries:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-threatinsight-block-suspicious-ip-addresses-api
     filters: asset.platform == "okta-org"
     mql: |
@@ -950,7 +950,7 @@ queries:
       - url: https://help.okta.com/en-us/content/topics/security/policies/configure-signon-policies.htm
         title: Okta Sign-On Policies
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-okta-auth-openid-saml-api
     filters: asset.platform == "okta-org"
     mql: |
@@ -1073,7 +1073,7 @@ queries:
       - url: https://help.okta.com/en-us/content/topics/security/threat-insight/ti-index.htm
         title: Okta ThreatInsight
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-enable-suspicious-activity-reporting-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.reportSuspiciousActivityEnabled == true
@@ -1179,7 +1179,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-sign-on-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForNewDeviceEnabled == true
@@ -1285,7 +1285,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-factor-enrollment-notifications-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForFactorEnrollmentEnabled == true
@@ -1391,7 +1391,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-factor-reset-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForFactorResetEnabled == true
@@ -1497,7 +1497,7 @@ queries:
             ```
     refs:
       - url: https://help.okta.com/en-us/content/topics/security/security_general.htm
-        title: Okta Security Administration
+        title: Okta General Security settings
   - uid: mondoo-okta-security-password-changed-notifications-for-end-users-api
     filters: asset.platform == "okta-org"
     mql: okta.organization.sendEmailForPasswordChangedEnabled == true

--- a/content/mondoo-opensearch-security.mql.yaml
+++ b/content/mondoo-opensearch-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-opensearch-security
     name: Mondoo OpenSearch Security
-    version: 1.0.0
+    version: 1.0.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-opensearch-security.mql.yaml
+++ b/content/mondoo-opensearch-security.mql.yaml
@@ -106,7 +106,7 @@ queries:
             ./securityadmin.sh -f config.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
             ```
     refs:
-      - url: https://opensearch.org/docs/latest/security/access-control/anonymous-authentication/
+      - url: https://docs.opensearch.org/latest/security/access-control/anonymous-authentication/
         title: OpenSearch anonymous authentication
   - uid: mondoo-opensearch-security-authentication-realm-enabled
     filters: asset.platform == "opensearch"
@@ -179,7 +179,7 @@ queries:
             ./securityadmin.sh -f config.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
             ```
     refs:
-      - url: https://opensearch.org/docs/latest/security/configuration/configuration/
+      - url: https://docs.opensearch.org/latest/security/configuration/configuration/
         title: OpenSearch backend configuration
   - uid: mondoo-opensearch-security-audit-logging-enabled
     filters: asset.platform == "opensearch"
@@ -251,5 +251,5 @@ queries:
             ./securityadmin.sh -f audit.yml -icl -nhnv -cacert root-ca.pem -cert admin.pem -key admin-key.pem
             ```
     refs:
-      - url: https://opensearch.org/docs/latest/security/audit-logs/index/
+      - url: https://docs.opensearch.org/latest/security/audit-logs/index/
         title: OpenSearch audit logs

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -513,7 +513,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/getting-started/integrate-the-firewall-into-your-management-network
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
         title: PAN-OS Device Management
   - uid: mondoo-panos-security-threat-content-installed
     title: Ensure threat content version is installed
@@ -1039,7 +1039,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/best-practices/10-1/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/zone-protection-for-the-internet-gateway
+      - url: https://docs.paloaltonetworks.com/best-practices/dos-and-zone-protection-best-practices/dos-and-zone-protection-best-practices
         title: Zone Protection Best Practices
   - uid: mondoo-panos-security-zone-packet-buffer-protection
     title: Ensure all zones have packet buffer protection enabled
@@ -1126,7 +1126,7 @@ queries:
             Zone-level packet buffer protection only takes effect when global packet buffer protection is enabled under **Device → Setup → Session**.
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/zone-protection-and-dos-protection/configure-packet-buffer-protection
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/zone-protection-and-dos-protection/zone-defense/packet-buffer-protection/configure-packet-buffer-protection
         title: Configure Packet Buffer Protection
   - uid: mondoo-panos-security-zone-log-forwarding
     title: Ensure all zones have log forwarding configured
@@ -1204,7 +1204,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/monitoring/configure-log-forwarding
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/monitoring/configure-log-forwarding
         title: Configure Log Forwarding
   # ============================================================
   # Security Rule Hygiene
@@ -1311,7 +1311,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/best-practices/10-1/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/build-your-internet-gateway-best-practice-security-policy
+      - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy
         title: Security Policy Best Practices
   - uid: mondoo-panos-security-rules-use-app-id
     title: Ensure security rules use App-ID instead of any application
@@ -1397,7 +1397,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/best-practices/10-1/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/build-your-internet-gateway-best-practice-security-policy
+      - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy
         title: Security Policy Best Practices
   - uid: mondoo-panos-security-rules-have-security-profiles
     title: Ensure allow rules have security profiles or profile groups attached
@@ -1498,7 +1498,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/best-practices/10-1/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/apply-security-profiles-and-profile-groups-to-policy-rules
+      - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles
         title: Security Profile Best Practices
   - uid: mondoo-panos-security-rules-url-filtering
     title: Ensure allow rules have URL filtering applied
@@ -1582,7 +1582,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/best-practices/10-1/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/apply-security-profiles-and-profile-groups-to-policy-rules
+      - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles
         title: Security Profile Best Practices
   - uid: mondoo-panos-security-rules-logging-enabled
     title: Ensure security rules have session-end logging enabled
@@ -1664,7 +1664,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/monitoring/configure-log-forwarding
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/monitoring/configure-log-forwarding
         title: Configure Log Forwarding
   - uid: mondoo-panos-security-no-disabled-rules
     title: Ensure no disabled security rules remain in the rulebase
@@ -2186,7 +2186,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
         title: Site-to-Site VPN Concepts
   - uid: mondoo-panos-security-ike-certificate-auth
     title: Ensure IKE gateways use certificate-based authentication
@@ -2274,7 +2274,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
         title: Site-to-Site VPN Concepts
   - uid: mondoo-panos-security-ike-dead-peer-detection
     title: Ensure IKE gateways have dead peer detection enabled
@@ -2363,7 +2363,7 @@ queries:
             Use the first command for gateways negotiating IKEv1 and the second for gateways negotiating IKEv2. Gateways set to IKEv2 preferred mode should have both configured.
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
         title: Site-to-Site VPN Concepts
   - uid: mondoo-panos-security-ike-no-aggressive-mode
     title: Ensure IKEv1 gateways do not use aggressive mode
@@ -2447,7 +2447,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
         title: Site-to-Site VPN Concepts
   - uid: mondoo-panos-security-ipsec-anti-replay
     title: Ensure IPsec tunnels have anti-replay protection enabled
@@ -2530,7 +2530,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/site-to-site-vpn-concepts
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
         title: Site-to-Site VPN Concepts
   - uid: mondoo-panos-security-ipsec-tunnel-monitoring
     title: Ensure IPsec tunnels have tunnel monitoring enabled
@@ -2616,7 +2616,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/vpn/set-up-tunnel-monitoring
+      - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/set-up-tunnel-monitoring
         title: Set Up Tunnel Monitoring
   # ============================================================
   # Decryption Policy
@@ -2704,7 +2704,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/decryption/decryption-best-practices
+      - url: https://docs.paloaltonetworks.com/best-practices/10-1/decryption-best-practices/decryption-best-practices
         title: Decryption Best Practices
   - uid: mondoo-panos-security-decryption-log-failures
     title: Ensure decryption rules log TLS handshake failures
@@ -2786,7 +2786,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/decryption/decryption-best-practices
+      - url: https://docs.paloaltonetworks.com/best-practices/10-1/decryption-best-practices/decryption-best-practices
         title: Decryption Best Practices
   # ============================================================
   # Routing Security
@@ -2874,7 +2874,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/networking/static-routes
+      - url: https://docs.paloaltonetworks.com/ngfw/networking/static-routes
         title: Static Routes
 
   - uid: mondoo-panos-security-ospf-interface-authentication
@@ -2962,7 +2962,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/networking/ospf
+      - url: https://docs.paloaltonetworks.com/ngfw/networking/ospf
         title: OSPF Configuration
 
   - uid: mondoo-panos-security-ospf-virtual-link-authentication
@@ -3050,7 +3050,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/networking/ospf
+      - url: https://docs.paloaltonetworks.com/ngfw/networking/ospf
         title: OSPF Configuration
 
   - uid: mondoo-panos-security-ospf-no-rfc1583
@@ -3133,7 +3133,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/networking/ospf
+      - url: https://docs.paloaltonetworks.com/ngfw/networking/ospf
         title: OSPF Configuration
 
   - uid: mondoo-panos-security-ospf-reject-default-route
@@ -3216,5 +3216,5 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin/networking/ospf
+      - url: https://docs.paloaltonetworks.com/ngfw/networking/ospf
         title: OSPF Configuration

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -179,7 +179,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Administration
+        title: Firewall Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-app-content-installed
@@ -264,7 +264,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Administration
+        title: Firewall Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-dns-security-license
@@ -431,7 +431,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Administration
+        title: Firewall Administration
   - uid: mondoo-panos-security-operational-mode-normal
     title: Ensure device operational mode is normal
     impact: 100
@@ -514,7 +514,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Firewall Administration
+        title: Firewall Administration
   - uid: mondoo-panos-security-threat-content-installed
     title: Ensure threat content version is installed
     impact: 85
@@ -599,7 +599,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Administration
+        title: Firewall Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-threat-prevention-license
@@ -858,7 +858,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Administration
+        title: Firewall Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-wildfire-license
@@ -1040,7 +1040,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices/dos-and-zone-protection-best-practices/dos-and-zone-protection-best-practices
-        title: Zone Protection Best Practices
+        title: DoS and Zone Protection Best Practices
   - uid: mondoo-panos-security-zone-packet-buffer-protection
     title: Ensure all zones have packet buffer protection enabled
     impact: 80
@@ -1312,7 +1312,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy
-        title: Security Policy Best Practices
+        title: Best Practice Internet Gateway Security Policy
   - uid: mondoo-panos-security-rules-use-app-id
     title: Ensure security rules use App-ID instead of any application
     impact: 85
@@ -1398,7 +1398,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy
-        title: Security Policy Best Practices
+        title: Best Practice Internet Gateway Security Policy
   - uid: mondoo-panos-security-rules-have-security-profiles
     title: Ensure allow rules have security profiles or profile groups attached
     impact: 90
@@ -1499,7 +1499,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles
-        title: Security Profile Best Practices
+        title: Create Best Practice Security Profiles for the Internet Gateway
   - uid: mondoo-panos-security-rules-url-filtering
     title: Ensure allow rules have URL filtering applied
     impact: 80
@@ -1583,7 +1583,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/best-practices/internet-gateway-best-practices/best-practice-internet-gateway-security-policy/create-best-practice-security-profiles
-        title: Security Profile Best Practices
+        title: Create Best Practice Security Profiles for the Internet Gateway
   - uid: mondoo-panos-security-rules-logging-enabled
     title: Ensure security rules have session-end logging enabled
     impact: 75
@@ -2187,7 +2187,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
-        title: Site-to-Site VPN Concepts
+        title: Site-to-Site VPN Overview
   - uid: mondoo-panos-security-ike-certificate-auth
     title: Ensure IKE gateways use certificate-based authentication
     impact: 85
@@ -2275,7 +2275,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
-        title: Site-to-Site VPN Concepts
+        title: Site-to-Site VPN Overview
   - uid: mondoo-panos-security-ike-dead-peer-detection
     title: Ensure IKE gateways have dead peer detection enabled
     impact: 70
@@ -2364,7 +2364,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
-        title: Site-to-Site VPN Concepts
+        title: Site-to-Site VPN Overview
   - uid: mondoo-panos-security-ike-no-aggressive-mode
     title: Ensure IKEv1 gateways do not use aggressive mode
     impact: 80
@@ -2448,7 +2448,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
-        title: Site-to-Site VPN Concepts
+        title: Site-to-Site VPN Overview
   - uid: mondoo-panos-security-ipsec-anti-replay
     title: Ensure IPsec tunnels have anti-replay protection enabled
     impact: 75
@@ -2531,7 +2531,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/network-security/ipsec-vpn/administration/get-started-with-ipsec-vpn-site-to-site/site-to-site-vpn-overview
-        title: Site-to-Site VPN Concepts
+        title: Site-to-Site VPN Overview
   - uid: mondoo-panos-security-ipsec-tunnel-monitoring
     title: Ensure IPsec tunnels have tunnel monitoring enabled
     impact: 65

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-panos-security
     name: Mondoo Palo Alto Networks PAN-OS Security
-    version: 2.0.4
+    version: 2.0.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -178,8 +178,8 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
-        title: PAN-OS Administrator's Guide
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
+        title: PAN-OS Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-app-content-installed
@@ -263,8 +263,8 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
-        title: PAN-OS Administrator's Guide
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
+        title: PAN-OS Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-dns-security-license
@@ -430,8 +430,8 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
-        title: PAN-OS Administrator's Guide
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
+        title: PAN-OS Administration
   - uid: mondoo-panos-security-operational-mode-normal
     title: Ensure device operational mode is normal
     impact: 100
@@ -514,7 +514,7 @@ queries:
 
     refs:
       - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
-        title: PAN-OS Device Management
+        title: PAN-OS Firewall Administration
   - uid: mondoo-panos-security-threat-content-installed
     title: Ensure threat content version is installed
     impact: 85
@@ -598,8 +598,8 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
-        title: PAN-OS Administrator's Guide
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
+        title: PAN-OS Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-threat-prevention-license
@@ -857,8 +857,8 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
-        title: PAN-OS Administrator's Guide
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/firewall-administration
+        title: PAN-OS Administration
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
   - uid: mondoo-panos-security-wildfire-license

--- a/content/mondoo-panos-security.mql.yaml
+++ b/content/mondoo-panos-security.mql.yaml
@@ -178,7 +178,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
         title: PAN-OS Administrator's Guide
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -263,7 +263,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
         title: PAN-OS Administrator's Guide
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -430,7 +430,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
         title: PAN-OS Administrator's Guide
   - uid: mondoo-panos-security-operational-mode-normal
     title: Ensure device operational mode is normal
@@ -598,7 +598,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
         title: PAN-OS Administrator's Guide
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices
@@ -857,7 +857,7 @@ queries:
             ```
 
     refs:
-      - url: https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-admin
+      - url: https://docs.paloaltonetworks.com/ngfw/administration/subscriptions
         title: PAN-OS Administrator's Guide
       - url: https://docs.paloaltonetworks.com/best-practices
         title: Palo Alto Networks Best Practices

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: phoenix-plcnext
     name: Phoenix PLCnext Security Policy
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       benchmark: Mondoo Phoenix PLCnext

--- a/content/mondoo-phoenix-plcnext-security.mql.yaml
+++ b/content/mondoo-phoenix-plcnext-security.mql.yaml
@@ -254,7 +254,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-04
     title: Ensure only strong MAC algorithms are used
@@ -314,7 +314,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-05
     title: Ensure only strong ciphers are used
@@ -374,7 +374,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-06
     title: Ensure current system time is synchronized
@@ -495,7 +495,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-08
     title: Ensure secure permissions on SSH public host key files are set
@@ -553,7 +553,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-09
     title: Ensure SSH Protocol is set to 2
@@ -661,7 +661,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-11
     title: Ensure SSH X11 forwarding is disabled
@@ -713,7 +713,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-12
     title: Ensure SSH MaxAuthTries is set to 4 or less
@@ -819,7 +819,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-14
     title: Ensure SSH HostbasedAuthentication is disabled
@@ -938,7 +938,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-16
     title: Ensure SSH PermitEmptyPasswords is disabled
@@ -1044,7 +1044,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-18
     title: Ensure SSH Idle Timeout Interval is configured
@@ -1159,7 +1159,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-20
     title: Ensure SSH access is limited
@@ -1273,7 +1273,7 @@ queries:
     refs:
       - url: https://www.plcnext.help/te/About/Home.htm
         title: PLCnext Technology Documentation
-      - url: https://csrc.nist.gov/publications/detail/sp/800-82/rev-3/final
+      - url: https://csrc.nist.gov/pubs/sp/800/82/r3/final
         title: NIST SP 800-82 Rev. 3 - Guide to OT Security
   - uid: phoenix-plcnext-22
     title: Ensure SSH password authentication is disabled

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -1169,7 +1169,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/admin/user
-        title: User-related
+        title: Portainer user management
   - uid: mondoo-portainer-security-users-limit-administrators-portainer
     filters: asset.platform == "portainer-server"
     props:

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -4,7 +4,7 @@ policies:
   - summary: Secure Portainer authentication, RBAC, user privileges, Edge trust, and connection settings
     uid: mondoo-portainer-security
     name: Mondoo Portainer Security
-    version: 1.0.1
+    version: 1.0.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -151,7 +151,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -265,7 +265,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -379,7 +379,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -493,7 +493,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -607,7 +607,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -721,7 +721,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer Environment Access and Security Settings
+        title: Portainer access control
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -150,7 +150,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -264,7 +264,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -378,7 +378,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -492,7 +492,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -606,7 +606,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -720,7 +720,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/environments/access
+      - url: https://docs.portainer.io/2.39-lts/advanced/access-control
         title: Portainer Environment Access and Security Settings
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
@@ -1168,7 +1168,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/users
+      - url: https://docs.portainer.io/2.39-lts/admin/user
         title: Portainer User Management
   - uid: mondoo-portainer-security-users-limit-administrators-portainer
     filters: asset.platform == "portainer-server"
@@ -1552,7 +1552,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.portainer.io/admin/settings/kubernetes
+      - url: https://docs.portainer.io/2.39-lts/admin/environments/policies/kubernetes-policies
         title: Portainer Kubernetes Settings
   - uid: mondoo-portainer-security-settings-disable-kube-shell-portainer
     filters: asset.platform == "portainer-server"

--- a/content/mondoo-portainer-security.mql.yaml
+++ b/content/mondoo-portainer-security.mql.yaml
@@ -151,7 +151,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-privileged-containers-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -265,7 +265,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-bind-mounts-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -379,7 +379,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-device-mapping-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -493,7 +493,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-host-namespace-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -607,7 +607,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-container-capabilities-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -721,7 +721,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/advanced/access-control
-        title: Portainer access control
+        title: Access control
   - uid: mondoo-portainer-security-settings-no-volume-browser-for-regular-users-portainer
     filters: asset.platform == "portainer-server"
     mql: |
@@ -1169,7 +1169,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/admin/user
-        title: Portainer User Management
+        title: User-related
   - uid: mondoo-portainer-security-users-limit-administrators-portainer
     filters: asset.platform == "portainer-server"
     props:
@@ -1553,7 +1553,7 @@ queries:
             ```
     refs:
       - url: https://docs.portainer.io/2.39-lts/admin/environments/policies/kubernetes-policies
-        title: Portainer Kubernetes Settings
+        title: Kubernetes Policies
   - uid: mondoo-portainer-security-settings-disable-kube-shell-portainer
     filters: asset.platform == "portainer-server"
     mql: |

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -40,7 +40,7 @@ policies:
         ## References
 
         - [CIS Debian Linux Benchmark](https://www.cisecurity.org/benchmark/debian_linux)
-        - [ANSSI-BP-028 Linux Hardening Guide](https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf)
+        - [ANSSI-BP-028 Linux Hardening Guide](https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux)
         - [BSI SYS.1.5 Virtualisation](https://www.bsi.bund.de/DE/Home/home_node.html)
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
@@ -3944,7 +3944,7 @@ queries:
       - title: CWE-200 Exposure of Sensitive Information
         url: https://cwe.mitre.org/data/definitions/200.html
       - title: Side-channel attacks on KSM
-        url: https://www.usenix.org/system/files/conference/usenixsecurity15/sec15-paper-razavi.pdf
+        url: https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_razavi.pdf
     mql: |
       file("/sys/kernel/mm/ksm/run").content.trim == "0"
     docs:
@@ -4802,7 +4802,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R9 Linux Hardening
-        url: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf
+        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
       - title: CVE-2021-4204 eBPF privilege escalation
         url: https://nvd.nist.gov/vuln/detail/CVE-2021-4204
       - title: CVE-2022-23222 eBPF privilege escalation
@@ -4905,7 +4905,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R5 Linux Hardening
-        url: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf
+        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["kernel.kexec_load_disabled"] == 1
     docs:
@@ -5004,7 +5004,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R10 Linux Hardening
-        url: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf
+        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["kernel.perf_event_paranoid"] >= 2
     docs:
@@ -5103,7 +5103,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R12 Linux Hardening
-        url: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf
+        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["dev.tty.ldisc_autoload"] == 0
     docs:

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -40,7 +40,7 @@ policies:
         ## References
 
         - [CIS Debian Linux Benchmark](https://www.cisecurity.org/benchmark/debian_linux)
-        - [ANSSI-BP-028 Linux Hardening Guide](https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux)
+        - [ANSSI-BP-028 Linux Hardening Guide](https://messervices.cyber.gouv.fr/guides/recommandations-de-securite-relatives-un-systeme-gnulinux)
         - [BSI SYS.1.5 Virtualisation](https://www.bsi.bund.de/DE/Home/home_node.html)
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
@@ -4802,7 +4802,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R9 Linux Hardening
-        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        url: https://messervices.cyber.gouv.fr/guides/recommandations-de-securite-relatives-un-systeme-gnulinux
       - title: CVE-2021-4204 eBPF privilege escalation
         url: https://nvd.nist.gov/vuln/detail/CVE-2021-4204
       - title: CVE-2022-23222 eBPF privilege escalation
@@ -4905,7 +4905,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R5 Linux Hardening
-        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        url: https://messervices.cyber.gouv.fr/guides/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["kernel.kexec_load_disabled"] == 1
     docs:
@@ -5004,7 +5004,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R10 Linux Hardening
-        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        url: https://messervices.cyber.gouv.fr/guides/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["kernel.perf_event_paranoid"] >= 2
     docs:
@@ -5103,7 +5103,7 @@ queries:
       compliance/vda-isa-5: vda-isa-5-5-2-1
     refs:
       - title: ANSSI-BP-028 R12 Linux Hardening
-        url: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        url: https://messervices.cyber.gouv.fr/guides/recommandations-de-securite-relatives-un-systeme-gnulinux
     mql: |
       kernel.parameters["dev.tty.ldisc_autoload"] == 0
     docs:

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -41,7 +41,7 @@ policies:
 
         - [CIS Debian Linux Benchmark](https://www.cisecurity.org/benchmark/debian_linux)
         - [ANSSI-BP-028 Linux Hardening Guide](https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.0.pdf)
-        - [BSI SYS.1.5 Virtualisation](https://www.bsi.bund.de/)
+        - [BSI SYS.1.5 Virtualisation](https://www.bsi.bund.de/DE/Home/home_node.html)
         - [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
         - [Proxmox VE Firewall Documentation](https://pve.proxmox.com/wiki/Firewall)
 
@@ -1852,7 +1852,7 @@ queries:
       - title: Proxmox VE Linux Container Security
         url: https://pve.proxmox.com/wiki/Linux_Container#_security_considerations
       - title: NIST SP 800-190 Container Security
-        url: https://csrc.nist.gov/publications/detail/sp/800-190/final
+        url: https://csrc.nist.gov/pubs/sp/800/190/final
     mql: |
       files.find(from: "/etc/pve/lxc", regex: "[0-9]+.conf$", type: "file").list.all(
         file(_.path).content.contains("unprivileged: 1")

--- a/content/mondoo-proxmox-security.mql.yaml
+++ b/content/mondoo-proxmox-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-proxmox-security
     name: Mondoo Proxmox VE Security
-    version: 1.1.5
+    version: 1.1.6
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -402,5 +402,5 @@ queries:
     refs:
       - url: https://www.shodan.io/
         title: Shodan
-      - url: https://www.rfc-editor.org/rfc/rfc2182
+      - url: https://www.rfc-editor.org/info/rfc2182/
         title: "RFC 2182: Selection and Operation of Secondary DNS Servers"

--- a/content/mondoo-shodan.mql.yaml
+++ b/content/mondoo-shodan.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-shodan
     name: Mondoo Shodan Security
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -115,7 +115,7 @@ queries:
 
         To learn more, read [Change a member's role](https://slack.com/help/articles/218124397-Change-a-members-role) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
@@ -193,7 +193,7 @@ queries:
 
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/204509068
+      - url: https://slack.com/help/articles/204509068-Set-up-two-factor-authentication
         title: Slack Two-Factor Authentication
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
@@ -270,9 +270,9 @@ queries:
 
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/204509068
+      - url: https://slack.com/help/articles/204509068-Set-up-two-factor-authentication
         title: Slack Two-Factor Authentication
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
   # No Terraform variants: the runtime check filters channels by isExtShared (a runtime
   # Slack Connect property reflecting whether the channel is currently shared with an
@@ -351,7 +351,7 @@ queries:
 
         To learn more, read [Rename a channel](https://slack.com/help/articles/201654214-Rename-a-channel) and [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
@@ -431,9 +431,9 @@ queries:
 
         To learn more, read [Create a channel](https://slack.com/help/articles/201402297-Create-a-channel) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
-      - url: https://slack.com/help/articles/360000281563
+      - url: https://slack.com/help/articles/360000281563-Manage-apps-in-an-Enterprise-organization
         title: Slack Enterprise Grid Administration
   # No Terraform variants: even though slack_conversation.permanent_members lists member
   # user IDs, the runtime check filters those members on per-user runtime properties
@@ -518,7 +518,7 @@ queries:
 
         To learn more, read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
       - url: https://slack.com/trust/security/security-practices
         title: Slack Security Practices
@@ -594,7 +594,7 @@ queries:
         3. Remove any member whose email domain is not on your approved list. Read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
         4. Investigate how each unauthorized account gained access. Deactivate accounts that do not belong to your organization from **Tools & settings > Manage members**. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
       - url: https://slack.com/help/articles/203772216
         title: Slack Single Sign-On
@@ -674,7 +674,7 @@ queries:
         3. For accounts you cannot attribute to a known person, deactivate them immediately. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
         4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/115005206006) in the Slack documentation.
     refs:
-      - url: https://slack.com/help/articles/360004635551
+      - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
       - url: https://slack.com/help/articles/213185747
         title: Deactivate a member

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -117,7 +117,7 @@ queries:
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
-      - url: https://slack.com/trust/security/security-practices
+      - url: https://slack.com/trust/security
         title: Slack Security Practices
   # No Terraform variants: per-user 2FA configuration (has_2fa, two_factor_type) is runtime
   # account state held by Slack — users enable 2FA from their own account settings. The
@@ -195,7 +195,7 @@ queries:
     refs:
       - url: https://slack.com/help/articles/204509068-Set-up-two-factor-authentication
         title: Slack Two-Factor Authentication
-      - url: https://slack.com/trust/security/security-practices
+      - url: https://slack.com/trust/security
         title: Slack Security Practices
   # No Terraform variants: per-user 2FA state is set by each user in their Slack account
   # settings. The pablovarela/slack provider has no user resource and no workspace-level
@@ -349,11 +349,11 @@ queries:
         3. Select the **Settings** tab, click **Edit** next to the channel name, and rename the channel to match the pattern.
         4. Share the naming guideline with channel creators so new external channels follow it from the start.
 
-        To learn more, read [Rename a channel](https://slack.com/help/articles/201654214-Rename-a-channel) and [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
+        To learn more, read [Rename a channel](https://slack.com/help/articles/201654073-Rename-a-channel) and [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
-      - url: https://slack.com/trust/security/security-practices
+      - url: https://slack.com/trust/security
         title: Slack Security Practices
   # No Terraform variants: this is a workspace-posture existence check (the workspace has
   # at least one purely-internal channel). The relevant predicates (is_shared,
@@ -520,7 +520,7 @@ queries:
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
-      - url: https://slack.com/trust/security/security-practices
+      - url: https://slack.com/trust/security
         title: Slack Security Practices
   # No Terraform variants: this check asserts each channel member's profile.email matches
   # an allowlisted domain. User profiles (including email addresses) are not Terraform-
@@ -592,7 +592,7 @@ queries:
         1. Open each internal channel and click the channel name in the conversation header.
         2. Select the **Members** tab and review the email address associated with each member.
         3. Remove any member whose email domain is not on your approved list. Read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
-        4. Investigate how each unauthorized account gained access. Deactivate accounts that do not belong to your organization from **Tools & settings > Manage members**. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
+        4. Investigate how each unauthorized account gained access. Deactivate accounts that do not belong to your organization from **Tools & settings > Manage members**. Read [Deactivate a member](https://slack.com/help/articles/204475027-Deactivate-a-members-account) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
@@ -671,12 +671,12 @@ queries:
 
         1. Confirm whether the account belongs to a real, current member of your organization.
         2. For legitimate users, have them complete the email confirmation flow. Slack sends a confirmation link when the email is added or changed, and users can request a new link from their [account settings](https://slack.com/account/settings).
-        3. For accounts you cannot attribute to a known person, deactivate them immediately. Read [Deactivate a member](https://slack.com/help/articles/213185747-Deactivate-a-member) in the Slack documentation.
-        4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/115005206006) in the Slack documentation.
+        3. For accounts you cannot attribute to a known person, deactivate them immediately. Read [Deactivate a member](https://slack.com/help/articles/204475027-Deactivate-a-members-account) in the Slack documentation.
+        4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/220403548-Manage-single-sign-on-settings) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
         title: Slack Workspace Administration Guide
-      - url: https://slack.com/help/articles/213185747
+      - url: https://slack.com/help/articles/204475027-Deactivate-a-members-account
         title: Deactivate a member
-      - url: https://slack.com/help/articles/115005206006
+      - url: https://slack.com/help/articles/220403548-Manage-single-sign-on-settings
         title: Manage sign-in options

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-slack-security
     name: Mondoo Slack Team Security
-    version: 1.6.2
+    version: 1.6.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-slack-security.mql.yaml
+++ b/content/mondoo-slack-security.mql.yaml
@@ -116,9 +116,9 @@ queries:
         To learn more, read [Change a member's role](https://slack.com/help/articles/218124397-Change-a-members-role) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/trust/security
-        title: Slack Security Practices
+        title: 'Slack Security: Enterprise-grade Encryption'
   # No Terraform variants: per-user 2FA configuration (has_2fa, two_factor_type) is runtime
   # account state held by Slack — users enable 2FA from their own account settings. The
   # pablovarela/slack provider exposes no user resource and no 2FA enforcement argument,
@@ -194,9 +194,9 @@ queries:
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/204509068-Set-up-two-factor-authentication
-        title: Slack Two-Factor Authentication
+        title: Set up two-factor authentication
       - url: https://slack.com/trust/security
-        title: Slack Security Practices
+        title: 'Slack Security: Enterprise-grade Encryption'
   # No Terraform variants: per-user 2FA state is set by each user in their Slack account
   # settings. The pablovarela/slack provider has no user resource and no workspace-level
   # 2FA-required setting, so HCL/plan/state cannot assert whether every user has 2FA
@@ -271,9 +271,9 @@ queries:
         To learn more, read [Set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/204509068-Set-up-two-factor-authentication
-        title: Slack Two-Factor Authentication
+        title: Set up two-factor authentication
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
   # No Terraform variants: the runtime check filters channels by isExtShared (a runtime
   # Slack Connect property reflecting whether the channel is currently shared with an
   # external workspace) and then asserts a naming pattern. The pablovarela/slack provider
@@ -352,9 +352,9 @@ queries:
         To learn more, read [Rename a channel](https://slack.com/help/articles/201654073-Rename-a-channel) and [Create guidelines for channel names](https://slack.com/help/articles/217626408-Create-guidelines-for-channel-names) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/trust/security
-        title: Slack Security Practices
+        title: 'Slack Security: Enterprise-grade Encryption'
   # No Terraform variants: this is a workspace-posture existence check (the workspace has
   # at least one purely-internal channel). The relevant predicates (is_shared,
   # is_ext_shared, is_org_shared, is_pending_ext_shared) are read-only attributes on
@@ -432,9 +432,9 @@ queries:
         To learn more, read [Create a channel](https://slack.com/help/articles/201402297-Create-a-channel) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/help/articles/360000281563-Manage-apps-in-an-Enterprise-organization
-        title: Slack Enterprise Grid Administration
+        title: Manage apps in an Enterprise organization
   # No Terraform variants: even though slack_conversation.permanent_members lists member
   # user IDs, the runtime check filters those members on per-user runtime properties
   # (is_stranger, is_restricted, is_ultra_restricted) that are not Terraform-managed —
@@ -519,9 +519,9 @@ queries:
         To learn more, read [Remove someone from a channel](https://slack.com/help/articles/201898668-Remove-someone-from-a-channel) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/trust/security
-        title: Slack Security Practices
+        title: 'Slack Security: Enterprise-grade Encryption'
   # No Terraform variants: this check asserts each channel member's profile.email matches
   # an allowlisted domain. User profiles (including email addresses) are not Terraform-
   # managed in the pablovarela/slack provider — there is no slack_user resource. The
@@ -595,7 +595,7 @@ queries:
         4. Investigate how each unauthorized account gained access. Deactivate accounts that do not belong to your organization from **Tools & settings > Manage members**. Read [Deactivate a member](https://slack.com/help/articles/204475027-Deactivate-a-members-account) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/help/articles/203772216
         title: Slack Single Sign-On
   # No Terraform variants: per-user email-confirmation state (is_email_confirmed) is
@@ -675,8 +675,8 @@ queries:
         4. Review your workspace invitation and sign-up settings to require SSO or a verified corporate domain so new accounts cannot be created with unverified addresses. Read [Manage sign-in options](https://slack.com/help/articles/220403548-Manage-single-sign-on-settings) in the Slack documentation.
     refs:
       - url: https://slack.com/help/articles/360004635551-Manage-channel-posting-permissions
-        title: Slack Workspace Administration Guide
+        title: Manage channel posting permissions
       - url: https://slack.com/help/articles/204475027-Deactivate-a-members-account
-        title: Deactivate a member
+        title: Deactivate a member's account
       - url: https://slack.com/help/articles/220403548-Manage-single-sign-on-settings
-        title: Manage sign-in options
+        title: Manage single sign-on settings

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-snowflake-security
     name: Mondoo Snowflake Security
-    version: 2.0.2
+    version: 2.0.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-snowflake-security.mql.yaml
+++ b/content/mondoo-snowflake-security.mql.yaml
@@ -28,7 +28,7 @@ policies:
         - Session management and single sign-on integrity
         - Data egress controls for stages, integrations, and functions
 
-        Learn more about scanning Snowflake in the [cnspec Snowflake documentation](https://mondoo.com/docs/cnspec/saas/snowflake).
+        Learn more about scanning Snowflake in the [cnspec Snowflake documentation](https://mondoo.com/docs/cnspec/databases/snowflake).
 
         Have suggestions for new checks in this policy? Visit our [cnspec repository](https://github.com/mondoohq/cnspec).
     groups:

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -3898,7 +3898,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.stackit.cloud/products/iam/service-accounts/
+      - url: https://docs.stackit.cloud/platform/access-and-identity/service-accounts/
         title: STACKIT Documentation - Service Accounts
   # ----------------------------- STACKIT Key Management -----------------------------
   # No Terraform variant: key versions are created by the KMS rotation API and stackit_kms_key declares
@@ -3969,5 +3969,5 @@ queries:
             In the STACKIT Portal, open the key under **Key Management Service** and rotate it to create a fresh key version. Establish a rotation schedule so a new version is created at least once a year, and keep the older versions enabled only as long as they are needed to decrypt existing data.
         # No Terraform remediation: key-version age is runtime state produced by rotation over time; keeping a recent version means performing or scheduling a rotation, an operational action rather than a configurable attribute on the key resource.
     refs:
-      - url: https://docs.stackit.cloud/products/security/key-management-service/
+      - url: https://docs.stackit.cloud/products/security/kms/
         title: STACKIT Documentation - Key Management Service

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-stackit-security
     name: Mondoo STACKIT Security
-    version: 1.2.1
+    version: 1.2.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-stackit-security.mql.yaml
+++ b/content/mondoo-stackit-security.mql.yaml
@@ -2915,7 +2915,7 @@ queries:
         # No Terraform remediation: scheduling or cancelling key deletion is an imperative KMS API action, not a configurable attribute on stackit_kms_key. Cancel an unintended deletion via the console or API.
     refs:
       - url: https://docs.stackit.cloud/products/security/kms/
-        title: STACKIT Documentation - Key Management Service (KMS)
+        title: STACKIT Documentation - KMS
   # No Terraform variant: key state is reported by the KMS API and stackit_kms_key exposes no argument
   # that sets it.
   - uid: mondoo-stackit-security-kms-key-healthy-state
@@ -2985,7 +2985,7 @@ queries:
         # No Terraform remediation: key health (errors_exist / not_available) is a runtime state of the key, not a configurable attribute on stackit_kms_key. Investigate and remediate via the console or API.
     refs:
       - url: https://docs.stackit.cloud/products/security/kms/
-        title: STACKIT Documentation - Key Management Service (KMS)
+        title: STACKIT Documentation - KMS
   # ----------------------------- STACKIT Kubernetes (SKE) -----------------------------
   # No Terraform variant: cluster health is reported by the SKE API and stackit_ske_cluster exposes no
   # argument that sets it.
@@ -3970,4 +3970,4 @@ queries:
         # No Terraform remediation: key-version age is runtime state produced by rotation over time; keeping a recent version means performing or scheduling a rotation, an operational action rather than a configurable attribute on the key resource.
     refs:
       - url: https://docs.stackit.cloud/products/security/kms/
-        title: STACKIT Documentation - Key Management Service
+        title: STACKIT Documentation - KMS

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -179,7 +179,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1099/device-authorization
+      - url: https://tailscale.com/docs/features/access-control/device-management/device-approval
         title: Tailscale device authorization documentation
   - uid: mondoo-tailscale-security-devices-authorized-device
     filters: asset.platform == 'tailscale-device'
@@ -303,7 +303,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1028/key-expiry
+      - url: https://tailscale.com/docs/features/access-control/key-expiry
         title: Tailscale key expiry documentation
   - uid: mondoo-tailscale-security-devices-key-expiry-enabled-device
     filters: asset.platform == 'tailscale-device'
@@ -514,7 +514,7 @@ queries:
 
             The node key also appears on the device's detail page in the admin console.
     refs:
-      - url: https://tailscale.com/kb/1226/tailnet-lock
+      - url: https://tailscale.com/docs/features/tailnet-lock
         title: Tailscale tailnet lock documentation
   - uid: mondoo-tailscale-security-devices-no-tailnet-lock-errors-device
     filters: asset.platform == 'tailscale-device'
@@ -602,7 +602,7 @@ queries:
               -X POST "https://api.tailscale.com/api/v2/users/<user-id>/approve"
             ```
     refs:
-      - url: https://tailscale.com/kb/1138/user-management
+      - url: https://tailscale.com/docs/reference/user-roles
         title: Tailscale user management documentation
   # No Terraform variants: the tailscale provider does not expose a per-user role-assignment
   # resource. As of provider v0.29.x there is no tailscale_user_role (only the tailnet-wide
@@ -686,7 +686,7 @@ queries:
               --data '{ "role": "member" }'
             ```
     refs:
-      - url: https://tailscale.com/kb/1138/user-management
+      - url: https://tailscale.com/docs/reference/user-roles
         title: Tailscale user roles documentation
   # No Terraform variants: user idle status ("idle") is runtime activity telemetry from the
   # Tailscale API based on last-seen timestamps. It is not a configuration field — there is
@@ -772,7 +772,7 @@ queries:
               -X POST "https://api.tailscale.com/api/v2/users/<user-id>/delete"
             ```
     refs:
-      - url: https://tailscale.com/kb/1138/user-management
+      - url: https://tailscale.com/docs/reference/user-roles
         title: Tailscale user management documentation
   - uid: mondoo-tailscale-security-device-approval-required
     title: Ensure new devices require admin approval to join the tailnet
@@ -873,7 +873,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1099/device-approval
+      - url: https://tailscale.com/docs/features/access-control/device-management/device-approval
         title: Tailscale device approval documentation
   - uid: mondoo-tailscale-security-device-approval-required-tailscale
     filters: asset.platform == 'tailscale'
@@ -990,7 +990,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1239/user-approval
+      - url: https://tailscale.com/docs/features/access-control/user-approval
         title: Tailscale user approval documentation
   - uid: mondoo-tailscale-security-user-approval-required-tailscale
     filters: asset.platform == 'tailscale'
@@ -1105,7 +1105,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1067/update
+      - url: https://tailscale.com/docs/features/client/update
         title: Tailscale client auto-update documentation
   - uid: mondoo-tailscale-security-devices-auto-updates-enabled-tailscale
     filters: asset.platform == 'tailscale'
@@ -1220,7 +1220,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1028/key-expiry
+      - url: https://tailscale.com/docs/features/access-control/key-expiry
         title: Tailscale key expiry documentation
   - uid: mondoo-tailscale-security-devices-key-duration-capped-tailscale
     filters: asset.platform == 'tailscale'
@@ -1367,9 +1367,9 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1018/acls
+      - url: https://tailscale.com/docs/features/access-control/acls
         title: Tailscale ACL policy documentation
-      - url: https://tailscale.com/kb/1192/tailnet-policy
+      - url: https://tailscale.com/docs/reference/examples/acls
         title: Writing a tailnet policy file
   - uid: mondoo-tailscale-security-authkeys-have-expiration
     title: Ensure active pre-auth keys have an expiration set
@@ -1492,7 +1492,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1085/auth-keys
+      - url: https://tailscale.com/docs/features/access-control/auth-keys
         title: Tailscale auth keys
   - uid: mondoo-tailscale-security-authkeys-have-expiration-tailscale
     filters: asset.platform == 'tailscale'
@@ -1618,7 +1618,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1085/auth-keys
+      - url: https://tailscale.com/docs/features/access-control/auth-keys
         title: Tailscale auth keys
   - uid: mondoo-tailscale-security-authkeys-not-reusable-tailscale
     filters: asset.platform == 'tailscale'
@@ -1743,7 +1743,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1255/log-streaming
+      - url: https://tailscale.com/docs/features/logging/log-streaming
         title: Tailscale log streaming
       - url: https://tailscale.com/kb/1156/audit-logs
         title: Tailscale audit logging
@@ -1860,7 +1860,7 @@ queries:
             }
             ```
     refs:
-      - url: https://tailscale.com/kb/1213/webhooks
+      - url: https://tailscale.com/docs/features/webhooks
         title: Tailscale webhooks
   - uid: mondoo-tailscale-security-webhooks-use-https-tailscale
     filters: asset.platform == 'tailscale'

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -603,7 +603,7 @@ queries:
             ```
     refs:
       - url: https://tailscale.com/docs/reference/user-roles
-        title: Tailscale user management documentation
+        title: User roles
   # No Terraform variants: the tailscale provider does not expose a per-user role-assignment
   # resource. As of provider v0.29.x there is no tailscale_user_role (only the tailnet-wide
   # users_role_allowed_to_join_external_tailnet setting), so role membership for owners and
@@ -687,7 +687,7 @@ queries:
             ```
     refs:
       - url: https://tailscale.com/docs/reference/user-roles
-        title: Tailscale user roles documentation
+        title: User roles
   # No Terraform variants: user idle status ("idle") is runtime activity telemetry from the
   # Tailscale API based on last-seen timestamps. It is not a configuration field — there is
   # no tailscale_user resource and no HCL argument that expresses or constrains user activity.
@@ -773,7 +773,7 @@ queries:
             ```
     refs:
       - url: https://tailscale.com/docs/reference/user-roles
-        title: Tailscale user management documentation
+        title: User roles
   - uid: mondoo-tailscale-security-device-approval-required
     title: Ensure new devices require admin approval to join the tailnet
     impact: 70
@@ -1370,7 +1370,7 @@ queries:
       - url: https://tailscale.com/docs/features/access-control/acls
         title: Tailscale ACL policy documentation
       - url: https://tailscale.com/docs/reference/examples/acls
-        title: Writing a tailnet policy file
+        title: ACL policy examples
   - uid: mondoo-tailscale-security-authkeys-have-expiration
     title: Ensure active pre-auth keys have an expiration set
     impact: 90
@@ -1746,7 +1746,7 @@ queries:
       - url: https://tailscale.com/docs/features/logging/log-streaming
         title: Tailscale log streaming
       - url: https://tailscale.com/docs/reference/logging-streaming-events
-        title: Tailscale audit logging
+        title: Logging, streaming, and events
   - uid: mondoo-tailscale-security-webhooks-use-https
     title: Ensure tailnet webhook endpoints use HTTPS
     impact: 80

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -1745,7 +1745,7 @@ queries:
     refs:
       - url: https://tailscale.com/docs/features/logging/log-streaming
         title: Tailscale log streaming
-      - url: https://tailscale.com/kb/1156/audit-logs
+      - url: https://tailscale.com/docs/reference/logging-streaming-events
         title: Tailscale audit logging
   - uid: mondoo-tailscale-security-webhooks-use-https
     title: Ensure tailnet webhook endpoints use HTTPS

--- a/content/mondoo-tailscale-security.mql.yaml
+++ b/content/mondoo-tailscale-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tailscale-security
     name: Mondoo Tailscale Security
-    version: 1.3.4
+    version: 1.3.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3203,7 +3203,7 @@ queries:
 
                 Then re-run the verification from step 1. `Verify return code: 0 (ok)` confirms success.
     refs:
-      - url: https://www.openssl.org/docs/man1.1.1/man1/verify.html
+      - url: https://docs.openssl.org/1.1.1/man1/verify/
         title: OpenSSL certificate chain verification
   - uid: mondoo-tls-security-tls13-supported
     title: Ensure TLS 1.3 is supported

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3014,8 +3014,8 @@ queries:
 
             **Important:** Do not use RC4 as a BEAST mitigation. RC4 has severe cryptographic weaknesses.
     refs:
-      - url: https://kb.vmware.com/s/article/2008784
-        title: VMware mitigation of CVE-2011-3389 (BEAST) for web server administrators
+      - url: https://nvd.nist.gov/vuln/detail/CVE-2011-3389
+        title: CVE-2011-3389 (BEAST) in the National Vulnerability Database
   - uid: mondoo-tls-security-cert-chain-verified
     title: Ensure the certificate chain is verified and trusted
     impact: 95

--- a/content/mondoo-tls-security.mql.yaml
+++ b/content/mondoo-tls-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-tls-security
     name: Mondoo TLS/SSL Security
-    version: 1.9.0
+    version: 1.9.1
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -755,7 +755,7 @@ queries:
             ```
     refs:
       - url: https://vercel.com/docs/cli/inspect
-        title: Vercel deployment inspector documentation
+        title: vercel inspect
 
   - uid: mondoo-vercel-security-project-supported-node-version
     title: Ensure the project builds on a supported Node.js version
@@ -1350,7 +1350,7 @@ queries:
             ```
     refs:
       - url: https://vercel.com/docs/accounts/access-tokens
-        title: Vercel access token documentation
+        title: Access tokens
 
   - uid: mondoo-vercel-security-tokens-have-expiration-vercel-team
     filters: asset.platform == "vercel-team"
@@ -1447,7 +1447,7 @@ queries:
         # carrying an attribute a snippet could show.
     refs:
       - url: https://vercel.com/docs/accounts/access-tokens
-        title: Vercel access token documentation
+        title: Access tokens
 
   # ---------------------------------------------------------------------------
   # Storage

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -180,7 +180,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection
+      - url: https://vercel.com/docs/deployment-protection
         title: Vercel deployment protection documentation
 
   - uid: mondoo-vercel-security-project-preview-deployments-authenticated-vercel-project
@@ -304,7 +304,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection
+      - url: https://vercel.com/docs/deployment-protection
         title: Vercel deployment protection documentation
 
   - uid: mondoo-vercel-security-project-password-protection-enabled-vercel-project
@@ -430,7 +430,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips
+      - url: https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/trusted-ips
         title: Vercel Trusted IPs documentation
 
   - uid: mondoo-vercel-security-project-trusted-ips-enforced-vercel-project
@@ -547,7 +547,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips
+      - url: https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/trusted-ips
         title: Vercel Trusted IPs documentation
 
   - uid: mondoo-vercel-security-project-git-fork-protection-enabled
@@ -754,7 +754,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/deployments/inspect-deployment
+      - url: https://vercel.com/docs/cli/inspect
         title: Vercel deployment inspector documentation
 
   - uid: mondoo-vercel-security-project-supported-node-version
@@ -1349,7 +1349,7 @@ queries:
             }
             ```
     refs:
-      - url: https://vercel.com/docs/rest-api/reference/welcome/api-scopes
+      - url: https://vercel.com/docs/accounts/access-tokens
         title: Vercel access token documentation
 
   - uid: mondoo-vercel-security-tokens-have-expiration-vercel-team
@@ -1446,7 +1446,7 @@ queries:
         # vercel_user_token resource expresses that by being deleted rather than by
         # carrying an attribute a snippet could show.
     refs:
-      - url: https://vercel.com/docs/rest-api/reference/welcome/api-scopes
+      - url: https://vercel.com/docs/accounts/access-tokens
         title: Vercel access token documentation
 
   # ---------------------------------------------------------------------------
@@ -1925,7 +1925,7 @@ queries:
         # rather than by carrying an attribute a snippet could show. Bypasses created
         # outside Terraform are revoked through the dashboard or the REST API.
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
+      - url: https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
         title: Vercel protection bypass for automation documentation
 
   - uid: mondoo-vercel-security-project-no-protection-bypass-vercel-project
@@ -2031,7 +2031,7 @@ queries:
         # exposes neither strict deployment-protection nor strict password-protection
         # settings, so they are set via the API or dashboard.
     refs:
-      - url: https://vercel.com/docs/security/deployment-protection
+      - url: https://vercel.com/docs/deployment-protection
         title: Vercel deployment protection documentation
 
   # No Terraform variants: vercel_shared_environment_variable exposes only a sensitive

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -755,8 +755,7 @@ queries:
             ```
     refs:
       - url: https://vercel.com/docs/cli/inspect
-        title: vercel inspect
-
+        title: Vercel CLI - vercel inspect
   - uid: mondoo-vercel-security-project-supported-node-version
     title: Ensure the project builds on a supported Node.js version
     impact: 70

--- a/content/mondoo-vercel-security.mql.yaml
+++ b/content/mondoo-vercel-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vercel-security
     name: Mondoo Vercel Security
-    version: 1.1.1
+    version: 1.1.2
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -191,7 +191,7 @@ queries:
 
         If your release does not protect the `/inference/` prefix with the built-in key, deny that prefix upstream as well. If client applications need any of these routes, require authentication and authorization at the proxy before forwarding requests to vLLM.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
       - url: https://owasp.github.io/www-project-top-10-for-large-language-model-applications/
         title: OWASP Top 10 for LLM Applications
@@ -258,7 +258,7 @@ queries:
 
         Restarting vLLM cancels in-flight requests, so drain traffic at the load balancer or proxy first. If development routes are required for debugging, additionally block them at the reverse proxy, API gateway, ingress controller, or firewall and expose them only on trusted internal networks.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-docs-not-exposed
     title: Ensure FastAPI documentation is not exposed
@@ -322,7 +322,7 @@ queries:
 
         Restarting the server to apply the flag cancels in-flight requests, so drain traffic at the load balancer or proxy first. If documentation must remain available, restrict `/docs`, `/redoc`, and `/openapi.json` to trusted networks or authenticated administrative users at the reverse proxy or gateway instead.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-load-not-exposed
     title: Ensure load tracking is not anonymously exposed
@@ -387,7 +387,7 @@ queries:
         }
         ```
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-metrics-not-exposed
     title: Ensure Prometheus metrics are not anonymously exposed
@@ -445,7 +445,7 @@ queries:
       remediation: |
         Restrict `/metrics` to the monitoring system only. Enforce network allow-lists, mTLS, authentication, or a private monitoring path before forwarding metrics requests to vLLM.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-openai-routes-require-authentication
     title: Ensure OpenAI-compatible routes require authentication
@@ -512,7 +512,7 @@ queries:
 
         The `VLLM_API_KEY` environment variable works as an alternative to the flag. Distribute the token to every trusted client before enabling enforcement: clients that do not send an `Authorization: Bearer` header lose access as soon as the server restarts, and the restart itself cancels in-flight requests, so schedule a maintenance window or drain traffic at the load balancer first. For defense in depth, also require authentication at the fronting gateway or reverse proxy so routes outside the built-in authentication scope are not left open.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
       - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
         title: vLLM OpenAI-Compatible Server
@@ -578,7 +578,7 @@ queries:
 
         Restarting the server to apply the flag cancels in-flight requests, so drain traffic at the load balancer or proxy first. If developers or operators need the specification, serve it from an authenticated internal documentation system instead of the public API, or restrict `/openapi.json` at the reverse proxy or gateway.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-operational-control-routes-not-anonymous
     title: Ensure operational control routes are not anonymously accessible
@@ -644,7 +644,7 @@ queries:
 
         If operational routes are required, expose them only through an authenticated administrative plane and restrict access to trusted operators or automation.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-profiler-routes-not-exposed
     title: Ensure profiler routes are not exposed
@@ -709,7 +709,7 @@ queries:
 
         Restarting vLLM cancels in-flight requests, so drain traffic at the load balancer or proxy first. If profiling is required for a controlled diagnostics window, enable it temporarily, restrict `/start_profile` and `/stop_profile` to authenticated operators on trusted administrative networks at the reverse proxy or firewall, and remove the profiler configuration when the window closes.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-tokenization-routes-not-anonymous
     title: Ensure tokenization routes are not anonymously accessible
@@ -769,7 +769,7 @@ queries:
       remediation: |
         Restrict `/tokenize` and `/detokenize` at the reverse proxy, gateway, ingress, or firewall. If client applications need these routes, require authentication before forwarding requests to vLLM.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-tokenizer-info-not-exposed
     title: Ensure tokenizer information is not exposed
@@ -827,7 +827,7 @@ queries:
       remediation: |
         Remove the `--enable-tokenizer-info-endpoint` flag from the vLLM launch command; the `/tokenizer_info` route only exists while that flag is set. Restarting the server to change launch flags cancels in-flight requests, so drain traffic at the load balancer or proxy first. If a trusted client requires tokenizer metadata, keep the flag but restrict `/tokenizer_info` to that client with authentication and network controls at the reverse proxy, API gateway, ingress, or firewall.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
   - uid: mondoo-vllm-security-use-tls
     title: Ensure the vLLM API is served over TLS
@@ -893,7 +893,7 @@ queries:
 
         Restarting the server to apply TLS flags cancels in-flight requests, so drain traffic first. Alternatively, terminate TLS in front of vLLM with a reverse proxy, load balancer, API gateway, or service mesh. In both layouts, expose only the HTTPS endpoint to clients and restrict direct network access to any plaintext backend listener so clients cannot bypass encryption.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
       - url: https://owasp.github.io/www-project-top-10-for-large-language-model-applications/
         title: OWASP Top 10 for LLM Applications
@@ -953,5 +953,5 @@ queries:
       remediation: |
         Block `/version` from untrusted clients at the reverse proxy, gateway, ingress, or firewall. Keep version inventory in internal asset management rather than exposing it through the public serving API.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/security.html
+      - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vllm-security
     name: Mondoo vLLM Security
-    version: 1.0.3
+    version: 1.0.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -125,7 +125,7 @@ queries:
 
         If your release renames the flag or expects repeated values, adjust the command accordingly. Restarting the server to apply the flag cancels in-flight requests, so drain traffic at the load balancer or proxy first. When vLLM is exposed through a reverse proxy or API gateway, enforce the same origin allowlist there and strip any wildcard or reflected `Access-Control-Allow-Origin` headers so the rule holds on every path to the server.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
+      - url: https://docs.vllm.ai/en/latest/serving/online_serving/
         title: vLLM OpenAI-Compatible Server
       - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS
         title: MDN Web Docs CORS
@@ -514,7 +514,7 @@ queries:
     refs:
       - url: https://docs.vllm.ai/en/latest/usage/security/
         title: vLLM Security
-      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
+      - url: https://docs.vllm.ai/en/latest/serving/online_serving/
         title: vLLM OpenAI-Compatible Server
   - uid: mondoo-vllm-security-openapi-not-exposed
     title: Ensure the OpenAPI specification is not exposed

--- a/content/mondoo-vllm-security.mql.yaml
+++ b/content/mondoo-vllm-security.mql.yaml
@@ -125,9 +125,9 @@ queries:
 
         If your release renames the flag or expects repeated values, adjust the command accordingly. Restarting the server to apply the flag cancels in-flight requests, so drain traffic at the load balancer or proxy first. When vLLM is exposed through a reverse proxy or API gateway, enforce the same origin allowlist there and strip any wildcard or reflected `Access-Control-Allow-Origin` headers so the rule holds on every path to the server.
     refs:
-      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
         title: vLLM OpenAI-Compatible Server
-      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+      - url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS
         title: MDN Web Docs CORS
   - uid: mondoo-vllm-security-custom-inference-routes-not-anonymous
     title: Ensure non-v1 inference routes are not anonymously accessible
@@ -193,7 +193,7 @@ queries:
     refs:
       - url: https://docs.vllm.ai/en/latest/serving/security.html
         title: vLLM Security
-      - url: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+      - url: https://owasp.github.io/www-project-top-10-for-large-language-model-applications/
         title: OWASP Top 10 for LLM Applications
   - uid: mondoo-vllm-security-development-routes-not-exposed
     title: Ensure development routes are not exposed
@@ -514,7 +514,7 @@ queries:
     refs:
       - url: https://docs.vllm.ai/en/latest/serving/security.html
         title: vLLM Security
-      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+      - url: https://docs.vllm.ai/en/latest/serving/openai_compatible_server/
         title: vLLM OpenAI-Compatible Server
   - uid: mondoo-vllm-security-openapi-not-exposed
     title: Ensure the OpenAPI specification is not exposed
@@ -895,7 +895,7 @@ queries:
     refs:
       - url: https://docs.vllm.ai/en/latest/serving/security.html
         title: vLLM Security
-      - url: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+      - url: https://owasp.github.io/www-project-top-10-for-large-language-model-applications/
         title: OWASP Top 10 for LLM Applications
   - uid: mondoo-vllm-security-version-not-exposed
     title: Ensure the vLLM version endpoint is not exposed

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -2532,7 +2532,7 @@ queries:
         # No Terraform remediation: UEFI Secure Boot is platform firmware configuration with no Terraform resource.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
-        title: UEFI Secure Boot for ESXi Hosts
+        title: Securing ESXi Hosts
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-vsphere
     filters: asset.platform == 'vmware-esxi'
     mql: |

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -140,7 +140,7 @@ queries:
             ```
         # No Terraform remediation: the account-lockout window is a runtime host advanced setting with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage installed VIBs or the kernel modules loaded by the VMkernel at runtime.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-all-loaded-esxi-kernel-modules-are-signed
@@ -223,7 +223,7 @@ queries:
             Configure the host image profile acceptance level so that unsigned VIBs cannot be installed in the first place. See "Ensure the Image Profile VIB acceptance level is configured properly".
         # No Terraform remediation: kernel module signing is verified against live host state, not declarable Terraform configuration.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi iSCSI host bus adapter CHAP authentication properties.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-bidirectional-chap-authentication-for-iscsi-traffic-is-enabled
@@ -401,7 +401,7 @@ queries:
             ```
         # No Terraform remediation: the host DNS configuration is runtime network state with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Net.DVFilterBindIpAddress.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-dvfilter-api-is-not-configured-if-not-used
@@ -480,7 +480,7 @@ queries:
             ```
         # No Terraform remediation: the dvfilter bind address is a runtime host advanced setting with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as UserVars.ESXiShellInteractiveTimeOut.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-idle-esxi-shell-and-ssh-sessions-time-out-after-300-seconds-or-less
@@ -558,7 +558,7 @@ queries:
             ```
         # No Terraform remediation: the interactive shell idle timeout is a runtime host advanced setting with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host advanced settings such as Config.HostAgent.plugins.solo.enableMob.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-managed-object-browser-mob-is-disabled
@@ -890,7 +890,7 @@ queries:
             ```
         # No Terraform remediation: the persistent log directory is a runtime host advanced setting with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-the-value-of-the-native-vlan
     title: Ensure port groups are not configured to the value of the native VLAN
@@ -987,7 +987,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-port-groups-are-not-configured-to-vlan-4095-and-0-except-for-virtual-
     title: Ensure port groups avoid VLAN 4095 and 0 except for VGT
@@ -1479,7 +1479,7 @@ queries:
             ```
         # No Terraform remediation: the Transparent Page Sharing salt setting is a runtime host advanced setting with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host firewall rulesets or their allowed-IP networks.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-host-firewall-is-configured-to-restrict-access-to-services-r
@@ -1643,7 +1643,7 @@ queries:
             For environments using custom CA-signed certificates, ensure a renewal process is in place well ahead of the expiration date.
         # No Terraform remediation: certificate expiry is observed runtime host state, not declarable Terraform configuration.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E9B71B85-FBA3-447C-8A60-DEA2FE111F4F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: Securing ESXi Hosts
   # No Terraform variants: the vsphere Terraform provider does not manage ESXi host services such as the TSM (ESXi Shell) daemon.
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-esxi-shell-is-disabled
@@ -2531,7 +2531,7 @@ queries:
             If any installed VIB is unsigned or improperly signed, the host will fail to boot with Secure Boot enabled. Resolve unsigned modules first (see "Ensure all loaded ESXi kernel modules are signed").
         # No Terraform remediation: UEFI Secure Boot is platform firmware configuration with no Terraform resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-5D5EE0D1-2596-43D7-95C8-0B29733191D9.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
         title: UEFI Secure Boot for ESXi Hosts
   - uid: mondoo-vmware-vsphere-esxi-security-baseline-ensure-the-vswitch-forged-transmits-policy-is-set-to-reject-vsphere
     filters: asset.platform == 'vmware-esxi'

--- a/content/mondoo-vmware-vsphere-esxi.mql.yaml
+++ b/content/mondoo-vmware-vsphere-esxi.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-esxi-security-baseline
     name: Mondoo VMware vSphere ESXi Security
-    version: 2.0.4
+    version: 2.0.5
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-vmware-vsphere-security-baseline
     name: Mondoo VMware vSphere Security Baseline
-    version: 2.1.3
+    version: 2.1.4
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -2369,7 +2369,7 @@ queries:
             **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before applying this change to existing virtual machines.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-virtual-machines-in-the-vsphere-client.html
-        title: Enable or Disable UEFI Secure Boot for a Virtual Machine
+        title: Securing Virtual Machines
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled
     title: Ensure unauthorized connection of devices is disabled
     impact: 60
@@ -5476,7 +5476,7 @@ queries:
             ```
         # No Terraform remediation: the vsphere_compute_cluster resource exposes vsan_dit_encryption_enabled for data-in-transit only and has no data-at-rest encryption argument; at-rest encryption is bound to a vCenter key provider that the resource cannot reference.
     refs:
-      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsan/vsan/8-0/vsan-administration/using-encryption-in-a-vsan-cluster-1/vsan-data-at-rest-encryption.html
         title: Using Data-at-Rest Encryption in vSAN
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled
     title: Ensure vSAN data-in-transit encryption is enabled
@@ -5570,7 +5570,7 @@ queries:
               Set-VsanClusterConfiguration -DataInTransitEncryptionEnabled $true
             ```
     refs:
-      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsan/vsan/8-0/vsan-administration/using-encryption-in-a-vsan-cluster-1/vsan-data-in-transit-encryption.html
         title: Using Data-in-Transit Encryption in vSAN
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-vsphere
     filters: asset.platform == 'vmware-vsphere'
@@ -5676,7 +5676,7 @@ queries:
         # No Terraform remediation: vCenter RBAC assignment governance has no single Terraform resource; use the vSphere Client or PowerCLI.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: Authorization in the vSphere Environment
+        title: vSphere Security
   # No Terraform variants: the vCenter Single Sign-On lockout policy is a management-plane security setting with no Terraform resource in the vsphere provider, so this check runs against the live vCenter only.
   - uid: mondoo-vmware-vsphere-security-baseline-sso-lockout-policy-enforced
     filters: asset.platform == "vmware-vsphere"
@@ -5749,4 +5749,4 @@ queries:
         # No Terraform remediation: the vCenter SSO lockout policy has no Terraform resource; use the vSphere Client or PowerCLI.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-authentication.html
-        title: Managing vCenter Single Sign-On Policies
+        title: vSphere Authentication

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -291,7 +291,7 @@ queries:
             ```
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled
     title: Ensure BIOS BBS is disabled
     impact: 60
@@ -1150,7 +1150,7 @@ queries:
             ```
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled
     title: Ensure Host Guest File System Server is disabled
     impact: 60
@@ -1365,7 +1365,7 @@ queries:
             ```
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited
     title: Ensure informational messages from the VM to the VMX file are limited
     impact: 60
@@ -1472,7 +1472,7 @@ queries:
             ```
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled
     title: Ensure memSchedFakeSampleStats is disabled
     impact: 60
@@ -1657,7 +1657,7 @@ queries:
         # No Terraform remediation: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time
     title: Ensure only one remote console connection is permitted to a VM at any time
     impact: 60
@@ -1842,7 +1842,7 @@ queries:
         # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
-        title: VMware vSphere Security Guide
+        title: vSphere Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled
     title: Ensure Request Disk Topology is disabled
     impact: 60
@@ -3962,7 +3962,7 @@ queries:
             ```
     refs:
       - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-windows-guest-operating-systems-with-virtual-based-security.html
-        title: Virtualization-based Security
+        title: Securing Windows Guest Operating Systems with Virtualization-based Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled
     title: Ensure VM Console Copy operations are disabled
     impact: 60

--- a/content/mondoo-vmware-vsphere.mql.yaml
+++ b/content/mondoo-vmware-vsphere.mql.yaml
@@ -183,7 +183,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-A45F1862-A2E1-4FFE-A2DF-29B3FE3A5D80.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-virtual-machines-with-virtual-trusted-platform-module.html
         title: Securing Virtual Machines with Virtual Trusted Platform Module
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-autologon-is-disabled
     title: Ensure Autologon is disabled
@@ -290,7 +290,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-bios-bbs-is-disabled
     title: Ensure BIOS BBS is disabled
@@ -1149,7 +1149,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-host-guest-file-system-server-is-disabled
     title: Ensure Host Guest File System Server is disabled
@@ -1364,7 +1364,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-informational-messages-from-the-vm-to-the-vmx-file-are-limited
     title: Ensure informational messages from the VM to the VMX file are limited
@@ -1471,7 +1471,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-memschedfakesamplestats-is-disabled
     title: Ensure memSchedFakeSampleStats is disabled
@@ -1656,7 +1656,7 @@ queries:
             ```
         # No Terraform remediation: the vsphere_virtual_machine disk block exposes no disk-mode or independent-nonpersistent argument.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-only-one-remote-console-connection-is-permitted-to-a-vm-at-any-time
     title: Ensure only one remote console connection is permitted to a VM at any time
@@ -1841,7 +1841,7 @@ queries:
             Removing the underlying `PCI device` hardware entries is not exposed by PowerCLI; complete that step with the vSphere Client method above.
         # No Terraform remediation: the vsphere_virtual_machine resource exposes PCI passthrough only as a pci_device_id list, with no advanced-setting key to assert against.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-20D8B362-E96F-4F78-B7C3-660C7C2F773D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: VMware vSphere Security Guide
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-request-disk-topology-is-disabled
     title: Ensure Request Disk Topology is disabled
@@ -2368,7 +2368,7 @@ queries:
 
             **Note:** Changing firmware from BIOS to EFI on an existing VM may make the installed guest OS unbootable. Verify guest OS compatibility before applying this change to existing virtual machines.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-898217D4-689D-4EB5-866C-888353FE241C.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-virtual-machines-in-the-vsphere-client.html
         title: Enable or Disable UEFI Secure Boot for a Virtual Machine
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-unauthorized-connection-of-devices-is-disabled
     title: Ensure unauthorized connection of devices is disabled
@@ -3864,7 +3864,7 @@ queries:
             Encrypted virtual machines cannot be migrated to hosts that lack access to the key provider, and some operations (such as content-based deduplication) are not available for encrypted VMs.
         # No Terraform remediation: the vsphere_virtual_machine resource has no encryption argument; VM encryption is applied through a storage policy, not the VM resource.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-E6C5CE29-CD1D-4555-859C-A0492E7CB45D.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/virtual-machine-encryption.html
         title: Virtual Machine Encryption
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-virtualization-based-security-is-enabled
     title: Ensure Virtualization-Based Security is enabled
@@ -3961,7 +3961,7 @@ queries:
             }
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-CC0C6FE0-2902-4DBC-BFFE-1710A971B57F.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-windows-guest-operating-systems-with-virtual-based-security.html
         title: Virtualization-based Security
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vm-console-copy-operations-are-disabled
     title: Ensure VM Console Copy operations are disabled
@@ -5476,7 +5476,7 @@ queries:
             ```
         # No Terraform remediation: the vsphere_compute_cluster resource exposes vsan_dit_encryption_enabled for data-in-transit only and has no data-at-rest encryption argument; at-rest encryption is bound to a vCenter key provider that the resource cannot reference.
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-F3B2714F-3406-48E7-AC2D-3677355C94D3.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: Using Data-at-Rest Encryption in vSAN
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled
     title: Ensure vSAN data-in-transit encryption is enabled
@@ -5570,7 +5570,7 @@ queries:
               Set-VsanClusterConfiguration -DataInTransitEncryptionEnabled $true
             ```
     refs:
-      - url: https://docs.vmware.com/en/VMware-vSphere/8.0/vsan-security/GUID-D8E5550C-8C0A-43AB-A3C9-4F4F0F0D6C9C.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: Using Data-in-Transit Encryption in vSAN
   - uid: mondoo-vmware-vsphere-security-baseline-ensure-vsan-data-in-transit-encryption-is-enabled-vsphere
     filters: asset.platform == 'vmware-vsphere'
@@ -5675,7 +5675,7 @@ queries:
             ```
         # No Terraform remediation: vCenter RBAC assignment governance has no single Terraform resource; use the vSphere Client or PowerCLI.
     refs:
-      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security-8-0/authorization-in-the-vsphere-environment.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security.html
         title: Authorization in the vSphere Environment
   # No Terraform variants: the vCenter Single Sign-On lockout policy is a management-plane security setting with no Terraform resource in the vsphere provider, so this check runs against the live vCenter only.
   - uid: mondoo-vmware-vsphere-security-baseline-sso-lockout-policy-enforced
@@ -5748,5 +5748,5 @@ queries:
             ```
         # No Terraform remediation: the vCenter SSO lockout policy has no Terraform resource; use the vSphere Client or PowerCLI.
     refs:
-      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-authentication-8-0/managing-vcenter-single-sign-on-policies.html
+      - url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-authentication.html
         title: Managing vCenter Single Sign-On Policies

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-security
     name: Mondoo Microsoft Windows Security
-    version: 2.5.2
+    version: 2.5.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -440,7 +440,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop always asks for a password at connection time rather than accepting one supplied automatically by the client.
 
@@ -4556,7 +4556,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop does not map the client's COM ports into the remote session.
 
@@ -4681,7 +4681,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop does not map the client's drives into the remote session.
 
@@ -4808,7 +4808,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop does not map the client's parallel ports into the remote session.
 
@@ -4933,7 +4933,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that the Remote Desktop client cannot save passwords.
 
@@ -5058,7 +5058,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop does not map the client's Plug and Play devices into the remote session.
 
@@ -5183,7 +5183,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop deletes each session's temporary folders when the session ends.
 
@@ -8786,7 +8786,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that the Remote Desktop service requires secure RPC for its management interface.
 
@@ -8919,7 +8919,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop connections use TLS as their security layer rather than the legacy RDP native protocol.
 
@@ -9060,7 +9060,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop requires Network Level Authentication, so that a user authenticates before a session is created on the server.
 
@@ -9459,7 +9459,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop encrypts session traffic at the high level, using 128-bit encryption in both directions.
 
@@ -9599,7 +9599,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop disconnects sessions that have been idle beyond a time limit.
 
@@ -9727,7 +9727,7 @@ queries:
     docs:
       refs:
         - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
-          title: Secure Remote Desktop Services
+          title: RemoteDesktopServices Policy CSP
       desc: |-
         This check verifies that Remote Desktop ends disconnected sessions after one minute rather than leaving them running.
 

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -4339,7 +4339,7 @@ queries:
 
             **Impact:**
 
-            Some legacy OSes such as Windows XP and Server 2003, along with older applications and appliances, may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://blogs.technet.microsoft.com/filecab/2017/06/01/smb1-product-clearinghouse/)
+            Some legacy OSes such as Windows XP and Server 2003, along with older applications and appliances, may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://techcommunity.microsoft.com/blog/filecab/smb1-product-clearinghouse/426008)
         - id: powershell
           desc: |
             **Using PowerShell**
@@ -4473,7 +4473,7 @@ queries:
 
             **Impact:**
 
-            Some legacy OSes such as Windows XP and Server 2003, along with older applications and appliances, may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://blogs.technet.microsoft.com/filecab/2017/06/01/smb1-product-clearinghouse/)
+            Some legacy OSes such as Windows XP and Server 2003, along with older applications and appliances, may no longer be able to communicate with the system once SMBv1 is disabled. We recommend careful testing be performed to determine the impact prior to configuring this as a widespread control, and where possible, remediate any incompatibilities found with the vendor of the incompatible system. Microsoft is also maintaining a thorough (although not comprehensive) list of known SMBv1 incompatibilities at this link: [SMB1 Product Clearinghouse \| Storage at Microsoft](https://techcommunity.microsoft.com/blog/filecab/smb1-product-clearinghouse/426008)
         - id: powershell
           desc: |
             **Using PowerShell**
@@ -5359,7 +5359,7 @@ queries:
             **Note:**
             This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084)
 
-            More information is available at [How to enable Structured Exception Handling Overwrite Protection (SEHOP) in Windows operating systems](https://support.microsoft.com/en-us/help/956607/how-to-enable-structured-exception-handling-overwrite-protection-sehop)
+            More information is available at [How to enable Structured Exception Handling Overwrite Protection (SEHOP) in Windows operating systems](https://support.microsoft.com/en-us/servicing/os/windows/2018/04/how-to-enable-structured-exception-handling-overwrite-protection-sehop-in-windows-operating-systems)
 
             **Impact:**
 
@@ -10686,7 +10686,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://blogs.technet.microsoft.com/secguide/2018/11/20/security-baseline-final-for-windows-10-v1809-and-windows-server-2019/)
+            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://learn.microsoft.com/en-us/archive/blogs/secguide/security-baseline-final-for-windows-10-v1809-and-windows-server-2019)
 
             **Impact:**
 

--- a/content/mondoo-windows-security.mql.yaml
+++ b/content/mondoo-windows-security.mql.yaml
@@ -439,7 +439,7 @@ queries:
       windows.rdp.alwaysPromptForPassword
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop always asks for a password at connection time rather than accepting one supplied automatically by the client.
@@ -877,7 +877,7 @@ queries:
 
             **Note:**
             This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at
-            [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084).
+            [this link](https://techcommunity.microsoft.com/blog/microsoft-security-baselines/security-baseline-final-for-windows-10-v1903-and-windows-server-v1903/701084).
 
             **Impact:**
 
@@ -4335,7 +4335,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084)
+            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/blog/microsoft-security-baselines/security-baseline-final-for-windows-10-v1903-and-windows-server-v1903/701084)
 
             **Impact:**
 
@@ -4469,7 +4469,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084)
+            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/blog/microsoft-security-baselines/security-baseline-final-for-windows-10-v1903-and-windows-server-v1903/701084)
 
             **Impact:**
 
@@ -4555,7 +4555,7 @@ queries:
       windows.rdp.comPortRedirectionDisabled
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop does not map the client's COM ports into the remote session.
@@ -4680,7 +4680,7 @@ queries:
       windows.rdp.driveRedirectionDisabled
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop does not map the client's drives into the remote session.
@@ -4807,7 +4807,7 @@ queries:
       windows.rdp.lptPortRedirectionDisabled
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop does not map the client's parallel ports into the remote session.
@@ -4932,7 +4932,7 @@ queries:
       windows.rdp.passwordSavingDisabled
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that the Remote Desktop client cannot save passwords.
@@ -5057,7 +5057,7 @@ queries:
       windows.rdp.pnpDeviceRedirectionDisabled
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop does not map the client's Plug and Play devices into the remote session.
@@ -5182,7 +5182,7 @@ queries:
       windows.rdp.deleteTempDirsOnExit
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop deletes each session's temporary folders when the session ends.
@@ -5357,7 +5357,7 @@ queries:
             ```
 
             **Note:**
-            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084)
+            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/blog/microsoft-security-baselines/security-baseline-final-for-windows-10-v1903-and-windows-server-v1903/701084)
 
             More information is available at [How to enable Structured Exception Handling Overwrite Protection (SEHOP) in Windows operating systems](https://support.microsoft.com/en-us/servicing/os/windows/2018/04/how-to-enable-structured-exception-handling-overwrite-protection-sehop-in-windows-operating-systems)
 
@@ -5980,7 +5980,7 @@ queries:
             This change does not take effect until the computer has been restarted.
 
             **Note #2:**
-            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/t5/Microsoft-Security-Baselines/Security-baseline-FINAL-for-Windows-10-v1903-and-Windows-Server/ba-p/701084). Please note that this setting is **only**
+            This Group Policy path does not exist by default. An additional Group Policy template ( `SecGuide.admx/adml` ) is required - it is available from Microsoft at [this link](https://techcommunity.microsoft.com/blog/microsoft-security-baselines/security-baseline-final-for-windows-10-v1903-and-windows-server-v1903/701084). Please note that this setting is **only**
             available in the _Security baseline (FINAL) for Windows 10 v1903 and Windows Server v1903_
             (or newer) release of `SecGuide.admx/adml`, so if you previously downloaded this template, you may need to update it from a newer Microsoft baseline to get this new _NetBT NodeType configuration_
             setting.
@@ -8785,7 +8785,7 @@ queries:
       windows.rdp.secureRpcRequired
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that the Remote Desktop service requires secure RPC for its management interface.
@@ -8918,7 +8918,7 @@ queries:
       windows.rdp.securityLayer == 2
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop connections use TLS as their security layer rather than the legacy RDP native protocol.
@@ -9059,7 +9059,7 @@ queries:
       windows.rdp.networkLevelAuthentication
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop requires Network Level Authentication, so that a user authenticates before a session is created on the server.
@@ -9458,7 +9458,7 @@ queries:
       windows.rdp.minEncryptionLevel == 3
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop encrypts session traffic at the high level, using 128-bit encryption in both directions.
@@ -9598,7 +9598,7 @@ queries:
       windows.rdp.maxIdleTimeMs != 0
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop disconnects sessions that have been idle beyond a time limit.
@@ -9726,7 +9726,7 @@ queries:
       windows.rdp.maxDisconnectionTimeMs == 60000
     docs:
       refs:
-        - url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-plan-secure
+        - url: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-remotedesktopservices
           title: Secure Remote Desktop Services
       desc: |-
         This check verifies that Remote Desktop ends disconnected sessions after one minute rather than leaving them running.

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -180,7 +180,7 @@ queries:
             ```
     refs:
       - url: https://support.microsoft.com/en-us/windows/security/encryption/device-encryption-in-windows
-        title: Turn on device encryption
+        title: Device Encryption in Windows
   - uid: mondoo-windows-workstation-security-secure-boot-is-enabled
     title: Ensure Secure Boot is enabled
     impact: 100

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -179,7 +179,7 @@ queries:
                       }
             ```
     refs:
-      - url: https://support.microsoft.com/en-us/windows/turn-on-device-encryption-0c453637-bc88-5f74-5105-741561aae838#:~:text=Turn%20on%20standard%20BitLocker%20encryption,-Sign%20in%20to&text=In%20the%20search%20box%20on,is%20available%20for%20your%20device.
+      - url: https://support.microsoft.com/en-us/windows/security/encryption/device-encryption-in-windows
         title: Turn on device encryption
   - uid: mondoo-windows-workstation-security-secure-boot-is-enabled
     title: Ensure Secure Boot is enabled

--- a/content/mondoo-windows-workstation-security.mql.yaml
+++ b/content/mondoo-windows-workstation-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-windows-workstation-security
     name: Mondoo Microsoft Windows Workstation Security
-    version: 0.4.2
+    version: 0.4.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security

--- a/content/querypacks/mondoo-github-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-github-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         Gathers evidence from a GitHub organization during a security incident: organization settings, MFA enforcement, owners, members, teams, repositories, and published packages.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
@@ -116,7 +116,7 @@ packs:
             title: GitHub Organization private repositories
             docs:
               desc: |
-                Lists the organization's public repositories, reporting whether each repo's default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) by branch protection rules.
+                Lists the organization's public repositories, reporting whether each repo's default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) by branch protection rules.
             mql: |
               github.organization.repositories.
                 where( private == false ) {

--- a/content/querypacks/mondoo-github-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-github-incident-response.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-incident-response-github-org
     name: GitHub Organization Incident Response Pack
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     require:
       - provider: github

--- a/content/querypacks/mondoo-github-inventory.mql.yaml
+++ b/content/querypacks/mondoo-github-inventory.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         Inventories a GitHub organization: profile identity, contact and social links, repository count, and creation and update timestamps.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub organizations, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
@@ -108,7 +108,7 @@ packs:
       desc: |
         Inventories a GitHub user: profile identity, contact and social links, repository count, and account timestamps.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory GitHub users, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory GitHub users, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>
@@ -197,7 +197,7 @@ packs:
       desc: |
         Inventories a GitHub repository: identity and description, popularity metrics, license and language, enabled features, clone URLs, visibility, and lifecycle timestamps.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub repositories, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with read access:
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically inventory your GitHub repositories, or scan one manually with cnspec. Manual scans need a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with read access:
 
         ```bash
         export GITHUB_TOKEN=<your personal access token>

--- a/content/querypacks/mondoo-github-inventory.mql.yaml
+++ b/content/querypacks/mondoo-github-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-github-inventory-org
     name: GitHub Organization Inventory Pack
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     require:
       - provider: github
@@ -94,7 +94,7 @@ packs:
         mql: github.organization.updatedAt
   - uid: mondoo-github-inventory-user
     name: GitHub User Inventory Pack
-    version: 1.0.0
+    version: 1.0.1
     require:
       - provider: github
     authors:
@@ -183,7 +183,7 @@ packs:
         mql: github.user.updatedAt
   - uid: mondoo-github-inventory-repo
     name: GitHub Repository Inventory Pack
-    version: 1.0.0
+    version: 1.0.1
     require:
       - provider: github
     authors:

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-googleworkspace-incident-response
     name: Google Workspace Incident Response Pack
-    version: 1.1.1
+    version: 1.1.2
     license: BUSL-1.1
     require:
       - provider: google-workspace

--- a/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-googleworkplace-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         Collects Google Workspace evidence for incident investigation: configured domains, user 2-Step Verification enrollment, super admin accounts, hardware security key usage, and account recovery email addresses.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Google Workspace account, or scan it manually with cnspec. Manual scans need a service account with domain-wide delegation and the required admin read scopes; see the [Google Workspace setup guide](https://mondoo.com/docs/cnspec/saas/google-workspace):
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Google Workspace account, or scan it manually with cnspec. Manual scans need a service account with domain-wide delegation and the required admin read scopes; see the [Google Workspace setup guide](https://mondoo.com/docs/cnspec/saas/google_workspace):
 
         ```bash
         export GOOGLEWORKSPACE_CREDENTIALS=$PWD/service-account.json

--- a/content/querypacks/mondoo-okta-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-okta-incident-response.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-okta-incident-response
     name: Okta Incident Response Pack
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     require:
       - provider: okta

--- a/content/querypacks/mondoo-okta-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-okta-incident-response.mql.yaml
@@ -19,7 +19,7 @@ packs:
       desc: |
         Collects Okta configuration evidence for incident investigation: the org's user accounts and integrated applications.
 
-        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Okta org, or scan it manually with cnspec. Manual scans need an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/):
+        Enable this query pack in [Mondoo Platform](https://mondoo.com/platform) to automatically gather this evidence from your Okta org, or scan it manually with cnspec. Manual scans need an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token/main/#create-the-token):
 
         ```bash
         export OKTA_TOKEN=<your api token>

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-vmware-incident-response
     name: VMware vCenter Incident Response Pack
-    version: 1.1.0
+    version: 1.1.1
     license: BUSL-1.1
     require:
       - provider: vsphere

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -43,9 +43,9 @@ packs:
         mql: vsphere.host.services
         refs:
           - title: VMSA-2021-0002
-            url: https://www.vmware.com/security/advisories/VMSA-2021-0002.html
+            url: https://support.broadcom.com/web/ecx/support-content-notification/-/external/content/SecurityAdvisories/0/23599
           - title: How to Disable/Enable the SLP Service on VMware ESXi (76372)
-            url: https://kb.vmware.com/s/article/76372
+            url: https://knowledge.broadcom.com/external/article?legacyId=76372
       - uid: mondoo-vmware-incident-response-acceptance-level
         title: Host acceptance level
         docs:

--- a/content/querypacks/mondoo-vmware-incident-response.mql.yaml
+++ b/content/querypacks/mondoo-vmware-incident-response.mql.yaml
@@ -53,7 +53,7 @@ packs:
         mql: vsphere.host.acceptanceLevel
         refs:
           - title:
-            url: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.upgrade.doc/GUID-27BBBAB8-01EA-4238-8140-1C3C3EFC0AA6.html
+            url: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/securing-esxi-hosts.html
       - uid: mondoo-vmware-incident-response-ntp-servers
         title: Configured NTP servers
         docs:


### PR DESCRIPTION
Every `http(s)` link in `content/` and `content/querypacks` was extracted with its file:line provenance (2,196 unique URLs across 117 bundles) and fetched. This fixes what was broken.

## Result

| | before | after |
|---|---|---|
| resolving cleanly | 1,285 | 1,880 |
| redirecting | 540 | 37 (all deliberate) |
| dead (404/410) | 182 | 0 real links |

1,119 link sites changed across 62 files. No MQL, filters, impact, or compliance tags were touched.

## What was wrong

**Redirects (691 sites).** Google Cloud docs moved to `docs.cloud.google.com` (permanent redirect, and the new pages declare themselves canonical). AWS retired guide paths, GitLab dropped `.html`, GitHub reorganized its code-security tree, Tailscale replaced `/kb/<id>/` with `/docs/`, MikroTik moved off Confluence `/display/`, MDN split HTTP docs, and Google Workspace help now serves from `knowledge.workspace.google.com`.

**Hard 404s (147 links).** Whole vendor doc sets had been reorganized: Oracle moved OCI topics between `Concepts/` and `Tasks/`, Juniper consolidated the per-statement SSH pages, Fortinet renumbered FortiOS topic ids, and VMware's GUID-addressed pages vanished with the move to Broadcom TechDocs.

**Soft 404s (114 links).** These answered `200 OK`. AWS, Fortinet, VMware and Elastic redirect a removed page to its guide's landing page, so a plain status check scores them healthy forever. `docs.aws.amazon.com/kms/latest/developerguide/best-practices.html` is not a page; it is a 302 to the KMS guide index. Detecting them needed a shape rule: a redirect landing on a strict ancestor of the source path, plus several distinct sources collapsing onto one destination.

## How replacements were chosen

Resolved against the system that owns the URL, never guessed. Google Cloud, DigitalOcean, Palo Alto, Juniper, Fortinet, Slack, Databricks and Broadcom publish sitemaps; AWS publishes a `toc-contents.json` per guide; Microsoft Learn has a search API. The remainder came from the vendor's own search. Every replacement was then fetched and its `<title>` compared against the ref title it replaces.

Fragments are carried across and re-verified against the target page. Where an anchor was renamed the nearest real one is used: GitLab's `#update-group` is now `#update-group-attributes`, and AWS split `EBSEncryption.html#encryption-by-default` into its own page.

Three refs had no equivalent page left, so the title changes with the URL: NIST has no "Guide to EDR" (now SP 800-83 Rev. 1), VMware's BEAST KB article is gone (now the NVD entry for CVE-2011-3389), and Apple reused the `mchlp2996` topic id, so the lock-screen link had been silently landing on "set the date and time automatically".

## Deliberately left alone

- **No `http` → `https` upgrades.** All four plain-http URLs are correct as they stand: `http://acs.amazonaws.com/groups/global/AllUsers` is an S3 ACL grantee identifier compared inside the MQL itself, `http://HOST:9200/` is the negative control in a TLS audit, and `download.proxmox.com` has no valid certificate (upstream's own wiki uses http).
- Login walls (`myaccount.google.com`, `login.tailscale.com/admin/*`, `account.shodan.io`), which redirect because they are console links.
- Vendor error pages that answer any request (`portal.azure.com`, `entra.microsoft.com`, `intune.microsoft.com` all serve `/Error/UE_404`).
- Region-pinned console URLs, NVD's lowercase CVE ids, `manpages.debian.org/stable` (an intentional rolling alias), and guide roots that redirect to their own first topic.
- 103 links answering `401`/`403` are bot-blocking, not rot. Spot-checked Cisco, OpenStack and MySQL pages render normally.

## Verification

`cnspec policy lint` and `typos` are clean on the changed files, and all 62 parse as YAML. The one `bundle-compile-error` in `mondoo-aws-security.mql.yaml` reproduces identically on `main` and is unrelated (a local provider-version mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
