### PR TITLE
🐛 oci: fix remediation steps that would not close their checks

### DIFF
--- a/content/mondoo-oci-security.mql.yaml
+++ b/content/mondoo-oci-security.mql.yaml
@@ -1133,14 +1133,24 @@ queries:
             6. Select **Assign**.
         - id: cli
           desc: |
-            To assign a customer-managed encryption key to an Object Storage bucket using the OCI CLI, update the bucket with the KMS key OCID:
+            To assign a customer-managed encryption key to an Object Storage bucket using the OCI CLI:
+
+            1. Allow the Object Storage service in the bucket's region to use the key. Without this grant OCI rejects the key assignment, because Object Storage encrypts and decrypts through Vault as its own service principal. Add a statement such as the following to a policy in the key's compartment, replacing `us-ashburn-1` with the bucket's region identifier and `KeyCompartment` with the compartment that holds the key:
+
+            ```text
+            Allow service objectstorage-us-ashburn-1 to use keys in compartment KeyCompartment
+            ```
+
+            2. Assign the key to the bucket, replacing `<key-ocid>` with the OCID of the Vault master encryption key:
 
             ```bash
-            oci os bucket update --bucket-name BUCKET_NAME --kms-key-id KEY_OCID
+            oci os bucket update --bucket-name <bucket-name> --kms-key-id <key-ocid>
             ```
+
+            The key protects objects written after the change. Existing objects stay encrypted under the previous key until you re-encrypt the bucket with `oci os bucket reencrypt --bucket-name <bucket-name>`.
         - id: terraform
           desc: |
-            To assign a customer-managed encryption key to an Object Storage bucket in Terraform, create a vault and key, then reference the key in the bucket resource:
+            To assign a customer-managed encryption key to an Object Storage bucket in Terraform, create a vault and key, allow the Object Storage service in the bucket's region to use the key, then reference the key in the bucket resource. The service grant must exist before the bucket is created, otherwise OCI rejects the `kms_key_id`:
 
             ```hcl
             resource "oci_kms_vault" "example" {
@@ -1160,13 +1170,27 @@ queries:
               }
             }
 
+            resource "oci_identity_policy" "objectstorage_keys" {
+              compartment_id = var.compartment_ocid
+              name           = "objectstorage-use-bucket-key"
+              description    = "Allow Object Storage to encrypt with the bucket key"
+
+              statements = [
+                "Allow service objectstorage-${var.region} to use keys in compartment id ${var.compartment_ocid} where target.key.id = '${oci_kms_key.example.id}'",
+              ]
+            }
+
             resource "oci_objectstorage_bucket" "example" {
               compartment_id = var.compartment_ocid
               namespace      = var.namespace
               name           = "example-bucket"
               kms_key_id     = oci_kms_key.example.id
+
+              depends_on = [oci_identity_policy.objectstorage_keys]
             }
             ```
+
+            Set `var.region` to the bucket's region identifier, such as `us-ashburn-1`.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/encryption.htm
         title: Object Storage Data Encryption
@@ -1711,28 +1735,32 @@ queries:
       remediation:
         - id: console
           desc: |
-            To identify and remediate stale active users using the OCI Console:
+            To deactivate stale active users using the OCI Console:
 
-            1. Navigate to **Identity & Security > Users**.
-            2. Review the **Last Sign-In** column for each active user.
-            3. For users who have not signed in within 90 days, select the user.
-            4. Select **Disable** or **Delete** depending on your organization's offboarding policy.
+            1. Navigate to **Identity & Security > Domains** and select the identity domain that holds the user.
+            2. Select **Users** and review the last sign-in date of each active user.
+            3. For each user who has not signed in within the last 90 days, open the **Actions** menu next to the user and select **Deactivate**, or delete the user if your offboarding policy calls for it.
+
+            The finding clears only when the account signs in again, is deactivated, or is deleted. Removing its API keys or auth tokens alone leaves an active account with an old sign-in date, so it keeps failing. A deactivated user can no longer sign in, so confirm with the account owner or their manager first.
         - id: cli
           desc: |
-            To identify stale active users using the OCI CLI, list users and filter by login activity:
+            To identify and delete stale active users using the OCI CLI, start by listing active users with their last sign-in time:
 
             ```bash
-            oci iam user list --compartment-id TENANCY_OCID --all --query "data[?\"lifecycle-state\"=='ACTIVE'].{Name:name, LastLogin:\"last-successful-login-time\"}" --output table
+            oci iam user list --compartment-id <tenancy-ocid> --all --query "data[?\"lifecycle-state\"=='ACTIVE'].{Name:name, Id:id, LastLogin:\"last-successful-login-time\"}" --output table
             ```
 
-            The OCI CLI does not support disabling a user directly. For each user whose last login exceeds 90 days, remove the credentials that grant access:
+            A user fails when `LastLogin` is more than 90 days ago. Deleting the user's API keys or auth tokens does not clear the finding, because the account stays active with the same sign-in date. The finding clears only when the user signs in again, the account is deactivated, or the account is deleted. The `oci iam user update-user-state` command can only unblock a user, so deactivate an account you want to keep through the Console.
+
+            To delete an account that is no longer needed, remove it from every group first, because OCI rejects deleting a user that still belongs to a group:
 
             ```bash
-            oci iam user api-key delete --user-id USER_OCID --fingerprint KEY_FINGERPRINT
-            oci iam auth-token delete --user-id USER_OCID --auth-token-id TOKEN_OCID
+            oci iam user list-groups --user-id <user-ocid> --query "data[].{Name:name, Id:id}" --output table
+            oci iam group remove-user --group-id <group-ocid> --user-id <user-ocid>
+            oci iam user delete --user-id <user-ocid>
             ```
 
-            Disable or delete the account itself through the OCI Console following your offboarding policy.
+            Deleting a user is permanent, so confirm with the account owner or their manager before you run it.
         # No Terraform remediation: last-login recency is runtime telemetry; the `oci_identity_user` Terraform resource has no field for `last-successful-login-time` and there is no HCL change that marks an account stale or active.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingusers.htm
@@ -1968,7 +1996,7 @@ queries:
       remediation:
         - id: console
           desc: |
-            Before creating a replication policy, two prerequisites must be in place or the policy creation fails: the destination bucket must already exist with object versioning enabled, and an IAM policy must grant the Object Storage service permission to manage objects in the destination compartment, for example `Allow service objectstorage-<region> to manage object-family in compartment <destination-compartment>`.
+            Before creating a replication policy, two prerequisites must be in place or the policy creation fails. First, the destination bucket must already exist in the destination region with versioning disabled and no retention rules, because OCI rejects a destination that has either. Second, an IAM policy must authorize the Object Storage service of the source region to manage objects in both the source and destination compartments, for example `Allow service objectstorage-us-ashburn-1 to manage object-family in tenancy` for a source bucket in `us-ashburn-1`.
 
             To enable replication on an Object Storage bucket using the OCI Console:
 
@@ -1978,48 +2006,56 @@ queries:
             4. Select **Create Policy**.
             5. Choose the destination region and destination bucket.
             6. Select **Create**.
+
+            Once the policy exists, the destination bucket becomes read-only and receives writes only through replication, and deletes in the source bucket are replicated to it.
         - id: cli
           desc: |
-            Before creating a replication policy, two prerequisites must be in place or the policy creation fails: the destination bucket must already exist with object versioning enabled, and an IAM policy must grant the Object Storage service permission to manage objects in the destination compartment, for example `Allow service objectstorage-<region> to manage object-family in compartment <destination-compartment>`.
+            Before creating a replication policy, two prerequisites must be in place or the policy creation fails. First, the destination bucket must already exist in the destination region with versioning disabled and no retention rules, because OCI rejects a destination that has either. Second, an IAM policy must authorize the Object Storage service of the source region to manage objects in both the source and destination compartments, for example `Allow service objectstorage-us-ashburn-1 to manage object-family in tenancy` for a source bucket in `us-ashburn-1`.
 
-            To enable replication on an Object Storage bucket using the OCI CLI, create a replication policy:
+            To enable replication on an Object Storage bucket using the OCI CLI, create a replication policy on the source bucket, setting `--destination-region` to the destination region identifier such as `us-phoenix-1`:
 
             ```bash
-            oci os replication create-replication-policy --bucket-name SOURCE_BUCKET_NAME \
-              --destination-bucket DESTINATION_BUCKET_NAME \
-              --destination-region DESTINATION_REGION \
+            oci os replication create-replication-policy --bucket-name <source-bucket-name> \
+              --destination-bucket <destination-bucket-name> \
+              --destination-region <destination-region> \
               --name "cross-region-replication"
             ```
+
+            Once the policy exists, the destination bucket becomes read-only and receives writes only through replication, and deletes in the source bucket are replicated to it.
         - id: terraform
           desc: |
-            To enable replication on an Object Storage bucket in Terraform, create a replication policy resource. The destination bucket must already exist with object versioning enabled, and an IAM policy must grant the Object Storage service permission to manage objects in the destination compartment, or the policy creation fails. The example below declares both prerequisites:
+            To enable replication on an Object Storage bucket in Terraform, create a replication policy resource. The destination bucket must already exist with versioning disabled and no retention rules, and an IAM policy must authorize the Object Storage service of the source region to manage objects in the source and destination compartments, or the policy creation fails. The example below declares both prerequisites, with `var.source_region` set to the source bucket's region identifier such as `us-ashburn-1`. The destination bucket uses a provider configuration aliased as `destination` whose `region` is the destination region, because a bucket is created in the region of the provider that manages it:
 
             ```hcl
             resource "oci_objectstorage_bucket" "destination" {
+              provider       = oci.destination
               compartment_id = var.destination_compartment_ocid
               namespace      = var.namespace
               name           = "backups-replica"
-              versioning     = "Enabled"
             }
 
             resource "oci_identity_policy" "replication" {
-              compartment_id = var.destination_compartment_ocid
+              compartment_id = var.tenancy_ocid
               name           = "objectstorage-replication"
-              description    = "Allow Object Storage to replicate into the destination compartment"
+              description    = "Allow Object Storage in the source region to replicate objects"
 
               statements = [
-                "Allow service objectstorage-${var.destination_region} to manage object-family in compartment id ${var.destination_compartment_ocid}",
+                "Allow service objectstorage-${var.source_region} to manage object-family in tenancy",
               ]
             }
 
             resource "oci_objectstorage_replication_policy" "example" {
-              bucket           = oci_objectstorage_bucket.source.name
-              namespace        = var.namespace
-              name             = "cross-region-replication"
-              destination_bucket_name   = oci_objectstorage_bucket.destination.name
-              destination_region_name   = var.destination_region
+              bucket                  = oci_objectstorage_bucket.source.name
+              namespace               = var.namespace
+              name                    = "cross-region-replication"
+              destination_bucket_name = oci_objectstorage_bucket.destination.name
+              destination_region_name = var.destination_region
+
+              depends_on = [oci_identity_policy.replication]
             }
             ```
+
+            Once the policy exists, the destination bucket becomes read-only and receives writes only through replication, and deletes in the source bucket are replicated to it.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingreplication.htm
         title: OCI Object Storage replication documentation
@@ -2231,13 +2267,13 @@ queries:
         1. List all security lists in the VCN:
 
         ```bash
-        oci network security-list list --compartment-id <compartment-ocid> --vcn-id <vcn-ocid> --all --query 'data[*].{id: id, name: "display-name", ingress: "ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`]}'
+        oci network security-list list --compartment-id <compartment-ocid> --vcn-id <vcn-ocid> --all --query 'data[*].{id: id, name: "display-name", ingress: "ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`]}'
         ```
 
         2. For any returned security list, inspect whether the ingress rules for `0.0.0.0/0` TCP cover port 22:
 
         ```bash
-        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`]'
+        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`]'
         ```
 
         A passing security list returns no rules that include port 22 in the destination port range from `0.0.0.0/0`. A failing security list returns one or more rules where the destination port range covers port 22.
@@ -2401,13 +2437,13 @@ queries:
         1. List all security lists in the VCN:
 
         ```bash
-        oci network security-list list --compartment-id <compartment-ocid> --vcn-id <vcn-ocid> --all --query 'data[*].{id: id, name: "display-name", ingress: "ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`]}'
+        oci network security-list list --compartment-id <compartment-ocid> --vcn-id <vcn-ocid> --all --query 'data[*].{id: id, name: "display-name", ingress: "ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`]}'
         ```
 
         2. For any returned security list, inspect whether the ingress rules for `0.0.0.0/0` TCP cover port 3389:
 
         ```bash
-        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`]'
+        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`]'
         ```
 
         A passing security list returns no rules that include port 3389 in the destination port range from `0.0.0.0/0`. A failing security list returns one or more rules where the destination port range covers port 3389.
@@ -2571,7 +2607,7 @@ queries:
         1. Retrieve all ingress rules for a security list and filter for UDP rules from `0.0.0.0/0`:
 
         ```bash
-        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`17`]'
+        oci network security-list get --security-list-id <security-list-ocid> --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"17"`]'
         ```
 
         A passing security list returns no results, or returns only UDP rules that include a `udp-options` block with an explicit destination port range. A failing security list returns one or more UDP rules from `0.0.0.0/0` where `udp-options` is absent (all UDP ports allowed).
@@ -2870,7 +2906,7 @@ queries:
         1. Retrieve all egress rules for a security list and filter for unrestricted TCP egress:
 
         ```bash
-        oci network security-list get --security-list-id <security-list-ocid> --query 'data."egress-security-rules"[?destination==`0.0.0.0/0` && protocol==`6`]'
+        oci network security-list get --security-list-id <security-list-ocid> --query 'data."egress-security-rules"[?destination==`0.0.0.0/0` && protocol==`"6"`]'
         ```
 
         A passing security list returns no results, or returns only TCP egress rules that include a `tcp-options` block with an explicit destination port range. A failing security list returns one or more TCP egress rules to `0.0.0.0/0` where `tcp-options` is absent (all TCP ports allowed).
@@ -3155,25 +3191,35 @@ queries:
       remediation:
         - id: console
           desc: |
-            Revoke and reissue long-lived tokens:
+            To rotate auth tokens older than 90 days using the OCI Console:
 
             1. Open **Identity & Security** → **Users** → select the user → **Auth Tokens**.
-            2. Delete any token that was created more than 90 days ago or is no longer needed.
-            3. Generate a replacement token and record its creation date.
-            4. Distribute the new token to the owning system and verify it works, then schedule the next rotation within 90 days.
+            2. Generate a replacement token and copy its value, because OCI displays it only once.
+            3. Update every system that uses the old token and confirm it authenticates with the new one.
+            4. Delete every token that was created more than 90 days ago.
+
+            A user can hold at most two auth tokens, so if the user already has two, delete the one that is no longer in use before generating the replacement. Deleting a token that is still in use immediately breaks every client that authenticates with it, which is why the replacement is deployed before the old token is removed. The finding clears once no active token on the user is older than 90 days, so schedule the next rotation before the new token reaches that age.
         - id: cli
           desc: |
-            Delete long-lived auth tokens via the OCI CLI:
+            To rotate auth tokens older than 90 days using the OCI CLI, start by listing the user's tokens with their creation time:
+
+            ```bash
+            oci iam auth-token list --user-id <user-ocid> --query "data[].{Id:id, Created:\"time-created\", State:\"lifecycle-state\"}" --output table
+            ```
+
+            Issue the replacement first and save the `token` value from the output, because OCI shows it only once:
+
+            ```bash
+            oci iam auth-token create --user-id <user-ocid> --description "Rotated on $(date +%Y-%m-%d)"
+            ```
+
+            Update every system that uses the old token, then delete each token whose `Created` time is more than 90 days ago, passing its `Id` as `<token-ocid>`:
 
             ```bash
             oci iam auth-token delete --user-id <user-ocid> --auth-token-id <token-ocid>
             ```
 
-            Issue a replacement token and record its creation date so it can be rotated again within 90 days:
-
-            ```bash
-            oci iam auth-token create --user-id <user-ocid> --description "Rotated on $(date +%Y-%m-%d)"
-            ```
+            A user can hold at most two auth tokens, so if the user already has two, delete the one that is no longer in use before creating the replacement. Deleting a token that is still in use breaks every client that authenticates with it. The finding clears once no active token on the user is older than 90 days.
         # No Terraform remediation: auth token expiry and creation timestamps are runtime-only fields; the `oci_identity_auth_token` Terraform resource exposes neither `expires` nor `time_created` as configurable arguments.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm
@@ -3256,19 +3302,29 @@ queries:
       remediation:
         - id: console
           desc: |
