### PR TITLE
🐛 kubernetes: fix remediation steps that would not close their checks

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3486,7 +3486,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A Pod created directly is never recreated when its node fails, so the hardened spec you fix here lives only as long as that node does; apply the same setting in whichever controller owns the durable copy of this workload.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3554,7 +3554,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A CronJob mints a fresh Job at every schedule tick, so an unsafe Pod template is not a single exposure. It returns on every interval until the template itself is corrected.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3630,7 +3630,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. StatefulSet Pods carry stable identities and attached persistent volumes, so anything that reaches one of them also reaches durable data rather than throwaway state.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3702,7 +3702,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. The fix belongs in the Deployment's Pod template. A change made to a running Pod is discarded the moment the ReplicaSet recreates it.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3774,7 +3774,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. Job Pods are kept after completion for log retrieval unless a TTL controller removes them, so a Pod that violated this control can sit on a node long after its work finished.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3846,7 +3846,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. Most ReplicaSets are generated by a Deployment. Where that is the case, edit the Deployment's Pod template, because a direct edit to a generated ReplicaSet is overwritten on the next rollout.
       audit: |
-        A container's `securityContext` that sets `allowPrivilegeEscalation: true` triggers this check, as shown in the manifest below:
+        A container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The manifest below shows a violating configuration:
 
         ```yaml
         ---
@@ -3918,7 +3918,7 @@ queries:
 
         Setting it to `false` breaks images that shell out to a setuid helper, which in practice means calls to `sudo` or `ping`. The right fix is usually to grant the one capability the helper needed, such as `CAP_NET_RAW` for `ping`, rather than leaving escalation open for everything. Pair it with a non-root `runAsUser` and a dropped capability set, because `no_new_privs` prevents gaining privileges and does nothing about the ones already granted. A DaemonSet places a Pod on every node it tolerates, including control plane nodes where tolerations allow it, so a weakness in this template repeats across the whole fleet rather than on one host.
       audit: |
-        A DaemonSet container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true`. The following manifest shows the violating configuration:
+        A DaemonSet container, init container, or ephemeral container fails this check when its `securityContext` sets `allowPrivilegeEscalation: true` or omits the field, because Kubernetes treats an omitted value as `true`. The following manifest shows a violating configuration:
 
         ```yaml
         ---

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -5903,7 +5903,15 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -298,9 +298,14 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--anonymous-auth', or running with 'authentication.anonymous.enabled' defined in the kubelet configuration file, ensure that the value is set to 'false'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `authentication.anonymous.enabled` to `false` in the kubelet configuration file. If the kubelet is started with `--anonymous-auth`, set that flag to `false` as well, because a command-line flag overrides the configuration file.
 
-        Set the '--anonymous-auth' CLI parameter and/or the 'authentication.anonymous.enabled' field in the kubelet configuration file to 'false'.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/#kubelet-authentication
         title: Kubelet authentication
@@ -342,9 +347,14 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--event-qps', or running with 'eventRecordQPS' defined in the kubelet configuration file, ensure that the value is set to '0'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `eventRecordQPS` to `0` in the kubelet configuration file. If the kubelet is started with `--event-qps`, set that flag to `0` as well, because a command-line flag overrides the configuration file. A value of `0` removes the rate limit so the kubelet records every event. It does not disable events, even though `0` may read that way.
 
-        Set the `--event-qps` CLI parameter and/or the `eventRecordQPS` field in the kubelet configuration file to `0`. A value of `0` removes the rate limit so the kubelet records every event. It does not disable events, even though `0` may read that way.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -386,9 +396,14 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--make-iptables-util-chains', or running with 'makeIPTablesUtilChains' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `makeIPTablesUtilChains` to `true` in the kubelet configuration file. If the kubelet is started with `--make-iptables-util-chains`, set that flag to `true` as well, because a command-line flag overrides the configuration file.
 
-        Set the '--make-iptables-util-chains' CLI parameter and/or the 'makeIPTablesUtilChains' field in the kubelet configuration file to 'true'.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -430,11 +445,16 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--protect-kernel-defaults', or running with 'protectKernelDefaults' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
-
-        Set the `--protect-kernel-defaults` CLI parameter and/or the `protectKernelDefaults` field in the kubelet configuration file to `true`.
+        Set `protectKernelDefaults` to `true` in the kubelet configuration file. If the kubelet is started with `--protect-kernel-defaults`, set that flag to `true` as well, because a command-line flag overrides the configuration file.
 
         When this is `true`, the kubelet refuses to start if the node's kernel sysctls do not already match the values it expects. Set the required sysctls on the node first, for example through `/etc/sysctl.d/` or your node provisioning tooling, then enable this setting. If the kubelet fails to start after the change, `journalctl -u kubelet` reports which sysctl is mismatched.
+
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -476,9 +496,14 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--read-only-port', or running with 'readOnlyPort' defined in the kubelet configuration file, ensure that the value is either '0' or simply not set ('0' is the default).
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `readOnlyPort` to `0` in the kubelet configuration file. If the kubelet is started with `--read-only-port`, set that flag to `0` as well, because a command-line flag overrides the configuration file.
 
-        Set the '--read-only-port' CLI parameter or the 'readOnlyPort' field in the kubelet configuration file to '0'.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -520,11 +545,14 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--authorization-mode', or running with 'authorization.mode' defined in the kubelet configuration file, ensure that the value is not set to 'AlwaysAllow'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `authorization.mode` to `Webhook` in the kubelet configuration file. `AlwaysAllow` is the only other mode, and it fails the check. If the kubelet is started with `--authorization-mode`, set that flag to `Webhook` as well, because a command-line flag overrides the configuration file.
 
-        If the kubelet is configured with the CLI parameter '--authorization-mode', set it to something that isn't 'AlwaysAllow' (eg 'Webhook').
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
 
-        If the kubelet is configured via the kubelet config file with the 'authorization.mode' parameter, set it to something that isn't 'AlwaysAllow' (eg. 'Webhook').
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/#kubelet-authorization
         title: Kubelet authorization
@@ -586,9 +614,24 @@ queries:
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `tlsCipherSuites` in the kubelet configuration file, or `--tls-cipher-suites` on the kubelet command line, to a non-empty list that names only suites from this approved list:
 
-        Set `tlsCipherSuites` in the kubelet configuration file, or `--tls-cipher-suites` on the kubelet command line, to a non-empty list that names only suites from this approved list: `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`, `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`, `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`, `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`, `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`, `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305`, `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`. Leaving the setting unset is a failure, because the kubelet then accepts the Go runtime's default suites, and so is naming any suite outside the list.
+        - `TLS_AES_128_GCM_SHA256`
+        - `TLS_AES_256_GCM_SHA384`
+        - `TLS_CHACHA20_POLY1305_SHA256`
+        - `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+        - `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`
+        - `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+        - `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`
+        - `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`
+        - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
+        - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+        - `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
+        - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+        - `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305`
+        - `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
+
+        Leaving the setting unset is a failure, because the kubelet then accepts the Go runtime's default suites, and so is naming any suite outside the list.
 
         For example, this entry in the kubelet configuration file keeps only forward-secret AEAD suites and works with both RSA and ECDSA serving certificates:
 
@@ -603,6 +646,13 @@ queries:
         ```
 
         The command-line form takes the same names as one comma-separated value, for example `--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, and overrides the configuration file. A client that supports none of the configured suites can no longer connect to port 10250, so check what connects to the kubelet before restarting it.
+
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -649,8 +699,6 @@ queries:
 
         Check the kubelet configuration file to see whether 'tlsCertFile' and 'tlsPrivateKeyFile' are set to a non-empty path/string.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
-
         Configure the kubelet to serve HTTPS with a certificate and private key you provide instead of the self-signed pair it generates at startup.
 
         1. Obtain a serving certificate for the node that is signed by the certificate authority the API server trusts through `--kubelet-certificate-authority`, with the node's hostname and IP addresses as subject alternative names. Place the PEM certificate and its private key on the node, for example at `/var/lib/kubelet/pki/kubelet-server.crt` and `/var/lib/kubelet/pki/kubelet-server.key`, with the key readable only by root.
@@ -665,6 +713,13 @@ queries:
            Where the kubelet still uses the deprecated command-line flags, set `--tls-cert-file` and `--tls-private-key-file` to the same paths instead. The flags override the configuration file.
 
         The kubelet fails to start if it cannot read either file, so confirm both paths before restarting it.
+
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
         title: Kubernetes Kubelet Reference
@@ -706,9 +761,14 @@ queries:
       audit: |
         Check the kubelet CLI parameters to ensure '--rotate-certificates' is not set to false, and that the kubelet config file has not set 'rotateCertificates' to false.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        Set `rotateCertificates` to `true` in the kubelet configuration file. If the kubelet is started with `--rotate-certificates`, set that flag to `true` as well, because a command-line flag overrides the configuration file.
 
-        Depending on where the configuration behavior is defined (CLI parameters override config file values), update the kubelet CLI parameters to set '--rotate-certificates' to true, and/or update the kubelet configuration to set 'rotateCertificates' to true.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes:
+
+        1. Back up the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, then edit the setting there or in the kubelet flags.
+        2. Make the same change under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node. `kubeadm upgrade` rewrites the file from that ConfigMap, so a change made only in the file is lost at the next upgrade.
+        3. Restart the kubelet with `systemctl restart kubelet`.
+        4. Confirm it came back with `systemctl status kubelet`. A bad setting can stop the kubelet from starting and take the node offline.
     refs:
       - url: https://kubernetes.io/docs/tasks/tls/certificate-rotation/
         title: Configure Certificate Rotation for the Kubelet
@@ -1707,7 +1767,17 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A running Pod cannot be updated in place.** Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -2054,7 +2124,13 @@ queries:
       remediation: |
         Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -2141,7 +2217,17 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -2309,7 +2395,17 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A running Pod cannot be updated in place.** Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -2653,7 +2749,13 @@ queries:
       remediation: |
         Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -2740,7 +2842,17 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -2908,7 +3020,17 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A running Pod cannot be updated in place.** Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -3252,7 +3374,13 @@ queries:
       remediation: |
         Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -3339,7 +3467,17 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -3502,7 +3640,13 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **A running Pod cannot be updated in place.** Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         ```yaml
         ---
@@ -3574,7 +3718,7 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         ```yaml
         ---
@@ -3648,7 +3792,7 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -3720,7 +3864,7 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -3792,7 +3936,13 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         ```yaml
         ---
@@ -3864,7 +4014,13 @@ queries:
       remediation: |
         Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         ```yaml
         ---
@@ -4004,7 +4160,13 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **A running Pod cannot be updated in place.** Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         ```yaml
         ---
@@ -4088,7 +4250,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         ```yaml
         ---
@@ -4178,7 +4340,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -4264,7 +4426,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -4350,7 +4512,13 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         ```yaml
         ---
@@ -4436,7 +4604,13 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         ```yaml
         ---
@@ -4522,7 +4696,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name. Applying the change rolls the DaemonSet's Pods, which causes a brief disruption.
 
         ```yaml
         ---
@@ -4606,7 +4780,15 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **Test this in staging first.** Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        **A running Pod cannot be updated in place.** Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -4680,7 +4862,9 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **Test this in staging first.** Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         The corrected manifest:
 
@@ -4756,7 +4940,9 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        **Test this in staging first.** Applying it rolls the StatefulSet's Pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name.
 
         The corrected manifest:
 
@@ -4830,7 +5016,9 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        **Test this in staging first.** Applying it rolls the Deployment's Pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name.
 
         The corrected manifest:
 
