### PR TITLE
🐛 kubernetes: stop requiring uppercase ALL for the drop-all checks

### DIFF
--- a/content/mondoo-kubernetes-security.mql.yaml
+++ b/content/mondoo-kubernetes-security.mql.yaml
@@ -3,7 +3,7 @@
 policies:
   - uid: mondoo-kubernetes-security
     name: Mondoo Kubernetes Cluster and Workload Security
-    version: 2.1.2
+    version: 2.1.3
     license: BUSL-1.1
     tags:
       mondoo.com/category: security
@@ -12361,7 +12361,7 @@ queries:
         kubectl get pods -A -o json | jq -r '.items[] | select( .spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update the Pod, or the controller that created it, to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+        Update the Pod, or the controller that created it, to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling.
 
         **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
 
@@ -12427,7 +12427,7 @@ queries:
         kubectl get daemonsets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update DaemonSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update DaemonSets to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
 
         Example manifest:
 
@@ -12491,7 +12491,7 @@ queries:
         kubectl get replicasets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update ReplicaSets to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+        Update ReplicaSets to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling.
 
         **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
 
@@ -12559,7 +12559,7 @@ queries:
         kubectl get jobs -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Jobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+        Update Jobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling.
 
         **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
 
@@ -12627,7 +12627,7 @@ queries:
         kubectl get deployments -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update Deployments to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update Deployments to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
 
         Example manifest:
 
@@ -12691,7 +12691,7 @@ queries:
         kubectl get statefulsets -A -o json | jq -r '.items[] | select( .spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update StatefulSets to drop ALL capabilities, then add back only the specific capabilities required. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
+        Update StatefulSets to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling. Test this in staging first, because dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`. Applying the change also rolls the workload's pods.
 
         Example manifest:
 
@@ -12755,7 +12755,7 @@ queries:
         kubectl get cronjobs -A -o json | jq -r '.items[] | select( .spec.jobTemplate.spec.template.spec.containers[].securityContext.capabilities.drop | . == null or ( any(.[] ; ascii_upcase == "ALL") | not ) ) | .metadata.namespace + "/" + .metadata.name' | uniq
         ```
       remediation: |