-            Trim the admin group to the minimum set of required members:
+            To trim an administrative group to five or fewer members using the OCI Console:
 
-            1. Open **Identity & Security** → **Groups** → select the flagged group.
+            1. Open **Identity & Security** → **Groups** → select the flagged group. A group counts as administrative when it is named like `Administrators` or `Admins`, or when a policy grants it `manage all-resources in tenancy`.
             2. Review each member against a documented list of personnel who require admin access.
-            3. **Remove user from group** for every member who no longer needs the privilege.
-            4. For users who only need occasional admin access, move them to a break-glass workflow (separate account activated only when needed).
+            3. **Remove user from group** for every member who no longer needs the privilege, until the group has five or fewer members.
+            4. For users who only need occasional admin access, move them to a break-glass workflow that uses a separate account activated only when needed.
+
+            Removing a member takes away their tenancy-wide access immediately, so confirm that each removed user keeps whatever narrower access their role still needs.
         - id: cli
           desc: |
-            Remove a user from an over-populated admin group:
+            To trim an administrative group to five or fewer members using the OCI CLI, start by listing its current members:
+
+            ```bash
+            oci iam group list-users --group-id <group-ocid> --all --query "data[].{Name:name, Id:id}" --output table
+            ```
+
+            Remove each member who no longer needs tenancy-wide access, passing the user's `Id` as `<user-ocid>`, until the group has five or fewer members:
 
             ```bash
             oci iam group remove-user --user-id <user-ocid> --group-id <group-ocid>
             ```
+
+            Removing a member takes away their administrative access immediately, so confirm that each removed user keeps whatever narrower access their role still needs.
         # No Terraform remediation: group membership count is cross-resource runtime state; Terraform resources for `oci_identity_user_group_membership` manage individual memberships and there is no HCL expression that enforces a maximum member count across all memberships referencing a group.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managinggroups.htm
@@ -3359,13 +3415,21 @@ queries:
             4. For administrative access, route through OCI Bastion or an approved VPN instead of opening SSH/RDP to the world.
         - id: cli
           desc: |
-            Remove an over-permissive ingress rule from an NSG:
+            To remove an over-permissive ingress rule from an NSG using the OCI CLI, start by listing the NSG's ingress rules:
+
+            ```bash
+            oci network nsg rules list --nsg-id <nsg-ocid> --direction INGRESS --all
+            ```
+
+            A rule fails when its `source` is `0.0.0.0/0` or `::/0`, its `protocol` is `6`, and its `tcp-options` destination port range is missing or covers port 22 or 3389. Remove each such rule by passing its `id` as `<rule-id>`:
 
             ```bash
             oci network nsg rules remove \
               --nsg-id <nsg-ocid> \
               --security-rule-ids '["<rule-id>"]'
             ```
+
+            If administrators still need SSH or RDP, add a rule scoped to your bastion or VPN CIDR before removing the open one so their access is not cut off.
         - id: terraform
           desc: |
             Define NSG ingress rules with `tcp_options.destination_port_range` blocks that exclude SSH (22) and RDP (3389), or restrict the source to a trusted CIDR rather than `0.0.0.0/0` / `::/0`:
@@ -3555,19 +3619,21 @@ queries:
       remediation:
         - id: console
           desc: |
-            Attach an NSG to the flagged VNIC:
+            To gate a public VNIC with a restrictive network security group using the OCI Console:
 
             1. Open **Compute** → **Instances** → select the instance → **Attached VNICs** → select the VNIC.
             2. **Edit VNIC** → **Network Security Groups** → **Add Network Security Group**.
-            3. Pick an NSG whose ingress rules match the services the host should expose.
-            4. Save. If no appropriate NSG exists, create one first scoped to the workload.
+            3. Pick an NSG whose ingress rules admit only specific source CIDR blocks. The finding clears only when every NSG attached to the instance's public VNICs has no ingress rule, other than ICMP, from `0.0.0.0/0`, `::/0`, or another public range as wide as a /8, so an NSG that opens even one port to the whole internet keeps the instance failing.
+            4. Save. If no appropriate NSG exists, create one first scoped to the workload. Internet-facing services that must accept traffic from any address belong behind a load balancer rather than on a public instance VNIC.
         - id: cli
           desc: |
-            Attach an NSG to a VNIC:
+            To attach a restrictive network security group to a public VNIC using the OCI CLI, pass the NSG OCID in `--nsg-ids`:
 
             ```bash
             oci network vnic update --vnic-id <vnic-ocid> --nsg-ids '["<nsg-ocid>"]'
             ```
+
+            `--nsg-ids` replaces the VNIC's complete NSG list, so include every NSG already attached that you want to keep. The finding clears only when none of the attached NSGs has an ingress rule, other than ICMP, from `0.0.0.0/0`, `::/0`, or another public range as wide as a /8, so choose or create an NSG whose ingress sources are specific CIDR blocks.
         - id: terraform
           desc: |
             Whenever the instance assigns a public IP, populate `nsg_ids` on the `create_vnic_details` block:
@@ -3715,13 +3781,15 @@ queries:
             4. Save. The setting takes effect immediately. Once legacy IMDS is disabled, any application still calling IMDSv1 fails immediately, so update those applications to IMDSv2 (which sends a PUT request to obtain a session token and includes that token as a header on subsequent calls) before disabling, then restart those applications.
         - id: cli
           desc: |
-            Disable legacy IMDS endpoints via the OCI CLI:
+            To disable the legacy IMDS endpoints using the OCI CLI, set `areLegacyImdsEndpointsDisabled` to `true` in the instance options:
 
             ```bash
             oci compute instance update \
               --instance-id <instance-ocid> \
               --instance-options '{"areLegacyImdsEndpointsDisabled": true}'
             ```
+
+            The change takes effect immediately. Any agent or application on the instance that still calls the legacy IMDSv1 endpoints fails from that moment, so update those clients to IMDSv2, which sends the `Authorization: Bearer Oracle` header on every request, before running the command.
         - id: terraform
           desc: |
             Declare an `instance_options` block on every `oci_core_instance` and set `are_legacy_imds_endpoints_disabled = true`:
@@ -3864,11 +3932,15 @@ queries:
             4. Replace the usage with Vault-backed configuration or a resource principal, neither of which leaves values visible in `GetInstance`.
         - id: cli
           desc: |
-            Rotate any exposed credential first. Then retrieve the current metadata, remove only the credential keys, and write the remaining map back. The update must include the `ssh_authorized_keys` and `user_data` values exactly as launched, because OCI rejects any update that adds, changes, or removes those keys:
+            To remove credentials from instance metadata using the OCI CLI, rotate any exposed credential first, because it must be treated as compromised. Then export the current metadata to a file:
 
             ```bash
-            oci compute instance get --instance-id <instance-ocid> --query 'data.metadata'
+            oci compute instance get --instance-id <instance-ocid> --query 'data.metadata' > metadata-without-credentials.json
+            ```
 
+            Edit `metadata-without-credentials.json`, deleting only the credential keys and values. Keep `ssh_authorized_keys` and `user_data` exactly as exported, because OCI rejects any update that adds, changes, or removes those keys. Write the edited map back, which replaces the instance's whole metadata map:
+
+            ```bash
             oci compute instance update --instance-id <instance-ocid> \
               --metadata file://metadata-without-credentials.json
             ```
@@ -4050,29 +4122,31 @@ queries:
             4. Update. Existing connections finish, new connections are required to use TLS 1.2+.
         - id: cli
           desc: |
-            Update the listener's SSL configuration to TLS 1.2+:
+            To restrict a listener to TLS 1.2 and newer using the OCI CLI, update its SSL configuration so `--protocols` lists only `TLSv1.2` and `TLSv1.3`:
 
             ```bash
             oci lb listener update \
               --load-balancer-id <lb-ocid> \
               --listener-name <listener-name> \
-              --protocol HTTPS \
+              --protocol HTTP \
               --port 443 \
-              --default-backend-set-name <backend> \
-              --ssl-certificate-name <cert-name> \
+              --default-backend-set-name <backend-set-name> \
+              --ssl-certificate-name <certificate-name> \
               --cipher-suite-name oci-default-ssl-cipher-suite-v1 \
               --protocols '["TLSv1.2","TLSv1.3"]'
             ```
+
+            OCI has no separate HTTPS listener protocol. A TLS listener is an `HTTP` or `HTTP2` listener with an SSL configuration, so keep the listener's current protocol. The update replaces the listener's whole SSL configuration and requires the port and default backend set, so read the current values with `oci lb load-balancer get --load-balancer-id <lb-ocid> --query 'data.listeners'` and pass the same port, backend set, and certificate name. Clients that can only negotiate TLS 1.0 or 1.1 can no longer connect after the change.
         - id: terraform
           desc: |
-            Declare every HTTPS / HTTP2 listener with an `ssl_configuration` block whose `protocols` list is restricted to TLS 1.2 and 1.3:
+            Declare every TLS listener with an `ssl_configuration` block whose `protocols` list is restricted to TLS 1.2 and 1.3. OCI has no separate HTTPS listener protocol, so a TLS listener uses `protocol = "HTTP"` or `"HTTP2"` together with the `ssl_configuration` block:
 
             ```hcl
             resource "oci_load_balancer_listener" "https" {
               load_balancer_id         = oci_load_balancer_load_balancer.app.id
               name                     = "https"
               default_backend_set_name = oci_load_balancer_backend_set.app.name
-              protocol                 = "HTTPS"
+              protocol                 = "HTTP"
               port                     = 443
 
               ssl_configuration {
@@ -4210,33 +4284,35 @@ queries:
             Switch the listener to a modern cipher suite:
 
             1. Open **Networking** → **Load Balancers** → select the load balancer → **SSL Cipher Suites**.
-            2. Change the listener's cipher suite to `oci-modern-ssl-cipher-suite-v1` (or the appropriate `oci-tls-1-2-*` / `oci-tls-1-3-*` variant for your compliance context).
+            2. Change the listener's cipher suite to `oci-modern-ssl-cipher-suite-v1`, or to `oci-default-ssl-cipher-suite-v1` if some clients cannot negotiate the modern suite's ciphers.
             3. Test with a non-legacy client to confirm handshakes still succeed before rolling out broadly.
         - id: cli
           desc: |
-            Update a listener to use a modern cipher suite:
+            To switch a listener to a modern cipher suite using the OCI CLI, update its SSL configuration with an accepted suite name:
 
             ```bash
             oci lb listener update \
               --load-balancer-id <lb-ocid> \
               --listener-name <listener-name> \
-              --protocol HTTPS \
+              --protocol HTTP \
               --port 443 \