@@ -4904,9 +5092,15 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+        **Test this in staging first.** Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -4980,7 +5174,15 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **Test this in staging first.** Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -5054,7 +5256,9 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        **Test this in staging first.** Applying it rolls the DaemonSet's Pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name.
 
         The corrected manifest:
 
@@ -5141,7 +5345,15 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        **A running Pod cannot be updated in place.** Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5248,7 +5460,9 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5358,7 +5572,9 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5464,7 +5680,9 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5571,9 +5789,15 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
 
-        The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5785,7 +6009,9 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name. Applying the change rolls the DaemonSet's Pods, which causes a brief disruption.
+
+        **The image must run as a non-root user.** Otherwise the Pods fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5871,7 +6097,13 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let `hostNetwork` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **A running Pod cannot be updated in place.** Kubernetes does not let `hostNetwork` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -5942,7 +6174,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         The corrected manifest:
 
@@ -6015,7 +6247,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6086,7 +6318,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6157,7 +6389,13 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -6229,7 +6467,13 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -6301,7 +6545,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name. Applying the change rolls the DaemonSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6369,7 +6613,13 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let `hostPID` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **A running Pod cannot be updated in place.** Kubernetes does not let `hostPID` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -6438,7 +6688,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         The corrected manifest:
 
@@ -6509,7 +6759,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6578,7 +6828,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6647,7 +6897,13 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -6716,7 +6972,13 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -6786,7 +7048,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name. Applying the change rolls the DaemonSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -6854,7 +7116,13 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let `hostIPC` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
+        **A running Pod cannot be updated in place.** Kubernetes does not let `hostIPC` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Pod with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod.
+        3. Recreate the Pod with `kubectl apply -f <file>.yaml`.
+
+        The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -6924,7 +7192,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
+        **A CronJob change applies only to the Jobs it starts afterward.** Jobs that are already running keep their original settings until they finish. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit cronjob/<name>`, where `<name>` is the CronJob's name.
 
         The corrected manifest:
 
@@ -6996,7 +7264,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit statefulset/<name>`, where `<name>` is the StatefulSet's name. Applying the change rolls the StatefulSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -7065,7 +7333,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit deployment/<name>`, where `<name>` is the Deployment's name. Applying the change rolls the Deployment's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -7135,7 +7403,13 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        **A Job cannot be updated in place.** Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. To apply the fix:
+
+        1. Update the source manifest.
+        2. Delete the Job with `kubectl delete -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job.
+        3. Recreate the Job with `kubectl apply -f <file>.yaml`.
+
+        Deleting the Job also deletes its Pods and stops any work they are still running. The new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -7205,7 +7479,13 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
+        **A ReplicaSet does not replace the Pods it already runs.** When its template changes, its running Pods keep the old setting until they are replaced. To apply the fix:
+
+        1. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit replicaset/<name>`, where `<name>` is the ReplicaSet's name.
+        2. List the ReplicaSet's Pods with `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`.
+        3. Delete those Pods one at a time with `kubectl delete pod <pod-name>`. The ReplicaSet recreates each deleted Pod from the corrected template.
+
+        Capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -7275,7 +7555,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or edit the live object with `kubectl edit daemonset/<name>`, where `<name>` is the DaemonSet's name. Applying the change rolls the DaemonSet's Pods, which causes a brief disruption.
 
         The corrected manifest:
 
@@ -8677,7 +8957,11 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8749,7 +9033,11 @@ queries:
                           cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8823,7 +9111,11 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8895,7 +9187,11 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8967,7 +9263,11 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9039,7 +9339,11 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9111,7 +9415,11 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core. A container that reaches its CPU limit is throttled rather than stopped.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9181,7 +9489,11 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9255,7 +9567,11 @@ queries:
                           memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9331,7 +9647,11 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9405,7 +9725,11 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9479,7 +9803,11 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9553,7 +9881,11 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9627,7 +9959,11 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`.
+
+        Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example. A container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts.
+
+        The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -12017,7 +12353,11 @@ queries:
         kubectl get pods -A -o json | jq -r '.items[] | select( .spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A running Pod's security context cannot be changed in place, so delete the Pod and create it again from the updated manifest, which stops the workload until the new Pod starts.
+        Update the Pod, or the controller that created it, to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+
+        **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
+
+        A running Pod's security context cannot be changed in place, so delete the Pod and create it again from the updated manifest, which stops the workload until the new Pod starts.
 
         Example manifest:
 
@@ -12143,7 +12483,11 @@ queries:
         kubectl get replicasets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update ReplicaSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A ReplicaSet does not replace the Pods it already runs when its template changes, so delete those Pods after applying the change to have the ReplicaSet recreate them from the updated template.
+        Update ReplicaSets to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+
+        **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
+
+        A ReplicaSet does not replace the Pods it already runs when its template changes, so delete those Pods after applying the change to have the ReplicaSet recreate them from the updated template.
 
         Example manifest:
 
@@ -12207,7 +12551,11 @@ queries:
         kubectl get jobs -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Jobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A Job's Pod template cannot be changed after the Job is created, so delete the Job with `kubectl delete job <name> -n <namespace>` and create it again from the updated manifest. Deleting the Job also deletes its Pods and stops a run in progress.
+        Update Jobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+
+        **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
+
+        A Job's Pod template cannot be changed after the Job is created, so delete the Job with `kubectl delete job <name> -n <namespace>` and create it again from the updated manifest. Deleting the Job also deletes its Pods and stops a run in progress.
 
         Example manifest:
 
@@ -12399,7 +12747,11 @@ queries:
         kubectl get cronjobs -A -o json | jq -r '.items[] | select( .spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update CronJobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running continue with their original settings until they finish.
+        Update CronJobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+
+        **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
+
+        The change applies only to Jobs the CronJob starts after the update. Jobs that are already running continue with their original settings until they finish.
 
         Example manifest:
 
@@ -13103,7 +13455,12 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Create an `EncryptionConfiguration` file whose first provider for `secrets` is a KMS v2 provider or `secretbox`. Do not use `aescbc`, which the Kubernetes documentation rates as weak because CBC mode is exposed to padding oracle attacks, and never list `identity` first, because it stores data unencrypted. A `secretbox` configuration looks like this, where `secret` is a random 32-byte key encoded in base64, such as the output of `head -c 32 /dev/urandom | base64`:
+        Create an `EncryptionConfiguration` file whose first provider for `secrets` is a KMS v2 provider or `secretbox`.
+
+        - Do not use `aescbc`. The Kubernetes documentation rates it as weak because CBC mode is exposed to padding oracle attacks.
+        - Never list `identity` first, because it stores data unencrypted.
+
+        A `secretbox` configuration looks like this, where `secret` is a random 32-byte key encoded in base64, such as the output of `head -c 32 /dev/urandom | base64`:
 
         ```yaml
         apiVersion: apiserver.config.k8s.io/v1
@@ -13366,7 +13723,11 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Generate a client certificate and key for the API server, signed by the CA that the kubelets trust through their `--client-ca-file`, and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-kubelet-client.crt` and `/etc/kubernetes/pki/apiserver-kubelet-client.key`. The identity in the certificate must be allowed to use the kubelet API, which on RBAC clusters means binding its user or group to the `system:kubelet-api-admin` ClusterRole; otherwise `kubectl logs` and `kubectl exec` are refused by the kubelet. Save the file so the kubelet restarts the static pod.
+        1. Generate a client certificate and key for the API server, signed by the CA that the kubelets trust through their `--client-ca-file`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-kubelet-client.crt` and `/etc/kubernetes/pki/apiserver-kubelet-client.key`.
+        2. Pass them with `--kubelet-client-certificate` and `--kubelet-client-key`.
+        3. Allow the identity in the certificate to use the kubelet API. On RBAC clusters, bind its user or group to the `system:kubelet-api-admin` ClusterRole. Without that binding the kubelet refuses `kubectl logs` and `kubectl exec`.
+        4. Save the file so the kubelet restarts the static pod.
+
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: Control Plane to Node communication
@@ -13531,7 +13892,12 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Generate a client certificate and key for the API server signed by the etcd CA, and pass them as `--etcd-certfile` and `--etcd-keyfile`, with the etcd CA certificate as `--etcd-cafile`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-etcd-client.crt`, `/etc/kubernetes/pki/apiserver-etcd-client.key`, and `/etc/kubernetes/pki/etcd/ca.crt`. Point `--etcd-servers` at `https://` endpoints, and confirm that etcd itself runs with `--client-cert-auth=true` and the same CA in `--trusted-ca-file`, since otherwise etcd accepts connections without a client certificate. Save the file so the kubelet restarts the static pod.
+        1. Generate a client certificate and key for the API server, signed by the etcd CA.
+        2. Pass them as `--etcd-certfile` and `--etcd-keyfile`, with the etcd CA certificate as `--etcd-cafile`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-etcd-client.crt`, `/etc/kubernetes/pki/apiserver-etcd-client.key`, and `/etc/kubernetes/pki/etcd/ca.crt`.
+        3. Point `--etcd-servers` at `https://` endpoints.
+        4. Confirm that etcd itself runs with `--client-cert-auth=true` and the same CA in `--trusted-ca-file`. Without both, etcd accepts connections that present no client certificate.
+        5. Save the file so the kubelet restarts the static pod.
+
     refs:
       - url: https://kubernetes.io/docs/setup/best-practices/certificates/
         title: Kubernetes - PKI certificates and requirements
@@ -13801,7 +14167,11 @@ queries:
       remediation:
         - id: kubectl
           desc: |
-            Remove the cluster-admin grant from the service account and replace it with a narrowly scoped Role bound only in the namespaces the workload uses. The grant can come from a ClusterRoleBinding or from a RoleBinding that references `cluster-admin` or another role allowing every verb on every resource. Deleting a binding removes access for every subject it lists, so inspect the subjects first, and if other subjects remain, run `kubectl edit` on the binding and remove only the service account entry. Replace `pods,configmaps` and `get,list,watch` below with the resources and verbs the workload actually calls:
+            Remove the cluster-admin grant from the service account and replace it with a narrowly scoped Role bound only in the namespaces the workload uses. The grant can come from a ClusterRoleBinding or from a RoleBinding that references `cluster-admin` or another role allowing every verb on every resource.
+
+            **Check the binding's other subjects before deleting it.** Deleting a binding removes access for every subject it lists. If other subjects remain, run `kubectl edit` on the binding and remove only the service account entry.
+
+            Replace `pods,configmaps` and `get,list,watch` below with the resources and verbs the workload actually calls:
 
             ```bash
             # Inspect who else the binding grants access to
@@ -14071,7 +14441,9 @@ queries:
           desc: |
             Delete the over-broad binding and replace it with a binding to a least-privilege role, or scope the access to specific namespaces with a RoleBinding. Check the binding's subjects with `kubectl get clusterrolebinding <binding-name> -o yaml` first, because deleting it revokes cluster-admin from all of them at once.
 
-            Do not delete `kubeadm:cluster-admins` on a kubeadm cluster. It grants cluster-admin to the group in `/etc/kubernetes/admin.conf`, the credential kubeadm and administrators use, so deleting it locks that kubeconfig out. Record it in the excluded cluster role bindings property instead. In the command below, the built-in `view` ClusterRole grants read-only access to most namespaced objects and excludes Secrets:
+            **Do not delete `kubeadm:cluster-admins` on a kubeadm cluster.** It grants cluster-admin to the group in `/etc/kubernetes/admin.conf`, the credential kubeadm and administrators use, so deleting it locks that kubeconfig out. Record it in the excluded cluster role bindings property instead.
+
+            In the command below, the built-in `view` ClusterRole grants read-only access to most namespaced objects and excludes Secrets:
 
             ```bash
             kubectl delete clusterrolebinding <binding-name>

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -298,7 +298,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--anonymous-auth', or running with 'authentication.anonymous.enabled' defined in the kubelet configuration file, ensure that the value is set to 'false'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Set the '--anonymous-auth' CLI parameter and/or the 'authentication.anonymous.enabled' field in the kubelet configuration file to 'false'.
     refs:
