### PR TITLE
🐛 aws: stop the static-credentials Terraform check failing providers with no keys

### DIFF
--- a/content/mondoo-aws-security.mql.yaml
+++ b/content/mondoo-aws-security.mql.yaml
@@ -12686,8 +12686,8 @@ queries:
     filters: asset.platform == "terraform-hcl" && terraform.providers.any(nameLabel == "aws")
     mql: |
       terraform.providers.where( nameLabel == "aws" ) {
-        arguments["access_key"] == null || arguments["access_key"].find(/(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/).all("AKIAIOSFODNN7EXAMPLE")
-        arguments["secret_key"] == null || arguments["secret_key"].find(/([A-Za-z0-9\\\/+\\]{40})/).all( "wJalrXUtnFEMI/A1AAAAA/bPxRfiCYAAAAAAAKEY")
+        arguments["access_key"] == null || arguments["access_key"] == "AKIAIOSFODNN7EXAMPLE" || arguments["access_key"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
+        arguments["secret_key"] == null || arguments["secret_key"] == "wJalrXUtnFEMI/A1AAAAA/bPxRfiCYAAAAAAAKEY" || arguments["secret_key"] != /([A-Za-z0-9\\\/+\\]{40})/
       }
   - uid: mondoo-aws-security-no-static-credentials-in-providers-terraform-plan
     filters: asset.platform == "terraform-plan" && terraform.plan.configuration.providerConfig.any(_['name'] == "aws")

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl/pass/aws-documentation-example-keys/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl/pass/aws-documentation-example-keys/main.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region = "us-east-1"
+  access_key = "AKIAIOSFODNN7EXAMPLE"
+  secret_key = "wJalrXUtnFEMI/A1AAAAA/bPxRfiCYAAAAAAAKEY"
+}

--- a/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl/pass/variable-reference/main.tf
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-aws-security/mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl/pass/variable-reference/main.tf
@@ -1,0 +1,6 @@
+variable "k" {}
+provider "aws" {
+  region = "us-east-1"
+  access_key = var.k
+  secret_key = var.k
+}


### PR DESCRIPTION
## Summary

The Content IaC Variant Tests workflow has been red on `main` since the mql `v14.0.0-rc.2` bump (#3611, first red run on `d37f346fd`, Sep 8). Every open content PR inherits the failure, including #3663, #3652 and #3651. Both failing jobs trace back to a single check, `mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl`:

- `terraform (shard 4/12)`: the `pass/no-creds` fixture scores 0.
- `remediation (shard 4/6)`: the check's own remediation snippet fails it for the same reason.

## Why it fails

The check guarded each key like this:

```
terraform.providers.where( nameLabel == "aws" ) {
  arguments["access_key"] == null || arguments["access_key"].find(/(A3T[A-Z0-9]|AKIA|...)[A-Z0-9]{16}/).all("AKIAIOSFODNN7EXAMPLE")
  ...
}
```

On a provider block with no `access_key`, the value is `null`. In mql `llx/builtin_map.go`, `dictFindV2` only handles strings and returns `dict value does not support field find` for anything else.

That function hasn't changed. What changed with rc.2 is scoring: inside a `{ }` block, the erroring right-hand side is now reported as its own failed assessment (`[failed] [].all() error: cannot find value for assessment`), even though the `== null` branch evaluates to `true`. Result: every `aws` provider block that correctly carries no static keys fails.

Reproduced locally against `origin/main` with `go test -tags iac_variants ./content/validation/scans -run 'TestTerraformVariants/mondoo-aws-security/mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl/'`, which gives `expected passed but got failed (score=0)`.

## The fix

Compare against the key-shaped regex directly, so no string method runs on a `null` value:

```
arguments["access_key"] == null || arguments["access_key"] == "AKIAIOSFODNN7EXAMPLE" || arguments["access_key"] != /(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}/
arguments["secret_key"] == null || arguments["secret_key"] == "wJalrXUtnFEMI/A1AAAAA/bPxRfiCYAAAAAAAKEY" || arguments["secret_key"] != /([A-Za-z0-9\\\/+\\]{40})/
```

The verdicts are unchanged:
- Absent keys pass.
- A value that isn't a literal key, such as `var.aws_access_key`, passes.
- The AWS documentation example keys pass.
- Anything shaped like a real key fails.

Two pass fixtures lock in the cases the old `.find().all(example)` form allowed and nothing tested:
- `pass/variable-reference`: `access_key = var.k`
- `pass/aws-documentation-example-keys`: `AKIAIOSFODNN7EXAMPLE` and its paired secret

## Checked and left alone

I searched `content/` for the same shape: a `null`/`empty` guard followed by a string method on the same value.

- **`mondoo-aws-security-identitycenter-session-duration-terraform-hcl`** (`arguments.session_duration == null || arguments.session_duration.find(...)`): wrapped in `.all(...)`, not a `{ }` block, and its `pass/omitted` fixture is green in CI. Only the block form surfaces the error as a separate assessment.
- **GCP `datastream-private-connection-not-default-vpc` and `memcache-instance-not-default-vpc` plan/state checks** (`_['vpc'].find(...)`): each `.find` ends an `&&` chain behind `!= empty`, so an absent value already fails and the error can't change the verdict.

## Validation

- `TestTerraformVariants/.../no-static-credentials-in-providers-terraform-hcl/`: all 5 scenarios pass. The 2 fail fixtures still fail, and the 3 pass fixtures pass.
- `TestRemediationSatisfiesCheck/^mondoo-aws-security-no-static-credentials-in-providers-terraform-hcl$`: passes.
- `TestTerraformVariantCoverage`: passes.
- `typos` over the changed files: clean.
- `cnspec policy lint` fails locally identically on `origin/main`, with an unrelated compile error in `iam-password-policy-aws` from the locally installed AWS provider schema. The `Lint Policies` CI job passes on the same bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