-              --default-backend-set-name <backend> \
-              --ssl-certificate-name <cert-name> \
+              --default-backend-set-name <backend-set-name> \
+              --ssl-certificate-name <certificate-name> \
               --cipher-suite-name oci-modern-ssl-cipher-suite-v1 \
               --protocols '["TLSv1.2","TLSv1.3"]'
             ```
+
+            The check accepts `oci-modern-ssl-cipher-suite-v1` and `oci-default-ssl-cipher-suite-v1`. OCI has no separate HTTPS listener protocol. A TLS listener is an `HTTP` or `HTTP2` listener with an SSL configuration, so keep the listener's current protocol. The update replaces the listener's whole SSL configuration and requires the port and default backend set, so read the current values with `oci lb load-balancer get --load-balancer-id <lb-ocid> --query 'data.listeners'` and pass the same port, backend set, and certificate name. Legacy clients that support only older ciphers can no longer connect after the change.
         - id: terraform
           desc: |
-            Set `cipher_suite_name` on every HTTPS / HTTP2 listener's `ssl_configuration` block to a modern Oracle-managed suite:
+            Set `cipher_suite_name` on every TLS listener's `ssl_configuration` block to a modern Oracle-managed suite. OCI has no separate HTTPS listener protocol, so a TLS listener uses `protocol = "HTTP"` or `"HTTP2"` together with the `ssl_configuration` block:
 
             ```hcl
             resource "oci_load_balancer_listener" "https" {
               load_balancer_id         = oci_load_balancer_load_balancer.app.id
               name                     = "https"
               default_backend_set_name = oci_load_balancer_backend_set.app.name
-              protocol                 = "HTTPS"
+              protocol                 = "HTTP"
               port                     = 443
 
               ssl_configuration {
@@ -4368,19 +4444,21 @@ queries:
             5. Route to the same backend set as the HTTP listener, or add an application-layer redirect to HTTPS.
         - id: cli
           desc: |
-            Create an HTTPS listener on the existing load balancer:
+            To add a TLS listener to the existing load balancer using the OCI CLI, create an `HTTP2` listener with an SSL configuration on port 443:
 
             ```bash
             oci lb listener create \
               --load-balancer-id <lb-ocid> \
               --name https-listener \
-              --protocol HTTPS \
+              --protocol HTTP2 \
               --port 443 \
-              --default-backend-set-name <backend> \
-              --ssl-certificate-name <cert-name> \
-              --cipher-suite-name oci-modern-ssl-cipher-suite-v1 \
+              --default-backend-set-name <backend-set-name> \
+              --ssl-certificate-name <certificate-name> \
+              --cipher-suite-name oci-default-http2-tls-12-13-ssl-cipher-suite-v1 \
               --protocols '["TLSv1.2","TLSv1.3"]'
             ```
+
+            OCI has no separate HTTPS listener protocol, and a TLS listener is an `HTTP` or `HTTP2` listener that carries an SSL configuration. Set `<backend-set-name>` to the backend set the HTTP listener already uses and `<certificate-name>` to a certificate bundle already uploaded to the load balancer. Clients keep reaching the HTTP listener until you redirect them or remove it.
         # No Terraform remediation: this check requires cross-resource correlation — grouping `oci_lb_listener` resources by their `load_balancer_id` and asserting that each group containing an HTTP listener also contains an HTTPS listener — which has no clean equivalent in HCL/plan/state without unsupported cross-resource graph traversal.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managinglisteners.htm
@@ -4601,11 +4679,19 @@ queries:
             4. Confirm the cluster is within two releases of the newest version OKE offers, which is what keeps it on a supported track.
         - id: cli
           desc: |
-            Upgrade the OKE control plane:
+            To upgrade an OKE control plane using the OCI CLI, start by listing the versions the cluster can move to:
+
+            ```bash
+            oci ce cluster get --cluster-id <cluster-ocid> --query 'data."available-kubernetes-upgrades"'
+            ```
+
+            Pick a version from that list for `<new-version>` and upgrade the control plane:
 
             ```bash
             oci ce cluster update --cluster-id <cluster-ocid> --kubernetes-version <new-version>
             ```
+
+            The finding clears once the cluster has fewer than three newer versions available, so repeat the upgrade until the list holds two versions or fewer. Upgrade each node pool afterward with `oci ce node-pool update --node-pool-id <node-pool-ocid> --kubernetes-version <new-version>`, then cordon, drain, and replace the existing worker nodes, which keep their old version until they are recreated.
         # No Terraform remediation: `availableKubernetesUpgrades` is runtime telemetry derived from Oracle's supported-version list at scan time; no `oci_containerengine_cluster` Terraform argument exposes the count of pending upgrades, so there is no static HCL change that resolves this finding.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm
@@ -5111,22 +5197,53 @@ queries:
           desc: |
             To create an OKE cluster that encrypts Kubernetes secrets with a customer-managed key using the OCI CLI:
 
+            1. Before creating the cluster, let clusters use the key. Create a dynamic group with the matching rule `ALL {resource.type = 'cluster', resource.compartment.id = '<cluster-compartment-ocid>'}`, then add this statement to a policy, replacing the placeholders with the dynamic group name, the key's compartment, and the key OCID:
+
+            ```text
+            Allow dynamic-group <dynamic-group-name> to use keys in compartment <key-compartment-name> where target.key.id = '<key-ocid>'
+            ```
+
+            2. Create the cluster with the key, setting `<version>` to a Kubernetes version OKE currently supports:
+
             ```bash
             oci ce cluster create --compartment-id <compartment-ocid> --name secure-cluster --vcn-id <vcn-ocid> --kubernetes-version <version> --kms-key-id <key-ocid>
             ```
+
+            The key can only be set when a cluster is created, so an existing cluster that fails this check must be replaced by a new cluster and its workloads migrated to it.
         - id: terraform
           desc: |
-            To encrypt Kubernetes secrets with a customer-managed key in Terraform, set `kms_key_id` on the cluster resource:
+            To encrypt Kubernetes secrets with a customer-managed key in Terraform, set `kms_key_id` on the cluster resource and declare the key-access policy the cluster needs, which must exist before the cluster is created:
 
             ```hcl
+            resource "oci_identity_dynamic_group" "oke_clusters" {
+              compartment_id = var.tenancy_ocid
+              name           = "oke-clusters"
+              description    = "OKE clusters that use the secrets encryption key"
+              matching_rule  = "ALL {resource.type = 'cluster', resource.compartment.id = '${var.compartment_ocid}'}"
+            }
+
+            resource "oci_identity_policy" "oke_keys" {
+              compartment_id = var.compartment_ocid
+              name           = "oke-use-secrets-key"
+              description    = "Allow OKE clusters to use the secrets encryption key"
+
+              statements = [
+                "Allow dynamic-group ${oci_identity_dynamic_group.oke_clusters.name} to use keys in compartment id ${var.compartment_ocid} where target.key.id = '${oci_kms_key.example.id}'",
+              ]
+            }
+
             resource "oci_containerengine_cluster" "example" {
               compartment_id     = var.compartment_ocid
               name               = "secure-cluster"
               vcn_id             = oci_core_vcn.example.id
-              kubernetes_version = "v1.29.1"
+              kubernetes_version = var.kubernetes_version # use a currently supported OKE version
               kms_key_id         = oci_kms_key.example.id
+
+              depends_on = [oci_identity_policy.oke_keys]
             }
             ```
+
+            Changing `kms_key_id` on an existing cluster forces Terraform to replace it, which destroys the cluster, so migrate workloads to the new cluster first.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengencryptingdata.htm
         title: OCI - Encrypting Kubernetes Secrets at Rest in Etcd
@@ -5546,10 +5663,16 @@ queries:
               --shape <shape> \
               --hostname <hostname> \
               --cpu-core-count <count> \
-              --ssh-authorized-keys-file <public-key-file>
+              --ssh-authorized-keys-file <public-key-file> \
+              --database-edition <database-edition> \
+              --db-version <db-version> \
+              --db-name <db-name> \
+              --admin-password <admin-password>
             ```
 
-            Migrate data to the replacement via Data Pump, Data Guard, or RMAN, then terminate the DB system in the public subnet:
+            Set `--cidr-block` to an unused range inside the VCN. Match `<shape>`, `<database-edition>`, and `<db-version>` to the original DB system so the migration target is compatible, and list the versions available in the region with `oci db version list --compartment-id <compartment-ocid>`. `<db-name>` must start with a letter and hold at most eight alphanumeric characters. Supply the SYS password from a secrets manager rather than typing it into shell history.
+
+            Migrate data to the replacement via Data Pump, Data Guard, or RMAN, then terminate the DB system in the public subnet. Termination permanently deletes the original system and its local storage, so confirm the migration and backups first:
 
             ```bash
             oci db system terminate --db-system-id <old-db-system-ocid>
@@ -5651,7 +5774,7 @@ queries:
               --query 'data."route-rules"' > route-rules.json
             ```
 
-            2. Edit `route-rules.json`, deleting the rule whose destination is `0.0.0.0/0` and whose target is an internet gateway. Where the database still needs egress, replace it with a NAT or service gateway route such as `{"destination":"all-<region>-services-in-oracle-services-network","destinationType":"SERVICE_CIDR_BLOCK","networkEntityId":"<service-gateway-ocid>"}`. Resubmit the edited file so every route you kept is preserved:
+            2. Edit `route-rules.json`, deleting the rule whose destination is `0.0.0.0/0` and whose target is an internet gateway. Where the database still needs egress, replace it with a NAT or service gateway route such as `{"destination":"<service-cidr-label>","destinationType":"SERVICE_CIDR_BLOCK","networkEntityId":"<service-gateway-ocid>"}`. Take `<service-cidr-label>` from the `cidr-block` value that `oci network service list` returns for the service your gateway enables, which has the form `all-iad-services-in-oracle-services-network`. Resubmit the edited file so every route you kept is preserved:
 
             ```bash
             oci network route-table update \
@@ -5891,11 +6014,19 @@ queries:
             4. Verify consumers pick up the new version; update downstream systems that cache the old version.
         - id: cli
           desc: |
-            Rotate an expired Vault secret:
+            To replace an expired Vault secret version using the OCI CLI, rotate secrets that have a rotation target configured:
 
             ```bash
             oci vault secret rotate --secret-id <secret-ocid>
             ```
+
+            `rotate` works only when the secret has a function or Autonomous Database target in its rotation configuration. For a secret you manage by hand, create a new current version instead, setting `<base64-secret-value>` to the new secret value encoded in base64:
+
+            ```bash
+            oci vault secret update-base64 --secret-id <secret-ocid> --secret-content-content <base64-secret-value>
+            ```
+
+            The finding clears once the new version is current and its expiry lies in the future. Update every consumer that caches the old value, because the expired version stops being served as current.
         # No Terraform remediation: `timeOfCurrentVersionExpiry` is runtime telemetry on the active secret version; the `oci_vault_secret` Terraform resource has no field that exposes whether the current version is past its expiry, and there is no HCL change that resolves an expired version.
     refs:
       - url: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/managingsecrets.htm
@@ -6187,9 +6318,10 @@ queries:
             3. Scan the mirrored image via OCIR's integrated vulnerability scanning.
             4. In the container instance spec, change the `imageUrl` to the OCIR path.
             5. Recreate the container instance with the updated spec.
+            6. After the replacement is running, delete the original container instance. The finding stays open while any instance still pulls from an outside registry.
         - id: cli
           desc: |
-            Recreate the container instance pointing at the OCIR copy:
+            To move a container instance to an image in the tenancy's OCIR registry using the OCI CLI, create a replacement pointing at the OCIR copy. Set `imageUrl` to the full OCIR path, where `<region>` is the region key such as `iad` and `<namespace>` is your Object Storage namespace:
 
             ```bash
             oci container-instances container-instance create \
@@ -6200,6 +6332,12 @@ queries:
               --shape-config '{"ocpus":1,"memoryInGBs":2}' \
               --vnics '[{"subnetId":"<subnet-ocid>"}]' \
               --containers '[{"displayName":"app","imageUrl":"<region>.ocir.io/<namespace>/<repo>:<tag>"}]'
+            ```
+
+            Once the replacement is running and serving traffic, delete the original instance. Container images cannot be changed on an existing instance, and the finding stays open while any instance still pulls from an outside registry:
+
+            ```bash
+            oci container-instances container-instance delete --container-instance-id <old-container-instance-ocid>
             ```
         - id: terraform
           desc: |
@@ -6350,22 +6488,22 @@ queries:
             Lock retention rules on every bucket that stores data with retention requirements:
 
             1. Open **Storage** → **Buckets** → select the bucket → **Retention Rules**.
-            2. For each unlocked rule, select **Edit** → set **Rule Locked Time** to a date no sooner than 14 days in the future (OCI enforces a 14-day grace period before the lock takes effect).
-            3. Save. After the grace period passes, the rule becomes non-deletable for the duration of its lifetime.
+            2. For each unlocked rule, select **Edit** → set **Rule Locked Time** to a date at least 14 days in the future, since OCI enforces a 14-day grace period before the lock takes effect. Choose a date close to that minimum, because the finding clears only after the lock time has passed and the rule stays deletable until then.
+            3. Save. After the lock time passes, the rule becomes non-deletable for the duration of its lifetime.
             4. Plan retention carefully. After the lock takes effect, the duration can only be increased, and the rule can only be removed by deleting the bucket.
         - id: cli
           desc: |
-            Lock an existing retention rule:
+            To lock an existing retention rule using the OCI CLI, set its lock time:
 
             ```bash
             oci os retention-rule update \
               --namespace-name <namespace> \
               --bucket-name <bucket> \
               --retention-rule-id <rule-ocid> \
-              --time-rule-locked 2099-01-01T00:00:00Z # set to a real future RFC 3339 timestamp ≥ 14 days from now
+              --time-rule-locked <lock-time>
             ```
 
-            Set the lock time to a real RFC 3339 timestamp at least 14 days in the future (OCI enforces a 14-day grace period before the lock takes effect). This is irreversible: once the lock takes effect the duration can only be increased, and the rule becomes non-deletable for the bucket's lifetime, so the only way to remove it is to delete the entire bucket. Plan the retention duration carefully before locking.
+            Set `<lock-time>` to an RFC 3339 timestamp in the form `YYYY-MM-DDThh:mm:ssZ` that is at least 14 days in the future, since OCI enforces a 14-day grace period before a lock. The finding clears only after the lock time has passed, so choose a date close to the 14-day minimum. A far-future date leaves the rule unlocked and deletable until that date arrives. This is irreversible: once the lock takes effect the duration can only be increased, and the rule becomes non-deletable for the bucket's lifetime, so the only way to remove it is to delete the entire bucket. Plan the retention duration carefully before locking.
         - id: terraform
           desc: |
             Set `time_rule_locked` on every `retention_rules` block to an RFC 3339 timestamp at least 14 days in the future so the rule transitions to a non-deletable lock. Use a fixed value committed in your repository. Do not use `timeadd(timestamp(), ...)` directly on this attribute, because `timestamp()` evaluates on every plan and would produce a perpetual diff. Update the value when you intentionally roll the lock, and add `lifecycle.ignore_changes = [retention_rules]` after the first apply if you want Terraform to stop tracking drift on the locked rule:
@@ -6978,7 +7116,7 @@ queries:
         ```bash
         oci network security-list get \
           --security-list-id <security-list-ocid> \
-          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`].{Source:source, MinPort:"tcp-options"."destination-port-range".min, MaxPort:"tcp-options"."destination-port-range".max}' \
+          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`].{Source:source, MinPort:"tcp-options"."destination-port-range".min, MaxPort:"tcp-options"."destination-port-range".max}' \
           --output table
         ```
 
@@ -7170,7 +7308,7 @@ queries:
         ```bash
         oci network security-list get \
           --security-list-id <security-list-ocid> \
-          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`6`].{Source:source, MinPort:"tcp-options"."destination-port-range".min, MaxPort:"tcp-options"."destination-port-range".max}' \
+          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && protocol==`"6"`].{Source:source, MinPort:"tcp-options"."destination-port-range".min, MaxPort:"tcp-options"."destination-port-range".max}' \
           --output table
         ```
 
@@ -7359,7 +7497,7 @@ queries:
         ```bash
         oci network security-list get \
           --security-list-id <security-list-ocid> \
-          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && (protocol==`1` || protocol==`58` || protocol==`all`)].{Source:source, Protocol:protocol, ICMPOptions:"icmp-options"}' \
+          --query 'data."ingress-security-rules"[?source==`0.0.0.0/0` && (protocol==`"1"` || protocol==`"58"` || protocol==`all`)].{Source:source, Protocol:protocol, ICMPOptions:"icmp-options"}' \
           --output json
         ```
 
@@ -7738,12 +7876,12 @@ queries:
             1. Open **Oracle Database** → **Autonomous Database** (or **DB Systems** → the database) → select the database.
             2. Under **Encryption**, select **Edit** and choose **Encrypt using a customer-managed key**.
             3. Select the vault and master encryption key, then save.
-            4. Subsequent automatic and on-demand backups inherit the new key. Existing backups remain encrypted with the previous key — re-create critical long-term backups after the rotation.
+            4. Subsequent automatic and on-demand backups inherit the new key. Existing backups stay encrypted with the previous key and keep failing until they are gone. Automatic backups age out at the end of their retention period, and full or long-term backups remain until you delete them from the database's **Backups** list. Take a new backup under the customer-managed key before deleting an old one, because a deleted backup cannot be restored.
         - id: cli
           desc: |
-            Re-keying the parent database only fixes backups taken after the change. Existing backups stay on the old key, so this finding persists for them until those backups are re-created. Plan to re-create any critical long-term backups you need to keep.
+            Re-keying the parent database only fixes backups taken after the change. Existing backups stay on the old key and keep this finding open until they are gone: automatic backups age out at the end of their retention period, and full or long-term backups remain until you delete them.
 
-            Switch the parent database to a customer-managed KMS key so subsequent backups inherit it.
+            1. Switch the parent database to a customer-managed KMS key so subsequent backups inherit it.
 
             For an Autonomous Database:
 
@@ -7763,7 +7901,12 @@ queries:
               --vault-id <vault-ocid>
             ```
 
-            Existing backups remain encrypted with the previous key. Re-create critical long-term backups after the migration.
+            2. Take a new backup of anything you still need, then delete the old full or long-term backups that report no KMS key. Deletion is permanent, so confirm each one is no longer needed for a restore:
+
+            ```bash
+            oci db backup delete --backup-id <old-backup-ocid>
+            oci db autonomous-database-backup delete --autonomous-database-backup-id <old-adb-backup-ocid>
+            ```
         - id: terraform
           desc: |
             Set `kms_key_id` (and `vault_id` for autonomous databases) on every database resource so its backups inherit customer-managed encryption:
@@ -8685,24 +8828,36 @@ queries:
           desc: |
             Issue a new version for each near-expiry or expired certificate:
 
-            1. Open **Identity & Security** → **Certificates** → **Certificates** → select the certificate.
-            2. Choose **Issue New Version**.
-            3. For internally issued certificates, enable a `CERTIFICATE_RENEWAL_RULE` so future versions auto-renew.
-            4. Trigger the new version, verify the consumers pick it up, and remove the old version once dependents have rotated.
+            1. Open **Identity & Security** → **Certificates** → **Certificates** and find the certificate.
+            2. For a certificate issued by an internal CA, select **Renew certificate** from its **Actions** menu. Leave **Not Valid Before** blank so the new version becomes current immediately, and set **Not Valid After** to a date more than 30 days away.
+            3. For an imported certificate, obtain a renewed certificate from the external CA and upload it as a new version of the same certificate, because the service cannot renew imported certificates.
+            4. For internally issued certificates, add a `CERTIFICATE_RENEWAL_RULE` so future versions renew automatically.
+            5. Verify the consumers pick up the new version, and remove the old version once dependents have rotated.
         - id: cli
           desc: |
             A renewal rule only governs future renewals, so a near-expiry certificate still expires this cycle unless you issue a new version now. Do both: issue a fresh version immediately, then add a renewal rule so this does not recur.
 
-            1. Issue a new version immediately so the certificate stops failing this cycle:
+            1. Issue a new version immediately so the certificate stops failing this cycle. Set `timeOfValidityNotAfter` to an RFC 3339 timestamp more than 30 days in the future and within the issuing CA's own validity:
 
             ```bash
             oci certs-mgmt certificate update-certificate-managed-internally \
               --certificate-id <certificate-ocid> \
-              --version-name <new-version-name> \
+              --validity '{"timeOfValidityNotAfter":"<not-after-timestamp>"}' \
               --force
             ```
 
-            2. Add or update a renewal rule so the next version is issued automatically before the current one expires:
+            For an imported certificate, the service cannot issue the version. Obtain the renewed certificate, chain, and private key from the external CA and upload them as a new version:
+
+            ```bash
+            oci certs-mgmt certificate update-certificate-by-importing-config-details \
+              --certificate-id <certificate-ocid> \
+              --certificate-pem "$(cat cert.pem)" \
+              --cert-chain-pem "$(cat chain.pem)" \
+              --private-key-pem "$(cat key.pem)" \
+              --force
+            ```
+
+            2. For an internally issued certificate, add or update a renewal rule so the next version is issued automatically before the current one expires. `renewalInterval` is how often a new version is issued and `advanceRenewalPeriod` is how far ahead of that renewal the process starts. Keep the interval short enough that the certificate never expires before it is renewed:
 
             ```bash
             oci certs-mgmt certificate update-certificate-managed-internally \
@@ -8792,12 +8947,14 @@ queries:
             Re-issue certificates with weak key algorithms using a strong key:
 
             1. Open **Identity & Security** → **Certificates** → **Certificates** → identify certificates with weak key algorithms.
-            2. For internally-issued certificates, choose **Issue New Version** and select **RSA2048**, **RSA4096**, **ECDSA_P256**, or **ECDSA_P384** as the key algorithm.
-            3. For imported certificates, regenerate the certificate externally with a strong key algorithm and re-import.
-            4. Update consumers to pick up the new version, then deprecate the old version.
+            2. For internally-issued certificates, create a replacement certificate with **RSA2048**, **RSA4096**, **ECDSA_P256**, or **ECDSA_P384** as the key algorithm. Renewing an existing certificate only changes its validity period, so it cannot fix the key algorithm.
+            3. For imported certificates, regenerate the certificate externally with a strong key algorithm and import it as a new certificate.
+            4. Move consumers to the replacement, then schedule the weak certificate for deletion. It stays active, and keeps failing, until deletion is scheduled.
         - id: cli
           desc: |
-            Key algorithms cannot be changed on an existing certificate. Issue a replacement internally-issued certificate with a strong key algorithm and migrate consumers:
+            Key algorithms cannot be changed on an existing certificate. Issue a replacement internally-issued certificate with a strong key algorithm, migrate consumers, then retire the weak certificate.
+
+            1. Create the replacement. `--key-algorithm` must be `RSA2048`, `RSA4096`, `ECDSA_P256`, or `ECDSA_P384`, and `--signature-algorithm` must suit the key type, such as `SHA256_WITH_RSA` for an RSA key. Set `commonName` to the name the certificate serves and `timeOfValidityNotAfter` to an expiry within the issuing CA's validity:
 
             ```bash
             oci certs-mgmt certificate create-certificate-issued-by-internal-ca \