@@ -342,7 +342,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--event-qps', or running with 'eventRecordQPS' defined in the kubelet configuration file, ensure that the value is set to '0'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Set the `--event-qps` CLI parameter and/or the `eventRecordQPS` field in the kubelet configuration file to `0`. A value of `0` removes the rate limit so the kubelet records every event. It does not disable events, even though `0` may read that way.
     refs:
@@ -386,7 +386,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--make-iptables-util-chains', or running with 'makeIPTablesUtilChains' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Set the '--make-iptables-util-chains' CLI parameter and/or the 'makeIPTablesUtilChains' field in the kubelet configuration file to 'true'.
     refs:
@@ -430,7 +430,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--protect-kernel-defaults', or running with 'protectKernelDefaults' defined in the kubelet configuration file, ensure that the value is set to 'true'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Set the `--protect-kernel-defaults` CLI parameter and/or the `protectKernelDefaults` field in the kubelet configuration file to `true`.
 
@@ -476,7 +476,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--read-only-port', or running with 'readOnlyPort' defined in the kubelet configuration file, ensure that the value is either '0' or simply not set ('0' is the default).
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Set the '--read-only-port' CLI parameter or the 'readOnlyPort' field in the kubelet configuration file to '0'.
     refs:
@@ -520,7 +520,7 @@ queries:
       audit: |
         If running the kubelet with the CLI parameter '--authorization-mode', or running with 'authorization.mode' defined in the kubelet configuration file, ensure that the value is not set to 'AlwaysAllow'.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         If the kubelet is configured with the CLI parameter '--authorization-mode', set it to something that isn't 'AlwaysAllow' (eg 'Webhook').
 
@@ -586,13 +586,23 @@ queries:
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
-        Define the list of allowed TLS ciphers to include only items from the strong list of ciphers.
+        Set `tlsCipherSuites` in the kubelet configuration file, or `--tls-cipher-suites` on the kubelet command line, to a non-empty list that names only suites from this approved list: `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`, `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`, `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`, `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`, `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`, `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305`, `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`. Leaving the setting unset is a failure, because the kubelet then accepts the Go runtime's default suites, and so is naming any suite outside the list.
 
-        If the kubelet is configured with the CLI parameter '--tls-cipher-suites', update the list (or define the parameter) to only include strong ciphers.
+        For example, this entry in the kubelet configuration file keeps only forward-secret AEAD suites and works with both RSA and ECDSA serving certificates:
 
-        If the kubelet is configured via the kubelet config file with the 'tlsCipherSuites' parameter, update the list (or create an entry for 'tlsCipherSuites') to only include string ciphers.
+        ```yaml
+        tlsCipherSuites:
+          - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+          - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+          - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ```
+
+        The command-line form takes the same names as one comma-separated value, for example `--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`, and overrides the configuration file. A client that supports none of the configured suites can no longer connect to port 10250, so check what connects to the kubelet before restarting it.
     refs:
       - url: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
         title: Kubelet configuration
@@ -635,17 +645,26 @@ queries:
       audit: |
         The kubelet CLI parameters override values in the kubelet configuration file.
 
-        Check the kubelet CLI parameters to see whether '--tls-cert-file' and '--tls-private-key' are set to a non-empty path/string.
+        Check the kubelet CLI parameters to see whether '--tls-cert-file' and '--tls-private-key-file' are set to a non-empty path/string.
 
         Check the kubelet configuration file to see whether 'tlsCertFile' and 'tlsPrivateKeyFile' are set to a non-empty path/string.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
-        Configure the kubelet to use a user-provided certificate/key pair for serving up HTTPS.
+        Configure the kubelet to serve HTTPS with a certificate and private key you provide instead of the self-signed pair it generates at startup.
 
-        After acquiring the TLS certificate/key pair, update the kubelet configuration file
+        1. Obtain a serving certificate for the node that is signed by the certificate authority the API server trusts through `--kubelet-certificate-authority`, with the node's hostname and IP addresses as subject alternative names. Place the PEM certificate and its private key on the node, for example at `/var/lib/kubelet/pki/kubelet-server.crt` and `/var/lib/kubelet/pki/kubelet-server.key`, with the key readable only by root.
 
-        Or if using the deprecated kubelet CLI parameters, update the '--tls-cert-file' and '--tls-private-key-file' parameters to use the new certificate/key.
+        2. In the kubelet configuration file, set `tlsCertFile` to the certificate path and `tlsPrivateKeyFile` to the key path. Both must be set to a non-empty path:
+
+           ```yaml
+           tlsCertFile: /var/lib/kubelet/pki/kubelet-server.crt
+           tlsPrivateKeyFile: /var/lib/kubelet/pki/kubelet-server.key
+           ```
+
+           Where the kubelet still uses the deprecated command-line flags, set `--tls-cert-file` and `--tls-private-key-file` to the same paths instead. The flags override the configuration file.
+
+        The kubelet fails to start if it cannot read either file, so confirm both paths before restarting it.
     refs:
       - url: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
         title: Kubernetes Kubelet Reference
@@ -687,7 +706,7 @@ queries:
       audit: |
         Check the kubelet CLI parameters to ensure '--rotate-certificates' is not set to false, and that the kubelet config file has not set 'rotateCertificates' to false.
       remediation: |
-        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
+        These settings apply to self-managed nodes only. On managed services such as EKS, GKE, and AKS the kubelet is provider-managed and may not be configurable. On kubeadm nodes, back up and edit the kubelet configuration file, usually `/var/lib/kubelet/config.yaml`, or its flags, then run `systemctl restart kubelet`. Because `kubeadm upgrade` overwrites that file from the `kubelet-config` ConfigMap in `kube-system`, a change made only in the file is lost at the next upgrade. To keep it, also change the setting under `data.kubelet` with `kubectl edit cm -n kube-system kubelet-config`, then run `kubeadm upgrade node phase kubelet-config` on each node before restarting the kubelet. A bad setting can stop the kubelet from starting and take the node offline, so verify with `systemctl status kubelet` after restarting.
 
         Depending on where the configuration behavior is defined (CLI parameters override config file values), update the kubelet CLI parameters to set '--rotate-certificates' to true, and/or update the kubelet configuration to set 'rotateCertificates' to true.
     refs:
@@ -888,6 +907,8 @@ queries:
           desc: |
             **Using Ansible**
 
+            Set `path` to the file named by `authentication.x509.clientCAFile` in the kubelet configuration. The example uses the GKE default. On kubeadm nodes the file is `/etc/kubernetes/pki/ca.crt`. The task fails on any node where the path does not exist:
+
             ```yaml
             ---
             - name: Secure kubelet certificate authorities file
@@ -905,6 +926,8 @@ queries:
         - id: bash
           desc: |
             **Using a Bash Script**
+
+            Replace `/etc/srv/kubernetes/pki/ca-certificates.crt`, the GKE default, with the file named by `authentication.x509.clientCAFile` in the kubelet configuration. On kubeadm nodes that is `/etc/kubernetes/pki/ca.crt`:
 
             ```bash
             #!/bin/bash
@@ -1109,7 +1132,14 @@ queries:
             ps -ef | grep etcd
             ```
 
-            Run the below command:
+            The directory must be owned by an `etcd` account. Check whether that account exists with `id etcd`. If it reports `no such user`, which is the case on kubeadm nodes where etcd runs as root in a static Pod, create a system group and account first, otherwise `chown` fails with `invalid user`:
+
+            ```bash
+            groupadd --system etcd
+            useradd --system --gid etcd --home-dir /var/lib/etcd --shell /usr/sbin/nologin etcd
+            ```
+
+            Then restrict the directory to that account with mode `700`, so no other local user can read or modify the stored cluster state. The commands use `/var/lib/etcd`; if that directory does not exist on the node, use the `--data-dir` value found above instead. An etcd process running as root keeps working after the change:
 
             ```bash
             chmod 700 /var/lib/etcd
@@ -1487,7 +1517,7 @@ queries:
             chown -R root:root /etc/kubernetes/pki/
             ```
 
-            or if your PKI/SSL directory is located elsewhere, adjust the path accordingly such as:
+            If the API server's `--etcd-certfile` flag points to a file outside `/etc/kubernetes/pki`, the directory that holds that file is the one that must be owned by `root:root`, so run the command against it instead, such as:
 
             ```bash
             chown -R root:root /etc/kubernetes/ssl/
@@ -1551,9 +1581,9 @@ queries:
       remediation: |
         This applies to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and this is handled for you.
 
-        The `--insecure-port` and `--insecure-bind-address` flags were removed in Kubernetes 1.20, and the insecure port no longer exists on supported clusters. On 1.20 and later, no action is needed beyond confirming you are on a supported version.
+        Kubernetes 1.20 removed the API server's ability to serve on an insecure port. From 1.20 through 1.23 the `--insecure-port` flag still exists but accepts only `0`, and Kubernetes 1.24 removed it together with `--insecure-bind-address`, `--address`, and `--port`, so on 1.24 and later the API server does not start with those flags present. On any supported version the insecure port cannot be opened.
 
-        On a self-managed cluster older than 1.20, back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, ensure no `--insecure-port` (set it to `0`) and no `--insecure-bind-address` remain, then save the file so the kubelet restarts the static pod. The strongest fix is to upgrade to a supported Kubernetes version where the insecure port is gone entirely.
+        On a self-managed cluster older than 1.24, back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, set `--insecure-port=0`, remove any `--insecure-bind-address`, then save the file so the kubelet restarts the static pod. On clusters older than 1.20 a value of `0` closes the unauthenticated HTTP listener. The strongest fix is to upgrade to a supported Kubernetes version where the insecure port is gone entirely.
     refs:
       - url: https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security
         title: Controlling Access to the Kubernetes API - Transport security
@@ -1677,7 +1707,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
 
         ```yaml
         ---
@@ -2022,7 +2052,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
 
         ```yaml
         ---
@@ -2107,7 +2137,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
 
         ```yaml
         ---
@@ -2275,7 +2305,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
 
         ```yaml
         ---
@@ -2617,7 +2647,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
 
         ```yaml
         ---
@@ -2702,7 +2732,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
 
         ```yaml
         ---
@@ -2870,7 +2900,7 @@ queries:
                   name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let `volumes` change on a running Pod, so `kubectl apply` and `kubectl edit` reject removing the volume with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The corrected manifest:
 
         ```yaml
         ---
@@ -3212,7 +3242,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
 
         ```yaml
         ---
@@ -3297,7 +3327,7 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The corrected manifest:
 
         ```yaml
         ---
@@ -3458,9 +3488,9 @@ queries:
                 allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         ```yaml
         ---
@@ -3530,9 +3560,9 @@ queries:
                         allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         ```yaml
         ---
@@ -3604,7 +3634,7 @@ queries:
                     allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
         Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
@@ -3676,7 +3706,7 @@ queries:
                     allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
         Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
 
@@ -3748,9 +3778,9 @@ queries:
                     allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         ```yaml
         ---
@@ -3820,9 +3850,9 @@ queries:
                     allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in each container's `securityContext`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         ```yaml
         ---