-        Update CronJobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`, written in uppercase, for the check to pass.
+        Update CronJobs to drop `ALL` capabilities, then add back only the specific capabilities required. Every container and init container must drop `ALL`. Write it in uppercase: containerd and CRI-O match `ALL` in any case, but the Pod Security Standards restricted profile admits only the uppercase spelling.
 
         **Test this in staging first.** Dropping every capability can break applications that rely on one. For example, binding to a port below 1024 needs `NET_BIND_SERVICE`, and changing file ownership needs `CHOWN`. If the workload fails after the change, identify the missing capability and add only that one back rather than restoring `ALL`.
 

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-drop-all/pass/lowercase-all/cronjob.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-drop-all/pass/lowercase-all/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-capability-drop-all
+  namespace: default
+spec:
+  schedule: '*/5 * * * *'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: cronjob-capability-drop-all
+        spec:
+          containers:
+          - name: app
+            image: nginx:1.25
+            securityContext:
+              capabilities:
+                drop:
+                - all
+          restartPolicy: Never

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-net-raw/pass/lowercase-all/cronjob.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-net-raw/pass/lowercase-all/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-capability-net-raw
+  namespace: default
+spec:
+  schedule: '*/5 * * * *'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: cronjob-capability-net-raw
+        spec:
+          containers:
+          - name: app
+            image: nginx:1.25
+            securityContext:
+              capabilities:
+                drop:
+                - all
+          restartPolicy: Never

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-sys-admin/fail/lowercase-add-all/cronjob.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-cronjob-capability-sys-admin/fail/lowercase-add-all/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob-capability-sys-admin
+  namespace: default
+spec:
+  schedule: '*/5 * * * *'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: cronjob-capability-sys-admin
+        spec:
+          containers:
+          - name: app
+            image: nginx:1.25
+            securityContext:
+              capabilities:
+                add:
+                - all
+          restartPolicy: Never

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-drop-all/pass/lowercase-all/daemonset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-drop-all/pass/lowercase-all/daemonset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: daemonset-capability-drop-all
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: daemonset-capability-drop-all
+  template:
+    metadata:
+      labels:
+        app: daemonset-capability-drop-all
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-net-raw/pass/lowercase-all/daemonset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-net-raw/pass/lowercase-all/daemonset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: daemonset-capability-net-raw
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: daemonset-capability-net-raw
+  template:
+    metadata:
+      labels:
+        app: daemonset-capability-net-raw
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-sys-admin/fail/lowercase-add-all/daemonset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-daemonset-capability-sys-admin/fail/lowercase-add-all/daemonset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: daemonset-capability-sys-admin
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: daemonset-capability-sys-admin
+  template:
+    metadata:
+      labels:
+        app: daemonset-capability-sys-admin
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            add:
+            - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-drop-all/pass/lowercase-all/deployment.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-drop-all/pass/lowercase-all/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-capability-drop-all
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: deployment-capability-drop-all
+  template:
+    metadata:
+      labels:
+        app: deployment-capability-drop-all
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-net-raw/pass/lowercase-all/deployment.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-net-raw/pass/lowercase-all/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-capability-net-raw
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: deployment-capability-net-raw
+  template:
+    metadata:
+      labels:
+        app: deployment-capability-net-raw
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-sys-admin/fail/lowercase-add-all/deployment.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-deployment-capability-sys-admin/fail/lowercase-add-all/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-capability-sys-admin
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: deployment-capability-sys-admin
+  template:
+    metadata:
+      labels:
+        app: deployment-capability-sys-admin
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            add:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-drop-all/pass/lowercase-all/job.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-drop-all/pass/lowercase-all/job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-capability-drop-all
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        app: job-capability-drop-all
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+      restartPolicy: Never

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-sys-admin/fail/lowercase-add-all/job.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-job-capability-sys-admin/fail/lowercase-add-all/job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-capability-sys-admin
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        app: job-capability-sys-admin
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            add:
+            - all
+      restartPolicy: Never

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-drop-all/pass/lowercase-all/pod.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-drop-all/pass/lowercase-all/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-capability-drop-all
+  namespace: default
+  labels:
+    app: pod-capability-drop-all
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25
+    securityContext:
+      capabilities:
+        drop:
+        - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-net-raw/pass/lowercase-all/pod.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-net-raw/pass/lowercase-all/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-capability-net-raw
+  namespace: default
+  labels:
+    app: pod-capability-net-raw
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25
+    securityContext:
+      capabilities:
+        drop:
+        - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-sys-admin/fail/lowercase-add-all/pod.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-pod-capability-sys-admin/fail/lowercase-add-all/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-capability-sys-admin
+  namespace: default
+  labels:
+    app: pod-capability-sys-admin
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25
+    securityContext:
+      capabilities:
+        add:
+        - all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-drop-all/pass/lowercase-all/replicaset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-drop-all/pass/lowercase-all/replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: replicaset-capability-drop-all
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: replicaset-capability-drop-all
+  template:
+    metadata:
+      labels:
+        app: replicaset-capability-drop-all
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-net-raw/pass/lowercase-all/replicaset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-net-raw/pass/lowercase-all/replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: replicaset-capability-net-raw
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: replicaset-capability-net-raw
+  template:
+    metadata:
+      labels:
+        app: replicaset-capability-net-raw
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-sys-admin/fail/lowercase-add-all/replicaset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-replicaset-capability-sys-admin/fail/lowercase-add-all/replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: replicaset-capability-sys-admin
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: replicaset-capability-sys-admin
+  template:
+    metadata:
+      labels:
+        app: replicaset-capability-sys-admin
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            add:
+            - all
+  replicas: 1

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-drop-all/pass/lowercase-all/KNOWN_BUG.md
@@ -1,0 +1,3 @@
+dropsAllCapabilities matches only uppercase ALL, but containerd and CRI-O drop every capability for a lowercase all: mondoohq/mql#10769
+
+The rollup in providers/k8s/resources/workload_security.go compares `d == "ALL"`. Once a provider with the strings.EqualFold fix is the one this suite resolves against, this scenario passes and the marker must be deleted. See mondoohq/cnspec#3660.

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-drop-all/pass/lowercase-all/statefulset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-drop-all/pass/lowercase-all/statefulset.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-capability-drop-all
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: statefulset-capability-drop-all
+  template:
+    metadata:
+      labels:
+        app: statefulset-capability-drop-all
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1
+  serviceName: statefulset-capability-drop-all

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-net-raw/pass/lowercase-all/statefulset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-net-raw/pass/lowercase-all/statefulset.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-capability-net-raw
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: statefulset-capability-net-raw
+  template:
+    metadata:
+      labels:
+        app: statefulset-capability-net-raw
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            drop:
+            - all
+  replicas: 1
+  serviceName: statefulset-capability-net-raw

--- a/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-sys-admin/fail/lowercase-add-all/statefulset.yaml
+++ b/content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/mondoo-kubernetes-security-statefulset-capability-sys-admin/fail/lowercase-add-all/statefulset.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-capability-sys-admin
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: statefulset-capability-sys-admin
+  template:
+    metadata:
+      labels:
+        app: statefulset-capability-sys-admin
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        securityContext:
+          capabilities:
+            add:
+            - all
+  replicas: 1
+  serviceName: statefulset-capability-sys-admin


### PR DESCRIPTION
## Summary

A container with `capabilities.drop: ["all"]` runs with an empty capability set on both containerd and CRI-O. The drop-all checks failed it because `k8s.<kind>.dropsAllCapabilities` matched only uppercase `ALL`. The NET_RAW and SYS_ADMIN checks upcase first, so they were already right. The drop-all side was too strict.

The fix for the check itself is in the provider: mondoohq/mql#10769. This PR aligns the content. The remediation stops saying uppercase is required "for the check to pass", but still tells users to write `ALL` in uppercase, because Pod Security Admission's `restricted` profile disagrees with the runtimes and rejects any other spelling. The PR also adds lowercase fixtures that lock in the behavior of all three check families.

## Evidence

**kubelet** hands the strings to the runtime unchanged, [`pkg/kubelet/kuberuntime/security_context.go#L152`](https://github.com/kubernetes/kubernetes/blob/v1.37.0/pkg/kubelet/kuberuntime/security_context.go#L152):