@@ -8808,6 +8965,12 @@ queries:
               --signature-algorithm SHA256_WITH_RSA \
               --subject '{"commonName":"app.example.com"}' \
               --validity '{"timeOfValidityNotAfter":"2027-01-01T00:00:00Z"}'
+            ```
+
+            2. After every consumer uses the replacement, schedule the weak certificate for deletion. It remains `ACTIVE`, and keeps failing, until you do:
+
+            ```bash
+            oci certs-mgmt certificate schedule-deletion --certificate-id <weak-certificate-ocid>
             ```
         - id: terraform
           desc: |
@@ -8960,11 +9123,14 @@ queries:
             Re-issue certificates with weak signatures using a SHA-2 algorithm:
 
             1. Open **Identity & Security** → **Certificates** → **Certificates** → identify certificates with weak signature algorithms.
-            2. For internally-issued certificates, choose **Issue New Version** and pick a `SHA256_WITH_*`, `SHA384_WITH_*`, or `SHA512_WITH_*` signature algorithm.
-            3. For imported certificates, re-issue them externally using a SHA-2 signature and re-import.
+            2. For internally-issued certificates, create a replacement certificate with a `SHA256_WITH_*`, `SHA384_WITH_*`, or `SHA512_WITH_*` signature algorithm. Renewing an existing certificate only changes its validity period, so it cannot fix the signature algorithm.
+            3. For imported certificates, re-issue them externally using a SHA-2 signature and import them as new certificates.
+            4. Move consumers to the replacement, then schedule the weak certificate for deletion. It stays active, and keeps failing, until deletion is scheduled.
         - id: cli
           desc: |
-            Signature algorithms cannot be changed on an existing certificate. Issue a replacement internally-issued certificate with a SHA-2 signature algorithm and migrate consumers:
+            Signature algorithms cannot be changed on an existing certificate. Issue a replacement internally-issued certificate with a SHA-2 signature algorithm, migrate consumers, then retire the weak certificate.
+
+            1. Create the replacement. `--signature-algorithm` must be `SHA256_WITH_RSA`, `SHA384_WITH_RSA`, or `SHA512_WITH_RSA` for an RSA key, or the matching `_WITH_ECDSA` value for an ECDSA key. Set `commonName` to the name the certificate serves and `timeOfValidityNotAfter` to an expiry within the issuing CA's validity:
 
             ```bash
             oci certs-mgmt certificate create-certificate-issued-by-internal-ca \
@@ -8975,6 +9141,12 @@ queries:
               --signature-algorithm SHA256_WITH_RSA \
               --subject '{"commonName":"app.example.com"}' \
               --validity '{"timeOfValidityNotAfter":"2027-01-01T00:00:00Z"}'
+            ```
+
+            2. After every consumer uses the replacement, schedule the weak certificate for deletion. It remains `ACTIVE`, and keeps failing, until you do:
+
+            ```bash
+            oci certs-mgmt certificate schedule-deletion --certificate-id <weak-certificate-ocid>
             ```
         - id: terraform
           desc: |
@@ -9308,7 +9480,9 @@ queries:
             3. To replace: create a new CA in **Create Certificate Authority** with **KMS Vault** and **KMS Key** set to a customer-managed key, re-issue subordinate CAs and certificates from the new root, then schedule deletion of the old CA.
         - id: cli
           desc: |
-            Create a replacement root CA backed by a customer-managed KMS key. (CA encryption keys are set at create time; existing CAs without a CMK must be replaced.)
+            CA encryption keys are set at create time, so a CA without a customer-managed key must be replaced rather than updated.
+
+            1. Create a replacement root CA. `<kms-key-ocid>` must be an HSM-protected asymmetric Vault key, RSA 2048 or 4096 bits or ECDSA NIST_P384, because the Certificates service does not accept software-protected or symmetric keys. Choose a `--signing-algorithm` that suits the key type, such as `SHA256_WITH_RSA` for an RSA key:
 
             ```bash
             oci certs-mgmt certificate-authority create-root-ca-by-generating-config-details \
@@ -9318,6 +9492,12 @@ queries:
               --signing-algorithm SHA256_WITH_RSA \
               --subject '{"commonName":"Internal Root CA"}' \
               --validity '{"timeOfValidityNotAfter":"2031-01-01T00:00:00Z"}'
+            ```
+
+            2. Re-issue subordinate CAs and certificates from the new CA and move consumers to them, then schedule the old CA for deletion. It remains `ACTIVE`, and keeps failing, until you do, and it can issue nothing once deleted, so finish the migration first:
+
+            ```bash
+            oci certs-mgmt certificate-authority schedule-deletion --certificate-authority-id <old-ca-ocid>
             ```
         - id: terraform
           desc: |
@@ -9465,14 +9645,20 @@ queries:
             4. Update application connection strings to the new cluster endpoint, then delete the old cluster.
         - id: cli
           desc: |
-            Take a backup, then recreate the cluster from the backup in a private subnet:
+            The subnet is fixed when a cluster is created, so the cluster is rebuilt in a private subnet from a backup. The old cluster keeps failing for as long as it exists.
+
+            1. Back up the existing cluster:
 
             ```bash
             oci redis oci-cache-backup oci-cache-backup create \
               --compartment-id <compartment-ocid> \
               --source-cluster-id <old-cluster-ocid> \
               --display-name pre-migration
+            ```
 
+            2. Create the replacement from that backup. `<private-subnet-ocid>` must be a subnet with `prohibit-public-ip-on-vnic` set to `true`, `<backup-ocid>` is the backup from step 1, and `--node-count` and `--node-memory-in-gbs` should match the old cluster so the restored data fits:
+
+            ```bash
             oci redis redis-cluster redis-cluster create \
               --compartment-id <compartment-ocid> \
               --display-name <name> \
@@ -9481,6 +9667,12 @@ queries:
               --software-version VALKEY_8_1 \
               --subnet-id <private-subnet-ocid> \
               --backup-id <backup-ocid>
+            ```
+
+            3. Point application connection strings at the new cluster endpoint, then delete the old cluster. Deletion is permanent and loses anything written to the old cluster after the backup:
+
+            ```bash
+            oci redis redis-cluster redis-cluster delete --redis-cluster-id <old-cluster-ocid>
             ```
         - id: terraform
           desc: |
@@ -9852,7 +10044,17 @@ queries:
             3. Build a custom recipe only when a specific policy must be relaxed; document the deviation.
         - id: cli
           desc: |
-            Create a security zone bound to a target compartment:
+            Create a security zone bound to a target compartment. Cloud Guard must already be enabled in the tenancy.
+
+            1. Find the OCID of the recipe to enforce. The Oracle-managed recipe is named **Maximum Security Recipe**:
+
+            ```bash
+            oci cloud-guard security-recipe-collection list-security-recipes \
+              --compartment-id <tenancy-ocid> \
+              --query 'data.items[].{name:"display-name",id:id}'
+            ```
+
+            2. Create the zone. `<compartment-ocid>` is the compartment the zone protects, and `<recipe-ocid>` is the recipe OCID from step 1:
 
             ```bash
             oci cloud-guard security-zone create \
@@ -10078,8 +10280,8 @@ queries:
           desc: |
             To strengthen the password policy using the OCI Console:
 
-            1. Navigate to **Identity & Security > Domains**, select the default domain, then open **Settings > Password policy**.
-            2. Set the minimum length to **14**.
+            1. Navigate to **Identity & Security > Domains**, select the default domain, then open **Settings > Password policy** and select the policy.
+            2. Select **Edit password rules** and choose **Custom**, since the individual criteria can only be edited on a custom policy. Set the minimum length to **14**.
             3. Require **uppercase**, **lowercase**, **numeric**, and **special** characters.
             4. Disable **Allow username in password**.
             5. Select **Save changes**.
@@ -10095,14 +10297,14 @@ queries:
               --password-policy '{"minimumPasswordLength": 14, "isUppercaseCharactersRequired": true, "isLowercaseCharactersRequired": true, "isNumericCharactersRequired": true, "isSpecialCharactersRequired": true, "isUsernameContainmentAllowed": false}'
             ```
 
-            2. Update the password policy in each identity domain, using that domain's own endpoint:
+            2. Update the password policy in each identity domain, using that domain's own endpoint. `<domain-url>` is the host name from the domain URL shown on the domain's details page, such as `idcs-0123456789abcdef.identity.oraclecloud.com`, and `oci identity-domains password-policies list --endpoint https://<domain-url>` returns the `<password-policy-id>` values. The first operation switches the policy to `Custom` strength, because the individual rules only apply to a custom policy:
 
             ```bash
             oci identity-domains password-policy patch \
               --endpoint https://<domain-url> \
               --password-policy-id <password-policy-id> \
               --schemas '["urn:ietf:params:scim:api:messages:2.0:PatchOp"]' \
-              --operations '[{"op":"replace","path":"minLength","value":14},{"op":"replace","path":"minUpperCase","value":1},{"op":"replace","path":"minLowerCase","value":1},{"op":"replace","path":"minNumerals","value":1},{"op":"replace","path":"minSpecialChars","value":1},{"op":"replace","path":"userNameDisallowed","value":true}]'
+              --operations '[{"op":"replace","path":"passwordStrength","value":"Custom"},{"op":"replace","path":"minLength","value":14},{"op":"replace","path":"minUpperCase","value":1},{"op":"replace","path":"minLowerCase","value":1},{"op":"replace","path":"minNumerals","value":1},{"op":"replace","path":"minSpecialChars","value":1},{"op":"replace","path":"userNameDisallowed","value":true}]'
             ```
         - id: terraform
           desc: |
@@ -10252,10 +10454,20 @@ queries:
             4. **Delete** the old API key once the new key is confirmed working.
         - id: cli
           desc: |
-            To rotate an API signing key using the OCI CLI, upload a replacement public key and delete the old one:
+            To rotate an API signing key using the OCI CLI, add the replacement before removing the old key so the consuming system never loses access. A user can hold at most three API keys, so delete an unused key first if the user is already at the limit.
+
+            1. Generate a new key pair and upload its public half:
 
             ```bash
-            oci iam user api-key upload --user-id <user-ocid> --key-file ./new_public_key.pem
+            oci setup keys --key-name new_api_key --output-dir ~/.oci
+            oci iam user api-key upload --user-id <user-ocid> --key-file ~/.oci/new_api_key_public.pem
+            ```
+
+            2. Point the consuming system at the new private key and the fingerprint the upload returned, such as the `key_file` and `fingerprint` entries in its OCI config file, and confirm it can still make API calls.
+
+            3. Delete the old key. `oci iam user api-key list --user-id <user-ocid>` shows each key's fingerprint and creation time, and the check keeps failing while any active key is older than 90 days:
+
+            ```bash
             oci iam user api-key delete --user-id <user-ocid> --fingerprint <old-key-fingerprint>
             ```
         # No Terraform remediation: API key creation timestamps are runtime-only; the `oci_identity_api_key` Terraform resource has no field that controls or evidences rotation age.
@@ -10338,9 +10550,12 @@ queries:
             3. For **Protection Mode**, choose **HSM**.
             4. Complete the key shape and name, then select **Create Key**.
             5. Re-assign the new HSM key to the resources that previously used a software key.
+            6. Disable the software key once nothing uses it. Enabled software keys keep failing, and data still encrypted only under a disabled key cannot be decrypted.
         - id: cli
           desc: |
-            To create an HSM-protected master encryption key using the OCI CLI:
+            Protection mode is fixed when a key is created, so a software key is replaced rather than converted.
+
+            1. Create an HSM-protected master encryption key. `<vault-management-endpoint>` is the vault's management endpoint, and an AES key shape with a `length` of 32 bytes is a 256-bit key:
 
             ```bash
             oci kms management key create --compartment-id <compartment-ocid> \
@@ -10348,6 +10563,14 @@ queries:
               --key-shape '{"algorithm": "AES", "length": 32}' \
               --protection-mode HSM \
               --endpoint <vault-management-endpoint>
+            ```
+
+            2. Move every resource that uses the software key, such as volumes, buckets, and databases, onto the new key.
+
+            3. Disable the software key once nothing depends on it. The check evaluates every enabled key, so the software key keeps failing until it is disabled. Data still encrypted only under a disabled key cannot be decrypted, so finish step 2 first:
+
+            ```bash
+            oci kms management key disable --key-id <software-key-ocid> --endpoint <vault-management-endpoint>
             ```
         - id: terraform
           desc: |
@@ -10470,11 +10693,11 @@ queries:
             1. Navigate to **Identity & Security > Vault** and open the vault.
             2. Open the master encryption key.
             3. Select **Edit** and enable **Automatic key rotation**.
-            4. Set the rotation interval.
+            4. Set the rotation interval to a value between 60 and 365 days. The option is available only for keys in a virtual private vault.
             5. Select **Save Changes**.
         - id: cli
           desc: |
-            To enable automatic key rotation using the OCI CLI, update the key with both the rotation flag and the rotation schedule details:
+            To enable automatic key rotation using the OCI CLI, update the key with both the rotation flag and the rotation schedule details. Automatic rotation is available only for keys in a virtual private vault, which is billed separately from a default vault, so a key in a default vault has to be recreated in a `VIRTUAL_PRIVATE` vault before it can pass. `rotationIntervalInDays` accepts 60 to 365, and 90 rotates the key quarterly:
 
             ```bash
             oci kms management key update --key-id <key-ocid> \
@@ -10484,9 +10707,15 @@ queries:
             ```
         - id: terraform
           desc: |
-            To enable automatic key rotation in Terraform, set `is_auto_rotation_enabled = true` and configure the `auto_key_rotation_details` block on the key:
+            To enable automatic key rotation in Terraform, set `is_auto_rotation_enabled = true` and configure the `auto_key_rotation_details` block on the key. Automatic rotation is available only for keys in a virtual private vault, and `rotation_interval_in_days` accepts 60 to 365:
 
             ```hcl
+            resource "oci_kms_vault" "example" {
+              compartment_id = var.compartment_ocid
+              display_name   = "example-vault"
+              vault_type     = "VIRTUAL_PRIVATE"
+            }
+
             resource "oci_kms_key" "example" {
               compartment_id      = var.compartment_ocid
               display_name        = "example-key"
@@ -11261,9 +11490,10 @@ queries:
             3. For **Service**, choose **Flow Logs**; for **Resource**, select the subnet.
             4. Choose the log group and set a log name.
             5. Select **Enable Log**.
+            6. Repeat for every subnet in the VCN, because the VCN keeps failing while any subnet has no enabled flow log.
         - id: cli
           desc: |
-            To enable a flow log for a subnet using the OCI CLI:
+            To enable a flow log for a subnet using the OCI CLI, run the command once for every subnet in the VCN. A log on one subnet covers only that subnet, and the VCN keeps failing while any subnet has none:
 
             ```bash
             oci logging log create --log-group-id <log-group-ocid> \
@@ -11382,7 +11612,7 @@ queries:
             4. Select **Save changes** and confirm the customer-premises equipment is configured for IKEv2.
         - id: cli
           desc: |
-            To set an IPSec tunnel to IKEv2 using the OCI CLI:
+            To set an IPSec tunnel to IKEv2 using the OCI CLI, run the command for both tunnels of the connection, whose OCIDs `oci network ip-sec-tunnel list --ipsc-id <ipsec-connection-ocid>` returns. A tunnel stays down until the customer-premises equipment also negotiates IKEv2, so change the device in the same maintenance window:
 
             ```bash
             oci network ip-sec-tunnel update --ipsc-id <ipsec-connection-ocid> --tunnel-id <tunnel-ocid> --ike-version V2
@@ -11715,11 +11945,11 @@ queries:
             3. Save and update client connections to use the private endpoint or an allowed source.
         - id: cli
           desc: |
-            Scope the public listener to a known network by enabling an access control list:
+            Scope the public listener to known networks by setting an access control list. List public clients by public IP or CIDR, such as the documentation range `203.0.113.0/24`, and tie private ranges to their VCN as `<vcn-ocid>;<cidr>`, because a bare private CIDR is not accepted. Leave out `0.0.0.0/0`, since an entry admitting any address still counts as reachable:
 
             ```bash
             oci db autonomous-database update --autonomous-database-id <adb-ocid> \