@@ -3892,7 +3922,7 @@ queries:
                     allowPrivilegeEscalation: true
         ```
       remediation: |
-        Set `allowPrivilegeEscalation` to `false` in every container's `securityContext`, or remove the field so it defaults to `false`. The following DaemonSet manifest applies the safe configuration:
+        Set `allowPrivilegeEscalation` to `false` in the `securityContext` of every container and init container. Set the field explicitly, because Kubernetes treats an omitted `allowPrivilegeEscalation` as `true`, so a container without it still allows privilege escalation. The following DaemonSet manifest applies the safe configuration:
 
         ```yaml
         ---
@@ -3962,7 +3992,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         ```yaml
         ---
@@ -4046,7 +4076,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         ```yaml
         ---
@@ -4308,7 +4338,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         ```yaml
         ---
@@ -4394,7 +4424,7 @@ queries:
       remediation: |
         Remove the `privileged` setting from each container's `securityContext`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         ```yaml
         ---
@@ -4562,9 +4592,9 @@ queries:
                 readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -4636,9 +4666,9 @@ queries:
                         readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         The corrected manifest:
 
@@ -4712,7 +4742,7 @@ queries:
                     readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
         Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
 
@@ -4786,7 +4816,7 @@ queries:
                     readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
         Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
 
@@ -4860,9 +4890,9 @@ queries:
                     readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -4934,9 +4964,9 @@ queries:
                     readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
+        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -5008,7 +5038,7 @@ queries:
                     readOnlyRootFilesystem: true
         ```
       remediation: |
-        Set `readOnlyRootFilesystem` to `true` in each container's `securityContext`. The manifest below shows the required configuration:
+        Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
         Test this in staging first. Applying it rolls the workload's pods, and any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object.
 
@@ -5095,9 +5125,9 @@ queries:
               image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Kubernetes does not let a container's `securityContext` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5202,9 +5232,9 @@ queries:
                       image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5312,7 +5342,7 @@ queries:
                   image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
         Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
@@ -5418,7 +5448,7 @@ queries:
                   image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
         Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
@@ -5525,9 +5555,9 @@ queries:
                   image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5631,9 +5661,9 @@ queries:
                   image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 
@@ -5737,7 +5767,7 @@ queries:
                   image: index.docker.io/yournamespace/repository
         ```
       remediation: |
-        Set `runAsNonRoot` to `true` in each container's `securityContext`. The manifest below shows the required configuration.
+        Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
         Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
@@ -5825,7 +5855,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let `hostNetwork` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -5896,7 +5926,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         The corrected manifest:
 
@@ -6111,7 +6141,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -6183,7 +6213,7 @@ queries:
       remediation: |
         Set `hostNetwork` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -6323,7 +6353,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let `hostPID` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -6392,7 +6422,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         The corrected manifest:
 
@@ -6601,7 +6631,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -6670,7 +6700,7 @@ queries:
       remediation: |
         Set `hostPID` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -6808,7 +6838,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let `hostIPC` change on a running Pod, so `kubectl apply` and `kubectl edit` reject the update with `pod updates may not change fields`. Update the source manifest, then recreate the Pod with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Pod. The Pod is unavailable from the delete until its replacement is ready.
 
         The corrected manifest:
 
@@ -6878,7 +6908,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running keep their original settings until they finish.
 
         The corrected manifest:
 
@@ -7089,7 +7119,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -7159,7 +7189,7 @@ queries:
       remediation: |
         Set `hostIPC` to `false` in the pod `spec`, or omit the field so it defaults to `false`. The manifest below shows the corrected configuration.
 
-        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit <kind>/<name>` to edit the live object. Applying the change rolls the workload's pods, which causes a brief disruption.
+        Update the source manifest and apply it with `kubectl apply -f <file>.yaml`, or run `kubectl edit replicaset/<name>` to edit the live object, where `<name>` is the ReplicaSet's name. A ReplicaSet does not update Pods that already exist when its template changes, so its running Pods keep the old setting until they are replaced. Delete them one at a time with `kubectl delete pod <pod-name>`, taking each `<pod-name>` from `kubectl get pods -l <key>=<value>`, where `<key>=<value>` is a label from the ReplicaSet's `spec.selector.matchLabels`. The ReplicaSet recreates each deleted Pod from the corrected template, and capacity drops by one Pod while each replacement starts.
 
         The corrected manifest:
 
@@ -7312,7 +7342,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: v1
@@ -7417,7 +7447,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: batch/v1
@@ -7526,7 +7556,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: apps/v1
@@ -7631,7 +7661,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: apps/v1
@@ -7736,7 +7766,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: batch/v1
@@ -7841,7 +7871,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: apps/v1
@@ -7946,7 +7976,7 @@ queries:
         Even when the deprecated field '.spec.serviceAccount' is not specified, it will get populated by Kubernetes inside the cluster when a manifest is applied.
         Because of that, we also need to check for the field.
       remediation: |
-        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. For example:
+        Create a ServiceAccount specifically for the Pod with only the permissions it needs when interacting with the Kubernetes API. Update the Pod's `spec.serviceAccountName` to the name of the ServiceAccount created for the Pod. If the manifest also sets the deprecated `serviceAccount` field, remove it or set it to the same name, because the check fails when the two fields name different accounts. For example:
 
         ```yaml
         apiVersion: apps/v1
@@ -8049,6 +8079,8 @@ queries:
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
 
+        The check passes only when every container, init container, and ephemeral container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
+
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
@@ -8131,6 +8163,8 @@ queries:
         For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
 
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
@@ -8217,6 +8251,8 @@ queries:
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
 
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
+
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
@@ -8299,6 +8335,8 @@ queries:
         For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
 
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
@@ -8383,6 +8421,8 @@ queries:
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
 
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
+
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
@@ -8465,6 +8505,8 @@ queries:
         For true consistency, pin each `image` to an immutable digest with `repo@sha256:...`. A digest always resolves to the exact same image, so every node and every restart runs identical bytes. A mutable tag can be repointed to different content over time, so it does not guarantee the same image.
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
+
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
 
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
@@ -8549,6 +8591,8 @@ queries:
 
         Setting `imagePullPolicy: Always` is about freshness, not determinism. It makes the node re-check the registry on every start instead of serving a cached layer, but if the `image` is a mutable tag, `Always` can pull a different digest than before. Use `Always` together with digest pinning when you want the node to confirm the pinned image is present without trusting its local cache.
 
+        The check passes only when every container and init container sets `imagePullPolicy: Always` explicitly and references its image by a tag that does not begin with `latest`, or by a digest. An image with no tag fails. Omitting `imagePullPolicy` is not enough, because Kubernetes sets it to `IfNotPresent` for any image referenced by a digest or by a tag other than `latest`.
+
         The manifest below pins a tag and sets `imagePullPolicy: Always`. For the strongest guarantee, replace the tag with a digest, for example `images.my-company.example/app@sha256:<digest>`:
 
         ```yaml
@@ -8617,7 +8661,7 @@ queries:
                   cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8689,7 +8733,7 @@ queries:
                           cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8763,7 +8807,7 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8835,7 +8879,7 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8907,7 +8951,7 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -8979,7 +9023,7 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9051,7 +9095,7 @@ queries:
                       cpu: "500m"
         ```
       remediation: |
-        Declare a CPU value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a CPU value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak CPU use. The `500m` below is an example that means half of one CPU core, and a container that reaches its CPU limit is throttled rather than stopped. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9121,7 +9165,7 @@ queries:
                   memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9195,7 +9239,7 @@ queries:
                           memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9271,7 +9315,7 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9345,7 +9389,7 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9419,7 +9463,7 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9493,7 +9537,7 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9567,7 +9611,7 @@ queries:
                       memory: "1Gi"
         ```
       remediation: |
-        Declare a memory value under `resources.limits` for each container. The manifest below shows the required configuration:
+        Declare a memory value under `resources.limits` for every container and every init container in the Pod template. The check fails if any one of them omits the limit or sets it to `0`. Base the value on the container's observed peak memory use with some headroom. The `1Gi` below is an example, and a container that exceeds its memory limit is killed and restarted, so a limit set too low causes restarts. The manifest below shows the required configuration:
 
         ```yaml
         ---
@@ -9632,7 +9676,7 @@ queries:
         Check to ensure no Pods have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -9714,7 +9758,7 @@ queries:
         Check to ensure no DaemonSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get daemonsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get daemonsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -9800,7 +9844,7 @@ queries:
         Check to ensure no ReplicaSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get replicasets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get replicasets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -9886,7 +9930,7 @@ queries:
         Check to ensure no Jobs have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get jobs -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get jobs -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -9972,7 +10016,7 @@ queries:
         Check to ensure no Deployments have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get deployments -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get deployments -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -10058,7 +10102,7 @@ queries:
         Check to ensure no StatefulSets have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get statefulsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get statefulsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -10144,7 +10188,7 @@ queries:
         Check to ensure no CronJobs have explicitly asked for the NET_RAW capability (or asked for ALL capabilities which includes NET_RAW):
 
         ```bash
-        kubectl get cronjobs -A -o json | jq -r '.items[] | select(.spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get cronjobs -A -o json | jq -r '.items[] | select(.spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|NET_RAW")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
 
 
@@ -10235,7 +10279,7 @@ queries:
         Check to ensure no Pods have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Pods that explicitly add the SYS_ADMIN or ALL capability, update the Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10296,7 +10340,7 @@ queries:
         Check to ensure no DaemonSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get daemonsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get daemonsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any DaemonSets that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10359,7 +10403,7 @@ queries:
         Check to ensure no ReplicaSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get replicasets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get replicasets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any ReplicaSets that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10422,7 +10466,7 @@ queries:
         Check to ensure no Jobs have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get jobs -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get jobs -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Jobs that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10484,7 +10528,7 @@ queries:
         Check to ensure no Deployments have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get deployments -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get deployments -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Deployments that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10547,7 +10591,7 @@ queries:
         Check to ensure no StatefulSets have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get statefulsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get statefulsets -A -o json | jq -r '.items[] | select(.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any StatefulSets that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10610,7 +10654,7 @@ queries:
         Check to ensure no CronJobs have explicitly asked for the SYS_ADMIN capability (or asked for ALL capabilities which includes SYS_ADMIN):
 
         ```bash