```go
capabilities.DropCapabilities[index] = string(value)
```

**containerd** v2.3.4, [`internal/cri/opts/spec_opts.go#L212`](https://github.com/containerd/containerd/blob/v2.3.4/internal/cri/opts/spec_opts.go#L212) and [`internal/cri/util/strings.go#L27-L29`](https://github.com/containerd/containerd/blob/v2.3.4/internal/cri/util/strings.go#L27-L29). Individual names are also upcased, [`#L228-L231`](https://github.com/containerd/containerd/blob/v2.3.4/internal/cri/opts/spec_opts.go#L228-L231):

```go
if util.InStringSlice(capabilities.GetDropCapabilities(), "ALL") {
	opts = append(opts, oci.WithCapabilities(nil))
}
...
func InStringSlice(ss []string, str string) bool {
	for _, s := range ss {
		if strings.EqualFold(s, str) {
...
caps = append(caps, "CAP_"+strings.ToUpper(c))
```

**CRI-O** v1.36.5, [`internal/factory/container/container.go#L665`](https://github.com/cri-o/cri-o/blob/v1.36.5/internal/factory/container/container.go#L665), [`#L790-L792`](https://github.com/cri-o/cri-o/blob/v1.36.5/internal/factory/container/container.go#L790-L792), and [`#L658`](https://github.com/cri-o/cri-o/blob/v1.36.5/internal/factory/container/container.go#L658) for individual names:

```go
dropAll := inStringSlice(caps.GetDropCapabilities(), "ALL")
...
func inStringSlice(ss []string, str string) bool {
	for _, s := range ss {
		if strings.EqualFold(s, str) {
...
return "CAP_" + strings.ToUpper(capability)
```

**Pod Security Admission** `restricted` compares exactly, [`check_capabilities_restricted.go#L30`](https://github.com/kubernetes/kubernetes/blob/v1.37.0/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#L30) and [`#L94`](https://github.com/kubernetes/kubernetes/blob/v1.37.0/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#L94):

```go
capabilityAll            = "ALL"
...
if c == capabilityAll {
```

So PSA and the runtimes disagree. Lowercase `all` removes every capability at runtime, and a namespace enforcing `restricted` still rejects it. The checks score what the container actually runs with, so they follow the runtimes. The remediation keeps recommending uppercase so the fix also satisfies PSA.

**Empirical**, minikube v1.39.0, Kubernetes v1.37.0. Each busybox Pod ran `grep -E '^Cap(Prm|Eff|Bnd)' /proc/1/status`; `CapPrm` and `CapBnd` matched `CapEff` in every case:

| `drop:` | containerd 2.3.4 `CapEff` | CRI-O 1.35.7 `CapEff` |
|---|---|---|
| unset | `00000000a80425fb` | `00000000000005fb` |
| `["ALL"]` | `0000000000000000` | `0000000000000000` |
| `["all"]` | `0000000000000000` | `0000000000000000` |
| `["All"]` | `0000000000000000` | `0000000000000000` |
| `["NET_RAW"]` | `00000000a80405fb` | `00000000000005fb` |
| `["net_raw"]` | `00000000a80405fb` | `00000000000005fb` |

On containerd, `net_raw` clears bit 13 (`CAP_NET_RAW`, `0x2000`) exactly like `NET_RAW`, so the NET_RAW checks are right to upcase capability names too. CRI-O's default set does not include `NET_RAW`, so those two rows show no change there.

PSA, same cluster, namespace labeled `pod-security.kubernetes.io/enforce=restricted`, otherwise compliant Pod, `--dry-run=server`: `["ALL"]` was admitted, and `["all"]` was denied with `violates PodSecurity "restricted:latest": unrestricted capabilities (container "c" must set securityContext.capabilities.drop=["ALL"])`.

## Changes

- `content/mondoo-kubernetes-security.mql.yaml`
  - Drop-all remediation on all seven kinds: replace "written in uppercase, for the check to pass" with a recommendation to write `ALL` in uppercase for PSA `restricted`. The DaemonSet, Deployment, and StatefulSet checks gain the same sentence so all seven match.
  - Version `2.1.2` → `2.1.3`.
- Fixtures under `content/validation/scans/fixtures/iac-variants/mondoo-kubernetes-security/`, each copied from the existing scenario with the capability swapped for `all`:
  - `*-capability-drop-all/pass/lowercase-all/` (7) with a `KNOWN_BUG.md` pointing at mondoohq/mql#10769. They pass as known-bug scenarios today and trip once a provider with the fix is what the suite resolves against, which is the signal to delete the markers.
  - `*-capability-net-raw/pass/lowercase-all/` (6): lowercase `all` in `drop` passes.
  - `*-capability-sys-admin/fail/lowercase-add-all/` (7): lowercase `all` in `add` fails, matching the runtimes, which also match `ALL` case-insensitively in `add`.

No query changes. The `mql:` on all three families is already right, or becomes right with the provider fix.

## Validation

- `cnspec policy lint content/mondoo-kubernetes-security.mql.yaml`: valid.
- `go test -tags iac_variants ./content/validation/scans -run 'TestKubernetesManifestVariants/mondoo-kubernetes-security/mondoo-kubernetes-security-.*-capability-(drop-all|net-raw|sys-admin)/'`: all 60 scenarios pass against the installed k8s provider.
- The same run with `PROVIDERS_PATH` pointing at a k8s provider built from mondoohq/mql#10769: only the 7 `drop-all/pass/lowercase-all` scenarios fail, each with "known-bug scenario now asserts correctly". The other 53 still pass. That confirms the provider fix makes the drop-all checks pass for `all` and changes nothing else.
- `typos` on the policy and fixtures: clean.

## Found but not changed

- #3694: the drop-all `audit` jq commands only look at regular containers. The check also scores init containers, and ephemeral containers on Pods, so the audit misses workloads that fail the check.

Fixes #3660

🤖 Generated with [Claude Code](https://claude.com/claude-code)