-              --whitelisted-ips '["10.0.0.0/16"]'
+              --whitelisted-ips '["203.0.113.0/24","<vcn-ocid>;10.0.0.0/16"]'
             ```
         # No Terraform remediation: internetReachable is a runtime verdict derived from the private-endpoint, access-control, and allowlist state; the configuration that drives it is remediated in Terraform by mondoo-oci-security-adb-mtls-or-restricted.
     refs:
@@ -11793,7 +12023,7 @@ queries:
             3. Save the change.
         - id: cli
           desc: |
-            Configure the standby to reuse the primary's allowlist so it inherits the same restrictions:
+            Configure the standby to reuse the primary's allowlist so it inherits the same restrictions. This closes the finding only when the primary's own list, returned by `oci db autonomous-database get --autonomous-database-id <adb-ocid> --query 'data."whitelisted-ips"'`, has no `0.0.0.0/0`, `0.0.0.0`, or `::/0` entry, so remove those from the primary first:
 
             ```bash
             oci db autonomous-database update --autonomous-database-id <adb-ocid> \
@@ -12005,11 +12235,11 @@ queries:
             3. Save the change.
         - id: cli
           desc: |
-            Enable prompt injection detection on an existing endpoint:
+            Enable prompt injection detection on an existing endpoint. `isEnabled` turns the guardrail on and is required in the payload, and `mode` set to `BLOCK` rejects flagged content instead of only recording it:
 
             ```bash
             oci generative-ai endpoint update --endpoint-id <endpoint-ocid> \
-              --prompt-injection-config '{"mode": "BLOCK"}'
+              --prompt-injection-config '{"isEnabled": true, "mode": "BLOCK"}'
             ```
         # No Terraform remediation: the endpoint's prompt-injection guardrail is a service-side setting with no verified Terraform resource argument; manage it through the console or CLI.
     refs:
@@ -12083,11 +12313,11 @@ queries:
             3. Save the change.
         - id: cli
           desc: |
-            Enable PII detection on an existing endpoint:
+            Enable PII detection on an existing endpoint. `isEnabled` turns the guardrail on and is required in the payload, and `mode` set to `BLOCK` rejects flagged content instead of only recording it:
 
             ```bash
             oci generative-ai endpoint update --endpoint-id <endpoint-ocid> \
-              --pii-detection-config '{"mode": "BLOCK"}'
+              --pii-detection-config '{"isEnabled": true, "mode": "BLOCK"}'
             ```
         # No Terraform remediation: the endpoint's PII-detection guardrail is a service-side setting with no verified Terraform resource argument; manage it through the console or CLI.
     refs:
@@ -12161,11 +12391,11 @@ queries:
             3. Save the change.
         - id: cli
           desc: |
-            Enable content moderation on an existing endpoint:
+            Enable content moderation on an existing endpoint. `isEnabled` turns the guardrail on and is required in the payload, and `mode` set to `BLOCK` rejects flagged content instead of only recording it:
 
             ```bash
             oci generative-ai endpoint update --endpoint-id <endpoint-ocid> \
-              --content-moderation-config '{"mode": "BLOCK"}'
+              --content-moderation-config '{"isEnabled": true, "mode": "BLOCK"}'
             ```
         # No Terraform remediation: the endpoint's content-moderation guardrail is a service-side setting with no verified Terraform resource argument; manage it through the console or CLI.
     refs:
@@ -12314,15 +12544,23 @@ queries:
 
             1. Under **Analytics & AI > Data Science**, create a Data Science private endpoint in the target VCN.
             2. Create notebook sessions with the private endpoint selected under **Networking**, since the association is set at creation.
-            3. Recreate existing sessions that lack a private endpoint.
+            3. Recreate existing sessions that lack a private endpoint, save their notebooks and data, then delete the old sessions, which keep failing while they exist.
         - id: cli
           desc: |
-            Create a notebook session bound to a Data Science private endpoint by supplying it in the configuration details:
+            The private endpoint can only be set when a notebook session is created, so each session without one is replaced.
+
+            1. Create a notebook session bound to a Data Science private endpoint by supplying it in the configuration details:
 
             ```bash
             oci data-science notebook-session create --project-id <project-ocid> \
               --compartment-id <compartment-ocid> \
               --config-details '{"privateEndpointId": "<private-endpoint-ocid>", "shape": "VM.Standard2.1", "blockStorageSizeInGBs": 50, "subnetId": "<subnet-ocid>"}'
+            ```
+
+            2. Copy any notebooks and data you need out of the old session, then delete it. The old session keeps failing for as long as it exists, and deleting it permanently removes its storage:
+
+            ```bash
+            oci data-science notebook-session delete --notebook-session-id <old-notebook-session-ocid>
             ```
         # No Terraform remediation: the notebook session's private endpoint is set at creation and is not verified against a Terraform resource argument here; manage it through the console or CLI.
     refs:
@@ -12411,7 +12649,7 @@ queries:
             4. Select **Save changes** and apply the policy.
         - id: cli
           desc: |
-            To harden a decryption profile using the OCI CLI:
+            To harden a decryption profile using the OCI CLI, keep `--type` set to the profile's existing type. The example is a forward-proxy profile. For an `SSL_INBOUND_INSPECTION` profile, pass only `isUnsupportedCipherBlocked`, `isUnsupportedVersionBlocked`, and `isOutOfCapacityBlocked`, because the certificate settings exist only on forward-proxy profiles:
 
             ```bash
             oci network-firewall decryption-profile update \
@@ -12584,6 +12822,14 @@ queries:
           desc: |
             To scope an allow rule using the OCI CLI:
 
+            1. Read the rule's current condition. `--condition` replaces the whole condition, so any `application`, `service`, or `url` list you leave out stops restricting the rule:
+
+            ```bash
+            oci network-firewall security-rule get --network-firewall-policy-id <policy-ocid> --security-rule-name <rule-name>
+            ```
+
+            2. Resubmit the full condition with `sourceAddress` added. Its values are names of address lists defined in the policy, not CIDRs, so `corporate-ranges` and `app-tier` stand for your own list names:
+
             ```bash
             oci network-firewall security-rule update --network-firewall-policy-id <policy-ocid> \
               --security-rule-name <rule-name> --action ALLOW \
@@ -12591,14 +12837,13 @@ queries:
             ```
         - id: terraform
           desc: |
-            To scope an allow rule in Terraform, name a source address list in the `condition` block:
+            To scope an allow rule in Terraform, name a source address list in the `condition` block. Rules are evaluated in order and the first match wins, so place the allow rule before any catch-all drop rule:
 
             ```hcl
             resource "oci_network_firewall_network_firewall_policy_security_rule" "example" {
               name                       = "allow-partner-api"
               network_firewall_policy_id = oci_network_firewall_network_firewall_policy.example.id
               action                     = "ALLOW"
-              inspection                 = "INTRUSION_PREVENTION"
 
               condition {
                 source_address      = ["corporate-ranges"]
@@ -12606,7 +12851,7 @@ queries:
               }
 
               position {
-                after_rule = "deny-all"
+                before_rule = "deny-all"
               }
             }
             ```
@@ -12734,7 +12979,7 @@ queries:
             3. Select **Save changes**.
         - id: cli
           desc: |
-            To narrow a bastion's allow list using the OCI CLI:
+            To narrow a bastion's allow list using the OCI CLI, pass every range operators connect from, such as corporate egress addresses and VPN pools. `--client-cidr-list` replaces the whole list, so leave out `0.0.0.0/0` and `::/0`, and replace the documentation range `203.0.113.0/24` with your own:
 
             ```bash
             oci bastion bastion update --bastion-id <bastion-ocid> \
@@ -13002,11 +13247,24 @@ queries:
           desc: |
             To enable DNSSEC on a zone using the OCI CLI:
 
+            1. Turn on signing:
+
             ```bash
             oci dns zone update --zone-name-or-id <zone-name> --scope GLOBAL --dnssec-state ENABLED
             ```
 
-            Then publish the resulting DS record at the parent zone or registrar.
+            2. Read the zone OCID and the key signing key's `uuid` and DS data:
+
+            ```bash
+            oci dns zone get --zone-name-or-id <zone-name> --scope GLOBAL \
+              --query 'data.{id:id,ksk:"dnssec-config"."ksk-dnssec-key-versions"[].{uuid:uuid,dsData:"ds-data"}}'
+            ```
+
+            3. Publish a DS record built from `dsData` at the parent zone or registrar. Once it is live, promote the key signing key so OCI knows the chain of trust is in place and its key management can proceed:
+
+            ```bash
+            oci dns zone promote-zone-dnssec-key-version --zone-id <zone-ocid> --dnssec-key-version-uuid <ksk-uuid> --scope GLOBAL
+            ```
         - id: terraform
           desc: |
             To enable DNSSEC in Terraform, set `dnssec_state` to `ENABLED`:
@@ -13135,12 +13393,12 @@ queries:
             4. Select **Save changes** and apply the matching proposal on the customer-premises equipment.
         - id: cli
           desc: |
-            To raise a tunnel's Diffie-Hellman group using the OCI CLI:
+            To raise a tunnel's Diffie-Hellman group using the OCI CLI, set a custom proposal on both phases. Phase 1 takes the group as `diffieHelmanGroup`, spelled as the API spells it, and phase 2 applies its group through perfect forward secrecy as `pfsDhGroup`. Use `GROUP14` or a stronger group such as `GROUP19` or `GROUP20`, and apply the same proposal on the customer-premises equipment, or the tunnel will not re-establish:
 
             ```bash
             oci network ip-sec-tunnel update --ipsc-id <ipsec-connection-ocid> --tunnel-id <tunnel-ocid> \
-              --phase-one-config '{"isCustomPhaseOneConfig":true,"customDhGroup":"GROUP14"}' \
-              --phase-two-config '{"isCustomPhaseTwoConfig":true,"dhGroup":"GROUP14"}'
+              --phase-one-config '{"isCustomPhaseOneConfig":true,"diffieHelmanGroup":"GROUP14"}' \
+              --phase-two-config '{"isCustomPhaseTwoConfig":true,"isPfsEnabled":true,"pfsDhGroup":"GROUP14"}'
             ```
         - id: terraform
           desc: |
@@ -13329,11 +13587,11 @@ queries:
             4. Select **Save changes** and apply the matching setting on the customer-premises equipment.
         - id: cli
           desc: |
-            To enable perfect forward secrecy using the OCI CLI:
+            To enable perfect forward secrecy using the OCI CLI, turn on `isPfsEnabled` and set `pfsDhGroup` to `GROUP14` or stronger. Apply the matching setting on the customer-premises equipment in the same window, because the tunnel will not re-establish until both sides agree:
 
             ```bash
             oci network ip-sec-tunnel update --ipsc-id <ipsec-connection-ocid> --tunnel-id <tunnel-ocid> \
-              --phase-two-config '{"isCustomPhaseTwoConfig":true,"isPfsEnabled":true,"dhGroup":"GROUP14"}'
+              --phase-two-config '{"isCustomPhaseTwoConfig":true,"isPfsEnabled":true,"pfsDhGroup":"GROUP14"}'
             ```
         - id: terraform
           desc: |
@@ -13471,11 +13729,12 @@ queries:
             3. Terminate the peering, then remove the route rules that pointed at it.
         - id: cli
           desc: |
-            To remove an unintended cross-tenancy peering using the OCI CLI:
+            To remove an unintended cross-tenancy peering using the OCI CLI, delete whichever construct carries it: a local peering gateway, a remote peering connection, or a DRG attachment. Deletion cuts off all traffic across that path at once, so confirm with the network owner first:
 
             ```bash
             oci network local-peering-gateway delete --local-peering-gateway-id <lpg-ocid>
             oci network remote-peering-connection delete --remote-peering-connection-id <rpc-ocid>
+            oci network drg-attachment delete --drg-attachment-id <drg-attachment-ocid>
             ```
         - id: terraform
           desc: |
@@ -13753,9 +14012,17 @@ queries:
           desc: |
             To narrow the ingress rules that make the load balancer reachable using the OCI CLI:
 
+            1. List the ingress rules on the load balancer's network security group and note the `id` of each rule whose source is `0.0.0.0/0`:
+
+            ```bash
+            oci network nsg rules list --nsg-id <nsg-ocid> --direction INGRESS
+            ```
+
+            2. Update each of those rules by `id`, replacing the any-address source with the range that should reach the load balancer and limiting it to the listener port. `203.0.113.0/24` and port 443 are examples to replace with your own values:
+
             ```bash
             oci network nsg rules update --nsg-id <nsg-ocid> \
-              --security-rules '[{"direction":"INGRESS","protocol":"6","source":"203.0.113.0/24","sourceType":"CIDR_BLOCK"}]'
+              --security-rules '[{"id":"<rule-id>","direction":"INGRESS","protocol":"6","source":"203.0.113.0/24","sourceType":"CIDR_BLOCK","tcpOptions":{"destinationPortRange":{"min":443,"max":443}}}]'
             ```
         # No Terraform remediation: the fix is to change whichever of the three inputs makes
         # the load balancer reachable, and which one applies depends on the deployment. The


### PR DESCRIPTION
## Summary

Audited the remediation of all 106 checks in `content/mondoo-oci-security.mql.yaml` (console, cli, terraform methods, plus the audit commands the command validator reads) against each check's own MQL. 74 proposed edits were verified and applied, three of them adjusted during review, and 7 more audit queries were fixed in the same way as the audited ones. The headline defects: load balancer listeners created with an `HTTPS` protocol OCI does not have, replication prerequisites that told readers to enable versioning on a destination OCI rejects, CLI payloads with field names the OCI API does not have (IPSec DH group, GenAI guardrails, NSG rule update), JMESPath audit filters that could never match, missing Vault key grants, and many steps that created a replacement but left the failing resource in place.

## Changes

### Commands, payloads and examples that fail as written

<details><summary>20 checks</summary>

- **Ensure compute instance metadata does not contain credentials** (`mondoo-oci-security-compute-metadata-no-secrets`, cli): The update command reads `metadata-without-credentials.json`, but the preceding get command only prints to the terminal, so the file the update depends on is never created. Redirecting the current metadata into the file and editing it in place gives the update a complete map that keeps user_data and ssh_authorized_keys unchanged, which OCI requires, while dropping the credential keys the check flags. Evidence: `oci compute instance update --help` for --metadata: 'Any set of key/value pairs provided here will completely replace the current set ... You must provide the same values for "user_data" and ...

- **Ensure load balancer HTTPS listeners only allow TLS 1.2 or newer** (`mondoo-oci-security-loadbalancer-tls-minimum-1-2`, cli, terraform): The CLI command passes `--protocol HTTPS`, which is not an OCI load balancer listener protocol, and never explains that the update rewrites the listener's SSL settings or which values must be carried over. An HTTPS listener in OCI is an HTTP listener with an SSL configuration, so `--protocol HTTP` with `--ssl-certificate-name` and `--protocols` restricted to TLSv1.2 and TLSv1.3 produces a listener whose sslProtocols contain none of TLSv1, TLSv1.1 or SSLv3. Evidence: Oracle's terraform-provider-oci examples/load_balancer/lb_full/lb_full.tf declares the port 443 listener as 'protocol = "HTTP"' with an ssl_configuration block; ... / The Terraform example sets `protocol = "HTTPS"`, which is not an OCI load balancer listener protocol, so the listener cannot be created as written. Oracle's own examples declare TLS listeners as protocol HTTP with an ssl_configuration block; the configuration check selects any listener that declares ssl_configuration, so the corrected listener with protocols TLSv1.2 and TLSv1.3 still passes it. Evidence: Oracle's terraform-provider-oci examples/load_balancer/lb_full/lb_full.tf declares the port 443 listener as 'protocol = "HTTP"' with an ssl_configuration block; ...