-        kubectl get cronjobs -A -o json | jq -r '.items[] | select(.spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.add | . != empty and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get cronjobs -A -o json | jq -r '.items[] | select(.spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.add | . != null and any(.[] ; ascii_upcase | test("ALL|SYS_ADMIN")) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any CronJobs that explicitly add the SYS_ADMIN or ALL capability, update them to ensure they do not ask for the SYS_ADMIN or ALL capability:
@@ -10676,7 +10720,7 @@ queries:
         Check to ensure no Pods are binding any of their containers to a host port:
 
         ```bash
-        kubectl get pods -A -o json | jq -r '.items[] | select( (.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get pods -A -o json | jq -r '.items[] | select( (.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any Pods that bind to a host port, update the Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to ensure they do not bind to a host port:
@@ -10741,7 +10785,7 @@ queries:
         Check to ensure no DaemonSets are binding any of their containers to a host port:
 
         ```bash
-        kubectl get daemonsets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get daemonsets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any DaemonSets that bind to a host port, update the DaemonSets to ensure they do not bind to a host port:
@@ -10808,7 +10852,7 @@ queries:
         Check to ensure no ReplicaSets are binding any of their containers to a host port:
 
         ```bash
-        kubectl get replicasets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get replicasets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any ReplicaSets that bind to a host port, update the ReplicaSets to ensure they do not bind to a host port:
@@ -10875,7 +10919,7 @@ queries:
         Check to ensure no Jobs are binding any of their containers to a host port:
 
         ```bash
-        kubectl get jobs -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get jobs -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any Jobs that bind to a host port, update the Jobs to ensure they do not bind to a host port:
@@ -10942,7 +10986,7 @@ queries:
         Check to ensure no Deployments are binding any of their containers to a host port:
 
         ```bash
-        kubectl get deployments -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get deployments -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any Deployments that bind to a host port, update the Deployments to ensure they do not bind to a host port:
@@ -11009,7 +11053,7 @@ queries:
         Check to ensure no StatefulSets are binding any of their containers to a host port:
 
         ```bash
-        kubectl get statefulsets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get statefulsets -A -o json | jq -r '.items[] | select( (.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any StatefulSets that bind to a host port, update the StatefulSets to ensure they do not bind to a host port:
@@ -11076,7 +11120,7 @@ queries:
         Check to ensure no CronJobs are binding any of their containers to a host port:
 
         ```bash
-        kubectl get cronjobs -A -o json | jq -r '.items[] | select( (.spec.jobTemplate.spec.template.spec.containers[].ports | . != empty and any(.[].hostPort; . != empty)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
+        kubectl get cronjobs -A -o json | jq -r '.items[] | select( (.spec.jobTemplate.spec.template.spec.containers[].ports | . != null and any(.[].hostPort; . != null)  ) ) | .metadata.namespace + "/" + .metadata.name'  | uniq
         ```
       remediation: |
         For any CronJobs that bind to a host port, update the CronJobs to ensure they do not bind to a host port:
@@ -11198,7 +11242,7 @@ queries:
         Check to ensure no containers in a Pod are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get pods -A -o json | jq -r '.items[] | [.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get pods -A -o json | jq -r '.items[] | [.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Pod containers that mount a hostPath volume as read-write, update them (or the Deployment/StatefulSet/etc that created the Pod):
@@ -11279,7 +11323,7 @@ queries:
         Check to ensure no containers in a DaemonSet are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get daemonsets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get daemonsets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any DaemonSet containers that mount a hostPath volume as read-write, update them:
@@ -11362,7 +11406,7 @@ queries:
         Check to ensure no containers in a ReplicaSet are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get replicasets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get replicasets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any ReplicaSet containers that mount a hostPath volume as read-write, update them:
@@ -11445,7 +11489,7 @@ queries:
         Check to ensure no containers in a Job are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get jobs -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get jobs -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Job containers that mount a hostPath volume as read-write, update them:
@@ -11528,7 +11572,7 @@ queries:
         Check to ensure no containers in a Deployment are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get deployments -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get deployments -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any Deployment containers that mount a hostPath volume as read-write, update them:
@@ -11611,7 +11655,7 @@ queries:
         Check to ensure no containers in a StatefulSet are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get statefulsets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get statefulsets -A -o json | jq -r '.items[] | [.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any StatefulSet containers that mount a hostPath volume as read-write, update them:
@@ -11694,7 +11738,7 @@ queries:
         Check to ensure no containers in a CronJob are mounting hostPath volumes as read-write:
 
         ```bash
-        kubectl get cronjobs -A -o json | jq -r '.items[] | [.spec.jobTemplate.spec.template.spec.volumes[] | select(.hostPath != empty) | .name] as $myVar | select(.spec.jobTemplate.spec.template.spec.containers[].volumeMounts | (. != empty and ( .[] | ( [.name] | inside($myVar) ) and .readOnly != true   )  ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
+        kubectl get cronjobs -A -o json | jq -r '.items[] | [.spec.jobTemplate.spec.template.spec.volumes[]? | select(.hostPath != null) | .name] as $hostPathVolumes | select(.spec.jobTemplate.spec.template.spec.containers[].volumeMounts | (. != null and any(.[]; (.name | IN($hostPathVolumes[])) and .readOnly != true))) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
         For any CronJob containers that mount a hostPath volume as read-write, update them:
@@ -11810,7 +11854,7 @@ queries:
         Verify there are no pods running Tiller:
 
         ```bash
-        kubectl get pods -A -o=custom-columns="NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image"
+        kubectl get pods -A -o=custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.containers[*].image"
         ```
       remediation: |
         Delete any pods that are running Tiller.
@@ -11908,7 +11952,7 @@ queries:
         Verify there are no pods running Kubernetes dashboard:
 
         ```bash
-        kubectl get pods -A -o=custom-columns="NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image"
+        kubectl get pods -A -o=custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.containers[*].image"
         ```
       remediation: |
         Delete any pods that are running Kubernetes dashboard.
@@ -11957,7 +12001,7 @@ queries:
         kubectl get pods -A -o json | jq -r '.items[] | select( .spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update Pods (or the Deployments/DaemonSets/CronJobs/etc that produced the Pods) to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A running Pod's security context cannot be changed in place, so delete the Pod and create it again from the updated manifest, which stops the workload until the new Pod starts.
 
         Example manifest:
 
@@ -12083,7 +12127,7 @@ queries:
         kubectl get replicasets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update ReplicaSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update ReplicaSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A ReplicaSet does not replace the Pods it already runs when its template changes, so delete those Pods after applying the change to have the ReplicaSet recreate them from the updated template.
 
         Example manifest:
 
@@ -12147,7 +12191,7 @@ queries:
         kubectl get jobs -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Jobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update Jobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. A Job's Pod template cannot be changed after the Job is created, so delete the Job with `kubectl delete job <name> -n <namespace>` and create it again from the updated manifest. Deleting the Job also deletes its Pods and stops a run in progress.
 
         Example manifest:
 
@@ -12339,7 +12383,7 @@ queries:
         kubectl get cronjobs -A -o json | jq -r '.items[] | select( .spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update CronJobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update CronJobs to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Every container and init container must drop `ALL`, written in uppercase, for the check to pass. The change applies only to Jobs the CronJob starts after the update. Jobs that are already running continue with their original settings until they finish.
 
         Example manifest:
 
@@ -12424,7 +12468,15 @@ queries:
             path: /data/app
         ```
 
-        Back the same volume with a CSI driver or cloud storage instead. Delete the hostPath PersistentVolume and apply the replacement, keeping the claim's capacity and access modes the same so the workload's PersistentVolumeClaim still binds:
+        Back the same volume with a CSI driver or cloud storage instead. Replacing the PersistentVolume does not move the data, and the data stays on the node's filesystem, so plan downtime and migrate it:
+
+        1. Scale the workload that uses the claim to zero so nothing writes to the volume.
+        2. Copy the data from the node path, `/data/app` in this example, onto the new storage volume.
+        3. Delete the PersistentVolumeClaim, then the hostPath PersistentVolume. Kubernetes does not remove a PersistentVolume while a claim is still bound to it.
+        4. Apply the replacement PersistentVolume below, keeping the capacity and access modes the same. Recreate the claim with `spec.volumeName: example-pv` and the same `storageClassName` as the PersistentVolume, which is `""` for this example, so it binds to that volume instead of being provisioned from the default StorageClass.
+        5. Scale the workload back up.
+
+        The `volumeHandle` must be the ID of the storage volume that now holds the data:
 
         ```yaml
         ---
@@ -12442,7 +12494,7 @@ queries:
             - ReadWriteOnce
         ```
 
-        If hostPath is required for development, use Pod Security Admission or OPA/Gatekeeper policies to restrict it to specific namespaces.
+        The check fails on any hostPath PersistentVolume, including one kept for development. Pod Security Admission does not help here, because it evaluates `hostPath` volumes declared in a Pod spec and not PersistentVolumes that a claim binds to.
     refs:
       - url: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
         title: Kubernetes Volumes - hostPath
@@ -12666,15 +12718,19 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        The actionable step is almost always labeling namespaces, not editing the flag. The `PodSecurity` plugin is enabled by default on Kubernetes 1.25 and later, so on a current cluster it is usually already on. Apply a Pod Security Standard to each namespace with a label:
+        Add `PodSecurity` to the API server `--enable-admission-plugins` flag, keeping the plugins already listed there. The plugin is enabled by default on Kubernetes 1.25 and later, but a plugin that is on by default does not appear in the flag, and the check passes only when `PodSecurity` is listed in it explicitly. Listing it has no side effect on a cluster where it is already on. On a kubeadm cluster the result looks like this:
+
+        ```bash
+        --enable-admission-plugins=NodeRestriction,PodSecurity
+        ```
+
+        The plugin enforces nothing until a namespace requests a profile. Apply a Pod Security Standard to each namespace with a label:
 
         ```bash
         kubectl label ns <namespace> pod-security.kubernetes.io/enforce=baseline
         ```
 
         Use `enforce=restricted` for the strictest profile. Test it first, because `enforce=restricted` can reject existing workloads that do not meet the profile. You can preview the impact without enforcing by setting `pod-security.kubernetes.io/warn` or `audit` labels before switching `enforce`.
-
-        Only if you are on a self-managed control plane older than 1.25, or you removed the plugin, add `PodSecurity` to the API server `--enable-admission-plugins` flag.
     refs:
       - url: https://kubernetes.io/docs/concepts/security/pod-security-admission/
         title: Kubernetes - Pod Security Admission
@@ -12727,7 +12783,52 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Add `EventRateLimit` to the API server `--enable-admission-plugins` flag and supply a configuration file via `--admission-control-config-file`.
+        Add `EventRateLimit` to the API server `--enable-admission-plugins` flag and give it limits through an admission configuration file. The flag is what the check reads, and the limits are what cap how fast clients can write Events.
+
+        1. Create `/etc/kubernetes/admission/eventconfig.yaml`. `qps` is the sustained number of Event writes per second allowed per bucket, `burst` is the short spike allowed above it, and `cacheSize` is how many per-namespace or per-user buckets are tracked. The values below are the examples from the Kubernetes documentation; raise them if legitimate controllers start receiving rejected Event writes:
+
+           ```yaml
+           apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+           kind: Configuration
+           limits:
+             - type: Namespace
+               qps: 50
+               burst: 100
+               cacheSize: 2000
+             - type: User
+               qps: 10
+               burst: 50
+           ```
+
+        2. Create `/etc/kubernetes/admission/admission-config.yaml` that points at it. If the API server already has an `--admission-control-config-file`, add the `EventRateLimit` entry to that file instead:
+
+           ```yaml
+           apiVersion: apiserver.config.k8s.io/v1
+           kind: AdmissionConfiguration
+           plugins:
+             - name: EventRateLimit
+               path: /etc/kubernetes/admission/eventconfig.yaml
+           ```
+
+        3. In `/etc/kubernetes/manifests/kube-apiserver.yaml`, add the plugin and the flag, and mount the directory into the static Pod, keeping every existing flag, mount, and volume. Without the mount the API server cannot read the file and does not start:
+
+           ```yaml
+           spec:
+             containers:
+               - command:
+                   - kube-apiserver
+                   - --enable-admission-plugins=NodeRestriction,EventRateLimit
+                   - --admission-control-config-file=/etc/kubernetes/admission/admission-config.yaml
+                 volumeMounts:
+                   - name: admission
+                     mountPath: /etc/kubernetes/admission
+                     readOnly: true
+             volumes:
+               - name: admission
+                 hostPath:
+                   path: /etc/kubernetes/admission
+                   type: DirectoryOrCreate
+           ```
     refs:
       - url: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#eventratelimit
         title: Kubernetes - EventRateLimit Admission Controller
@@ -12780,7 +12881,26 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Set the API server `--audit-log-path` flag to a writable file location such as `/var/log/kubernetes/audit.log` and save the file so the kubelet restarts the static pod.
+        Set the API server `--audit-log-path` flag to a file location such as `/var/log/kubernetes/audit/audit.log`. On a static-Pod API server, also mount that directory from the host, keeping every existing flag, mount, and volume. Without the mount the log is written inside the container and lost whenever the Pod restarts:
+
+        ```yaml
+        spec:
+          containers:
+            - command:
+                - kube-apiserver
+                - --audit-log-path=/var/log/kubernetes/audit/audit.log
+              volumeMounts:
+                - name: audit-log
+                  mountPath: /var/log/kubernetes/audit/
+                  readOnly: false
+          volumes:
+            - name: audit-log
+              hostPath:
+                path: /var/log/kubernetes/audit/
+                type: DirectoryOrCreate
+        ```
+
+        The log stays empty until `--audit-policy-file` also points at an audit policy. Save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
         title: Kubernetes - Auditing
@@ -12833,7 +12953,35 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Create an audit policy YAML and pass it to the API server via `--audit-policy-file=/etc/kubernetes/audit-policy.yaml`. Save the manifest so the kubelet restarts the static pod after the file is in place.
+        Create an audit policy file on each control plane node. The policy must contain at least one rule. This minimal policy records every request at the `Metadata` level, which captures who made each request and what it touched without storing request or response bodies:
+
+        ```yaml
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        rules:
+          - level: Metadata
+        ```
+
+        Save it as `/etc/kubernetes/audit-policy.yaml` and pass it to the API server via `--audit-policy-file=/etc/kubernetes/audit-policy.yaml`. On a static-Pod API server, also mount the file into the Pod, keeping every existing flag, mount, and volume. The API server does not start if it cannot read the policy file:
+
+        ```yaml
+        spec:
+          containers:
+            - command:
+                - kube-apiserver
+                - --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+              volumeMounts:
+                - name: audit
+                  mountPath: /etc/kubernetes/audit-policy.yaml
+                  readOnly: true
+          volumes:
+            - name: audit
+              hostPath:
+                path: /etc/kubernetes/audit-policy.yaml
+                type: File
+        ```
+
+        Save the manifest so the kubelet restarts the static pod after the file is in place.
     refs:
       - url: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy
         title: Kubernetes - Audit policy
@@ -12939,7 +13087,44 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Create an `EncryptionConfiguration` file specifying a strong provider (`aescbc`, `kms`, or `secretbox`) and pass it to the API server with `--encryption-provider-config=/etc/kubernetes/enc/enc.yaml`. Prefer a KMS provider in production. Re-write existing secrets so they are encrypted with the new keys:
+        Create an `EncryptionConfiguration` file whose first provider for `secrets` is a KMS v2 provider or `secretbox`. Do not use `aescbc`, which the Kubernetes documentation rates as weak because CBC mode is exposed to padding oracle attacks, and never list `identity` first, because it stores data unencrypted. A `secretbox` configuration looks like this, where `secret` is a random 32-byte key encoded in base64, such as the output of `head -c 32 /dev/urandom | base64`:
+
+        ```yaml
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+          - resources:
+              - secrets
+            providers:
+              - secretbox:
+                  keys:
+                    - name: key1
+                      secret: <base64-encoded-32-byte-key>
+              - identity: {}
+        ```
+
+        The trailing `identity` entry lets the API server still read Secrets stored before encryption was enabled. Save the file as `/etc/kubernetes/enc/enc.yaml`, readable only by the user that runs the API server, and back it up securely, because losing the key makes every Secret encrypted with it unreadable. `secretbox` keeps the key on the control plane node, so prefer a KMS v2 provider in production.
+
+        Pass the file with `--encryption-provider-config=/etc/kubernetes/enc/enc.yaml` and, on a static-Pod API server, mount the directory into the Pod, keeping every existing flag, mount, and volume. The API server does not start if it cannot read the file. Repeat this on every control plane node:
+
+        ```yaml
+        spec:
+          containers:
+            - command:
+                - kube-apiserver
+                - --encryption-provider-config=/etc/kubernetes/enc/enc.yaml
+              volumeMounts:
+                - name: enc
+                  mountPath: /etc/kubernetes/enc
+                  readOnly: true
+          volumes:
+            - name: enc
+              hostPath:
+                path: /etc/kubernetes/enc
+                type: DirectoryOrCreate
+        ```
+
+        Once every API server has restarted with the file, rewrite existing Secrets so they are encrypted with the new key:
 
         ```bash
         kubectl get secrets --all-namespaces -o json | kubectl replace -f -
@@ -13165,7 +13350,7 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Generate an API-server client cert/key signed by the cluster CA and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. Save the file so the kubelet restarts the static pod.
+        Generate a client certificate and key for the API server, signed by the CA that the kubelets trust through their `--client-ca-file`, and pass them via `--kubelet-client-certificate` and `--kubelet-client-key`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-kubelet-client.crt` and `/etc/kubernetes/pki/apiserver-kubelet-client.key`. The identity in the certificate must be allowed to use the kubelet API, which on RBAC clusters means binding its user or group to the `system:kubelet-api-admin` ClusterRole; otherwise `kubectl logs` and `kubectl exec` are refused by the kubelet. Save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: Control Plane to Node communication
@@ -13270,7 +13455,13 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Pass `--kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt`, or the cluster's kubelet CA bundle, to the API server.
+        Pass `--kubelet-certificate-authority` to the API server, set to the CA bundle that signed the kubelets' serving certificates, such as `/etc/kubernetes/pki/ca.crt` when the cluster CA issues them.
+
+        By default kubeadm gives each kubelet a self-signed serving certificate that the cluster CA did not sign. Setting this flag on such a cluster makes `kubectl logs`, `kubectl exec`, and `kubectl port-forward` fail certificate verification on every node. Before setting it, move the kubelets to CA-signed serving certificates:
+
+        1. Set `serverTLSBootstrap: true` in the `kubelet-config` ConfigMap in `kube-system` and in `/var/lib/kubelet/config.yaml` on each node, then run `systemctl restart kubelet`.
+        2. List the pending serving certificate requests with `kubectl get csr` and approve each one with `kubectl certificate approve <csr-name>`.
+        3. Add the flag and save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/#apiserver-to-kubelet
         title: API server to kubelet
@@ -13324,7 +13515,7 @@ queries:
       remediation: |
         These flags apply to self-managed control planes only. On managed services such as EKS, GKE, and AKS the control plane is provider-managed and these flags cannot be changed. On kubeadm clusters the API server runs as a static pod: back up and edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the kubelet automatically restarts the static pod when you save the file. Do not run `kubectl rollout restart` for the API server. After saving, watch `kubectl -n kube-system get pod -l component=kube-apiserver` or `crictl ps` to confirm it comes back, because a bad flag can stop the API server from starting and lock you out of the cluster.
 
-        Generate API-server-to-etcd certs from the etcd CA and pass them as `--etcd-cafile`, `--etcd-certfile`, and `--etcd-keyfile`. Confirm etcd is configured with the matching peer/server certificates.
+        Generate a client certificate and key for the API server signed by the etcd CA, and pass them as `--etcd-certfile` and `--etcd-keyfile`, with the etcd CA certificate as `--etcd-cafile`. On kubeadm clusters these are `/etc/kubernetes/pki/apiserver-etcd-client.crt`, `/etc/kubernetes/pki/apiserver-etcd-client.key`, and `/etc/kubernetes/pki/etcd/ca.crt`. Point `--etcd-servers` at `https://` endpoints, and confirm that etcd itself runs with `--client-cert-auth=true` and the same CA in `--trusted-ca-file`, since otherwise etcd accepts connections without a client certificate. Save the file so the kubelet restarts the static pod.
     refs:
       - url: https://kubernetes.io/docs/setup/best-practices/certificates/
         title: Kubernetes - PKI certificates and requirements
@@ -13594,11 +13785,16 @@ queries:
       remediation:
         - id: kubectl
           desc: |
-            Remove the cluster-admin grant from the service account and replace it with a narrowly scoped Role bound only in the namespaces the workload uses:
+            Remove the cluster-admin grant from the service account and replace it with a narrowly scoped Role bound only in the namespaces the workload uses. The grant can come from a ClusterRoleBinding or from a RoleBinding that references `cluster-admin` or another role allowing every verb on every resource. Deleting a binding removes access for every subject it lists, so inspect the subjects first, and if other subjects remain, run `kubectl edit` on the binding and remove only the service account entry. Replace `pods,configmaps` and `get,list,watch` below with the resources and verbs the workload actually calls:
 
             ```bash
-            # Remove the offending binding
+            # Inspect who else the binding grants access to
+            kubectl get clusterrolebinding <binding-name> -o yaml
+
+            # Remove the offending binding when the service account is its only subject
             kubectl delete clusterrolebinding <binding-name>
+            # or, when the grant comes from a namespaced RoleBinding
+            kubectl delete rolebinding <binding-name> -n <namespace>
 
             # Grant only the permissions the workload needs, scoped to its namespace
             kubectl create role app-reader --verb=get,list,watch --resource=pods,configmaps -n <namespace>
@@ -13694,6 +13890,7 @@ queries:
 
             ```bash
             kubectl edit clusterrole <role-name>   # remove escalate/bind/impersonate and wildcard verbs
+            kubectl edit role <role-name> -n <namespace>   # same, when a namespaced Role grants them
             # or rebind the service account to a purpose-built least-privilege role
             kubectl create role app-role --verb=get,list,watch --resource=pods -n <namespace>
             kubectl create rolebinding app-binding --role=app-role --serviceaccount=<namespace>:<name> -n <namespace>
@@ -13780,7 +13977,10 @@ queries:
 
             ```bash
             kubectl edit clusterrole <role-name>   # replace "*" with concrete verbs/resources/apiGroups
+            kubectl edit role <role-name> -n <namespace>
             ```
+
+            If the ClusterRole has an `aggregationRule`, the control plane rebuilds its rules from the ClusterRoles it selects and overwrites manual edits, so remove the wildcard from those source ClusterRoles instead.
         - id: manifest
           desc: |
             Enumerate the concrete permissions instead of using `*`. Apply the manifest with `kubectl apply -f <file>.yaml`:
@@ -13853,7 +14053,9 @@ queries:
       remediation:
         - id: kubectl
           desc: |
-            Delete the over-broad binding and replace it with a binding to a least-privilege role, or scope the access to specific namespaces with a RoleBinding:
+            Delete the over-broad binding and replace it with a binding to a least-privilege role, or scope the access to specific namespaces with a RoleBinding. Check the binding's subjects with `kubectl get clusterrolebinding <binding-name> -o yaml` first, because deleting it revokes cluster-admin from all of them at once.
+
+            Do not delete `kubeadm:cluster-admins` on a kubeadm cluster. It grants cluster-admin to the group in `/etc/kubernetes/admin.conf`, the credential kubeadm and administrators use, so deleting it locks that kubeconfig out. Record it in the excluded cluster role bindings property instead. In the command below, the built-in `view` ClusterRole grants read-only access to most namespaced objects and excludes Secrets:
 
             ```bash
             kubectl delete clusterrolebinding <binding-name>

--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -2052,7 +2052,11 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/docker.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -2647,7 +2651,11 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/run/containerd/containerd.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -3242,7 +3250,11 @@ queries:
                       name: vol
         ```
       remediation: |
-        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The corrected manifest:
+        Delete the `hostPath` volume that mounts `/var/run/crio/crio.sock` from the `volumes` list, and delete the `volumeMounts` entry that references it. A workload that genuinely needs to build images or inspect containers should use a rootless image builder or the Kubernetes API rather than the runtime socket.
+
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+
+        The corrected manifest:
 
         ```yaml
         ---
@@ -4892,7 +4904,9 @@ queries:
       remediation: |
         Set `readOnlyRootFilesystem` to `true` in the `securityContext` of every container and init container. A container that omits the field keeps a writable root filesystem. The manifest below shows the required configuration:
 
-        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting. Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+        Test this in staging first. Any process that writes to the container filesystem will fail once the root filesystem is read-only. Mount an `emptyDir`, or another writable volume, at each path the application needs to write, such as a cache, scratch, or temp directory, before enforcing this setting.
+
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
 
         The corrected manifest:
 
@@ -5557,7 +5571,9 @@ queries:
       remediation: |
         Set `runAsNonRoot` to `true` in the `securityContext` of every container and init container. The manifest below shows the required configuration.
 
-        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning. The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
+        Kubernetes does not let a Job's pod template change after the Job is created, so `kubectl apply` and `kubectl edit` reject the update with `field is immutable`. Update the source manifest, then recreate the Job with `kubectl delete -f <file>.yaml` followed by `kubectl apply -f <file>.yaml`, where `<file>.yaml` is the manifest that defines the Job. Deleting the Job also deletes its Pods and stops any work they are still running, and the new Job starts that work from the beginning.
+
+        The image must run as a non-root user, or the pods will fail to start, so confirm the image's user or set `runAsUser` to a non-zero UID.
 
         The corrected manifest:
 


### PR DESCRIPTION
## Summary

This audits the `remediation:` and CLI `audit:` sections of all 183 checks in `content/mondoo-kubernetes-security.mql.yaml`. Each one was checked against its own `mql:`. Methods covered: `manifest`, `cli`, `kubectl`, `ansible`, `bash`, `manual`. The main problems:

- Workload remediations told readers to `kubectl apply` or `kubectl edit` standalone Pods and Jobs. The API rejects both changes.
- ReplicaSet and CronJob remediations promised a rollout that never happens.
- The `allowPrivilegeEscalation` checks said an omitted field defaults to `false`. It is treated as `true`.
- 30 jq audit commands could never list anything.
- Several API server flags were set without the config file or static Pod mount they need, so the API server would not start.

## Changes

### Fix would not close the check, or the command is rejected

<details><summary>Standalone Pods: the API rejects the change on a running Pod (11 checks, <code>manifest</code>)</summary>

The text said to `kubectl apply` or `kubectl edit` the live Pod and that it would roll. Every change except image, activeDeadlineSeconds, tolerations and terminationGracePeriodSeconds fails with `pod updates may not change fields` (`updatablePodSpecFields` in kubernetes `pkg/apis/core/validation/validation.go`; Pods docs, "Pod update and replacement"). The new text says to delete the Pod and recreate it from the corrected manifest, and warns that the Pod is down until the new one is ready. The provider scans only Pods with no owning controller (`PodOwnerReferencesFilter`), so bare Pods are the ones this affects.

- `mondoo-kubernetes-security-pod-allowprivilegeescalation`
- `mondoo-kubernetes-security-pod-privilegedcontainer`
- `mondoo-kubernetes-security-pod-readonlyrootfilesystem`
- `mondoo-kubernetes-security-pod-runasnonroot`
- `mondoo-kubernetes-security-pod-hostnetwork`
- `mondoo-kubernetes-security-pod-hostpid`
- `mondoo-kubernetes-security-pod-hostipc`
- `mondoo-kubernetes-security-pod-docker-socket`: volumes cannot be removed from a running Pod either
- `mondoo-kubernetes-security-pod-containerd-socket`
- `mondoo-kubernetes-security-pod-crio-socket`
- `mondoo-kubernetes-security-pod-capability-drop-all`
</details>

<details><summary>Standalone Jobs: the pod template cannot change after creation (11 checks, <code>manifest</code>)</summary>

The text said to apply or edit the live Job and that its pods would roll. `validatePodTemplateUpdate` in `pkg/apis/batch/validation/validation.go` rejects the change with `field is immutable`. The Job docs list only scheduling directives, labels and annotations as mutable. The new text says to delete the Job and recreate it, and warns that deleting it stops work in progress, which then starts over.

- `mondoo-kubernetes-security-job-allowprivilegeescalation`
- `mondoo-kubernetes-security-job-privilegedcontainer`
- `mondoo-kubernetes-security-job-readonlyrootfilesystem`
- `mondoo-kubernetes-security-job-runasnonroot`
- `mondoo-kubernetes-security-job-hostnetwork`
- `mondoo-kubernetes-security-job-hostpid`
- `mondoo-kubernetes-security-job-hostipc`
- `mondoo-kubernetes-security-job-docker-socket`
- `mondoo-kubernetes-security-job-containerd-socket`
- `mondoo-kubernetes-security-job-crio-socket`
- `mondoo-kubernetes-security-job-capability-drop-all`
</details>

<details><summary>ReplicaSets: existing Pods never pick up a template change (11 checks, <code>manifest</code>)</summary>

The text said applying the change rolls the pods. The ReplicaSet docs say a ReplicaSet "will not make any effort to make existing Pods match a new, different pod template". The check then passes on the template while the running Pods keep the insecure setting, and those Pods are never scanned because they are controller-owned. The new text says to delete the Pods one at a time so the ReplicaSet recreates them, explains how to find them with the selector labels, and notes the lost capacity.

- `mondoo-kubernetes-security-replicaset-allowprivilegeescalation`
- `mondoo-kubernetes-security-replicaset-privilegedcontainer`
- `mondoo-kubernetes-security-replicaset-readonlyrootfilesystem`
- `mondoo-kubernetes-security-replicaset-runasnonroot`
- `mondoo-kubernetes-security-replicaset-hostnetwork`
- `mondoo-kubernetes-security-replicaset-hostpid`
- `mondoo-kubernetes-security-replicaset-hostipc`
- `mondoo-kubernetes-security-replicaset-docker-socket`
- `mondoo-kubernetes-security-replicaset-containerd-socket`
- `mondoo-kubernetes-security-replicaset-crio-socket`
- `mondoo-kubernetes-security-replicaset-capability-drop-all`
</details>

<details><summary>CronJobs: an update does not roll anything (8 checks, <code>manifest</code>)</summary>

The text said applying the change rolls the workload's pods. The CronJob docs ("Modifying a CronJob") say changes "apply to new Jobs that start after your modification is complete. Jobs (and their Pods) that have already started continue to run without changes." The new text says exactly that.

- `mondoo-kubernetes-security-cronjob-allowprivilegeescalation`
- `mondoo-kubernetes-security-cronjob-privilegedcontainer`
- `mondoo-kubernetes-security-cronjob-readonlyrootfilesystem`
- `mondoo-kubernetes-security-cronjob-runasnonroot`
- `mondoo-kubernetes-security-cronjob-hostnetwork`
- `mondoo-kubernetes-security-cronjob-hostpid`
- `mondoo-kubernetes-security-cronjob-hostipc`
- `mondoo-kubernetes-security-cronjob-capability-drop-all`
</details>

- **allowPrivilegeEscalation**, 7 checks (`mondoo-kubernetes-security-{pod,cronjob,statefulset,deployment,job,replicaset,daemonset}-allowprivilegeescalation`, `manifest`): the text said to "omit the field so it defaults to `false`". The provider's `specAllowsPrivilegeEscalation` returns true when the field is nil, and the check's own desc says Kubernetes defaults it to `true`. Scanning a Pod without the field with `mql run k8s` returns `allowsPrivilegeEscalation: true`. The text now says to set `false` explicitly on every container and init container.
- **readOnlyRootFilesystem** and **runAsNonRoot**, 14 checks (`...-readonlyrootfilesystem`, `...-runasnonroot` for all 7 kinds, `manifest`): the text named only regular containers. `specHasWritableRootFilesystem` and `specRunsAsRoot` also iterate init and ephemeral containers. A Pod whose init container omits the field still fails when scanned. The text now names init containers.
- **Capability drop ALL**, pod, job, replicaset and cronjob (`manifest`): the text now also says that every container and init container must drop `ALL`, in uppercase. `specDropsAllCapabilities` compares `d == "ALL"` case-sensitively.
- **Ensure the kube-apiserver enables the PodSecurity admission plugin** (`mondoo-kubernetes-security-api-server-admission-pod-security`, `cli`): the text said the action is to label namespaces and that the flag usually needs no change. The check reads only `flags["enable-admission-plugins"].contains("PodSecurity")`, and a plugin enabled by default is not in the flag, so a cluster that followed the text kept failing. The text now says to list `PodSecurity` explicitly, which is harmless, and keeps namespace labelling as the step that makes it enforce anything. The contradicting "only if older than 1.25" sentence is removed.
- **Kubelet checks with a plain-string remediation**, 9 checks (anonymous-auth, event-qps, iptables-util-chains, protect-kernel-defaults, read-only-port, authorization-mode, rotate-certificates, strong-ciphers, tls-certificate): the text said to edit `/var/lib/kubelet/config.yaml` on kubeadm nodes. The kubeadm reconfigure docs say "During `kubeadm upgrade`, kubeadm downloads the `KubeletConfiguration` from the `kubelet-config` ConfigMap and overwrite the contents of `/var/lib/kubelet/config.yaml`", so the fix was lost at the next upgrade. The text now adds `kubectl edit cm -n kube-system kubelet-config` and `kubeadm upgrade node phase kubelet-config`, both taken from that page.
- **API server kubelet certificate authority** (`mondoo-kubernetes-security-api-server-kubelet-ca`, `cli`): kubeadm kubelets use self-signed serving certificates by default ("By default the kubelet serving certificate deployed by kubeadm is self-signed", kubeadm-certs.md), so setting the flag as written breaks `kubectl logs`, `exec` and `port-forward` on every node. The text now adds the documented `serverTLSBootstrap: true` and CSR approval steps before the flag is set.
- **hostPath PersistentVolumes** (`mondoo-kubernetes-security-no-hostpath-persistent-volumes`, `manifest`): the text said to delete the PV and apply a CSI replacement. It did not say to migrate the data. It also missed that a bound PV is not removed until its claim is deleted (persistent-volumes.md, "Storage Object in Use Protection"). The steps now scale down, copy the data, delete the claim and then the PV, and rebind with `volumeName` and `storageClassName: ""`. The closing advice to keep hostPath PVs for development under Pod Security Admission is also replaced: the check has no exception, and PSA inspects only `spec.volumes[*].hostPath` in Pods.
- **Service accounts should not be bound to cluster-admin** (`mondoo-kubernetes-security-serviceaccount-no-cluster-admin`, `kubectl`): the text deleted the whole ClusterRoleBinding without checking its other subjects, and ignored RoleBindings, which `effectiveRules()` also collects. It now inspects the subjects first, adds the RoleBinding form, and explains the example verbs and resources.
- **Wildcard rules** and **service account privilege escalation** (`mondoo-kubernetes-security-rbac-no-wildcard-rules`, `mondoo-kubernetes-security-serviceaccount-no-privilege-escalation`, `kubectl`): the text only edited ClusterRoles, but the checks also evaluate Roles (`k8s.roles...hasWildcardRule`, RoleBinding rules). A `kubectl edit role` line is added, plus a note that manual edits to an aggregated ClusterRole are overwritten (rbac.md).
- **Standalone Pods, Jobs and ReplicaSets that mount the Docker, containerd or CRI-O socket** (9 checks, `manifest`): these gave only the corrected manifest. The recreate or replace-the-Pods step is now added, as described above.

### Commands that fail as written

- **Audit jq filters that compare against `empty`**, 21 checks (`...-capability-net-raw`, `...-capability-sys-admin`, `...-ports-hostport` for all 7 kinds, `audit`): `empty` produces no value in jq, so `. != empty and ...` produces nothing and `select` never matches. The commands printed nothing even for offending workloads. Now `. != null`. Verified with jq 1.7.1 on sample JSON: the old filter printed nothing, the new one printed only the offending object.
- **hostPath read-only audits**, 7 checks (`...-hostpath-readonly`, `audit`): besides the `empty` bug, `.spec.volumes[]` aborts with `Cannot iterate over null` on the first object with no volumes, and `inside` matches substrings. They are rewritten with `[]?`, `!= null` and exact matching via `IN`. Verified the same way.
- **Tiller and Kubernetes Dashboard Pod audits** (`mondoo-kubernetes-security-pod-tiller`, `mondoo-kubernetes-security-pod-k8s-dashboard`, `audit`): these read `.spec.template.spec.containers[*].image`, which Pods don't have, so IMAGE was always `<none>`. Now `.spec.containers[*].image`, following the `kubectl get --help` custom-columns example, plus a namespace column.
- **kubelet TLS certificate** (`mondoo-kubernetes-security-kubelet-tls-certificate`, `audit`): the text named `--tls-private-key`, which is not a kubelet flag. It is now `--tls-private-key-file` (kubelet reference; `kubelet_flags.go`).
- **etcd data directory** (`mondoo-kubernetes-security-secure-etcd-data-dir`, `cli`): `chown etcd:etcd` fails with `invalid user` on kubeadm nodes. kubeadm creates no `etcd` account: it creates `kubeadm-etcd`, and only with the RootlessControlPlane gate (`cmd/kubeadm/app/phases/etcd/local.go`). The text now checks `id etcd` and creates a system account first. It also says when to use the `--data-dir` value instead of `/var/lib/etcd`, which matches the check's fallback.
- **API server audit policy, audit log, encryption config and EventRateLimit** (`mondoo-kubernetes-security-api-server-audit-policy-file`, `-audit-log-path`, `-encryption-provider-config`, `-admission-event-rate-limit`, `cli`): the text set a flag that points at a file but gave neither the file's content nor the hostPath mount a static Pod API server needs. On kubeadm the API server cannot read the file and does not start, or the audit log disappears when the Pod restarts. The text now includes:
  - the documented minimal audit policy (a zero-rule policy is illegal)
  - the EventRateLimit `Configuration` and `AdmissionConfiguration`, with qps, burst and cacheSize explained
  - the audit log volume
  - the `enc` volume

  All of these come from the Kubernetes audit, admission-controllers and encrypt-data docs.

### Values not explained

- **Kubelet strong ciphers** (`mondoo-kubernetes-security-kubelet-strong-ciphers`, `manual`): the text never named the suites that pass and had the typo "string ciphers". It now lists the 14 suites in the check's allow-list, which are confirmed against component-base `ciphersuites_flag.go`, and adds a valid `tlsCipherSuites` example and the flag form.
- **Kubelet TLS certificate** (`manual`): the text broke off mid-sentence without naming `tlsCertFile` and `tlsPrivateKeyFile`, the fields the mql reads. It now names both, with example paths and the certificate requirements.
- **Kubelet client CA file** (`mondoo-kubernetes-security-secure-kubelet-cert-authorities`, `ansible`, `bash`): both snippets hardcode the GKE path. A sentence now says to use the `authentication.x509.clientCAFile` value, which is the file the mql reads, and gives the kubeadm path.
- **PKI directory** (`mondoo-kubernetes-security-secure-pki-directory`, `cli`): "adjust the path" now names the directory the mql actually reads, the one holding the `--etcd-certfile` file.
- **Insecure API server port** (`mondoo-kubernetes-security-https-api-server`, `manual`): the version history was wrong. From 1.20 to 1.23 the flags accepted only `0`, and 1.24 removed them (CHANGELOG-1.20 #95856, CHANGELOG-1.24 #106859). The text is corrected so readers know where `--insecure-port=0` is valid.
- **Kubelet client certificate** and **etcd certificate files** (`mondoo-kubernetes-security-api-server-kubelet-client-cert`, `-etcd-cert-files`, `cli`): no file paths were given. The kubeadm paths from `constants.go` are added, along with the `system:kubelet-api-admin` binding and the etcd `--client-cert-auth` and `--trusted-ca-file` settings that make the certificates actually authenticate.
- **CPU and memory limits**, 14 checks (`...-limitcpu`, `...-limitmemory` for all 7 kinds, `manifest`): `resourceContainers()` includes init containers and `resourceQuantitySet` rejects `0`. The text now says both and explains the example values `500m` and `1Gi`, including throttling for CPU and OOM kills for memory.
- **Image pull policy**, 7 checks (`...-imagepull`, `manifest`): the text presented `Always` as optional. The mql requires `imagePullPolicy == 'Always'`, a tag or digest, and no `:latest` on every container, and Kubernetes sets an omitted policy to `IfNotPresent` for pinned images (images.md). The pass criteria are now stated.
- **Service account name**, 7 checks (`...-serviceaccount`, `manifest`): the mql fails when the deprecated `serviceAccount` field names a different account. The text now says to remove that field or make it match.

### Insecure example

- **Encryption provider config** (`mondoo-kubernetes-security-api-server-encryption-provider-config`, `cli`): the text called `aescbc` strong, but encrypt-data.md rates it "Weak ... Not recommended due to CBC's vulnerability to padding oracle attacks". It now recommends KMS v2 or `secretbox`, shows a valid config with the key format, and warns that a lost key makes Secrets unreadable.

### Destructive steps not flagged

- **Cluster role bindings should not grant cluster-admin** (`mondoo-kubernetes-security-rbac-restrict-cluster-admin-bindings`, `kubectl`): on kubeadm 1.29 and later, the flagged set includes `kubeadm:cluster-admins`, which backs `/etc/kubernetes/admin.conf` (kubeadm `constants.go`). Deleting it as instructed locks out the admin kubeconfig. The text now warns about this, says to add it to the exclusion property, checks subjects before deleting, and explains the `view` role.

### Auditor edits rejected or amended

All 127 proposed edits were verified and applied. Two were amended: for `job-hostipc` and `replicaset-hostipc`, the proposed wording used unexplained `<name>`/`<namespace>` placeholders and differed from the wording used for the same object kinds in the other families, so the shared text was used instead. On top of the proposed edits, the integrator added the 7 CronJob corrections and the 9 kubeadm kubelet persistence sentences, both of which the auditors had recorded but not edited.

### Follow-up edits

- **Audit text for the seven `allowPrivilegeEscalation` checks** (`mondoo-kubernetes-security-{pod,cronjob,statefulset,deployment,job,replicaset,daemonset}-allowprivilegeescalation`, `audit`): the audit said only an explicit `allowPrivilegeEscalation: true` triggers the finding, the same wrong assumption the remediation had. `specAllowsPrivilegeEscalation` in the k8s provider returns true when `securityContext` or the field is nil, and it iterates `allWorkloadContainers`, which covers containers, init containers, and ephemeral containers. The audit now says an omitted field fails and names all three container kinds. The query itself, `k8s.<kind>.allowsPrivilegeEscalation == false`, is correct and is unchanged.
- **Markdown formatting** (47 remediation paragraphs, plus 20 older rollout sentences): several remediations had grown into one paragraph mixing the fix, the rollout procedure, and a disruption warning, so the warning was easy to miss. Procedures are now numbered steps: delete and recreate a Pod or Job, replace a ReplicaSet's Pods, apply a kubelet setting on kubeadm, set up API server client certificates. Warnings open with a bold sentence, for example **A Job cannot be updated in place.**, **Test this in staging first.**, and **The image must run as a non-root user.** The kubelet cipher suite allow list is a bulleted list. No instruction changed meaning.
- **Kubelet remediations** (`anonymous-authentication`, `event-record-qps`, `iptables-util-chains`, `protect-kernel-defaults`, `read-only-port`, `authorization-mode`, `rotate-certificates`, `tls-cipher-suites`, `tls-certificate`): the kubeadm procedure said "edit the setting" before the paragraph that named the setting. The setting now comes first. The older sentences are rewritten to put identifiers in code formatting instead of quotes, without "and/or" or "(eg ...)". The authorization text now names `Webhook` as the value, since `AlwaysAllow` is the only other kubelet authorization mode.
- **`<kind>/<name>` placeholder** (20 Deployment, StatefulSet, and DaemonSet remediations): `kubectl edit <kind>/<name>` never said what `<kind>` was, in checks that each cover a single kind. It now reads `kubectl edit deployment/<name>`, `statefulset/<name>`, or `daemonset/<name>`, and explains `<name>`.

## Found but not changed

Each item below is tracked in its own issue: #3653, #3654, #3655, #3656, #3657, #3658, #3659, #3660, #3661, #3662.

- `mondoo-kubernetes-security-https-api-server`: `flags["insecure-port"] == 0` fails when the flag is absent, and Kubernetes 1.24 removed the flag (CHANGELOG-1.24 #106859). The check can never pass on a supported cluster, and no remediation can fix that. A correct query needs the cluster version, because before 1.20 an absent flag meant port 8080 was open. The desc also says the flag was "removed in 1.20".
- `mondoo-kubernetes-security-kubelet-tls-certificate`: the desc recommends serving-certificate rotation (`serverTLSBootstrap`), but that leaves `tlsCertFile` and `tlsPrivateKeyFile` empty, which the mql requires to be non-empty. Found by reading the code, not run on a node.
- `mondoo-kubernetes-security-secure-etcd-data-dir`: on a control plane node with external etcd there is no local etcd process, so the else branch calls `file(null)`. Found by reading the code.
- `...-serviceaccount` checks for deployment, statefulset, daemonset, replicaset, job and cronjob pass when `serviceAccountName` is omitted, because only Pods get it defaulted. `mql run k8s` on a Deployment without it returned `[ok] value: true`.
- `mondoo-kubernetes-security-api-server-admission-pod-security`: a check that also passed when `PodSecurity` is absent from `--disable-admission-plugins` would match what Kubernetes actually does.
- `mondoo-kubernetes-security-rbac-restrict-cluster-admin-bindings`: the default exclusion list does not cover `kubeadm:cluster-admins`, so every kubeadm cluster at 1.29 or later fails by default.
- `mondoo-kubernetes-security-rbac-no-cluster-wide-secret-read`: the desc suggests that a ClusterRole restricted by `resourceNames` is acceptable, but `rbacRuleMatchesResourceName` still counts it as a secret read.
- The capability-drop-all family compares `ALL` case-sensitively, while the net-raw and sys-admin checks upcase. A manifest with `drop: ["all"]` fails drop-all but passes NET_RAW.
- `content/mondoo-kubernetes-best-practices.mql.yaml` has the same `. != empty` jq bug in 7 audit commands. That file is out of scope here.
- The `runasnonroot` refs point to the v1.25 API reference but are titled "Configure a Security Context for a Pod or Container".

## Validation

- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" content/mondoo-kubernetes-security.mql.yaml`: parses
- `cnspec policy lint content/mondoo-kubernetes-security.mql.yaml`: valid policy bundle
- `python3 content/validation/remediation/commands/validate.py kubernetes`: 88 passed, 0 failed
- `python3 content/validation/remediation/code/bash.py kubernetes`: 23 passed, 0 failed
- `python3 content/validation/remediation/code/ansible.py kubernetes`: 6 passed, 0 failed
- `typos content/mondoo-kubernetes-security.mql.yaml`: no findings
- jq 1.7.1: the old and new capability, hostPort and hostPath filters were run on sample JSON. The old filters printed nothing, and the new ones printed only the offending objects.

## Overlapping open PRs

- #2850 (Add Kyverno content and mappings) also edits `content/mondoo-kubernetes-security.mql.yaml`, where it adds RBAC binding checks and a policy group. Expect textual conflicts near the RBAC checks, but not overlapping remediation changes.
- #2852 and #3299 matched the search, but neither touches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