- **Ensure load balancer listeners use a modern cipher suite** (`mondoo-oci-security-loadbalancer-no-weak-cipher-suites`, cli, console, terraform): The CLI command passes `--protocol HTTPS`, which is not an OCI load balancer listener protocol, and never explains which cipher suite names satisfy the check or that the update rewrites the SSL configuration. Using the listener's real protocol with `--cipher-suite-name` set to one of the accepted Oracle suites makes sslCipherSuite.name match the check's allow-list. Evidence: Oracle's terraform-provider-oci examples/load_balancer/lb_full/lb_full.tf declares the port 443 listener as 'protocol = "HTTP"' with an ssl_configuration block; ... / The Terraform example sets `protocol = "HTTPS"`, which is not an OCI load balancer listener protocol, so the listener cannot be created as written. Declaring the listener as protocol HTTP with an ssl_configuration block matches Oracle's examples, and the configuration check still selects it through the ssl_configuration block and passes on the modern cipher suite name. Evidence: Oracle's terraform-provider-oci examples/load_balancer/lb_full/lb_full.tf declares the port 443 listener as 'protocol = "HTTP"' with an ssl_configuration block; ... / The console step tells the reader to choose an `oci-tls-1-2-*` or `oci-tls-1-3-*` suite, but no predefined suite has those names, and the check accepts only `oci-modern-ssl-cipher-suite-v1` and `oci-default-ssl-cipher-suite-v1` among the real ones. Naming the two predefined suites that satisfy the check's allow-list gives the reader a choice that exists in OCI and makes sslCipherSuite.name match. Evidence: docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingciphersuites_topic-Predefined_Cipher_Suites.htm lists oci-tls-12-ssl-cipher-suite-v3, oci-tls-13-ssl-cipher-suite-v3, ...

- **Ensure load balancers that run HTTP listeners also expose HTTPS** (`mondoo-oci-security-loadbalancer-http-listener-has-https`, cli): The CLI command creates a listener with `--protocol HTTPS`, which is not an OCI load balancer listener protocol, so it cannot run as written, and `<backend>` and `<cert-name>` are unexplained. A TLS listener in OCI is created with protocol HTTP2 or HTTP plus an SSL configuration; HTTP2 is used here because the check's query accepts HTTP2 listeners, with the HTTP/2 cipher suite and TLS versions Oracle documents for HTTP2 listeners, and the placeholders now say which existing backend set and certificate to use. Evidence: Oracle's terraform-provider-oci examples/load_balancer/lb_full/lb_full.tf declares the port 443 listener as 'protocol = "HTTP"' with an ssl_configuration block; ...

- **Ensure DB systems are deployed in subnets that prohibit public IPs on VNICs** (`mondoo-oci-security-dbsystem-private-subnet`, cli): The `oci db system launch` command omits the required `--database-edition`, `--admin-password`, `--db-name` and `--db-version` options, so the CLI rejects it before any DB system is created. Adding the required options, with each placeholder explained, lets the replacement DB system launch in the subnet created with prohibit-public-ip-on-vnic true, which is what subnet.prohibitPublicIpOnVnic reads. Evidence: `oci db system launch --help` marks [required]: --compartment-id, --availability-domain, --subnet-id, --shape, --hostname, --database-edition, --admin-password, --db-name, --db-version, ...

- **Ensure OCI Vault active secret versions are not past their expiry time** (`mondoo-oci-security-vault-secrets-not-expired`, cli): The CLI method runs `oci vault secret rotate` on every expired secret, but that operation only works for secrets that already have a rotation target configured, so it fails on the common case of a manually managed secret. Creating a new secret version with update-base64 resets the current version and its expiry, which makes timeOfCurrentVersionExpiry null or in the future; rotate remains the path for secrets with a target system. Evidence: `oci vault secret rotate --help`: 'API to force rotation of an existing secret in Vault and the specified target system; expects secret to have a valid Target System Details object'; `oci vault ...

- **Ensure VCN security lists block legacy admin port ingress from 0.0.0.0/0** (`mondoo-oci-security-vcn-no-unrestricted-ingress-legacy-admin-ports`, audit): The audit CLI filters `protocol==`6``, a JMESPath number literal, but OCI returns protocol as the string "6", so the query never matches and every security list looks like it passes. `` `"6"` `` is a JSON string literal that equals the string the API returns, so failing TCP rules from 0.0.0.0/0 are listed. Evidence: Ran the query with the OCI CLI's bundled jmespath: `[?source==`0.0.0.0/0` && protocol==`6`]` returned [] against a rule with protocol "6"; `protocol==`"6"`` returned the rule.

- **Ensure VCN security lists block unrestricted ICMP ingress from 0.0.0.0/0** (`mondoo-oci-security-vcn-no-unrestricted-icmp-ingress`, audit): The audit CLI compares protocol to the JMESPath number literals `1` and `58`, which never equal the string protocol values OCI returns, so unrestricted ICMP and ICMPv6 rules are silently omitted and only `all` rules show. String literals `"1"` and `"58"` match the API's string protocol field, so every rule the check fails is listed. Evidence: OCI CLI bundled jmespath: the original filter returned only the protocol `all` rule from a sample with protocol "1"; the string-literal filter returned both.

- **Ensure managed certificates are not expired or near expiry** (`mondoo-oci-security-certificates-not-expired`, console): The console method names an 'Issue New Version' action that the Certificates console does not have, gives no expiry value that satisfies the 30-day threshold, and has no path for imported certificates, which the check also evaluates. Uses the documented Renew certificate action with a Not Valid After date more than 30 days out, and covers imported certificates, which the service cannot renew itself. Evidence: https://docs.oracle.com/en-us/iaas/Content/certificates/renewing-certificate.htm: 'From the Actions menu for the certificate, select Renew Certificate ... Select Not Valid After'. ...

- **Ensure managed certificates use strong key algorithms** (`mondoo-oci-security-certificates-strong-key-algorithms`, console): The console method says to choose a stronger key algorithm when issuing a new version, but a renewal only sets validity and cannot change the key algorithm, and the weak certificate is never retired so it stays ACTIVE and failing. Directs the reader to create a replacement certificate and schedule the weak one for deletion, which is what makes the ACTIVE set pass. Evidence: `oci certs-mgmt certificate update-certificate-managed-internally --help` exposes only --stage, --validity, --version-name, --certificate-rules (no key algorithm); renewing-certificate.htm lists only ...

- **Ensure managed certificates use strong signature algorithms** (`mondoo-oci-security-certificates-strong-signature-algorithms`, console): The console method says to pick a SHA-2 signature algorithm when issuing a new version, but renewal only sets validity, and the weak certificate is never retired so it stays ACTIVE and failing. Directs the reader to create a replacement certificate and schedule the weak one for deletion. Evidence: `oci certs-mgmt certificate update-certificate-managed-internally --help` has no signature-algorithm option; renewing-certificate.htm lists only validity fields. Check mql filters `state == "ACTIVE"`.

- **Ensure the IAM password policy enforces strong complexity requirements** (`mondoo-oci-security-iam-password-policy-strong`, console): The console steps set length and character rules directly, but an identity domain password policy only allows editing those criteria after choosing Custom under Edit password rules. Adds the Edit password rules and Custom selection Oracle documents as the prerequisite for editing the criteria the check reads. Evidence: https://docs.oracle.com/en-us/iaas/Content/Identity/passwordpolicies/modify-custom-password-policy.htm: 'To change the password rules, select Edit password rules ... Select Custom and edit the ...

- **Ensure Generative AI endpoints enable prompt injection detection** (`mondoo-oci-security-genai-endpoint-prompt-injection-detection`, cli): The CLI sends `--prompt-injection-config '{"mode": "BLOCK"}'` without `isEnabled`, which the API model marks as required, so the call is rejected or leaves the guardrail disabled and the check failing. Adds `"isEnabled": true`, the field that turns the guardrail on, and explains what `mode` controls. Evidence: oci SDK model oci/generative_ai/models/prompt_injection_config.py: `**[Required]** Gets the is_enabled` with attribute map `isEnabled`; ContentModerationConfig mode allowed values "INFORM", "BLOCK".

- **Ensure Generative AI endpoints enable PII detection** (`mondoo-oci-security-genai-endpoint-pii-detection`, cli): The CLI sends `--pii-detection-config '{"mode": "BLOCK"}'` without `isEnabled`, which the API model marks as required, so the call is rejected or leaves the guardrail disabled and the check failing. Adds `"isEnabled": true`, the field that turns the guardrail on, and explains what `mode` controls. Evidence: oci SDK model oci/generative_ai/models/pii_detection_config.py: `**[Required]** Gets the is_enabled` with attribute map `isEnabled`; ContentModerationConfig mode allowed values "INFORM", "BLOCK".

- **Ensure Generative AI endpoints enable content moderation** (`mondoo-oci-security-genai-endpoint-content-moderation`, cli): The CLI sends `--content-moderation-config '{"mode": "BLOCK"}'` without `isEnabled`, which the API model marks as required, so the call is rejected or leaves the guardrail disabled and the check failing. Adds `"isEnabled": true`, the field that turns the guardrail on, and explains what `mode` controls. Evidence: oci SDK model oci/generative_ai/models/content_moderation_config.py: `**[Required]** Gets the is_enabled` with attribute map `isEnabled`; ContentModerationConfig mode allowed values "INFORM", "BLOCK".

- **Ensure Autonomous Databases are not reachable from the public internet** (`mondoo-oci-security-adb-not-internet-reachable`, cli): The example ACL `["10.0.0.0/16"]` is a bare private CIDR, which Autonomous Database access control lists do not accept, and the method does not explain what entries are valid or that 0.0.0.0/0 must not appear. Uses a public CIDR plus the VCN-scoped `<vcn-ocid>;<cidr>` form the API documents for private ranges, and states the rule the check enforces. Evidence: `oci db autonomous-database update --help` --whitelisted-ips: 'an array of CIDR ... for a subnet or VCN OCID ... Example: ...

- **Ensure Network Firewall allow rules name a source address list** (`mondoo-oci-security-network-firewall-no-allow-any-source`, terraform): The snippet places the allow rule after a `deny-all` rule, where first-match evaluation means it never matches, and sets `inspection` on an ALLOW rule although inspection applies only to INSPECT actions. Positions the rule before the catch-all drop so it takes effect and removes the inapplicable `inspection` argument; the asserted `source_address` is unchanged. Evidence: https://docs.oracle.com/en-us/iaas/Content/network-firewall/policies.htm: 'The firewall evaluates the security rules in priority list order ... When a rule action is applied, the firewall doesn't ...

- **Ensure IPSec tunnels do not use Diffie-Hellman group 2 or 5** (`mondoo-oci-security-ipsec-tunnel-strong-dh-group`, cli): The CLI payload uses `customDhGroup` and `dhGroup`, which are Terraform-style names that do not exist in the OCI API's PhaseOneConfigDetails and PhaseTwoConfigDetails, so the DH group is never set and the check keeps failing. Uses the API field names `diffieHelmanGroup` for phase 1 and `isPfsEnabled` plus `pfsDhGroup` for phase 2, and explains the passing groups and the CPE dependency. Evidence: oci SDK oci/core/models/phase_one_config_details.py attribute_map: isCustomPhaseOneConfig, authenticationAlgorithm, encryptionAlgorithm, diffieHelmanGroup, lifetimeInSeconds; ...

- **Ensure established IPSec tunnels have perfect forward secrecy** (`mondoo-oci-security-ipsec-tunnel-pfs-enabled`, cli): The phase two payload sets the group as `dhGroup`, a field the OCI API does not have, so the PFS group is not applied as written. Uses the API field `pfsDhGroup` and explains the group choice and the CPE dependency; `isPfsEnabled` stays true, which is what the check reads. Evidence: oci SDK oci/core/models/phase_two_config_details.py attribute_map includes isPfsEnabled and pfsDhGroup; no dhGroup field.

- **Ensure network load balancers are not reachable from the internet** (`mondoo-oci-security-network-loadbalancer-not-internet-reachable`, cli): `oci network nsg rules update` requires each rule's `id`, which the payload omits, so the command fails; it also gives no way to find the offending rule and no port scope. Adds listing the NSG's ingress rules to get the id, includes `id` in the payload, and explains the example source range and listener port. Evidence: oci SDK oci/core/models/update_security_rule_details.py: '**[Required]** Gets the id of this UpdateSecurityRuleDetails.' `oci network nsg rules list --help`: --direction [EGRESS|INGRESS].

</details>

### Missing or wrong prerequisites

- **Ensure Object Storage buckets use customer-managed encryption keys** (`mondoo-oci-security-object-storage-buckets-customer-managed-encryption`, cli, terraform): The CLI method assigns a Vault key without granting the Object Storage service permission to use it, so the update is rejected, and it never explains KEY_OCID. Object Storage calls Vault as the objectstorage-<region> service principal and needs KEY_ENCRYPT, KEY_DECRYPT and KEY_READ on the key, which `use keys` grants; with the grant in place the bucket's kmsKeyId becomes non-empty, which is what the check reads. Evidence: docs.oracle.com/en-us/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm: CreateBucket with a KMS key ID requires KEY_ASSOCIATE and 'The objectstorage-<location> subject must also have: ... / The Terraform example creates a vault, key and bucket but omits the service policy that lets Object Storage use the key, so the bucket creation with kms_key_id fails. Adding an oci_identity_policy that grants the objectstorage-<region> service `use keys` on the key, and making the bucket depend on it, lets the apply succeed with kms_key_id set, which is what the check asserts. Evidence: docs.oracle.com/en-us/iaas/Content/Identity/Reference/objectstoragepolicyreference.htm: 'If the KMS Key ID is provided to the operation ... The objectstorage-<location> subject must also have: ...

- **Ensure Object Storage buckets have replication enabled** (`mondoo-oci-security-object-storage-buckets-replication-enabled`, cli, console, terraform): The console prerequisites require versioning on the destination bucket, which is the opposite of OCI's rule, and authorize the Object Storage service of an unspecified region only on the destination compartment. OCI refuses to create a replication policy whose destination has versioning or retention rules, and the service principal of the source region performs the copy, so it needs object access in both compartments; following the corrected steps lets the policy be created and replicationEnabled becomes true. Evidence: docs.oracle.com/en-us/iaas/Content/Object/Troubleshooting/usingreplication_topic-Troubleshooting_Replication.htm: 'The destination bucket can't have versioning enabled.' 'The destination bucket can't ... / The CLI prerequisites require versioning on the destination bucket, which makes OCI reject the replication policy, and the placeholders for the destination region are not explained. With a destination bucket that has versioning disabled and no retention rules, and the source region's service principal authorized, create-replication-policy succeeds and replicationEnabled becomes true. Evidence: usingreplication_topic-Troubleshooting_Replication.htm: 'The destination bucket can't have versioning enabled.' 'The destination bucket can't have retention rules.'; `oci os replication ... / The Terraform example enables versioning on the destination bucket, which OCI rejects as a replication destination, and authorizes the destination region's service on the destination compartment only instead of the source region's service. Leaving the destination unversioned and authorizing objectstorage-<source region> for object-family in the tenancy lets oci_objectstorage_replication_policy be created, which is the resource the IaC checks count. Evidence: usingreplication_topic-Troubleshooting_Replication.htm: 'The destination bucket can't have versioning enabled.'; usingreplication.htm: authorize 'the Object Storage service for each region carrying ...

- **Ensure OKE clusters encrypt Kubernetes secrets with customer-managed keys** (`mondoo-oci-security-oke-secrets-customer-managed-encryption`, cli, terraform): The CLI method creates a cluster with `--kms-key-id` but omits the IAM grant that must exist before creation for the cluster to use the key, and never says that existing clusters must be replaced. Granting clusters `use keys` on the key through a dynamic group before running `oci ce cluster create --kms-key-id` produces a cluster with kmsKey set, which is the check's assertion; the dynamic-group form avoids an `Allow any-user` statement that the any-user policy check would flag. Evidence: docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengencryptingdata.htm: the dynamic group rule 'ALL {resource.type = 'cluster', resource.compartment.id = '<compartment-ocid>'}' with 'Allow ... / The Terraform example omits the key-access policy that must exist before the cluster is created and pins `kubernetes_version = "v1.29.1"`, a release OKE no longer supports. Declaring the dynamic group and policy, with the cluster depending on them, lets the apply create a cluster with kms_key_id set; using a variable for the version avoids shipping an end-of-life release. Evidence: docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengencryptingdata.htm: the dynamic group rule 'ALL {resource.type = 'cluster', resource.compartment.id = '<compartment-ocid>'}' with 'Allow ...

### Fix would not close the check

<details><summary>14 checks</summary>

- **Ensure active IAM users have logged in within the last 90 days** (`mondoo-oci-security-iam-stale-active-users`, cli, console): The console steps point at the pre-identity-domains Users page and offer a Disable action that no longer exists, and never say that the finding clears only when the account is deactivated, deleted, or signs in. The check evaluates only ACTIVE users with lastLogin older than 90 days, so deactivating or deleting the account removes it from scope; the steps now follow the identity domain Users page and its Deactivate action. Evidence: docs.oracle.com/en-us/iaas/Content/Identity/users/change-status-user-account.htm: select the domain, go to Users, 'select the Actions menu (three dots) next to the user whose status you want to ... / The CLI method tells the reader to delete API keys and auth tokens, which leaves the user ACTIVE with a stale lastLogin so the check keeps failing, and it offers no CLI step that actually clears the finding. Deleting the user removes it from the check's scope; OCI refuses to delete a user that still belongs to a group, so the group memberships are removed first. The text also states the 90-day threshold and that `update-user-state` cannot deactivate a user. Evidence: `oci iam user delete --help`: 'Deletes the specified user. The user must not be in any groups.'; `oci iam user update-user-state --help`: '--blocked BOOLEAN Update state to blocked or unblocked. Only ...

- **Ensure public compute VNICs are gated by a network security group** (`mondoo-oci-security-public-vnic-has-nsg`, cli, console): The console steps accept any NSG whose rules match the services the host exposes, but the check fails whenever an attached NSG admits traffic from any address, so attaching an NSG that opens a port to 0.0.0.0/0 leaves the finding in place. exposure.securityGroupAllowsIngress is false only when at least one NSG is attached and none of the attached NSGs has a non-ICMP ingress rule from 0.0.0.0/0, ::/0, or a public range as wide as a /8; the new text states that requirement. Evidence: mql providers/oci/resources/oci_exposure.go: ociCollectOpenNsgRules returns 'nsgCount == 0 || len(typedOpen) > 0'; ociRuleValuesOpenIngress requires INGRESS, CIDR_BLOCK source where ... / The CLI method attaches an arbitrary NSG without saying the NSG must not admit traffic from any address, and does not warn that `--nsg-ids` replaces the VNIC's existing NSG list. The check passes only when the attached NSGs contain no internet-wide ingress rule, and `--nsg-ids` sets the complete list, so the text now requires a restrictive NSG and tells the reader to include any NSG already attached that they want to keep. Evidence: oci_exposure.go ociCollectOpenNsgRules / ociRuleValuesOpenIngress as above; `oci network vnic update --help` lists --nsg-ids as a complex type list of NSG OCIDs.

- **Ensure container instances pull images from the tenancy's OCIR registry** (`mondoo-oci-security-container-instances-approved-registry`, cli, console): The CLI method creates a new container instance pointing at OCIR but never deletes the original, and the check evaluates every container instance, so the old non-OCIR instance keeps the finding open. Deleting the original instance after the replacement is running leaves only instances whose imageUrl matches the ocir.io pattern, which is what the check requires. Evidence: Check mql: oci.containerInstances.instances.all(containers.all(imageUrl == /^[a-z0-9-]+\.ocir\.io\//)); `oci container-instances container-instance delete --help` lists --container-instance-id and ... / The console steps end with recreating the container instance but never delete the original, which keeps failing the check because every instance is evaluated. Deleting the original instance once the replacement runs leaves only OCIR-backed instances, which is what the check requires. Evidence: Check mql: oci.containerInstances.instances.all(containers.all(imageUrl == /^[a-z0-9-]+\.ocir\.io\//)).

- **Ensure object storage bucket retention rules are locked** (`mondoo-oci-security-object-storage-retention-rules-locked`, cli, console): The CLI example locks the rule at 2099-01-01, but the check passes only once timeRuleLocked is in the past, so that value leaves the rule unlocked and the finding open until 2099. Setting the lock time to the earliest allowed value, 14 days ahead, locks the rule as soon as OCI permits, after which timeRuleLocked <= time.now is true. Evidence: Check mql: retentionRules.all(timeRuleLocked != null && timeRuleLocked <= time.now); `oci os retention-rule update --help` lists --time-rule-locked 'The date and time as per [RFC 3339] after which ... / The console steps say to pick a lock time no sooner than 14 days out but never say the check keeps failing until that time passes, so a reader who picks a distant date leaves the rule unlocked indefinitely. The check requires timeRuleLocked to be in the past; telling the reader to choose a date near the 14-day minimum and that the finding clears once it passes aligns the steps with the query. Evidence: Check mql: retentionRules.all(timeRuleLocked != null && timeRuleLocked <= time.now).

- **Ensure database backups are encrypted with customer-managed keys** (`mondoo-oci-security-database-backups-customer-managed-encryption`, cli, console): The console method says existing backups stay on the old key but tells the reader to re-create backups, which leaves the old backups in place and the check failing; it also uses an em dash. The check reads every backup's kmsKey, so the old backups must age out or be deleted; the new text says which ones can be deleted and warns that deletion is permanent. Evidence: `oci db backup delete --help`: 'Deletes a full backup. You cannot delete automatic backups using this API.' `oci db autonomous-database-backup delete --help`: 'Deletes a long-term backup. You cannot ... / The CLI method claims the finding persists until backups are 're-created', but new backups do not remove the old ones the check keeps reading, and no command removes them. Adds the verified delete commands for full and long-term backups, notes that automatic backups can only age out, and flags that deletion is permanent, so following the steps actually clears every backup without a KMS key. Evidence: `oci db backup delete --help` (--backup-id, full backups only); `oci db autonomous-database-backup delete --help` (--autonomous-database-backup-id, long-term backups only). OCI validator passes the ... / The closing CLI step repeats 're-create critical long-term backups' without any way to remove the old backups that keep the check failing. Replaces it with a numbered step that takes a fresh backup first and deletes the old full or long-term backups with the verified commands, warning that deletion is permanent. Evidence: `oci db backup delete --help`; `oci db autonomous-database-backup delete --help`.

- **Ensure managed certificates use strong key algorithms** (`mondoo-oci-security-certificates-strong-key-algorithms`, cli): The CLI creates a replacement certificate but never retires the weak one, which remains ACTIVE and keeps the check failing, and it does not explain the algorithm and validity values. Adds the verified schedule-deletion step that moves the weak certificate out of ACTIVE, and states which key and signature values pass and what the validity date must satisfy. Evidence: Check mql: `oci.certificates.certificates.where(state == "ACTIVE").all(keyAlgorithm.in([...]))`. `oci certs-mgmt certificate schedule-deletion --help`: --certificate-id [required], sets ... / Same CLI method: no step removes the weak certificate from the ACTIVE set the check evaluates. Appends the schedule-deletion command so the weak certificate leaves the ACTIVE state. Evidence: `oci certs-mgmt certificate schedule-deletion --help`.

- **Ensure managed certificates use strong signature algorithms** (`mondoo-oci-security-certificates-strong-signature-algorithms`, cli): The CLI creates a replacement certificate but never retires the weak one, which remains ACTIVE and keeps the check failing, and it does not say which signature values pass. Adds the schedule-deletion step and states the passing signature algorithms for each key type. Evidence: Check mql: `oci.certificates.certificates.where(state == "ACTIVE").all(signatureAlgorithm.in([...SHA-2 list...]))`. `oci certs-mgmt certificate schedule-deletion --help`.

- **Ensure certificate authorities use customer-managed KMS keys** (`mondoo-oci-security-certificate-authorities-customer-managed-keys`, cli): The CLI creates a replacement CA but never retires the old one, which stays ACTIVE and keeps the check failing, and it does not say what kind of Vault key `<kms-key-ocid>` must be, uses a parenthetical aside. Adds the schedule-deletion step so the old CA leaves the ACTIVE set, and states the HSM-protected asymmetric key requirement the service enforces so the create call succeeds. Evidence: Check mql: `oci.certificates.certificateAuthorities.where(state == "ACTIVE").all(kmsKey != null)`. `oci certs-mgmt certificate-authority schedule-deletion --help`: --certificate-authority-id. ...

- **Ensure OCI Cache clusters are deployed in private subnets** (`mondoo-oci-security-redis-cluster-private-subnet`, cli): The CLI recreates the cluster but never deletes the original, which stays in the public-IP subnet and keeps the check failing, and it leaves `<n>`, `<gb>`, `<backup-ocid>`, and the subnet requirement unexplained. Adds the verified delete step with a data-loss warning and explains each placeholder, including the prohibit-public-ip-on-vnic requirement the check reads. Evidence: Check mql: `oci.redis.cluster.subnet.prohibitPublicIpOnVnic == true` per cluster asset. `oci redis redis-cluster redis-cluster delete --help`: --redis-cluster-id [required]. `redis-cluster create ...

- **Ensure KMS master encryption keys are protected by an HSM** (`mondoo-oci-security-kms-keys-hsm-protected`, cli, console): The CLI only creates a new HSM key; the software key stays ENABLED and the check, which evaluates all enabled keys, keeps failing, with no step to re-key dependents or retire the old key. Adds the re-key step and the verified disable command with a warning about undecryptable data, so the enabled key set becomes HSM-only. Evidence: Check mql: `oci.kms.vaults.all(keys.where(state == "ENABLED").all(protectionMode == "HSM"))`. `oci kms management key disable --help`: --key-id [required]; --endpoint is a global OCI CLI flag. / The console method re-assigns resources to the new HSM key but leaves the software key enabled, so the check keeps failing. Adds a final step to disable the software key after dependents move, with the data-access warning. Evidence: Check mql filters `state == "ENABLED"`; `oci kms management key --help` lists `disable`.

- **Ensure VCN flow logs are enabled** (`mondoo-oci-security-vcn-flow-logs-enabled`, cli, console): The CLI enables a flow log on one subnet, but the check fails a VCN unless it has a VCN-level log or every subnet has one, and the method never says to repeat it. States that the command must be run for every subnet in the VCN, which is the state the check asserts. Evidence: Check mql: `oci.network.vcns.all(flowLogs.where(isEnabled == true) != empty || subnets.all(flowLogs.where(isEnabled == true) != empty))`. / The console steps enable a flow log on a single subnet without saying every subnet in the VCN needs one for the VCN to pass. Adds the repeat-per-subnet step matching the check's subnets.all() assertion. Evidence: Check mql: `subnets.all(flowLogs.where(isEnabled == true) != empty)`.

- **Ensure Data Science notebook sessions use a private endpoint** (`mondoo-oci-security-datascience-notebook-private-endpoint`, cli, console): The CLI creates a new session but never removes the existing session without a private endpoint, which the check keeps failing. Adds the verified delete command, with a warning that the old session's storage is lost, so no session without a private endpoint remains. Evidence: Check mql: `oci.ai.dataScience.notebookSessions.all(privateEndpointID != empty)`. `oci data-science notebook-session delete --help`: --notebook-session-id. / The console step 'Recreate existing sessions' never says to delete the originals, which keep failing. Adds deleting the old sessions after their work is saved. Evidence: Check mql: `notebookSessions.all(privateEndpointID != empty)`.

- **Ensure Autonomous Database standby ACLs exclude any-address entries** (`mondoo-oci-security-adb-standby-acl-not-open`, cli): Reusing the primary's allowlist only fixes the standby if the primary's list has no any-address entry, and the method does not say to check it. Adds the verification of the primary list, so the inherited standby list really excludes 0.0.0.0/0, 0.0.0.0, and ::/0. Evidence: `oci db autonomous-database update --help` --are-primary-whitelisted-ips-used: '`TRUE` if the Autonomous AI Database has Data Guard and Access Control enabled, and the Autonomous AI Database uses the ...

- **Ensure public DNS zones have DNSSEC signing enabled** (`mondoo-oci-security-dns-zone-dnssec-enabled`, cli): The CLI says to publish the DS record but gives no way to read it and omits promoting the key signing key, the step Oracle requires after the DS record exists. Adds the command that returns the zone OCID, KSK uuid, and DS data, and the verified promote command, completing the documented enablement flow. Evidence: https://docs.oracle.com/en-us/iaas/Content/DNS/Concepts/dnssec.htm: 'Create a DS record on the parent zone ... After the DS record has been created, promote the KSK. This step informs OCI that you ...

</details>

### Values or thresholds not explained

<details><summary>10 checks</summary>

- **Ensure groups with tenancy-wide admin access have limited membership** (`mondoo-oci-security-iam-admin-group-membership-limited`, cli, console): The console steps never state the membership limit the check enforces, so a reader cannot tell when the group is small enough. The check passes when every administrative group has five or fewer members; stating that number, and which groups count as administrative, tells the reader exactly how far to trim. Evidence: Check mql: oci.identity.groups.where(<admin-named> || holds manage all-resources in tenancy).all(members.length <= 5). / The CLI method removes a user with no way to see the current members and never states the five-member limit the check enforces. Listing the group's members shows how many must be removed, and removing users until five or fewer remain makes members.length <= 5 true. Evidence: `oci iam group list-users --help`: 'Lists the users in the specified group.' with --group-id; `oci iam group remove-user --help` lists --user-id and --group-id [required]. Check mql: ...

- **Ensure NSGs do not permit SSH or RDP ingress from 0.0.0.0/0** (`mondoo-oci-security-nsg-no-unrestricted-admin-ports`, cli): The CLI method removes a rule by `<rule-id>` without showing how to find that ID or which rules the check flags. Listing the NSG's ingress rules exposes each rule's id, source, protocol and port range, so the reader can pick exactly the rules from 0.0.0.0/0 or ::/0 that cover port 22 or 3389 or have no port range, which are the rules the check rejects. Evidence: `oci network nsg rules list --help` lists --nsg-id, --direction [EGRESS|INGRESS], --all; `oci network nsg rules remove --help` lists --nsg-id and --security-rule-ids. Check mql: ...

- **Ensure OKE clusters run a supported Kubernetes version** (`mondoo-oci-security-oke-supported-kubernetes-version`, cli): The CLI method leaves `<new-version>` unexplained and never states the check's threshold of fewer than three available upgrades, nor that node pools are upgraded separately. Reading available-kubernetes-upgrades shows the valid targets, and upgrading until that list holds fewer than three versions makes availableKubernetesUpgrades.length < 3 true. Evidence: oci.container_engine.models.Cluster attribute_map: 'available_kubernetes_upgrades': 'availableKubernetesUpgrades'; `oci ce cluster update --help` lists --kubernetes-version; `oci ce node-pool update ...

- **Ensure DB system subnets have no route to an internet gateway** (`mondoo-oci-security-dbsystem-subnet-no-internet-gateway`, cli): The example service gateway route uses `all-<region>-services-in-oracle-services-network` without saying what value replaces `<region>` or where to find the exact label, so a reader guessing the region name produces a rule OCI rejects. The service CIDR label is published by `oci network service list`, so reading it from there gives a valid SERVICE_CIDR_BLOCK destination; removing the internet gateway rule is what makes routes.none(destination 0.0.0.0/0 && internetGateway) true. Evidence: `oci network service list --help`: 'Lists the available [Service] objects that you can enable for a service gateway in this region.'; oci.core.models.Service attribute_map includes 'cidr_block': ...

- **Ensure managed certificates are not expired or near expiry** (`mondoo-oci-security-certificates-not-expired`, cli): The CLI renews with only `--version-name`, never setting the new expiry the check measures, explains neither the renewal rule values nor the threshold, and has no command for imported certificates, which the check also evaluates. Follows Oracle's documented renewal command with `--validity` and a stated more-than-30-days requirement, adds the import-update command for externally issued certificates, and explains the renewal rule fields. Evidence: renewing-certificate.htm CLI example: `oci certs-mgmt certificate update-certificate-managed-internally --certificate-id ... --validity file://path/to/validity.json`. `oci certs-mgmt certificate ...

- **Ensure at least one Cloud Guard security zone is configured** (`mondoo-oci-security-cloudguard-security-zones-configured`, cli): The CLI requires `--security-zone-recipe-id <recipe-ocid>` without saying where the recipe OCID comes from or that Cloud Guard must be enabled first, so a reader cannot run it. Adds the verified recipe listing command and the documented Cloud Guard prerequisite, so the create call has every value it needs. Evidence: `oci cloud-guard security-zone create --help`: --security-zone-recipe-id [required], -c/--compartment-id [required]. `oci cloud-guard security-recipe-collection list-security-recipes --help` exists. ...

- **Ensure the IAM password policy enforces strong complexity requirements** (`mondoo-oci-security-iam-password-policy-strong`, cli): The domain patch never sets the policy to Custom strength, which the individual rules depend on, and does not say how to find `<password-policy-id>` or `<domain-url>`. Adds a `passwordStrength` replace to Custom as the first operation and explains both placeholders, so the patched rules are the ones the domain enforces and the check reads. Evidence: `oci.identity_domains.models.PasswordPolicy.password_strength`: 'Indicates whether the password policy is configured as Simple, Standard, or Custom. Allowed values ... "Simple", "Standard", "Custom"' ...

- **Ensure KMS master encryption keys have automatic rotation enabled** (`mondoo-oci-security-kms-keys-auto-rotation-enabled`, cli, console, terraform): The CLI does not say that automatic rotation only works for keys in a virtual private vault, so it fails for keys in default vaults, and it does not explain the allowed rotation interval. States the vault-type prerequisite and the 60 to 365 day range Oracle enforces, so readers know when the update can succeed and what value to use. Evidence: https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Concepts/keyoverview.htm: 'This feature is available only for private vaults ... you chose a rotation interval between 60 days and 365 days.' ... / The Terraform snippet references a vault it never declares and omits that automatic rotation requires a VIRTUAL_PRIVATE vault, so applying it against a default vault fails. Declares the vault with `vault_type = "VIRTUAL_PRIVATE"` and states the 60 to 365 day interval range. Evidence: keyoverview.htm: 'This feature is available only for private vaults ... between 60 days and 365 days.' `oci_kms_vault` vault_type accepts VIRTUAL_PRIVATE (CLI enum). / The console step 'Set the rotation interval' gives no allowed range and omits the virtual private vault requirement. Adds the documented 60 to 365 day range and the vault-type limitation. Evidence: keyoverview.htm Automatic Key Rotation section.

- **Ensure Network Firewall decryption profiles block unsafe TLS sessions** (`mondoo-oci-security-network-firewall-decryption-profile-strict`, cli): The CLI hardcodes `--type SSL_FORWARD_PROXY` and forward-proxy certificate fields without saying the type must match the existing profile or what to pass for an SSL_INBOUND_INSPECTION profile, which the check also evaluates. Explains that the type must stay the profile's own and which fields apply to inbound inspection profiles. Evidence: OCI CLI extended command (services/network_firewall/.../networkfirewall_cli_extended.py) maps isExpiredCertificateBlocked, isUntrustedIssuerBlocked, isRevocationStatusTimeoutBlocked, ...

- **Ensure bastions do not accept sessions from every address** (`mondoo-oci-security-bastion-client-cidr-not-open`, cli): The CLI passes `203.0.113.0/24` without saying it is a placeholder range or that `--client-cidr-list` replaces the whole allow list. Explains the replacement semantics and what ranges to supply, which excludes 0.0.0.0/0 and ::/0 as the check requires. Evidence: `oci bastion bastion update --help` --client-cidr-list (complex list). Check mql: `clientCidrBlockAllowList.none(_ == "0.0.0.0/0" || _ == "::/0")`.

</details>

### Destructive or disruptive steps not flagged

- **Ensure IAM auth tokens are rotated within 90 days of creation** (`mondoo-oci-security-iam-auth-tokens-short-lived`, cli, console): The console steps delete the old token before generating the replacement, which breaks every client still using it, and never mention the two-token limit that dictates the order. Issuing and deploying the replacement first, then deleting tokens older than 90 days, leaves no active token older than the threshold without an outage; deleting an unused token first is only needed when the user already holds two. Evidence: docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcredentials.htm: 'Each user can have up to two auth tokens at a time.' and after deletion 'The auth token is no longer valid for accessing ... / The CLI method deletes the old token before creating its replacement, causing an outage for clients such as docker login and Swift, gives no way to find which tokens exceed 90 days, and leaves <token-ocid> unexplained. Listing tokens with their creation time identifies those older than 90 days; creating and deploying the replacement first and then deleting the old tokens satisfies the check without breaking consumers, within the two-token limit. Evidence: managingcredentials.htm: 'Each user can have up to two auth tokens at a time.'; oci.identity.models.AuthToken attribute_map includes id, timeCreated, lifecycleState, token; `oci iam auth-token ...

- **Ensure compute instances have the legacy IMDSv1 endpoints disabled** (`mondoo-oci-security-compute-imds-v2-only`, cli): The CLI method disables the legacy IMDS endpoints without the warning, present only in the console method, that any software still calling IMDSv1 on the instance breaks immediately. Stating the breakage and the IMDSv2 migration prerequisite in the method a CLI user follows lets them update instance software before legacyImdsEndpointsDisabled becomes true. Evidence: Console method in the same check: 'Once legacy IMDS is disabled, any application still calling IMDSv1 fails immediately'; docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm; `oci ...

- **Ensure IAM user API signing keys are rotated within 90 days** (`mondoo-oci-security-iam-api-keys-rotated`, cli): The CLI uploads a new key and immediately deletes the old one in the same block, with no step to move the consuming system to the new key, so following it as written breaks every client still signing with the old key; it also never says how to generate the key pair or find the old fingerprint. Orders the steps as generate, upload, cut over, then delete, and explains the fingerprint lookup and the 90-day age the check enforces. Evidence: `oci setup keys --help`: 'Generated key files will be {key-name}.pem and {key-name}_public.pem', --output-dir. `oci iam user api-key upload --help`: --key-file 'A file containing the public key'. ...

- **Ensure IPSec VPN tunnels negotiate IKEv2** (`mondoo-oci-security-ipsec-tunnel-ikev2`, cli): The CLI changes the IKE version on one tunnel with no warning that the tunnel drops until the customer-premises equipment matches, and no note that both tunnels of the connection must change for the check to pass. Tells the reader to run it for both tunnels, where to find their OCIDs, and to coordinate the CPE change to avoid an outage. Evidence: Check mql: `oci.network.ipsecConnections.all(tunnels.all(ikeVersion == "V2"))`. `oci network ip-sec-tunnel update --help`: --tunnel-id [required], --ike-version [V1|V2].

- **Ensure Network Firewall allow rules name a source address list** (`mondoo-oci-security-network-firewall-no-allow-any-source`, cli): `--condition` replaces the entire match condition, so the example silently drops any application, service, or url lists the rule had and widens it, and the example list names are unexplained. Adds reading the current rule first, warns about the replacement semantics, and explains that the values are address-list names. Evidence: `oci.network_firewall.models.SecurityRuleMatchCriteria` fields: source_address, destination_address, application, service, url. `oci network-firewall address-list --help`: 'List of addresses with a ...

- **Ensure VCN peering does not cross a tenancy boundary** (`mondoo-oci-security-network-no-cross-tenancy-peering`, cli): The CLI deletes local and remote peering but not cross-tenancy DRG attachments, which the check also fails, and gives no warning that deletion cuts traffic immediately. Adds the verified DRG attachment delete command and the disruption warning. Evidence: Check mql: `oci.network.drgs.all(attachments.all(isCrossTenancy == false))`. `oci network drg-attachment delete --help`: --drg-attachment-id [required].

### Audit queries that could never match (found during integration)

- **Ensure VCN security lists block SSH ingress from 0.0.0.0/0** (`mondoo-oci-security-vcn-no-unrestricted-ssh-ingress`), **Ensure VCN security lists block RDP ingress from 0.0.0.0/0** (`mondoo-oci-security-vcn-no-unrestricted-rdp-ingress`), **Ensure VCN security lists block unrestricted UDP ingress** (`mondoo-oci-security-vcn-no-unrestricted-udp-ingress`), **Ensure VCN security lists block unrestricted TCP egress** (`mondoo-oci-security-vcn-no-unrestricted-egress-all-tcp-ports`), **Ensure VCN security lists block database port ingress from 0.0.0.0/0** (`mondoo-oci-security-vcn-no-unrestricted-ingress-db-ports`), audit: the `--query` filter compared `protocol` to a JMESPath number literal such as `` `6` `` or `` `17` ``, but OCI returns protocol as a string, so the filter returned nothing and every security list looked like it passed. These are the same defect the auditors fixed in the legacy-admin-ports and ICMP checks. Changed to the string literals `` `"6"` `` and `` `"17"` ``. Evidence: with the OCI CLI's bundled jmespath, a `protocol==` filter using the number literal 6 returns `[]` against a rule whose protocol is the string `"6"`, and the string literal returns the rule.

### Auditor edits adjusted during review

No proposed edit was rejected. Three were applied with a correction:

- `object-storage-retention-rules-locked` (cli): the example lock time `2026-10-01T00:00:00Z` would itself become a past or too-near date within weeks; replaced with the format `YYYY-MM-DDThh:mm:ssZ`, keeping the 14-day minimum and the advice to stay close to it.
- `object-storage-buckets-replication-enabled` (terraform): the edit correctly moved the destination bucket to `provider = oci.destination` but did not say what that alias is; added a sentence that it is a provider configuration whose `region` is the destination region.
- `iam-password-policy-strong` (cli): the edit told readers to pass `https://<domain-url>` with `<domain-url>` being the console's Domain URL, which already includes `https://`; now names the host name, with an example.

## Found but not changed

Each item below is tracked in its own issue: #3725, #3726, #3727, #3728, #3729, #3730, #3731, #3732, #3733, #3735, #3736, #3737, #3738, #3739, #3740, #3741, mondoohq/mql#10771.

- **`iam-no-overly-permissive-policies`** (#3725): each IAM policy is scored as its own asset. The built-in Tenant Admin Policy `Allow group Administrators to manage all-resources in tenancy` cannot be changed or deleted, so that one policy asset fails on every tenancy and can never be fixed. The query does not exclude it.
- **Security-list plan/state variants read `tcp_options[].destination_port_range`** (#3726): `oci_core_security_list` has flat `min`/`max` on `tcp_options`, and only `source_port_range` is a block (`terraform providers schema -json`, oracle/oci 9.1.0). The port comparison never matches. A scan of a scratch plan confirmed that open 22/3389/5432/445 rules pass the `ssh-ingress`, `rdp-ingress`, `ingress-db-ports`, `ingress-legacy-admin-ports` and `ipv6-ingress` plan variants. Plan/state variants are not fixture-gated.
- **Load balancer TLS checks key on protocol name** (#3727): OCI listener protocols are HTTP, HTTP2, TCP and GRPC. A TLS listener is HTTP or HTTP2 plus `ssl_configuration`, and Oracle's `lb_full.tf` port 443 listener uses `protocol = "HTTP"`. The runtime and plan/state variants of `loadbalancer-tls-minimum-1-2` and `loadbalancer-no-weak-cipher-suites` filter on `protocol.in(["HTTPS","HTTP2"])`, so HTTP+SSL listeners are never evaluated. Their HCL variants already also match on `ssl_configuration`. `loadbalancer-http-listener-has-https` fails a load balancer whose only TLS listener is HTTP+SSL, and its desc, audit and console steps still say "Protocol: HTTPS". That is why its CLI fix now creates an `HTTP2` listener.
- **`loadbalancer-no-weak-cipher-suites` allow-list** (#3728): the `^oci-tls-1-2-…`/`^oci-tls-1-3-…` branches match no real suite. The predefined names are `oci-tls-12-ssl-cipher-suite-v3`, `oci-tls-13-ssl-cipher-suite-v3`, `oci-tls-12-13-ssl-cipher-suite-v3`, `oci-default-http2-tls-12-13-ssl-cipher-suite-v1` and others. Only `oci-modern-ssl-cipher-suite-v1` and `oci-default-ssl-cipher-suite-v1` pass, so strong suites fail, including the HTTP2 suite used by the `http-listener-has-https` CLI fix. The runtime variant also reads `sslCipherSuite.name`, which the provider documents as null for predefined suites (mondoohq/mql#10771).
- **Replication versus versioning conflict** (#3729): OCI rejects versioning on a replication destination bucket, so `object-storage-buckets-versioning-enabled` and `object-storage-archive-buckets-versioning` fail every bucket that is a replication destination. The provider's `isReadOnly` field can exclude them.
- **`iam-no-any-user-policies`** (#3730) fails Oracle's documented OKE secrets-encryption grant `Allow any-user to use keys ... where ALL {request.principal.type = 'cluster', ...}`. The OKE remediation here uses the documented dynamic-group form instead.
- **`vcn-no-unrestricted-ingress-db-ports-oci` and `vcn-no-unrestricted-ingress-legacy-admin-ports-oci`** (#3731) filter on `destinationPortMin != empty`, so a 0.0.0.0/0 TCP rule with no port range passes, while the IaC variants flag it.
- **Console navigation** (#3732): `Identity & Security > Users/Groups` in the audit and console steps of eight IAM checks predates identity domains. Only the stale-users console method was updated.
- **Boot volume encryption Terraform** (#3733): the variants, the remediation and the desc cover only a standalone `oci_core_boot_volume`, not `oci_core_instance.source_details.kms_key_id`.
- **`certificate-authorities-customer-managed-keys`** (#3735): Oracle requires an HSM-protected asymmetric Vault key to create a CA, so the only CAs that can fail are externally managed root CAs, whose keys never enter OCI. The "Oracle-managed encryption" framing in the desc is inaccurate.
- **`network-firewall-no-allow-any-source` desc** (#3736) says to order allow rules after a catch-all drop, which conflicts with first-match evaluation (policies.htm).
- **`certificates-strong-signature-algorithms` desc** (#3737) calls reissuing under SHA-2 a configuration change and points to `oci certs-mgmt certificate update`. No certificate update operation can change the algorithm.
- **`certificates-not-expired`** (#3738): the SDK and the console docs describe `advanceRenewalPeriod` differently, so it is unclear whether a renewal rule with P30D lands before the check's more-than-30-days threshold.
- **`apigateway-deployment-authentication-configured` CLI** (#3739) sets only `"type": "JWT_AUTHENTICATION"`. The SDK marks `issuers`, `audiences` and `publicKeys` as required for JWT, `validationPolicy` for TOKEN and `functionId` for CUSTOM.
- **Block volume, boot volume and file storage** (#3740): no remediation method grants the storage service use of the key. The block volume desc mentions the grant, the file storage desc mentions it only in part, and the boot volume desc does not mention it at all.
- **`redis-cluster-private-subnet` Terraform** (#3741) does not warn that changing the subnet replaces the cluster. `subnet_id` is `ForceNew` in terraform-provider-oci.

Dropped after verification: the DB system encryption Terraform example's `VM.Standard2.2` shape. Nothing showed it can no longer be provisioned.

## Validation

- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" content/mondoo-oci-security.mql.yaml`: parses.
- `cnspec policy lint content/mondoo-oci-security.mql.yaml`: valid policy bundle; 2 pre-existing `query-deprecated-symbol` warnings (`oci.objectStorage.bucket.kmsKeyId`, `oci.database.autonomousDatabase.publicConnectionUrls`), unchanged from main.
- `python3 content/validation/remediation/commands/validate.py oci`: 283 passed, 0 failed (main: 260 passed, 0 failed).
- `python3 content/validation/remediation/code/terraform.py oci`: 76 passed, 0 failed.
- `go test -tags iac_variants ./content/validation/scans -run 'TestRemediationSatisfiesCheck/^mondoo-oci-security-(object-storage-buckets-customer-managed-encryption|object-storage-buckets-replication-enabled|loadbalancer-tls-minimum-1-2|loadbalancer-no-weak-cipher-suites|oke-secrets-customer-managed-encryption|kms-keys-auto-rotation-enabled|network-firewall-no-allow-any-source)-terraform-hcl$'`: all 7 PASS (none skipped).
- Required-flag check: walked the installed OCI CLI 3.92.1 Click tree and compared every `oci` command in the policy against options whose help ends in `[required]`. No new gaps; `oci db system launch` no longer misses `--database-edition`, `--admin-password`, `--db-name`, `--db-version`. The other hits are compartment and namespace options the CLI fills from config.
- SDK models (`oci` Python SDK bundled with the CLI): `PhaseOneConfigDetails` has `diffieHelmanGroup`, `PhaseTwoConfigDetails` has `isPfsEnabled`/`pfsDhGroup`; `PromptInjectionConfig`, `PiiDetectionConfig`, `ContentModerationConfig` mark `isEnabled` required; `UpdateSecurityRuleDetails` marks `id` required; `UpdateClusterDetails` has no KMS key. terraform-provider-oci marks `oci_containerengine_cluster.kms_key_id` `ForceNew`.
- `typos content/mondoo-oci-security.mql.yaml`: clean.
- `bash.py` has no OCI target, so the shellcheck validator does not apply to this policy.

## Overlapping open PRs

- #3628 (`feat/oci-terraform-variants`) also edits `content/mondoo-oci-security.mql.yaml` to add Terraform variants to four checks; expect a textual rebase conflict only if it touches the same remediation blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

